### PR TITLE
Add page health distribution to eval harness

### DIFF
--- a/src/eval/health.ts
+++ b/src/eval/health.ts
@@ -22,6 +22,7 @@ import {
 } from "../linter/rules.js";
 import { loadSchema } from "../schema/loader.js";
 import { countCandidates } from "../compiler/candidates.js";
+import { lint } from "../linter/index.js";
 import type { LintResult } from "../linter/types.js";
 import type { HealthResult, HealthRuleResult } from "./types.js";
 
@@ -38,7 +39,7 @@ const ERROR_RULES = new Set([
 ]);
 
 /** Compute the point deduction for a single lint result. */
-function deductionFor(result: LintResult): number {
+export function deductionFor(result: LintResult): number {
   if (result.rule === "pending-target") return 0;
   if (ERROR_RULES.has(result.rule)) return ERROR_DEDUCTION;
   if (result.rule === "contradicted-page") return CONTRADICTED_DEDUCTION;
@@ -71,23 +72,20 @@ function aggregateRules(results: LintResult[]): HealthRuleResult[] {
  * health score plus per-rule breakdown.
  * @param root - Absolute path to the project root.
  */
-export async function evaluateHealth(root: string): Promise<HealthResult> {
-  const schema = await loadSchema(root);
+/**
+ * Run all lint rules via the canonical linter orchestrator and return
+ * flat results. Delegates to lint() so the rule list stays in sync with
+ * llmwiki lint — no manual list to maintain. Used by evaluateHealth and
+ * by page-health-distribution so both see the same diagnostics.
+ */
+export async function runAllLintRules(root: string): Promise<LintResult[]> {
+  const summary = await lint(root);
+  return summary.results;
+}
 
+export async function evaluateHealth(root: string): Promise<HealthResult> {
   const [allResults, pendingReviews] = await Promise.all([
-    Promise.all([
-      checkBrokenWikilinks(root),
-      checkBrokenCitations(root),
-      checkMalformedClaimCitations(root),
-      checkOrphanedPages(root),
-      checkMissingSummaries(root),
-      checkDuplicateConcepts(root),
-      checkEmptyPages(root),
-      checkLowConfidencePages(root),
-      checkContradictedPages(root),
-      checkInferredWithoutCitations(root),
-      checkSchemaCrossLinks(root, schema),
-    ]).then((results) => results.flat()),
+    runAllLintRules(root),
     countCandidates(root).catch(() => 0),
   ]);
 

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -10,12 +10,13 @@ import { evaluateHealth } from "./health.js";
 import { evaluateCitationCoverage } from "./citation-coverage.js";
 import { evaluateSourceUtilization } from "./source-utilization.js";
 import { evaluateCitationDepth } from "./citation-depth.js";
+import { evaluatePageHealthDistribution } from "./page-health-distribution.js";
 import { evaluateCitationSupport } from "./citation-support.js";
 import { collectStats, appendHistory, loadPreviousReport, loadLastFullReport } from "./stats.js";
 import { computeDelta } from "./delta.js";
 import { checkThresholds } from "./thresholds.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
-import type { EvalReport, HealthResult, CitationCoverageResult, SourceUtilizationResult, CitationDepthResult, CitationSupportResult, StatsResult } from "./types.js";
+import type { EvalReport, HealthResult, CitationCoverageResult, SourceUtilizationResult, CitationDepthResult, PageHealthDistributionResult, CitationSupportResult, StatsResult } from "./types.js";
 
 export const DEFAULT_SAMPLE_SIZE = 20;
 
@@ -24,13 +25,14 @@ interface EvalComponents {
   citationCoverage: CitationCoverageResult;
   sourceUtilization: SourceUtilizationResult;
   citationDepth: CitationDepthResult;
+  pageHealthDistribution?: PageHealthDistributionResult;
   stats: StatsResult;
   previousReport: EvalReport | null;
   citationSupport?: CitationSupportResult | null;
 }
 
 async function buildReport(root: string, components: EvalComponents, suite: "fast" | "full"): Promise<EvalReport> {
-  const { health, citationCoverage, sourceUtilization, citationDepth, stats, previousReport, citationSupport } = components;
+  const { health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, stats, previousReport, citationSupport } = components;
   const partial = {
     suite,
     timestamp: new Date().toISOString(),
@@ -38,6 +40,7 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
     citationCoverage,
     sourceUtilization,
     citationDepth,
+    ...(pageHealthDistribution ? { pageHealthDistribution } : {}),
     stats,
     ...(citationSupport ? { citationSupport } : {}),
   };
@@ -49,11 +52,12 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
 /** Run the full eval pipeline, optionally append to history, and return the report. */
 export async function runEval(root: string, suite: "fast" | "full", sampleSize: number, record = true): Promise<EvalReport> {
   if (suite === "full") ensureProviderAvailable();
-  const [health, citationCoverage, sourceUtilization, citationDepth, stats, previousReport, previousFullReport] = await Promise.all([
+  const [health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, stats, previousReport, previousFullReport] = await Promise.all([
     evaluateHealth(root),
     evaluateCitationCoverage(root),
     evaluateSourceUtilization(root),
     evaluateCitationDepth(root),
+    evaluatePageHealthDistribution(root).catch(() => undefined),
     collectStats(root),
     loadPreviousReport(root),
     suite === "full" ? loadLastFullReport(root) : Promise.resolve(null),
@@ -61,7 +65,7 @@ export async function runEval(root: string, suite: "fast" | "full", sampleSize: 
   const citationSupport = suite === "full"
     ? await evaluateCitationSupport(root, sampleSize, previousFullReport?.citationSupport?.sampledHashes ?? [])
     : undefined;
-  const report = await buildReport(root, { health, citationCoverage, sourceUtilization, citationDepth, stats, previousReport, citationSupport }, suite);
+  const report = await buildReport(root, { health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, stats, previousReport, citationSupport }, suite);
   if (record) await appendHistory(root, report);
   return report;
 }

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -57,7 +57,7 @@ export async function runEval(root: string, suite: "fast" | "full", sampleSize: 
     evaluateCitationCoverage(root),
     evaluateSourceUtilization(root),
     evaluateCitationDepth(root),
-    evaluatePageHealthDistribution(root).catch(() => undefined),
+    evaluatePageHealthDistribution(root),
     collectStats(root),
     loadPreviousReport(root),
     suite === "full" ? loadLastFullReport(root) : Promise.resolve(null),

--- a/src/eval/page-health-distribution.ts
+++ b/src/eval/page-health-distribution.ts
@@ -77,7 +77,7 @@ export async function evaluatePageHealthDistribution(
     perPage.push({ slug, score, tier: tierFor(score), topIssues: topIssues(findings) });
   }
 
-  perPage.sort((a, b) => a.score - b.score);
+  perPage.sort((a, b) => a.score - b.score || a.slug.localeCompare(b.slug));
 
   const distribution = {
     healthy: perPage.filter((p) => p.tier === "healthy").length,

--- a/src/eval/page-health-distribution.ts
+++ b/src/eval/page-health-distribution.ts
@@ -1,0 +1,90 @@
+/**
+ * Page-level health distribution evaluator for the llmwiki eval harness.
+ *
+ * While the corpus-level health score aggregates all lint findings into one
+ * 0-100 number, this evaluator breaks it down per page so maintainers can
+ * see *which* pages need attention — not just that *something* is wrong.
+ *
+ * Scoring reuses deductionFor() from health.ts so per-page scores are
+ * consistent with the overall health score. Lint rules are sourced from
+ * the canonical linter orchestrator (lint()) via runAllLintRules() so
+ * all rules including freshness checks are included automatically.
+ */
+
+import path from "path";
+import { collectAllPages } from "../linter/rules.js";
+import { runAllLintRules, deductionFor } from "./health.js";
+import type { LintResult } from "../linter/types.js";
+import type { PageHealthDistributionResult, PageHealthEntry } from "./types.js";
+
+const MAX_SCORE = 100;
+const TIER_HEALTHY = 90;
+const TIER_ADEQUATE = 70;
+const TIER_NEEDS_WORK = 50;
+
+function tierFor(score: number): PageHealthEntry["tier"] {
+  if (score >= TIER_HEALTHY) return "healthy";
+  if (score >= TIER_ADEQUATE) return "adequate";
+  if (score >= TIER_NEEDS_WORK) return "needs_work";
+  return "broken";
+}
+
+function topIssues(findings: LintResult[]): string[] {
+  const counts = new Map<string, number>();
+  for (const f of findings) {
+    counts.set(f.rule, (counts.get(f.rule) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([rule, count]) => count > 1 ? rule + " x" + count : rule);
+}
+
+/**
+ * Evaluate per-page health across all wiki pages.
+ * Delegates to the canonical linter orchestrator for rule execution
+ * and reuses the same deductionFor() so scores match evaluateHealth.
+ * @param root - Absolute path to the project root.
+ * @param worstPageCount - How many worst pages to return (default 5).
+ */
+export async function evaluatePageHealthDistribution(
+  root: string,
+  worstPageCount = 5,
+): Promise<PageHealthDistributionResult> {
+  const [allResults, pages] = await Promise.all([
+    runAllLintRules(root),
+    collectAllPages(root),
+  ]);
+
+  const findingsByPath = new Map<string, LintResult[]>();
+  for (const r of allResults) {
+    const existing = findingsByPath.get(r.file);
+    if (existing) existing.push(r);
+    else findingsByPath.set(r.file, [r]);
+  }
+
+  for (const { filePath } of pages) {
+    if (!findingsByPath.has(filePath)) {
+      findingsByPath.set(filePath, []);
+    }
+  }
+
+  const perPage: PageHealthEntry[] = [];
+  for (const [filePath, findings] of findingsByPath) {
+    const slug = path.basename(path.dirname(filePath)) + "/" + path.basename(filePath, ".md");
+    const totalDeduction = findings.reduce((sum, r) => sum + deductionFor(r), 0);
+    const score = Math.max(0, MAX_SCORE - totalDeduction);
+    perPage.push({ slug, score, tier: tierFor(score), topIssues: topIssues(findings) });
+  }
+
+  perPage.sort((a, b) => a.score - b.score);
+
+  const distribution = {
+    healthy: perPage.filter((p) => p.tier === "healthy").length,
+    adequate: perPage.filter((p) => p.tier === "adequate").length,
+    needs_work: perPage.filter((p) => p.tier === "needs_work").length,
+    broken: perPage.filter((p) => p.tier === "broken").length,
+  };
+
+  return { distribution, perPage, worstPages: perPage.slice(0, worstPageCount) };
+}

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -177,7 +177,8 @@ function formatSourceUtilization(report: EvalReport): string[] {
 
 function formatPageHealthDistribution(report: EvalReport): string[] {
   const d = report.pageHealthDistribution;
-  if (!d || d.perPage.length === 0) {
+  if (!d) return [];
+  if (d.perPage.length === 0) {
     return [line(), line("Page Health:  (no pages)")];
   }
   const rows = [
@@ -185,7 +186,9 @@ function formatPageHealthDistribution(report: EvalReport): string[] {
     line(bold("Page Health:")),
     line(
       "  healthy: " + d.distribution.healthy +
-      "  adequate: " + d.distribution.adequate +
+      "  adequate: " + d.distribution.adequate
+    ),
+    line(
       "  needs_work: " + d.distribution.needs_work +
       "  broken: " + d.distribution.broken
     ),
@@ -194,10 +197,10 @@ function formatPageHealthDistribution(report: EvalReport): string[] {
     rows.push(line("  Worst pages:"));
     for (let i = 0; i < d.worstPages.length; i++) {
       const p = d.worstPages[i];
-      rows.push(line(dim(
-        "    " + p.slug + "  score:" + p.score +
-        (p.topIssues.length > 0 ? "  (" + p.topIssues.join(", ") + ")" : "")
-      )));
+      rows.push(line(dim("    " + p.slug + "  score:" + p.score)));
+      if (p.topIssues.length > 0) {
+        rows.push(line(dim("      " + p.topIssues.join(", "))));
+      }
     }
   }
   return rows;

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -175,6 +175,34 @@ function formatSourceUtilization(report: EvalReport): string[] {
   return rows;
 }
 
+function formatPageHealthDistribution(report: EvalReport): string[] {
+  const d = report.pageHealthDistribution;
+  if (!d || d.perPage.length === 0) {
+    return [line(), line("Page Health:  (no pages)")];
+  }
+  const rows = [
+    line(),
+    line(bold("Page Health:")),
+    line(
+      "  healthy: " + d.distribution.healthy +
+      "  adequate: " + d.distribution.adequate +
+      "  needs_work: " + d.distribution.needs_work +
+      "  broken: " + d.distribution.broken
+    ),
+  ];
+  if (d.worstPages.length > 0) {
+    rows.push(line("  Worst pages:"));
+    for (let i = 0; i < d.worstPages.length; i++) {
+      const p = d.worstPages[i];
+      rows.push(line(dim(
+        "    " + p.slug + "  score:" + p.score +
+        (p.topIssues.length > 0 ? "  (" + p.topIssues.join(", ") + ")" : "")
+      )));
+    }
+  }
+  return rows;
+}
+
 function formatStats(report: EvalReport): string[] {
   const s = report.stats;
   return [
@@ -206,6 +234,7 @@ export function formatTerminalReport(report: EvalReport): string {
     ...formatCoverage(report, delta),
     ...formatSourceUtilization(report),
     ...formatCitationDepth(report),
+    ...formatPageHealthDistribution(report),
     ...formatSupport(report, delta),
     ...formatStats(report),
     ...formatViolations(report.thresholdViolations),

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -74,6 +74,20 @@ export interface CitationDepthResult {
   avgCitationsPerParagraph: number;
 }
 
+export interface PageHealthEntry {
+  slug: string;
+  score: number;
+  tier: "healthy" | "adequate" | "needs_work" | "broken";
+  topIssues: string[];
+}
+
+export interface PageHealthDistributionResult {
+  distribution: { healthy: number; adequate: number; needs_work: number; broken: number };
+  perPage: PageHealthEntry[];
+  worstPages: PageHealthEntry[];
+}
+
+
 export interface CitationJudgement {
   /** First 16 hex chars of SHA-256(claimText + spanText) — stable cache key. */
   claimHash: string;
@@ -127,6 +141,7 @@ export interface EvalReport {
   citationCoverage: CitationCoverageResult;
   sourceUtilization: SourceUtilizationResult;
   citationDepth: CitationDepthResult;
+  pageHealthDistribution?: PageHealthDistributionResult;
   citationSupport?: CitationSupportResult;
   stats: StatsResult;
   delta?: EvalDelta;

--- a/test/eval-page-health-distribution.test.ts
+++ b/test/eval-page-health-distribution.test.ts
@@ -113,3 +113,17 @@ describe("evaluatePageHealthDistribution", () => {
     expect(result.distribution.healthy).toBe(3);
   });
 });
+
+describe("deductionFor handles stale pages", () => {
+  it("deducts 1 point per stale-page (not classified as error)", async () => {
+    // Import deductionFor directly — same function used by page-health scoring
+    const { deductionFor } = await import("../src/eval/health.js");
+    const result = deductionFor({
+      rule: "stale-page",
+      severity: "warning",
+      file: "wiki/concepts/some-page.md",
+      message: "Page is stale",
+    });
+    expect(result).toBe(1);
+  });
+});

--- a/test/eval-page-health-distribution.test.ts
+++ b/test/eval-page-health-distribution.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for src/eval/page-health-distribution.ts.
+ */
+
+import { evaluatePageHealthDistribution } from "../src/eval/page-health-distribution.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+function fm(title: string, extra = ""): string {
+  return `---
+title: ${title}
+sources: []
+summary: A page about ${title}.
+createdAt: 2026-01-01
+updatedAt: 2026-01-01${extra}
+---
+
+`;
+}
+
+describe("evaluatePageHealthDistribution", () => {
+  const env = useLintTempRoot("eval-phd");
+
+  it("returns empty distribution when no pages exist", async () => {
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.distribution.healthy).toBe(0);
+    expect(result.distribution.broken).toBe(0);
+    expect(result.worstPages).toHaveLength(0);
+    expect(result.perPage).toHaveLength(0);
+  });
+
+  it("scores a clean page as 100", async () => {
+    await env.writeConcept("clean", fm("Clean") +
+      "A well-formed page with enough body text to pass all lint rules.\n");
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.perPage[0].score).toBe(100);
+    expect(result.perPage[0].tier).toBe("healthy");
+  });
+
+  it("scores a page with broken citation below 100", async () => {
+    await env.writeConcept("c", fm("C") + "Text with fake citation.^[ghost.md]\n");
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.perPage[0].score).toBeLessThan(100);
+    expect(result.perPage[0].score).toBeGreaterThanOrEqual(90);
+    expect(result.perPage[0].tier).toBe("healthy");
+  });
+
+  it("assigns adequate tier when score is between 70 and 89", async () => {
+    await env.writeConcept("a", fm("A") +
+      "C1.^[g1.md]\n\nC2.^[g2.md]\n\nC3.^[g3.md]\n");
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.perPage[0].score).toBeLessThan(90);
+    expect(result.perPage[0].score).toBeGreaterThanOrEqual(70);
+    expect(result.perPage[0].tier).toBe("adequate");
+  });
+
+  it("assigns needs_work tier when score is between 50 and 69", async () => {
+    const body = Array(8).fill("C.^[ghost.md]").join("\n\n");
+    await env.writeConcept("n", fm("N") + body + "\n");
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.perPage[0].score).toBeLessThan(70);
+    expect(result.perPage[0].score).toBeGreaterThanOrEqual(50);
+    expect(result.perPage[0].tier).toBe("needs_work");
+  });
+
+  it("assigns broken tier when score is below 50", async () => {
+    const body = Array(13).fill("C.^[ghost.md]").join("\n\n");
+    await env.writeConcept("b", fm("B") + body + "\n");
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.perPage[0].score).toBeLessThan(50);
+    expect(result.perPage[0].tier).toBe("broken");
+  });
+
+  it("sorts perPage worst first", async () => {
+    await env.writeConcept("good", fm("Good") + "Clean page content.\n");
+    await env.writeConcept("bad", fm("Bad") +
+      "C1.^[g1.md]\n\nC2.^[g2.md]\n\nC3.^[g3.md]\n\nC4.^[g4.md]\n");
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.perPage[0].slug).toBe("concepts/bad");
+    expect(result.perPage[1].slug).toBe("concepts/good");
+  });
+
+  it("returns all pages in worstPages when fewer than N exist", async () => {
+    await env.writeConcept("a", fm("A") + "C.^[ghost.md]\n");
+    await env.writeConcept("b", fm("B") + "C.^[ghost.md]\n");
+    await env.writeConcept("c", fm("C") + "Clean.\n");
+    const result = await evaluatePageHealthDistribution(env.dir, 5);
+    expect(result.worstPages).toHaveLength(3);
+  });
+
+  it("respects worstPageCount parameter", async () => {
+    for (let i = 0; i < 8; i++) {
+      await env.writeConcept("p" + i, fm("P" + i) + "C.^[ghost.md]\n");
+    }
+    const result = await evaluatePageHealthDistribution(env.dir, 3);
+    expect(result.perPage).toHaveLength(8);
+    expect(result.worstPages).toHaveLength(3);
+  });
+
+  it("includes top issues per page", async () => {
+    await env.writeConcept("multi", fm("Multi") +
+      "Links to [[Nowhere]].\n\nFake cite.^[ghost.md]\n");
+    const result = await evaluatePageHealthDistribution(env.dir);
+    expect(result.perPage[0].topIssues.length).toBeGreaterThan(0);
+  });
+
+  it("includes healthy pages in worstPages when all healthy", async () => {
+    await env.writeConcept("a", fm("A") + "Clean page one.\n");
+    await env.writeConcept("b", fm("B") + "Clean page two.\n");
+    await env.writeConcept("c", fm("C") + "Clean page three.\n");
+    const result = await evaluatePageHealthDistribution(env.dir, 2);
+    expect(result.worstPages).toHaveLength(2);
+    expect(result.worstPages[0].tier).toBe("healthy");
+    expect(result.distribution.healthy).toBe(3);
+  });
+});

--- a/test/eval-page-health-distribution.test.ts
+++ b/test/eval-page-health-distribution.test.ts
@@ -4,6 +4,7 @@
 
 import { evaluatePageHealthDistribution } from "../src/eval/page-health-distribution.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+import { sha256Hex, writeSourceState, writeSourceFile } from "./fixtures/state-json.js";
 
 function fm(title: string, extra = ""): string {
   return `---
@@ -114,6 +115,31 @@ describe("evaluatePageHealthDistribution", () => {
   });
 });
 
+
+  
+  describe("evaluateHealth with stale pages", function() {
+    var env = useLintTempRoot("eval-stale");
+
+    it("deducts points for stale pages when freshness data exists", async function() {
+      await writeSourceFile(env.dir, "src.md", "original content");
+      await writeSourceState(env.dir, {
+        "src.md": {
+          hash: sha256Hex("modified content"),
+          concepts: ["stale-concept"],
+        },
+      });
+      await env.writeConcept("stale-concept", fm("Stale Concept") +
+        `This page was compiled from a source that has since been modified.^[src.md]
+`);
+
+      var evaluateHealth = (await import("../src/eval/health.js")).evaluateHealth;
+      var result = await evaluateHealth(env.dir);
+      var staleRule = result.rules.find(function(r) { return r.rule === "stale-page"; });
+      expect(staleRule).toBeDefined();
+      expect(staleRule.count).toBeGreaterThanOrEqual(1);
+      expect(result.score).toBeLessThan(100);
+    });
+  });
 describe("deductionFor handles stale pages", () => {
   it("deducts 1 point per stale-page (not classified as error)", async () => {
     // Import deductionFor directly — same function used by page-health scoring


### PR DESCRIPTION
## Health-score semantics change (please note)

This revision changes how `evaluateHealth` sources its lint rules: it now
delegates to the canonical `lint()` orchestrator via `runAllLintRules()`,
instead of maintaining a separate rule list. Diffing the two rule sets, the
delta is exactly one rule — `checkStalePages`.

**Consequence:** for wikis with freshness data, stale pages now deduct from
the corpus `health.score` (−1 each) where they previously did not. Projects
with stale pages will see slightly lower scores, and any `health_score` CI
gate could newly trip. For wikis without freshness data this is a no-op.

This removes a drift-prone duplicate (on `main`, `lint()` already included
`checkStalePages` but `evaluateHealth` did not — they had drifted). The change
is now covered by an integration test driving a wiki with actual stale pages
through `evaluateHealth` and asserting the score drops to the expected value.