### PR TITLE
feat(review): add policy-driven candidate holds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Inspired by Karpathy's [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914
 - **Hybrid retrieval.** Semantic chunk embeddings (incremental, content-hash-aware) narrow hundreds of pages to a small top-K; BM25 reranking and wikilink-graph expansion build the final evidence pack.
 - **Local web viewer.** `llmwiki view` opens a read-only browser UI with sidebar navigation, search, a force-directed graph, and provenance/citation chips per page.
 - **Eval harness.** `llmwiki eval` measures health score (0–100), citation coverage and precision, optional LLM-as-judge support scoring, regression deltas, and CI-gateable thresholds.
+- **Review policy.** A `.llmwiki/config.json` policy holds risky generated pages (low confidence, contradicted, schema- or provenance-violating) for review instead of writing them live — each held candidate records *why*, and `compile`/`refresh` honor the policy fail-closed.
 - **Source freshness.** `llmwiki lint` flags pages whose sources changed (`stale`) or were deleted (`orphaned`) since the last compile — surfaced across the viewer, MCP, context packs, the JSON export, and `llmwiki next` — and `llmwiki refresh --stale` repairs them with a targeted recompile.
 - **MCP server.** `llmwiki serve` exposes the full pipeline to Claude Desktop, Cursor, Claude Code, and any MCP-compatible agent — including `get_context_pack` for budgeted, citation-aware evidence packs.
 - **In-process SDK.** `createWiki({ root })` drives the whole pipeline programmatically — ingest, compile, query, status/freshness, context packs, export, eval — for embedding llmwiki in your own tooling without shelling out.
@@ -416,9 +417,33 @@ llmwiki review reject <id>   # archive to .llmwiki/candidates/archive/
 A few things to know:
 
 - **Approve and reject acquire `.llmwiki/lock`** so they serialize cleanly against each other and against any concurrent `compile`.
-- **Source state is deferred per-source.** When one source produces multiple candidates, the source isn't marked compiled until the last candidate is approved — so unresolved siblings stay re-detectable on the next `compile --review`.
+- **Source state tracks live concepts.** A source records only the concepts actually written to `wiki/`; approving a held candidate adds just that concept (siblings are approved independently, each recording its own), and rejecting one suppresses it until the source changes. Held candidates for an unchanged source aren't re-extracted on the next compile.
 - **Deletion bookkeeping is deferred.** `compile --review` does not orphan-mark deleted sources; the next non-review `compile` does that. The `--review` help text advertises this.
 - MCP `wiki_status` exposes `pendingCandidates` so agents can see the queue depth.
+
+### Review policy
+
+`--review` is all-or-nothing. A project can instead declare a **review policy** in `.llmwiki/config.json` so a normal `compile` automatically **holds risky pages** for review while writing the rest live:
+
+```json
+{
+  "version": 1,
+  "review": {
+    "hold": ["low-confidence", "contradicted", "schema-violating", "provenance-violating"],
+    "lowConfidenceThreshold": 0.5
+  }
+}
+```
+
+A page is held as a candidate (the live `wiki/` page is left untouched) if it trips **any** enabled mode — union semantics:
+
+- `low-confidence` — page `confidence` below `lowConfidenceThreshold` (default 0.5). A page with **no** confidence is held by default; set `"treatMissingConfidenceAs": "ok"` to let it pass.
+- `contradicted` — the page declares `contradictedBy` entries.
+- `schema-violating` — the page fails a schema cross-link rule.
+- `provenance-violating` — the page has broken or malformed citations.
+- `all` / `off` — hold every page / nothing (each standalone). An absent config, a missing `review` key, or `"hold": []` all mean **off** — today's direct-write behavior.
+
+Each held candidate records **why**: `review list` and `review show` print the reason codes, and `compile` reports the split (`Wrote 8 page(s), held 2 for review — run \`llmwiki review list\``). `refresh --stale` honors the same policy. Configuration is **fail-closed** — an unknown mode or a corrupt config aborts the compile rather than silently disabling review. (`query --save` is not policy-gated in this version.)
 
 ## Page metadata
 

--- a/README.md
+++ b/README.md
@@ -749,6 +749,10 @@ Karpathy described an abstract pattern for turning raw data into compiled knowle
 
 ## Roadmap
 
+Available on main, will ship in 0.9.1:
+
+- ✅ Review policy — a `.llmwiki/config.json` policy holds risky generated pages (low confidence, contradicted, schema- or provenance-violating) for review instead of writing them live; each held candidate records why it was held, `review list`/`show` explain the holds, `compile` reports the split, and `refresh --stale` honors the same policy. Configuration is fail-closed — a malformed config aborts the compile rather than silently disabling review.
+
 Shipped in 0.9.0:
 
 - ✅ Source freshness — `llmwiki lint` flags pages whose sources changed (`stale`) or were all deleted (`orphaned`) since compile, surfaced across MCP (`wiki_status`, `get_context_pack`), context packs, the viewer (badges, a per-axis filter, health counts, a corrupt-state banner), the JSON export, and `llmwiki next`

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -366,6 +366,12 @@ export function summarizeAnswer(answer: string): string {
 /**
  * Save a query answer as a wiki page in the queries/ directory,
  * then regenerate the wiki index so the answer is immediately retrievable.
+ *
+ * NOTE: This path writes directly to wiki/queries/ with NO review-policy evaluation.
+ * Query saves are user-initiated and deliberately out of scope for the compile-time
+ * review gate. This is a known unguarded write path that will be addressed in the
+ * Security cycle. Do not add policy evaluation here without updating the spec.
+ *
  * @param root - Absolute path to the project root directory.
  * @param question - The original question used as the page title.
  * @param answer - The generated answer body.

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -78,15 +78,15 @@ async function runRefresh(
 }
 
 /**
- * Warn that refresh writes directly to wiki/ (bypassing the review workflow)
- * when pending candidates exist, so a review-workflow user isn't surprised by
- * un-reviewed direct writes. Advisory only — never blocks the recompile.
+ * Warn that pending candidates exist when the project uses a review policy.
+ * Refresh respects the project review policy — pages tripping policy are held
+ * for review rather than written directly. Advisory only — never blocks the recompile.
  */
 async function warnOnReviewBypass(root: string): Promise<void> {
   const pending = await countCandidates(root);
   if (pending > 0) {
     output.status("!", output.warn(
-      `refresh --stale writes directly to wiki/ and does not create review candidates (${pending} pending candidate(s) exist).`,
+      `${pending} pending review candidate(s) exist — refresh respects the project review policy; pages tripping policy are held for review, not written directly.`,
     ));
   }
 }
@@ -95,6 +95,8 @@ async function warnOnReviewBypass(root: string): Promise<void> {
  * Surface the compile result: print any pipeline errors and exit 1 on failure
  * (lock contention, extraction/validation errors), or a one-line success
  * summary and exit 0. Without this, refresh swallowed errors and always exited 0.
+ * When a review policy held pages, those are reported separately as held — only
+ * pages actually written live are counted as "refreshed".
  */
 function reportCompileOutcome(result: CompileResult, plan: RefreshPlan): number {
   if (result.errors.length > 0) {
@@ -102,11 +104,29 @@ function reportCompileOutcome(result: CompileResult, plan: RefreshPlan): number 
     reportNewSkipped(plan.newSkipped);
     return 1;
   }
-  output.status("✓", output.success(
-    `Refreshed ${plan.recompiledPages.length} page(s); cleaned up ${plan.computedOrphanedPages.length} orphaned page(s).`,
-  ));
+  const heldCount = (result.review?.held.length ?? 0) + (result.review?.forced.length ?? 0);
+  const liveRefreshed = plan.recompiledPages.length - heldCount;
+  const orphanedCount = plan.computedOrphanedPages.length;
+  output.status("✓", output.success(buildRefreshSummary(liveRefreshed, heldCount, orphanedCount)));
   reportNewSkipped(plan.newSkipped);
   return 0;
+}
+
+/**
+ * Build the human-readable refresh summary line. Separates live-written pages
+ * from held candidates so the user is never told a page was "refreshed" when
+ * the review policy held it for human review instead.
+ */
+function buildRefreshSummary(liveRefreshed: number, heldCount: number, orphanedCount: number): string {
+  const parts: string[] = [];
+  if (liveRefreshed > 0 || heldCount === 0) {
+    parts.push(`Refreshed ${liveRefreshed} page(s)`);
+  }
+  if (heldCount > 0) {
+    parts.push(`held ${heldCount} for review — run \`llmwiki review list\``);
+  }
+  parts.push(`cleaned up ${orphanedCount} orphaned page(s)`);
+  return parts.join("; ");
 }
 
 /**

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -18,10 +18,7 @@ import {
   atomicWrite,
   validateWikiPage,
 } from "../utils/markdown.js";
-import {
-  deleteCandidate,
-  listCandidates,
-} from "../compiler/candidates.js";
+import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
@@ -72,11 +69,10 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
  * and approval adds exactly the approved slug. This prevents a rejected sibling
  * from leaking into state when its source's first held candidate is approved.
  *
- * When a single source produced multiple candidates, we defer writing the
- * source's state until no OTHER pending candidate references that source —
- * to keep the source re-detectable until all its candidates are reviewed.
- * The source hash comes from the candidate's sourceStates snapshot so the
- * compile pipeline can later verify the source hasn't changed.
+ * Each approval immediately union-adds its own slug via addApprovedSlugToSourceState
+ * (which reads current state, appends, and deduplicates). No deferral is needed:
+ * the old "wait for last sibling" guard was a leftover from the snapshot-write model
+ * and caused earlier-approved slugs to be silently dropped.
  */
 async function persistCandidateSourceStates(
   root: string,
@@ -84,9 +80,7 @@ async function persistCandidateSourceStates(
 ): Promise<void> {
   const states = candidate.sourceStates;
   if (!states) return;
-  const otherSources = await collectOtherCandidateSources(root, candidate.id);
   for (const [sourceFile, candidateEntry] of Object.entries(states)) {
-    if (otherSources.has(sourceFile)) continue;
     await addApprovedSlugToSourceState(root, sourceFile, candidate.slug, candidateEntry.hash);
   }
 }
@@ -111,24 +105,6 @@ async function addApprovedSlugToSourceState(
     concepts: merged,
     compiledAt: new Date().toISOString(),
   });
-}
-
-/**
- * Build the set of source filenames referenced by every pending candidate
- * other than the one currently being approved. Used to defer source-state
- * persistence until the LAST candidate from a given source is reviewed.
- */
-async function collectOtherCandidateSources(
-  root: string,
-  approvingId: string,
-): Promise<Set<string>> {
-  const pending = await listCandidates(root);
-  const sources = new Set<string>();
-  for (const candidate of pending) {
-    if (candidate.id === approvingId) continue;
-    for (const source of candidate.sources) sources.add(source);
-  }
-  return sources;
 }
 
 /** Refresh interlinks, index, MOC, and embeddings after writing a candidate. */

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -26,7 +26,7 @@ import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
-import { updateSourceState } from "../utils/state.js";
+import { readState, updateSourceState } from "../utils/state.js";
 import { CONCEPTS_DIR } from "../utils/constants.js";
 import * as output from "../utils/output.js";
 import type { ReviewCandidate } from "../utils/types.js";
@@ -65,18 +65,18 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
 }
 
 /**
- * Flush the source-state snapshot stored on the candidate into
- * `.llmwiki/state.json` so the contributing source files are marked
- * compiled. Without this, approved candidates would re-appear on the next
- * `compile` run because the source still looks "new" or "changed" to the
- * change detector.
+ * Add the approved concept slug to each contributing source's live-concepts
+ * list in state.json.
  *
- * When a single source produced multiple candidates (e.g. an extraction
- * yielded several concepts), persisting state on the first approval would
- * mark the source as fully compiled and silently strand the remaining
- * pending candidates — the next `compile --review` would skip the source
- * entirely. To avoid that, we only persist a source's state when no OTHER
- * pending candidate still references that source filename.
+ * State records only LIVE concepts: held/rejected concepts are never in state,
+ * and approval adds exactly the approved slug. This prevents a rejected sibling
+ * from leaking into state when its source's first held candidate is approved.
+ *
+ * When a single source produced multiple candidates, we defer writing the
+ * source's state until no OTHER pending candidate references that source —
+ * to keep the source re-detectable until all its candidates are reviewed.
+ * The source hash comes from the candidate's sourceStates snapshot so the
+ * compile pipeline can later verify the source hasn't changed.
  */
 async function persistCandidateSourceStates(
   root: string,
@@ -85,10 +85,32 @@ async function persistCandidateSourceStates(
   const states = candidate.sourceStates;
   if (!states) return;
   const otherSources = await collectOtherCandidateSources(root, candidate.id);
-  for (const [sourceFile, entry] of Object.entries(states)) {
+  for (const [sourceFile, candidateEntry] of Object.entries(states)) {
     if (otherSources.has(sourceFile)) continue;
-    await updateSourceState(root, sourceFile, entry);
+    await addApprovedSlugToSourceState(root, sourceFile, candidate.slug, candidateEntry.hash);
   }
+}
+
+/**
+ * Merge the approved slug into a source's existing live-concepts list.
+ * Reads the current state entry so any already-live concepts are preserved,
+ * then appends the approved slug (deduplicating in case it is already present).
+ */
+async function addApprovedSlugToSourceState(
+  root: string,
+  sourceFile: string,
+  approvedSlug: string,
+  sourceHash: string,
+): Promise<void> {
+  const currentState = await readState(root);
+  const existing = currentState.sources[sourceFile];
+  const concepts = existing?.concepts ?? [];
+  const merged = Array.from(new Set([...concepts, approvedSlug]));
+  await updateSourceState(root, sourceFile, {
+    hash: sourceHash,
+    concepts: merged,
+    compiledAt: new Date().toISOString(),
+  });
 }
 
 /**

--- a/src/commands/review-list.ts
+++ b/src/commands/review-list.ts
@@ -11,13 +11,12 @@ import type { ReviewCandidate } from "../utils/types.js";
 
 /** Human-readable review mode for old and new candidate records. */
 function formatMode(candidate: ReviewCandidate): string {
-  return candidate.reviewMode ?? "forced";
+  return candidate.reviewMode;
 }
 
 /** Compact reason summary for review list rows. */
 function formatReasons(candidate: ReviewCandidate): string {
-  const reasons = candidate.heldReasons?.map((r) => r.code) ?? ["manual-review-requested"];
-  return reasons.join(", ");
+  return candidate.heldReasons.map((r) => r.code).join(", ");
 }
 
 /** List every pending candidate from .llmwiki/candidates/. */

--- a/src/commands/review-list.ts
+++ b/src/commands/review-list.ts
@@ -7,6 +7,18 @@
 
 import { listCandidates } from "../compiler/candidates.js";
 import * as output from "../utils/output.js";
+import type { ReviewCandidate } from "../utils/types.js";
+
+/** Human-readable review mode for old and new candidate records. */
+function formatMode(candidate: ReviewCandidate): string {
+  return candidate.reviewMode ?? "forced";
+}
+
+/** Compact reason summary for review list rows. */
+function formatReasons(candidate: ReviewCandidate): string {
+  const reasons = candidate.heldReasons?.map((r) => r.code) ?? ["manual-review-requested"];
+  return reasons.join(", ");
+}
 
 /** List every pending candidate from .llmwiki/candidates/. */
 export default async function reviewListCommand(): Promise<void> {
@@ -20,7 +32,8 @@ export default async function reviewListCommand(): Promise<void> {
 
   for (const candidate of candidates) {
     const sources = candidate.sources.join(", ");
-    const meta = output.dim(`${candidate.generatedAt} | sources: ${sources}`);
+    const mode = `${formatMode(candidate)}: ${formatReasons(candidate)}`;
+    const meta = output.dim(`${candidate.generatedAt} | ${mode} | sources: ${sources}`);
     output.status("?", `${output.info(candidate.id)} → ${candidate.slug} ${meta}`);
   }
 

--- a/src/commands/review-show.ts
+++ b/src/commands/review-show.ts
@@ -7,6 +7,25 @@
 
 import { loadCandidateOrFail } from "../compiler/candidates.js";
 import * as output from "../utils/output.js";
+import type { ReviewCandidate } from "../utils/types.js";
+
+/** Reasons to show for legacy candidates that predate heldReasons. */
+function candidateReasons(candidate: ReviewCandidate): string[] {
+  return (candidate.heldReasons ?? [{ code: "manual-review-requested" }])
+    .map((reason) => reason.detail ? `${reason.code} (${reason.detail})` : reason.code);
+}
+
+/** Print review metadata added by policy-aware candidate generation. */
+function printReviewMetadata(candidate: ReviewCandidate): void {
+  output.status("i", output.dim(`review:    ${candidate.reviewMode ?? "forced"}`));
+  output.status("i", output.dim(`reasons:   ${candidateReasons(candidate).join(", ")}`));
+  if (candidate.confidence !== undefined) {
+    output.status("i", output.dim(`confidence: ${candidate.confidence}`));
+  }
+  if (candidate.contradicted !== undefined) {
+    output.status("i", output.dim(`contradicted: ${candidate.contradicted}`));
+  }
+}
 
 /** Print a single candidate's full content to stdout. */
 export default async function reviewShowCommand(id: string): Promise<void> {
@@ -19,6 +38,7 @@ export default async function reviewShowCommand(id: string): Promise<void> {
   output.status("i", output.dim(`summary:    ${candidate.summary}`));
   output.status("i", output.dim(`sources:    ${candidate.sources.join(", ")}`));
   output.status("i", output.dim(`generated:  ${candidate.generatedAt}`));
+  printReviewMetadata(candidate);
 
   console.log();
   console.log(candidate.body);

--- a/src/commands/review-show.ts
+++ b/src/commands/review-show.ts
@@ -9,15 +9,15 @@ import { loadCandidateOrFail } from "../compiler/candidates.js";
 import * as output from "../utils/output.js";
 import type { ReviewCandidate } from "../utils/types.js";
 
-/** Reasons to show for legacy candidates that predate heldReasons. */
+/** Reasons to show for a candidate (guaranteed non-empty by the IO boundary). */
 function candidateReasons(candidate: ReviewCandidate): string[] {
-  return (candidate.heldReasons ?? [{ code: "manual-review-requested" }])
+  return candidate.heldReasons
     .map((reason) => reason.detail ? `${reason.code} (${reason.detail})` : reason.code);
 }
 
 /** Print review metadata added by policy-aware candidate generation. */
 function printReviewMetadata(candidate: ReviewCandidate): void {
-  output.status("i", output.dim(`review:    ${candidate.reviewMode ?? "forced"}`));
+  output.status("i", output.dim(`review:    ${candidate.reviewMode}`));
   output.status("i", output.dim(`reasons:   ${candidateReasons(candidate).join(", ")}`));
   if (candidate.confidence !== undefined) {
     output.status("i", output.dim(`confidence: ${candidate.confidence}`));

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -27,6 +27,7 @@ import {
   CANDIDATES_ARCHIVE_DIR,
 } from "../utils/constants.js";
 import type { ReviewCandidate, SourceState } from "../utils/types.js";
+import type { HeldReason, ReviewMode } from "../review/policy.js";
 import type { LintResult } from "../linter/types.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
@@ -60,7 +61,18 @@ interface CandidateDraft {
    * approving.
    */
   provenanceViolations?: LintResult[];
+  /** Whether this candidate was forced by --review or held by policy. */
+  reviewMode?: ReviewMode;
+  /** Structured reasons for holding this candidate. */
+  heldReasons?: HeldReason[];
+  /** Confidence parsed from the generated page frontmatter, for display. */
+  confidence?: number;
+  /** True when the generated page frontmatter declares contradictions. */
+  contradicted?: boolean;
 }
+
+/** Default metadata for legacy `compile --review` callers. */
+const DEFAULT_HELD_REASONS: HeldReason[] = [{ code: "manual-review-requested" }];
 
 /** Build a deterministic-but-unique id from a slug and a short random suffix. */
 function buildCandidateId(slug: string): string {
@@ -89,21 +101,41 @@ export async function writeCandidate(
   root: string,
   draft: CandidateDraft,
 ): Promise<ReviewCandidate> {
+  const existing = await readCandidateBySlug(root, draft.slug);
   const candidate: ReviewCandidate = {
-    id: buildCandidateId(draft.slug),
+    id: existing?.id ?? buildCandidateId(draft.slug),
     title: draft.title,
     slug: draft.slug,
     summary: draft.summary,
     sources: draft.sources,
     body: draft.body,
     generatedAt: new Date().toISOString(),
+    reviewMode: draft.reviewMode ?? "forced",
+    heldReasons: draft.heldReasons ?? DEFAULT_HELD_REASONS,
     ...(draft.sourceStates ? { sourceStates: draft.sourceStates } : {}),
     ...(draft.schemaViolations ? { schemaViolations: draft.schemaViolations } : {}),
     ...(draft.provenanceViolations ? { provenanceViolations: draft.provenanceViolations } : {}),
+    ...(draft.confidence !== undefined ? { confidence: draft.confidence } : {}),
+    ...(draft.contradicted !== undefined ? { contradicted: draft.contradicted } : {}),
   };
 
   await atomicWrite(candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
   return candidate;
+}
+
+/** Find the pending candidate for a slug, if one exists. */
+export async function readCandidateBySlug(
+  root: string,
+  slug: string,
+): Promise<ReviewCandidate | null> {
+  const candidates = await listCandidates(root);
+  return candidates.find((candidate) => candidate.slug === slug) ?? null;
+}
+
+/** Collect every slug currently pending review. */
+export async function listPendingCandidateSlugs(root: string): Promise<Set<string>> {
+  const candidates = await listCandidates(root);
+  return new Set(candidates.map((candidate) => candidate.slug));
 }
 
 /**
@@ -221,6 +253,13 @@ export async function deleteCandidate(root: string, id: string): Promise<boolean
   if (!existsSync(filePath)) return false;
   await unlink(filePath);
   return true;
+}
+
+/** Delete the pending candidate for a slug, if one exists. */
+export async function deleteCandidateBySlug(root: string, slug: string): Promise<boolean> {
+  const candidate = await readCandidateBySlug(root, slug);
+  if (!candidate) return false;
+  return deleteCandidate(root, candidate.id);
 }
 
 /**

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -198,10 +198,23 @@ export async function readCandidate(
   try {
     const parsed = JSON.parse(raw) as ReviewCandidate;
     if (!isValidCandidate(parsed)) return null;
-    return parsed;
+    return applyLegacyDefaults(parsed);
   } catch {
     return null;
   }
+}
+
+/**
+ * Apply defaults for legacy candidates written before `reviewMode` and
+ * `heldReasons` were required fields. Called at the IO boundary so every
+ * in-memory candidate always has these fields populated.
+ */
+function applyLegacyDefaults(candidate: ReviewCandidate): ReviewCandidate {
+  return {
+    ...candidate,
+    reviewMode: candidate.reviewMode ?? "forced",
+    heldReasons: candidate.heldReasons ?? DEFAULT_HELD_REASONS,
+  };
 }
 
 /** Defensive type-guard so corrupted candidate files don't blow up the CLI. */

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -27,7 +27,7 @@ import {
   CANDIDATES_ARCHIVE_DIR,
 } from "../utils/constants.js";
 import type { ReviewCandidate, SourceState } from "../utils/types.js";
-import type { HeldReason, ReviewMode } from "../review/policy.js";
+import type { HeldReason, HeldReasonCode, ReviewMode } from "../review/policy.js";
 import type { LintResult } from "../linter/types.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
@@ -74,6 +74,19 @@ interface CandidateDraft {
 /** Default metadata for legacy `compile --review` callers. */
 const DEFAULT_HELD_REASONS: HeldReason[] = [{ code: "manual-review-requested" }];
 
+/** All valid ReviewMode values. */
+const VALID_REVIEW_MODES: ReviewMode[] = ["policy", "forced"];
+
+/** All valid HeldReasonCode values — mirrors the union in policy.ts. */
+const VALID_HELD_REASON_CODES: HeldReasonCode[] = [
+  "low-confidence",
+  "contradicted",
+  "schema-violating",
+  "provenance-violating",
+  "all",
+  "manual-review-requested",
+];
+
 /** Build a deterministic-but-unique id from a slug and a short random suffix. */
 function buildCandidateId(slug: string): string {
   const suffix = randomBytes(ID_SUFFIX_BYTES).toString("hex");
@@ -93,6 +106,10 @@ function archivePath(root: string, id: string): string {
 /**
  * Persist a new candidate record and return it. The id is generated from the
  * slug plus a short random suffix so multiple compile runs can co-exist.
+ *
+ * When multiple candidate files for the same slug already exist (e.g. from a
+ * hand-edited state or a legacy run), this canonicalizes to the earliest id and
+ * deletes all extra duplicate files so at most one file per slug remains.
  * @param root - Project root directory.
  * @param draft - The candidate fields to persist.
  * @returns The full ReviewCandidate (with id + generatedAt populated).
@@ -101,9 +118,9 @@ export async function writeCandidate(
   root: string,
   draft: CandidateDraft,
 ): Promise<ReviewCandidate> {
-  const existing = await readCandidateBySlug(root, draft.slug);
+  const { canonicalId, duplicateIds } = await findSlugDuplicates(root, draft.slug);
   const candidate: ReviewCandidate = {
-    id: existing?.id ?? buildCandidateId(draft.slug),
+    id: canonicalId ?? buildCandidateId(draft.slug),
     title: draft.title,
     slug: draft.slug,
     summary: draft.summary,
@@ -120,7 +137,36 @@ export async function writeCandidate(
   };
 
   await atomicWrite(candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
+  await deleteDuplicates(root, duplicateIds);
   return candidate;
+}
+
+/**
+ * Collect all candidate ids matching a slug and return the canonical (earliest)
+ * id plus the list of extra duplicate ids to remove.
+ * @param root - Project root directory.
+ * @param slug - The page slug to search for.
+ */
+async function findSlugDuplicates(
+  root: string,
+  slug: string,
+): Promise<{ canonicalId: string | null; duplicateIds: string[] }> {
+  const all = await listCandidates(root);
+  const matching = all.filter((c) => c.slug === slug);
+  if (matching.length === 0) return { canonicalId: null, duplicateIds: [] };
+  // Preserve the first match as canonical (listCandidates sorts by generatedAt).
+  const [canonical, ...extras] = matching;
+  return {
+    canonicalId: canonical!.id,
+    duplicateIds: extras.map((c) => c.id),
+  };
+}
+
+/** Delete a list of candidate files by id, ignoring missing entries. */
+async function deleteDuplicates(root: string, ids: string[]): Promise<void> {
+  for (const id of ids) {
+    await deleteCandidate(root, id);
+  }
 }
 
 /** Find the pending candidate for a slug, if one exists. */
@@ -188,7 +234,12 @@ export async function loadCandidateUnderLockOrFail(
   return candidate;
 }
 
-/** Parse a single candidate JSON file. Returns null when the file is missing or malformed. */
+/**
+ * Parse a single candidate JSON file. Returns null when the file is missing.
+ * Structurally invalid files (unparseable JSON or missing required fields) are
+ * skipped with a warning rather than throwing, so `review list`/`show` never
+ * crash due to a hand-edited or truncated candidate file.
+ */
 export async function readCandidate(
   root: string,
   id: string,
@@ -197,24 +248,54 @@ export async function readCandidate(
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as ReviewCandidate;
-    if (!isValidCandidate(parsed)) return null;
-    return applyLegacyDefaults(parsed);
+    if (!isValidCandidate(parsed)) {
+      output.note(`[llmwiki] Skipping malformed candidate file: ${id}.json (missing required fields)`);
+      return null;
+    }
+    return sanitizeCandidate(parsed);
   } catch {
+    output.note(`[llmwiki] Skipping unparseable candidate file: ${id}.json`);
     return null;
   }
 }
 
 /**
- * Apply defaults for legacy candidates written before `reviewMode` and
- * `heldReasons` were required fields. Called at the IO boundary so every
- * in-memory candidate always has these fields populated.
+ * Sanitize and default every consumed field at the IO boundary. Ensures that
+ * user-edited or legacy candidate files can never crash downstream consumers
+ * (review list, review show, listCandidates).
+ *
+ * Fields that can be safely defaulted are corrected in place:
+ * - `generatedAt`: non-string values are replaced with a sentinel ISO string.
+ * - `reviewMode`: unknown values default to `"forced"` (safe legacy assumption).
+ * - `heldReasons`: non-array, missing, or entries with invalid codes are cleaned;
+ *   if the result is empty after filtering, defaults to `DEFAULT_HELD_REASONS`.
  */
-function applyLegacyDefaults(candidate: ReviewCandidate): ReviewCandidate {
-  return {
-    ...candidate,
-    reviewMode: candidate.reviewMode ?? "forced",
-    heldReasons: candidate.heldReasons ?? DEFAULT_HELD_REASONS,
-  };
+function sanitizeCandidate(candidate: ReviewCandidate): ReviewCandidate {
+  const generatedAt =
+    typeof candidate.generatedAt === "string"
+      ? candidate.generatedAt
+      : new Date(0).toISOString();
+
+  const reviewMode: ReviewMode = VALID_REVIEW_MODES.includes(candidate.reviewMode)
+    ? candidate.reviewMode
+    : "forced";
+
+  const heldReasons = sanitizeHeldReasons(candidate.heldReasons);
+
+  return { ...candidate, generatedAt, reviewMode, heldReasons };
+}
+
+/** Filter `heldReasons` to only entries with a valid code shape; default when empty. */
+function sanitizeHeldReasons(raw: unknown): HeldReason[] {
+  if (!Array.isArray(raw)) return DEFAULT_HELD_REASONS;
+  const valid = raw.filter(
+    (r): r is HeldReason =>
+      r !== null &&
+      typeof r === "object" &&
+      typeof (r as Record<string, unknown>).code === "string" &&
+      VALID_HELD_REASON_CODES.includes((r as HeldReason).code),
+  );
+  return valid.length > 0 ? valid : DEFAULT_HELD_REASONS;
 }
 
 /** Defensive type-guard so corrupted candidate files don't blow up the CLI. */

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -269,6 +269,9 @@ export async function readCandidate(
  * - `reviewMode`: unknown values default to `"forced"` (safe legacy assumption).
  * - `heldReasons`: non-array, missing, or entries with invalid codes are cleaned;
  *   if the result is empty after filtering, defaults to `DEFAULT_HELD_REASONS`.
+ * - `sourceStates`: non-object values are treated as absent; entries with unsafe
+ *   keys (path separators, `..` traversal) or invalid field types are dropped so
+ *   approval can never write malformed state from a bad candidate file.
  */
 function sanitizeCandidate(candidate: ReviewCandidate): ReviewCandidate {
   const generatedAt =
@@ -281,8 +284,12 @@ function sanitizeCandidate(candidate: ReviewCandidate): ReviewCandidate {
     : "forced";
 
   const heldReasons = sanitizeHeldReasons(candidate.heldReasons);
+  const sourceStates = sanitizeSourceStates(candidate.sourceStates);
 
-  return { ...candidate, generatedAt, reviewMode, heldReasons };
+  const result: ReviewCandidate = { ...candidate, generatedAt, reviewMode, heldReasons };
+  if (sourceStates !== undefined) result.sourceStates = sourceStates;
+  else delete result.sourceStates;
+  return result;
 }
 
 /** Filter `heldReasons` to only entries with a valid code shape; default when empty. */
@@ -296,6 +303,53 @@ function sanitizeHeldReasons(raw: unknown): HeldReason[] {
       VALID_HELD_REASON_CODES.includes((r as HeldReason).code),
   );
   return valid.length > 0 ? valid : DEFAULT_HELD_REASONS;
+}
+
+/**
+ * Return true when a source-state key is a safe plain basename.
+ * Rejects any key containing `/`, `\`, or the sequence `..` to prevent
+ * path-traversal attacks when the key is later used as a state.json entry.
+ */
+function isSourceKeysafe(key: string): boolean {
+  return !key.includes("/") && !key.includes("\\") && !key.includes("..");
+}
+
+/**
+ * Validate and filter a raw `sourceStates` value from disk.
+ *
+ * Rules enforced per entry:
+ * - Key must be a safe plain basename (no path separators, no `..`).
+ * - `hash` must be a non-empty string.
+ * - `concepts` must be a `string[]`.
+ * - `compiledAt` must be a string.
+ *
+ * If `raw` is not a plain object, returns `undefined` (treated as absent).
+ * Valid entries are kept; invalid ones are silently dropped.
+ */
+function sanitizeSourceStates(
+  raw: unknown,
+): Record<string, SourceState> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const result: Record<string, SourceState> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!isSourceKeyValid(key, value)) continue;
+    result[key] = value as SourceState;
+  }
+  return result;
+}
+
+/** Return true when both the key is path-safe and the entry fields are valid. */
+function isSourceKeyValid(key: string, value: unknown): boolean {
+  if (!isSourceKeysafe(key)) return false;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.hash === "string" &&
+    entry.hash.length > 0 &&
+    Array.isArray(entry.concepts) &&
+    (entry.concepts as unknown[]).every((c) => typeof c === "string") &&
+    typeof entry.compiledAt === "string"
+  );
 }
 
 /** Defensive type-guard so corrupted candidate files don't blow up the CLI. */
@@ -349,11 +403,21 @@ export async function deleteCandidate(root: string, id: string): Promise<boolean
   return true;
 }
 
-/** Delete the pending candidate for a slug, if one exists. */
+/**
+ * Delete ALL pending candidate files for a slug.
+ *
+ * When duplicates exist (e.g. legacy or hand-dropped files) the direct-write
+ * reconcile path must remove every file matching the slug, not just the first
+ * canonical one, so no stale duplicates remain after a page is written directly.
+ */
 export async function deleteCandidateBySlug(root: string, slug: string): Promise<boolean> {
-  const candidate = await readCandidateBySlug(root, slug);
-  if (!candidate) return false;
-  return deleteCandidate(root, candidate.id);
+  const all = await listCandidates(root);
+  const matching = all.filter((c) => c.slug === slug);
+  if (matching.length === 0) return false;
+  for (const candidate of matching) {
+    await deleteCandidate(root, candidate.id);
+  }
+  return true;
 }
 
 /**

--- a/src/compiler/delta.ts
+++ b/src/compiler/delta.ts
@@ -22,7 +22,7 @@
 import { compileAndReport } from "./index.js";
 import { collectExportPages } from "../export/collect.js";
 import type { ExportPage } from "../export/types.js";
-import type { CompileOptions } from "../utils/types.js";
+import type { CompileOptions, ReviewedCandidateRef } from "../utils/types.js";
 
 /** Options for {@link compileDelta}. Pass-through to the compile pipeline. */
 export type CompileDeltaOptions = CompileOptions;
@@ -45,6 +45,18 @@ export interface CompileDeltaResult {
   deleted: number;
   /** Non-fatal errors collected during the compile. */
   errors: string[];
+  /**
+   * Count of pages held for review this run (policy-held or forced by --review).
+   * Zero when no policy is active or no pages were held. Present so callers can
+   * distinguish "empty delta because nothing changed" from "empty delta because
+   * everything was held for review".
+   */
+  held: number;
+  /**
+   * Structured refs for pages held for review this run. Empty when held is 0.
+   * Carries id, slug, and the reason codes that triggered the hold.
+   */
+  heldCandidates: ReviewedCandidateRef[];
 }
 
 /**
@@ -74,6 +86,10 @@ export async function compileDelta(
     (page) => page.pageDirectory === "concepts" && changedSlugSet.has(page.slug),
   );
 
+  const heldCandidates = [
+    ...(result.review?.held ?? []),
+    ...(result.review?.forced ?? []),
+  ];
   return {
     changedPages,
     changedSlugs: changedPages.map((page) => page.slug),
@@ -81,5 +97,7 @@ export async function compileDelta(
     skipped: result.skipped,
     deleted: result.deleted,
     errors: result.errors,
+    held: heldCandidates.length,
+    heldCandidates,
   };
 }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -750,18 +750,19 @@ async function generateMergedPage(
 ): Promise<MergedPageOutcome> {
   const fullPage = await renderMergedPageContent(root, entry, schema);
   const diagnostics = await collectReviewDiagnostics(root, entry, fullPage, schema);
-  const reasons = evaluatePolicy(buildPolicySignals(fullPage, diagnostics), policy);
+  const signals = buildPolicySignals(fullPage, diagnostics);
+  const reasons = evaluatePolicy(signals, policy);
 
   if (options.review) {
     const heldReasons = [{ code: "manual-review-requested" } as HeldReason, ...reasons];
-    return await persistReviewCandidate(root, entry, fullPage, sourceStates, diagnostics, {
+    return await persistReviewCandidate(root, entry, fullPage, sourceStates, diagnostics, signals, {
       reviewMode: "forced",
       heldReasons,
     });
   }
 
   if (reasons.length > 0) {
-    return await persistReviewCandidate(root, entry, fullPage, sourceStates, diagnostics, {
+    return await persistReviewCandidate(root, entry, fullPage, sourceStates, diagnostics, signals, {
       reviewMode: "policy",
       heldReasons: reasons,
     });
@@ -814,10 +815,9 @@ async function persistReviewCandidate(
   fullPage: string,
   sourceStates: SourceStateMap,
   diagnostics: ReviewDiagnostics,
+  signals: ReturnType<typeof buildPolicySignals>,
   meta: ReviewCandidateMeta,
 ): Promise<MergedPageOutcome> {
-  const signals = buildPolicySignals(fullPage, diagnostics);
-
   const candidate: ReviewCandidate = await writeCandidate(root, {
     title: entry.concept.concept,
     slug: entry.slug,

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -189,20 +189,25 @@ async function generatePagesPhase(
     ? await buildExtractionSourceStates(root, extractions)
     : {};
   const limit = pLimit(COMPILE_CONCURRENCY);
-  const errors: string[] = [];
-  const candidates: string[] = [];
-  const review = { held: [] as ReviewedCandidateRef[], forced: [] as ReviewedCandidateRef[] };
+  // Collect per-outcome errors and candidate info into the ordered outcomes array
+  // AFTER Promise.all, then derive candidates/review by iterating outcomes in source order.
+  // This ensures stable, source-order ordering regardless of parallel completion timing.
   const outcomes = await Promise.all(
     merged.map((entry) => limit(async () => {
       const result = await generateMergedPage(root, entry, schema, options, sourceStates, policy);
-      if (result.error) errors.push(result.error);
-      if (result.candidate) {
-        candidates.push(result.candidate.id);
-        review[result.candidate.mode].push(result.candidate.ref);
-      }
       return { entry, result };
     })),
   );
+  const errors: string[] = [];
+  const candidates: string[] = [];
+  const review = { held: [] as ReviewedCandidateRef[], forced: [] as ReviewedCandidateRef[] };
+  for (const { result } of outcomes) {
+    if (result.error) errors.push(result.error);
+    if (result.candidate) {
+      candidates.push(result.candidate.id);
+      review[result.candidate.mode].push(result.candidate.ref);
+    }
+  }
   const pages = outcomes.map(({ entry }) => entry);
   const writtenPages = outcomes.filter(({ result }) => result.wrotePage).map(({ entry }) => entry);
   return { pages, writtenPages, errors, candidates, review, seedSlugs: [] };

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -19,6 +19,7 @@ import {
   atomicWrite,
   buildFrontmatter,
   parseFrontmatter,
+  parseProvenanceMetadata,
   safeReadFile,
   validateWikiPage,
   slugify,
@@ -48,7 +49,7 @@ import { buildBudgetedCombinedContent, type SourceSlice } from "./prompt-budget.
 import { addObsidianMeta, generateMOC } from "./obsidian.js";
 import { addModelProvenanceMeta } from "./provenance.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
-import { writeCandidate } from "./candidates.js";
+import { deleteCandidateBySlug, listCandidates, writeCandidate } from "./candidates.js";
 import { appendLog, formatList, formatWikilinkList } from "../utils/activity-log.js";
 import {
   checkPageBrokenCitations,
@@ -58,6 +59,9 @@ import {
 import type { LintResult } from "../linter/types.js";
 import { renderMergedPageContent } from "./page-renderer.js";
 import * as output from "../utils/output.js";
+import { loadReviewPolicy } from "../review/config.js";
+import { evaluatePolicy, isPolicyOff } from "../review/policy.js";
+import type { HeldReason, ReviewPolicy } from "../review/policy.js";
 import {
   COMPILE_CONCURRENCY,
   CONCEPTS_DIR,
@@ -70,6 +74,7 @@ import type {
   CompileOptions,
   CompileResult,
   ExtractedConcept,
+  ReviewedCandidateRef,
   ReviewCandidate,
   SourceChange,
   SourceState,
@@ -145,10 +150,20 @@ function bucketChanges(changes: SourceChange[]): ChangeBuckets {
 
 /** Result of phase 2: page writes plus any errors collected along the way. */
 interface PageGenerationResult {
+  /** All merged concepts generated this run, including held candidates. */
   pages: MergedConcept[];
+  /** Concept pages actually written into wiki/concepts this run. */
+  writtenPages: MergedConcept[];
   errors: string[];
-  /** Candidate ids written when running in --review mode. Empty otherwise. */
+  /** Candidate ids written by --review or review policy. Empty otherwise. */
   candidates: string[];
+  /** Structured split of candidates created this run. */
+  review: {
+    held: ReviewedCandidateRef[];
+    forced: ReviewedCandidateRef[];
+  };
+  /** Source files that fed at least one held candidate this run. */
+  heldSourceFiles: string[];
   /**
    * Slugs of seed pages written this run (overview / comparison / entity).
    * Concept pages live on `pages`; seed pages don't fit MergedConcept's
@@ -166,34 +181,46 @@ async function generatePagesPhase(
   frozenSlugs: Set<string>,
   schema: SchemaConfig,
   options: CompileOptions,
+  policy: ReviewPolicy,
 ): Promise<PageGenerationResult> {
   const merged = mergeExtractions(extractions, frozenSlugs);
   // Build the per-source state snapshot once so each candidate can carry the
   // exact data needed to mark its sources compiled on approval.
-  const sourceStates = options.review
+  const shouldBuildSourceStates = options.review || !isPolicyOff(policy);
+  const sourceStates = shouldBuildSourceStates
     ? await buildExtractionSourceStates(root, extractions)
     : {};
   const limit = pLimit(COMPILE_CONCURRENCY);
   const errors: string[] = [];
   const candidates: string[] = [];
-  const pages = await Promise.all(
+  const review = { held: [] as ReviewedCandidateRef[], forced: [] as ReviewedCandidateRef[] };
+  const heldSourceFiles = new Set<string>();
+  const outcomes = await Promise.all(
     merged.map((entry) => limit(async () => {
-      const result = await generateMergedPage(root, entry, schema, options, sourceStates);
+      const result = await generateMergedPage(root, entry, schema, options, sourceStates, policy);
       if (result.error) errors.push(result.error);
-      if (result.candidateId) candidates.push(result.candidateId);
-      return entry;
+      if (result.candidate) {
+        candidates.push(result.candidate.id);
+        review[result.candidate.mode].push(result.candidate.ref);
+        for (const source of entry.sourceFiles) heldSourceFiles.add(source);
+      }
+      return { entry, result };
     })),
   );
-  return { pages, errors, candidates, seedSlugs: [] };
+  const pages = outcomes.map(({ entry }) => entry);
+  const writtenPages = outcomes.filter(({ result }) => result.wrotePage).map(({ entry }) => entry);
+  return { pages, writtenPages, errors, candidates, review, heldSourceFiles: [...heldSourceFiles], seedSlugs: [] };
 }
 
 /** Persist source state for every extraction that produced concepts. */
 async function persistExtractionStates(
   root: string,
   extractions: ExtractionResult[],
+  deferredSources: Set<string> = new Set(),
 ): Promise<void> {
   for (const result of extractions) {
     if (result.concepts.length === 0) continue;
+    if (deferredSources.has(result.sourceFile)) continue;
     await persistSourceState(root, result.sourcePath, result.sourceFile, result.concepts);
   }
 }
@@ -231,7 +258,7 @@ async function logCompile(
   existingIds: Set<string>,
 ): Promise<void> {
   if (buckets.toCompile.length === 0 && buckets.deleted.length === 0) return;
-  const produced = [...new Set([...generation.pages.map((entry) => entry.slug), ...generation.seedSlugs])];
+  const produced = [...new Set([...generation.writtenPages.map((entry) => entry.slug), ...generation.seedSlugs])];
   const existed = (slug: string): boolean => existingIds.has(`${CONCEPTS_DIR}/${slug}`);
   const created = produced.filter((slug) => !existed(slug));
   const updated = produced.filter((slug) => existed(slug));
@@ -257,9 +284,9 @@ function summarizeCompile(
   output.status("✓", output.success(
     `${buckets.toCompile.length} compiled, ${buckets.unchanged.length} skipped, ${buckets.deleted.length} deleted`,
   ));
-  if (options.review && generation.candidates.length > 0) {
+  if (generation.candidates.length > 0) {
     output.status("?", output.info(
-      `${generation.candidates.length} candidate(s) awaiting review — run \`llmwiki review list\``,
+      reviewSummaryLine(generation),
     ));
   } else if (buckets.toCompile.length > 0) {
     output.status("→", output.dim('Next: llmwiki query "your question here"'));
@@ -276,7 +303,7 @@ function summarizeCompile(
   // downstream consumers see every page the compile actually produced.
   // Seed pages are deterministic schema-driven writes; before this they
   // landed on disk silently and never appeared on CompileResult.pages.
-  const conceptSlugs = generation.pages.map((entry) => entry.slug);
+  const conceptSlugs = generation.writtenPages.map((entry) => entry.slug);
   const baseResult: CompileResult = {
     compiled: buckets.toCompile.length,
     skipped: buckets.unchanged.length,
@@ -285,10 +312,21 @@ function summarizeCompile(
     pages: [...conceptSlugs, ...generation.seedSlugs],
     errors,
   };
-  if (options.review) {
+  if (generation.candidates.length > 0) {
     baseResult.candidates = generation.candidates;
+    baseResult.review = generation.review;
   }
   return baseResult;
+}
+
+/** Human completion line for candidates created this run. */
+function reviewSummaryLine(generation: PageGenerationResult): string {
+  const held = generation.review.held.length;
+  const forced = generation.review.forced.length;
+  if (held > 0 && forced === 0) {
+    return `Wrote ${generation.writtenPages.length} page(s), held ${held} for review — run \`llmwiki review list\``;
+  }
+  return `${generation.candidates.length} candidate(s) awaiting review — run \`llmwiki review list\``;
 }
 
 /**
@@ -325,10 +363,12 @@ async function runCompilePipeline(
   options: CompileOptions,
 ): Promise<CompileResult> {
   const schema = await loadSchema(root);
+  const reviewPolicy = await loadReviewPolicy(root);
   reportSchemaStatus(schema);
   const state = await readState(root);
   const detected = await detectChanges(root, state);
   const changes = applyChangeFilter(detected, options.changeFilter);
+  await markUnchangedPendingSources(root, changes);
   augmentWithAffectedSources(changes, findAffectedSources(state, changes));
 
   const buckets = bucketChanges(changes);
@@ -340,14 +380,17 @@ async function runCompilePipeline(
     if (!options.review) {
       const emptyGeneration: PageGenerationResult = {
         pages: [],
+        writtenPages: [],
         errors: [],
         candidates: [],
+        review: { held: [], forced: [] },
+        heldSourceFiles: [],
         seedSlugs: [],
       };
       await maybeSeedPages(root, schema, emptyGeneration, options);
       // Rebuild index/MOC so the newly-written seed pages become discoverable,
       // and propagate any seed-page validation errors into the returned result.
-      await finalizeWiki(root, emptyGeneration.pages, emptyGeneration.seedSlugs);
+      await finalizeWiki(root, emptyGeneration.writtenPages, emptyGeneration.seedSlugs);
       return {
         ...emptyCompileResult(),
         skipped: buckets.unchanged.length,
@@ -384,10 +427,17 @@ async function runCompilePipeline(
   // Snapshot pages on disk before generation so the journal can tell which
   // produced pages are new (created) versus overwritten (updated).
   const existingIds = await listExistingPageIds(root);
-  const generation = await generatePagesPhase(root, extractions, frozenSlugs, schema, options);
+  const generation = await generatePagesPhase(
+    root,
+    extractions,
+    frozenSlugs,
+    schema,
+    options,
+    reviewPolicy,
+  );
 
   if (!options.review) {
-    await persistExtractionStates(root, extractions);
+    await persistExtractionStates(root, extractions, new Set(generation.heldSourceFiles));
     if (frozenSlugs.size > 0) {
       await orphanUnownedFrozenPages(root, frozenSlugs);
     }
@@ -395,10 +445,34 @@ async function runCompilePipeline(
     // Seed pages write directly into wiki/, so skip them in review mode
     // to honour the "no wiki/ mutation" contract of that mode.
     await maybeSeedPages(root, schema, generation, options);
-    await finalizeWiki(root, generation.pages, generation.seedSlugs);
+    await finalizeWiki(root, generation.writtenPages, generation.seedSlugs);
     await logCompile(root, buckets, generation, existingIds);
   }
   return summarizeCompile(buckets, generation, extractions, options);
+}
+
+/** Treat unchanged pending-candidate sources as skipped to avoid LLM churn. */
+async function markUnchangedPendingSources(root: string, changes: SourceChange[]): Promise<void> {
+  const pendingHashes = await collectPendingSourceHashes(root);
+  if (pendingHashes.size === 0) return;
+  for (const change of changes) {
+    if (change.status !== "new" && change.status !== "changed") continue;
+    const pendingHash = pendingHashes.get(change.file);
+    if (!pendingHash) continue;
+    const currentHash = await hashFile(path.join(root, SOURCES_DIR, change.file));
+    if (currentHash === pendingHash) change.status = "unchanged";
+  }
+}
+
+/** Source hash snapshots currently held inside pending candidates. */
+async function collectPendingSourceHashes(root: string): Promise<Map<string, string>> {
+  const hashes = new Map<string, string>();
+  for (const candidate of await listCandidates(root)) {
+    for (const [source, entry] of Object.entries(candidate.sourceStates ?? {})) {
+      hashes.set(source, entry.hash);
+    }
+  }
+  return hashes;
 }
 
 /** Log where the schema was loaded from so the user can confirm it was picked up. */
@@ -639,7 +713,24 @@ function mergeExtractions(
 /** Outcome of generating a single merged concept page. */
 interface MergedPageOutcome {
   error?: string;
-  candidateId?: string;
+  wrotePage?: boolean;
+  candidate?: {
+    mode: "held" | "forced";
+    id: string;
+    ref: ReviewedCandidateRef;
+  };
+}
+
+/** Review diagnostics computed from the final generated page. */
+interface ReviewDiagnostics {
+  schemaViolations: LintResult[];
+  provenanceViolations: LintResult[];
+}
+
+/** Metadata needed when persisting a candidate. */
+interface ReviewCandidateMeta {
+  reviewMode: "policy" | "forced";
+  heldReasons: HeldReason[];
 }
 
 /**
@@ -655,26 +746,40 @@ async function generateMergedPage(
   schema: SchemaConfig,
   options: CompileOptions,
   sourceStates: SourceStateMap,
+  policy: ReviewPolicy,
 ): Promise<MergedPageOutcome> {
   const fullPage = await renderMergedPageContent(root, entry, schema);
+  const diagnostics = await collectReviewDiagnostics(root, entry, fullPage, schema);
+  const reasons = evaluatePolicy(buildPolicySignals(fullPage, diagnostics), policy);
 
   if (options.review) {
-    return await persistReviewCandidate(root, entry, fullPage, sourceStates, schema);
+    const heldReasons = [{ code: "manual-review-requested" } as HeldReason, ...reasons];
+    return await persistReviewCandidate(root, entry, fullPage, sourceStates, diagnostics, {
+      reviewMode: "forced",
+      heldReasons,
+    });
+  }
+
+  if (reasons.length > 0) {
+    return await persistReviewCandidate(root, entry, fullPage, sourceStates, diagnostics, {
+      reviewMode: "policy",
+      heldReasons: reasons,
+    });
   }
 
   const pagePath = path.join(root, CONCEPTS_DIR, `${entry.slug}.md`);
   const error = await writePageIfValid(pagePath, fullPage, entry.concept.concept);
-  return { error: error ?? undefined };
+  if (!error) await deleteCandidateBySlug(root, entry.slug);
+  return { error: error ?? undefined, wrotePage: !error };
 }
 
 /** Persist a candidate JSON record for later review and report it on stdout. */
-async function persistReviewCandidate(
+async function collectReviewDiagnostics(
   root: string,
   entry: MergedConcept,
   fullPage: string,
-  sourceStates: SourceStateMap,
   schema: SchemaConfig,
-): Promise<MergedPageOutcome> {
+): Promise<ReviewDiagnostics> {
   // Run schema-aware AND provenance-aware lint against the candidate body so
   // both classes of violation are visible in `review show` before a reviewer
   // approves the page. The virtual file path uses the slug so diagnostics
@@ -687,6 +792,31 @@ async function persistReviewCandidate(
     fullPage,
     virtualPath,
   );
+  return { schemaViolations, provenanceViolations };
+}
+
+/** Build review-policy signals from final page frontmatter and diagnostics. */
+function buildPolicySignals(fullPage: string, diagnostics: ReviewDiagnostics) {
+  const { meta } = parseFrontmatter(fullPage);
+  const provenance = parseProvenanceMetadata(meta);
+  return {
+    confidence: provenance.confidence,
+    contradicted: (provenance.contradictedBy?.length ?? 0) > 0,
+    schemaViolations: diagnostics.schemaViolations,
+    provenanceViolations: diagnostics.provenanceViolations,
+  };
+}
+
+/** Persist a candidate JSON record for later review and report it on stdout. */
+async function persistReviewCandidate(
+  root: string,
+  entry: MergedConcept,
+  fullPage: string,
+  sourceStates: SourceStateMap,
+  diagnostics: ReviewDiagnostics,
+  meta: ReviewCandidateMeta,
+): Promise<MergedPageOutcome> {
+  const signals = buildPolicySignals(fullPage, diagnostics);
 
   const candidate: ReviewCandidate = await writeCandidate(root, {
     title: entry.concept.concept,
@@ -695,12 +825,23 @@ async function persistReviewCandidate(
     sources: entry.sourceFiles,
     body: fullPage,
     sourceStates: pickStatesForSources(sourceStates, entry.sourceFiles),
-    schemaViolations: schemaViolations.length > 0 ? schemaViolations : undefined,
+    schemaViolations:
+      diagnostics.schemaViolations.length > 0 ? diagnostics.schemaViolations : undefined,
     provenanceViolations:
-      provenanceViolations.length > 0 ? provenanceViolations : undefined,
+      diagnostics.provenanceViolations.length > 0 ? diagnostics.provenanceViolations : undefined,
+    reviewMode: meta.reviewMode,
+    heldReasons: meta.heldReasons,
+    confidence: signals.confidence,
+    contradicted: signals.contradicted,
   });
   output.status("?", output.info(`Candidate ready: ${candidate.id} (${entry.slug})`));
-  return { candidateId: candidate.id };
+  return {
+    candidate: {
+      id: candidate.id,
+      mode: meta.reviewMode === "policy" ? "held" : "forced",
+      ref: { id: candidate.id, slug: entry.slug, reasons: meta.heldReasons.map((r) => r.code) },
+    },
+  };
 }
 
 /**

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -162,8 +162,6 @@ interface PageGenerationResult {
     held: ReviewedCandidateRef[];
     forced: ReviewedCandidateRef[];
   };
-  /** Source files that fed at least one held candidate this run. */
-  heldSourceFiles: string[];
   /**
    * Slugs of seed pages written this run (overview / comparison / entity).
    * Concept pages live on `pages`; seed pages don't fit MergedConcept's
@@ -194,7 +192,6 @@ async function generatePagesPhase(
   const errors: string[] = [];
   const candidates: string[] = [];
   const review = { held: [] as ReviewedCandidateRef[], forced: [] as ReviewedCandidateRef[] };
-  const heldSourceFiles = new Set<string>();
   const outcomes = await Promise.all(
     merged.map((entry) => limit(async () => {
       const result = await generateMergedPage(root, entry, schema, options, sourceStates, policy);
@@ -202,27 +199,67 @@ async function generatePagesPhase(
       if (result.candidate) {
         candidates.push(result.candidate.id);
         review[result.candidate.mode].push(result.candidate.ref);
-        for (const source of entry.sourceFiles) heldSourceFiles.add(source);
       }
       return { entry, result };
     })),
   );
   const pages = outcomes.map(({ entry }) => entry);
   const writtenPages = outcomes.filter(({ result }) => result.wrotePage).map(({ entry }) => entry);
-  return { pages, writtenPages, errors, candidates, review, heldSourceFiles: [...heldSourceFiles], seedSlugs: [] };
+  return { pages, writtenPages, errors, candidates, review, seedSlugs: [] };
 }
 
-/** Persist source state for every extraction that produced concepts. */
+/** Persist source state for every extraction that produced concepts.
+ *
+ * State records only LIVE concepts per source — slugs that were actually
+ * written to wiki/ this run. Held or rejected concepts are never recorded
+ * as compiled; approval adds the approved slug via persistCandidateSourceStates.
+ * A source whose concepts are all held records hash + empty concepts list.
+ */
 async function persistExtractionStates(
   root: string,
   extractions: ExtractionResult[],
-  deferredSources: Set<string> = new Set(),
+  writtenPages: MergedConcept[],
 ): Promise<void> {
+  // Build a set of live slugs per source: slugs from writtenPages that list
+  // this source as a contributor.
+  const liveSlugsForSource = buildLiveSlugsForSource(writtenPages);
   for (const result of extractions) {
     if (result.concepts.length === 0) continue;
-    if (deferredSources.has(result.sourceFile)) continue;
-    await persistSourceState(root, result.sourcePath, result.sourceFile, result.concepts);
+    const liveSlugs = liveSlugsForSource.get(result.sourceFile) ?? [];
+    await persistSourceStateFiltered(
+      root, result.sourcePath, result.sourceFile, result.concepts, new Set(liveSlugs),
+    );
   }
+}
+
+/** Build a map from source filename to the slugs written live this run. */
+function buildLiveSlugsForSource(writtenPages: MergedConcept[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const page of writtenPages) {
+    for (const sourceFile of page.sourceFiles) {
+      const existing = map.get(sourceFile) ?? [];
+      existing.push(page.slug);
+      map.set(sourceFile, existing);
+    }
+  }
+  return map;
+}
+
+/** Persist source state, filtering concepts to only those in the live set. */
+async function persistSourceStateFiltered(
+  root: string,
+  sourcePath: string,
+  sourceFile: string,
+  concepts: ReturnType<typeof parseConcepts>,
+  liveSlugs: Set<string>,
+): Promise<void> {
+  const hash = await hashFile(sourcePath);
+  const entry: SourceState = {
+    hash,
+    concepts: concepts.map((c) => slugify(c.concept)).filter((s) => liveSlugs.has(s)),
+    compiledAt: new Date().toISOString(),
+  };
+  await updateSourceState(root, sourceFile, entry);
 }
 
 /**
@@ -384,7 +421,6 @@ async function runCompilePipeline(
         errors: [],
         candidates: [],
         review: { held: [], forced: [] },
-        heldSourceFiles: [],
         seedSlugs: [],
       };
       await maybeSeedPages(root, schema, emptyGeneration, options);
@@ -437,7 +473,7 @@ async function runCompilePipeline(
   );
 
   if (!options.review) {
-    await persistExtractionStates(root, extractions, new Set(generation.heldSourceFiles));
+    await persistExtractionStates(root, extractions, generation.writtenPages);
     if (frozenSlugs.size > 0) {
       await orphanUnownedFrozenPages(root, frozenSlugs);
     }
@@ -995,27 +1031,4 @@ async function safelyUpdateEmbeddings(root: string, changedSlugs: string[]): Pro
     const message = err instanceof Error ? err.message : String(err);
     output.status("!", output.warn(`Skipped embeddings update: ${message}`));
   }
-}
-
-/**
- * Update the persisted state for a compiled source file.
- * @param root - Project root directory.
- * @param sourcePath - Absolute path to the source file.
- * @param sourceFile - Filename within sources/.
- * @param concepts - Concepts extracted from this source.
- */
-async function persistSourceState(
-  root: string,
-  sourcePath: string,
-  sourceFile: string,
-  concepts: ReturnType<typeof parseConcepts>,
-): Promise<void> {
-  const hash = await hashFile(sourcePath);
-  const entry: SourceState = {
-    hash,
-    concepts: concepts.map((c) => slugify(c.concept)),
-    compiledAt: new Date().toISOString(),
-  };
-
-  await updateSourceState(root, sourceFile, entry);
 }

--- a/src/eval/health.ts
+++ b/src/eval/health.ts
@@ -21,6 +21,7 @@ import {
   checkSchemaCrossLinks,
 } from "../linter/rules.js";
 import { loadSchema } from "../schema/loader.js";
+import { countCandidates } from "../compiler/candidates.js";
 import type { LintResult } from "../linter/types.js";
 import type { HealthResult, HealthRuleResult } from "./types.js";
 
@@ -73,8 +74,8 @@ function aggregateRules(results: LintResult[]): HealthRuleResult[] {
 export async function evaluateHealth(root: string): Promise<HealthResult> {
   const schema = await loadSchema(root);
 
-  const allResults = (
-    await Promise.all([
+  const [allResults, pendingReviews] = await Promise.all([
+    Promise.all([
       checkBrokenWikilinks(root),
       checkBrokenCitations(root),
       checkMalformedClaimCitations(root),
@@ -86,12 +87,13 @@ export async function evaluateHealth(root: string): Promise<HealthResult> {
       checkContradictedPages(root),
       checkInferredWithoutCitations(root),
       checkSchemaCrossLinks(root, schema),
-    ])
-  ).flat();
+    ]).then((results) => results.flat()),
+    countCandidates(root).catch(() => 0),
+  ]);
 
   const rules = aggregateRules(allResults);
   const totalDeduction = rules.reduce((sum, r) => sum + r.deduction, 0);
   const score = Math.max(0, MAX_SCORE - totalDeduction);
 
-  return { score, maxScore: MAX_SCORE, rules };
+  return { score, maxScore: MAX_SCORE, rules, pendingReviews };
 }

--- a/src/eval/health.ts
+++ b/src/eval/health.ts
@@ -38,6 +38,7 @@ const ERROR_RULES = new Set([
 
 /** Compute the point deduction for a single lint result. */
 function deductionFor(result: LintResult): number {
+  if (result.rule === "pending-target") return 0;
   if (ERROR_RULES.has(result.rule)) return ERROR_DEDUCTION;
   if (result.rule === "contradicted-page") return CONTRADICTED_DEDUCTION;
   return DEFAULT_DEDUCTION;

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -78,6 +78,9 @@ function formatHealth(report: EvalReport, delta: EvalDelta | undefined): string[
     const row = ruleRow(rule);
     if (row) rows.push(row);
   }
+  if (report.health.pendingReviews > 0) {
+    rows.push(line(`    pending review:  ${report.health.pendingReviews} candidate(s) awaiting approval`));
+  }
   return rows;
 }
 

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -21,6 +21,11 @@ export interface HealthResult {
   score: number;
   maxScore: 100;
   rules: HealthRuleResult[];
+  /**
+   * Number of pages currently awaiting review in .llmwiki/candidates/.
+   * Informational only — does not affect the health score.
+   */
+  pendingReviews: number;
 }
 
 export interface CitationPageResult {

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -33,6 +33,7 @@ import {
 } from "../schema/index.js";
 import { computeFreshness } from "../freshness/index.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
+import { listPendingCandidateSlugs } from "../compiler/candidates.js";
 
 /** Minimum body length (in characters) for a page to be considered non-empty. */
 const MIN_BODY_LENGTH = 50;
@@ -118,13 +119,22 @@ function buildPageSlugSet(
 export async function checkBrokenWikilinks(root: string): Promise<LintResult[]> {
   const pages = await collectAllPages(root);
   const existingSlugs = buildPageSlugSet(pages);
+  const pendingSlugs = await listPendingCandidateSlugs(root);
   const results: LintResult[] = [];
 
   for (const page of pages) {
     for (const { captured, line } of findMatchesInContent(page.content, WIKILINK_PATTERN)) {
       const linkTarget = captured.split("|")[0].trim();
       const linkSlug = slugify(linkTarget);
-      if (!existingSlugs.has(linkSlug)) {
+      if (!existingSlugs.has(linkSlug) && pendingSlugs.has(linkSlug)) {
+        results.push({
+          rule: "pending-target",
+          severity: "info",
+          file: page.filePath,
+          message: `Wikilink [[${captured}]] points to a page awaiting review`,
+          line,
+        });
+      } else if (!existingSlugs.has(linkSlug)) {
         results.push({
           rule: "broken-wikilink",
           severity: "error",

--- a/src/review/config.ts
+++ b/src/review/config.ts
@@ -1,0 +1,140 @@
+/**
+ * Project-level review policy config loader.
+ *
+ * `.llmwiki/config.json` is intentionally fail-closed for review policy:
+ * a missing file means policy off, but a present corrupt or invalid file is a
+ * hard error so a typo cannot silently disable the review gate. The normalized
+ * shape returned here is consumed by the compile pipeline and by tests without
+ * needing to understand the raw JSON file shape.
+ */
+
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { LLMWIKI_DIR, LOW_CONFIDENCE_THRESHOLD } from "../utils/constants.js";
+import type { MissingConfidencePolicy, ReviewPolicy, ReviewPolicyMode } from "./policy.js";
+
+/** Project config file path relative to root. */
+const PROJECT_CONFIG_FILE = path.join(LLMWIKI_DIR, "config.json");
+
+/** Normalized off policy used when config is absent or review.hold is empty. */
+const REVIEW_POLICY_OFF: ReviewPolicy = {
+  hold: [],
+  lowConfidenceThreshold: LOW_CONFIDENCE_THRESHOLD,
+  treatMissingConfidenceAs: "low",
+};
+
+/** Error type used for fail-closed review config validation. */
+export class ReviewConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReviewConfigError";
+  }
+}
+
+const SIGNAL_MODES: readonly ReviewPolicyMode[] = [
+  "low-confidence",
+  "contradicted",
+  "schema-violating",
+  "provenance-violating",
+];
+
+const MODE_VALUES = new Set<ReviewPolicyMode>([
+  ...SIGNAL_MODES,
+  "all",
+  "off",
+]);
+
+/** Load and normalize review policy from `.llmwiki/config.json`. */
+export async function loadReviewPolicy(root: string): Promise<ReviewPolicy> {
+  const filePath = path.join(root, PROJECT_CONFIG_FILE);
+  if (!existsSync(filePath)) return { ...REVIEW_POLICY_OFF };
+  const raw = await readConfigJson(filePath);
+  return normalizeReviewPolicy(raw);
+}
+
+/** Parse the raw JSON config or fail closed on corruption. */
+async function readConfigJson(filePath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf-8"));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ReviewConfigError(`Invalid .llmwiki/config.json: ${message}`);
+  }
+}
+
+/** Normalize raw project config into review policy. */
+export function normalizeReviewPolicy(raw: unknown): ReviewPolicy {
+  const config = requireRecord(raw, "config");
+  validateVersion(config.version);
+  const review = config.review;
+  if (review === undefined) return { ...REVIEW_POLICY_OFF };
+  const reviewConfig = requireRecord(review, "review");
+  const hold = normalizeHoldModes(reviewConfig.hold);
+  if (hold.length === 0 || hold.includes("off")) {
+    return { ...REVIEW_POLICY_OFF };
+  }
+  return {
+    hold,
+    lowConfidenceThreshold: normalizeThreshold(reviewConfig.lowConfidenceThreshold),
+    treatMissingConfidenceAs: normalizeMissingConfidence(reviewConfig.treatMissingConfidenceAs),
+  };
+}
+
+/** Return object records only; arrays/scalars are invalid config roots. */
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ReviewConfigError(`${label} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+/** Validate config version when present. */
+function validateVersion(version: unknown): void {
+  if (version === undefined || version === 1) return;
+  throw new ReviewConfigError("Unsupported .llmwiki/config.json version; expected 1");
+}
+
+/** Normalize and validate review.hold. */
+function normalizeHoldModes(value: unknown): ReviewPolicyMode[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new ReviewConfigError("review.hold must be an array");
+  const modes = value.map(readMode);
+  validateModeCombination(modes);
+  return [...new Set(modes)];
+}
+
+/** Validate one hold mode string. */
+function readMode(value: unknown): ReviewPolicyMode {
+  if (typeof value !== "string" || !MODE_VALUES.has(value as ReviewPolicyMode)) {
+    throw new ReviewConfigError(`Unknown review.hold mode: ${String(value)}`);
+  }
+  return value as ReviewPolicyMode;
+}
+
+/** `off` and `all` are standalone by contract. */
+function validateModeCombination(modes: ReviewPolicyMode[]): void {
+  if (modes.length <= 1) return;
+  if (modes.includes("off")) {
+    throw new ReviewConfigError('review.hold mode "off" cannot be combined with other modes');
+  }
+  if (modes.includes("all")) {
+    throw new ReviewConfigError('review.hold mode "all" cannot be combined with other modes');
+  }
+}
+
+/** Normalize optional low-confidence threshold. */
+function normalizeThreshold(value: unknown): number {
+  if (value === undefined) return LOW_CONFIDENCE_THRESHOLD;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new ReviewConfigError("review.lowConfidenceThreshold must be a finite number in [0,1]");
+  }
+  return value;
+}
+
+/** Normalize optional missing-confidence handling. */
+function normalizeMissingConfidence(value: unknown): MissingConfidencePolicy {
+  if (value === undefined) return "low";
+  if (value === "low" || value === "ok") return value;
+  throw new ReviewConfigError('review.treatMissingConfidenceAs must be "low" or "ok"');
+}

--- a/src/review/config.ts
+++ b/src/review/config.ts
@@ -89,10 +89,10 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-/** Validate config version when present. */
+/** Require `version: 1`; a missing or unsupported version is a hard error. */
 function validateVersion(version: unknown): void {
-  if (version === undefined || version === 1) return;
-  throw new ReviewConfigError("Unsupported .llmwiki/config.json version; expected 1");
+  if (version === 1) return;
+  throw new ReviewConfigError('.llmwiki/config.json requires "version": 1');
 }
 
 /** Normalize and validate review.hold. */

--- a/src/review/policy.ts
+++ b/src/review/policy.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure review-policy evaluation.
+ *
+ * The compile pipeline produces review signals from the final rendered page
+ * (confidence/contradictions from frontmatter plus independently-computed
+ * schema/provenance violations). This module contains only the deterministic
+ * policy decision: given normalized project policy and those signals, return
+ * the structured reasons that require the page to be held for review.
+ */
+
+import type { LintResult } from "../linter/types.js";
+
+/** Policy reasons stored on review candidates and surfaced in CLI output. */
+export type HeldReasonCode =
+  | "low-confidence"
+  | "contradicted"
+  | "schema-violating"
+  | "provenance-violating"
+  | "all"
+  | "manual-review-requested";
+
+/** Structured reason a generated page was held for review. */
+export interface HeldReason {
+  code: HeldReasonCode;
+  detail?: string;
+}
+
+/** Candidate origin: policy-selected or explicitly forced by compile --review. */
+export type ReviewMode = "policy" | "forced";
+
+/** Configurable review policy modes. */
+export type ReviewPolicyMode = Exclude<HeldReasonCode, "manual-review-requested"> | "off";
+
+/** How low-confidence policy treats a missing confidence signal. */
+export type MissingConfidencePolicy = "low" | "ok";
+
+/** Normalized project review policy. */
+export interface ReviewPolicy {
+  hold: ReviewPolicyMode[];
+  lowConfidenceThreshold: number;
+  treatMissingConfidenceAs: MissingConfidencePolicy;
+}
+
+/** Signals used by review policy evaluation for one generated page. */
+export interface PolicySignals {
+  confidence?: number;
+  contradicted: boolean;
+  schemaViolations: LintResult[];
+  provenanceViolations: LintResult[];
+}
+
+/** True when policy cannot hold any page. */
+export function isPolicyOff(policy: ReviewPolicy): boolean {
+  return policy.hold.length === 0 || policy.hold.includes("off");
+}
+
+/** Return every policy reason that fires for this page. Empty means write live. */
+export function evaluatePolicy(signals: PolicySignals, policy: ReviewPolicy): HeldReason[] {
+  if (isPolicyOff(policy)) return [];
+  const reasons: HeldReason[] = [];
+  for (const mode of policy.hold) {
+    const reason = reasonForMode(mode, signals, policy);
+    if (reason) reasons.push(reason);
+  }
+  return reasons;
+}
+
+/** Evaluate one configured policy mode. */
+function reasonForMode(
+  mode: ReviewPolicyMode,
+  signals: PolicySignals,
+  policy: ReviewPolicy,
+): HeldReason | null {
+  if (mode === "all") return { code: "all" };
+  if (mode === "low-confidence") return lowConfidenceReason(signals, policy);
+  if (mode === "contradicted" && signals.contradicted) return { code: "contradicted" };
+  if (mode === "schema-violating" && signals.schemaViolations.length > 0) {
+    return { code: "schema-violating", detail: summarizeViolations(signals.schemaViolations) };
+  }
+  if (mode === "provenance-violating" && signals.provenanceViolations.length > 0) {
+    return { code: "provenance-violating", detail: summarizeViolations(signals.provenanceViolations) };
+  }
+  return null;
+}
+
+/** Build the low-confidence reason, including the missing-signal policy. */
+function lowConfidenceReason(signals: PolicySignals, policy: ReviewPolicy): HeldReason | null {
+  if (signals.confidence === undefined) {
+    if (policy.treatMissingConfidenceAs === "low") {
+      return { code: "low-confidence", detail: "confidence missing" };
+    }
+    return null;
+  }
+  if (signals.confidence < policy.lowConfidenceThreshold) {
+    return {
+      code: "low-confidence",
+      detail: `confidence ${signals.confidence} < ${policy.lowConfidenceThreshold}`,
+    };
+  }
+  return null;
+}
+
+/** Compact violation summary for candidate display. */
+function summarizeViolations(violations: LintResult[]): string {
+  const first = violations[0];
+  const suffix = violations.length === 1 ? "" : ` (+${violations.length - 1} more)`;
+  return `${first.rule}${suffix}`;
+}
+

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -176,9 +176,9 @@ export interface ReviewCandidate {
   /** ISO timestamp recorded when the candidate was generated. */
   generatedAt: string;
   /** Whether this candidate was policy-held or explicitly forced by --review. */
-  reviewMode?: ReviewMode;
+  reviewMode: ReviewMode;
   /** Structured reasons the candidate is awaiting review. */
-  heldReasons?: HeldReason[];
+  heldReasons: HeldReason[];
   /** Confidence parsed from the generated page frontmatter, for review display. */
   confidence?: number;
   /** True when the generated page frontmatter declares contradictions. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { PageKind } from "../schema/types.js";
+import type { HeldReason, HeldReasonCode, ReviewMode } from "../review/policy.js";
 
 /**
  * Lifecycle state of a concept or page's provenance.
@@ -115,8 +116,20 @@ export interface CompileResult {
   concepts: string[];
   pages: string[];
   errors: string[];
-  /** Candidate IDs created when the pipeline runs in --review mode. */
+  /** Candidate IDs created by --review or policy-held compile outputs. */
   candidates?: string[];
+  /** Structured review split for candidates created by the compile run. */
+  review?: {
+    held: ReviewedCandidateRef[];
+    forced: ReviewedCandidateRef[];
+  };
+}
+
+/** Candidate reference returned in CompileResult.review. */
+export interface ReviewedCandidateRef {
+  id: string;
+  slug: string;
+  reasons: HeldReasonCode[];
 }
 
 /** Optional behaviour controls for the compile pipeline. */
@@ -162,6 +175,14 @@ export interface ReviewCandidate {
   body: string;
   /** ISO timestamp recorded when the candidate was generated. */
   generatedAt: string;
+  /** Whether this candidate was policy-held or explicitly forced by --review. */
+  reviewMode?: ReviewMode;
+  /** Structured reasons the candidate is awaiting review. */
+  heldReasons?: HeldReason[];
+  /** Confidence parsed from the generated page frontmatter, for review display. */
+  confidence?: number;
+  /** True when the generated page frontmatter declares contradictions. */
+  contradicted?: boolean;
   /**
    * Per-source incremental-state snapshots captured at compile time.
    *

--- a/test/compile-delta.test.ts
+++ b/test/compile-delta.test.ts
@@ -7,6 +7,7 @@
  *  - A second delta compile with the now-up-to-date state returns an EMPTY
  *    delta (nothing changed ⇒ nothing to ship).
  *  - Adding a new source yields ONLY that new source's page in the delta.
+ *  - When review policy holds a page, held count and heldCandidates are surfaced.
  *
  * Strategy mirrors compile-provenance.test.ts: stub AnthropicProvider so the
  * extraction tool and page-generation calls are deterministic and no real
@@ -15,7 +16,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { writeFile } from "fs/promises";
+import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { compileDelta } from "../src/compiler/delta.js";
 import { AnthropicProvider } from "../src/providers/anthropic.js";
@@ -89,5 +90,36 @@ describe("compileDelta — incremental change-gated delta", () => {
     expect(delta.changedSlugs).toEqual([SECOND_SLUG]);
     expect(delta.changedPages).toHaveLength(1);
     expect(delta.changedPages[0]?.slug).toBe(SECOND_SLUG);
+  });
+});
+
+describe("compileDelta — held pages surfaced in result", () => {
+  const ctx = useCompileProject({
+    dirSuffix: "delta-held",
+    sourceFile: FIRST_SOURCE,
+    sourceContent: `# ${FIRST_TITLE}\n\nAbout alpha.`,
+  });
+
+  it("surfaces held count and heldCandidates when policy holds a page", async () => {
+    // Write a review config that holds low-confidence pages
+    await mkdir(path.join(ctx.dir, ".llmwiki"), { recursive: true });
+    await writeFile(
+      path.join(ctx.dir, ".llmwiki", "config.json"),
+      JSON.stringify({ version: 1, review: { hold: ["low-confidence"], lowConfidenceThreshold: 0.5 } }),
+      "utf-8",
+    );
+    // Stub LLM: extraction yields low-confidence (0.1) so policy holds it
+    vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(
+      JSON.stringify({ concepts: [{ concept: FIRST_TITLE, summary: "A topic.", is_new: true, confidence: 0.1 }] }),
+    );
+    vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(STUB_BODY);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const delta = await compileDelta(ctx.dir);
+
+    expect(delta.changedPages).toEqual([]);
+    expect(delta.held).toBe(1);
+    expect(delta.heldCandidates).toHaveLength(1);
+    expect(delta.heldCandidates[0]?.slug).toBe(FIRST_SLUG);
   });
 });

--- a/test/eval-health.test.ts
+++ b/test/eval-health.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { evaluateHealth } from "../src/eval/health.js";
+import { writeCandidate } from "../src/compiler/candidates.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
 
 describe("evaluateHealth", () => {
@@ -86,5 +87,21 @@ describe("evaluateHealth", () => {
 
     const result = await evaluateHealth(env.dir);
     expect(result.score).toBe(0);
+  });
+
+  it("surfaces pending-review count without penalising health score", async () => {
+    await writeCandidate(env.dir, {
+      title: "Pending Concept",
+      slug: "pending-concept",
+      summary: "Pending.",
+      sources: [],
+      body: "pending body",
+      reviewMode: "policy",
+      heldReasons: [{ code: "low-confidence" }],
+    });
+
+    const result = await evaluateHealth(env.dir);
+    expect(result.pendingReviews).toBe(1);
+    expect(result.score).toBe(100);
   });
 });

--- a/test/mcp-stdio.test.ts
+++ b/test/mcp-stdio.test.ts
@@ -1,0 +1,83 @@
+/**
+ * First real MCP-over-stdio integration test for llmwiki.
+ *
+ * Previous MCP tests drive registered handlers in-process (no transport). This
+ * file spawns the actual `llmwiki serve --root <tmp>` binary over stdio, connects
+ * an SDK Client via StdioClientTransport, and calls `wiki_status` through the
+ * full JSON-RPC stack — verifying the pending-review count from a seeded candidate.
+ *
+ * The candidate is written directly into `.llmwiki/candidates/` so no LLM is
+ * needed and the test is fully deterministic. `wiki_status` is read-only and
+ * never calls a provider, so no API key is required.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { CLI } from "./fixtures/run-cli.js";
+import { useMcpRoot } from "./fixtures/mcp-test-env.js";
+
+const rootHandle = useMcpRoot("mcp-stdio");
+
+/** Write a minimal valid ReviewCandidate JSON into the candidates directory. */
+async function seedPendingCandidate(root: string): Promise<void> {
+  const now = new Date().toISOString();
+  const candidate = {
+    id: "alpha-deadbeef",
+    title: "Alpha",
+    slug: "alpha",
+    summary: "Alpha summary.",
+    sources: ["intro.md"],
+    body: `---\ntitle: Alpha\nsummary: Alpha summary.\nsources: []\ncreatedAt: '${now}'\nupdatedAt: '${now}'\n---\n\n# Alpha\n\nAlpha summary.`,
+    generatedAt: now,
+    reviewMode: "policy",
+    heldReasons: [{ code: "low-confidence" }],
+  };
+  const candidatesDir = path.join(root, ".llmwiki", "candidates");
+  await mkdir(candidatesDir, { recursive: true });
+  await writeFile(
+    path.join(candidatesDir, `${candidate.id}.json`),
+    JSON.stringify(candidate, null, 2),
+    "utf-8",
+  );
+}
+
+/** Connect an SDK Client to a freshly spawned llmwiki MCP server. */
+async function connectMcpClient(root: string): Promise<{ client: Client; transport: StdioClientTransport }> {
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [CLI, "serve", "--root", root],
+    stderr: "ignore",
+  });
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await client.connect(transport);
+  return { client, transport };
+}
+
+/** Parse the JSON status payload from a wiki_status tool response. */
+function parseStatusResult(result: Awaited<ReturnType<Client["callTool"]>>): { pendingCandidates: number } {
+  const text = (result.content as Array<{ type: string; text: string }>)
+    .filter((c) => c.type === "text")
+    .map((c) => c.text)
+    .join("");
+  return JSON.parse(text) as { pendingCandidates: number };
+}
+
+describe("MCP stdio: wiki_status pending-review count", () => {
+  it("reports pendingCandidates ≥ 1 after seeding a candidate file", async () => {
+    const root = rootHandle.value;
+    await seedPendingCandidate(root);
+
+    const { client, transport } = await connectMcpClient(root);
+    try {
+      const result = await client.callTool({ name: "wiki_status", arguments: {} });
+      const status = parseStatusResult(result);
+      expect(status.pendingCandidates).toBeGreaterThanOrEqual(1);
+    } finally {
+      await client.close();
+      await transport.close();
+    }
+  }, 30_000);
+});

--- a/test/pending-target-lint.test.ts
+++ b/test/pending-target-lint.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pending-target lint tests.
+ *
+ * Policy-held pages can be linked from live pages before approval. Those links
+ * should be visible as informational `pending-target` diagnostics, not broken
+ * wikilink errors, and they should not lower eval health.
+ */
+
+import { describe, it, expect } from "vitest";
+import { lint } from "../src/linter/index.js";
+import { evaluateHealth } from "../src/eval/health.js";
+import { writeCandidate } from "../src/compiler/candidates.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+const env = useLintTempRoot("pending-target-lint");
+
+const LIVE_PAGE = [
+  "---",
+  "title: Live Page",
+  "summary: Links to a pending page.",
+  "sources: []",
+  'createdAt: "2026-01-01T00:00:00.000Z"',
+  'updatedAt: "2026-01-01T00:00:00.000Z"',
+  "---",
+  "",
+  "This live page links to [[Pending Page]] while that page awaits review.",
+  "Extra body text keeps the empty-page lint rule quiet.",
+].join("\n");
+
+describe("pending-target lint", () => {
+  it("reports pending-target instead of broken-wikilink and does not penalize health", async () => {
+    await env.writeConcept("live-page", LIVE_PAGE);
+    await writeCandidate(env.dir, {
+      title: "Pending Page",
+      slug: "pending-page",
+      summary: "Pending.",
+      sources: [],
+      body: "pending body",
+      reviewMode: "policy",
+      heldReasons: [{ code: "low-confidence" }],
+    });
+
+    const summary = await lint(env.dir);
+    expect(summary.errors).toBe(0);
+    expect(summary.results.map((r) => r.rule)).toContain("pending-target");
+    expect(summary.results.map((r) => r.rule)).not.toContain("broken-wikilink");
+
+    const health = await evaluateHealth(env.dir);
+    const pending = health.rules.find((r) => r.rule === "pending-target");
+    expect(pending?.deduction).toBe(0);
+    expect(health.score).toBe(100);
+  });
+});
+

--- a/test/refresh-cli.test.ts
+++ b/test/refresh-cli.test.ts
@@ -153,13 +153,13 @@ describe("llmwiki refresh --stale (live, cleanup-only)", () => {
     expect(result.stdout + result.stderr).toMatch(/could not acquire .*lock/i);
   });
 
-  it("warns that refresh bypasses review when pending candidates exist", async () => {
+  it("warns about pending candidates and review policy when pending candidates exist", async () => {
     const root = await setupCleanupOnlyStale("refresh-bypass");
     await writePendingCandidate(root);
 
     const result = await runCLI(["refresh", "--stale"], root, NO_KEY_ENV);
 
     expectCLIExit(result, 0);
-    expect(result.stdout + result.stderr).toMatch(/writes directly to wiki\/.*does not create review candidates/i);
+    expect(result.stdout + result.stderr).toMatch(/pending review candidate.*refresh respects the project review policy/i);
   });
 });

--- a/test/refresh-integration.test.ts
+++ b/test/refresh-integration.test.ts
@@ -3,21 +3,26 @@
  *
  * Exercises the full in-process recompile path via `resolveStaleRefresh` +
  * `compileAndReport` with a stubbed AnthropicProvider (same convention as
- * compile-delta.test.ts). Proves three guarantees of the v1 implementation:
+ * compile-delta.test.ts). Proves four guarantees of the implementation:
  *
  *  1. A stale page (changed source hash) IS recompiled.
  *  2. A new source (not in state) is skipped — refresh does not compile new sources.
  *  3. A partial-deletion "shared" page has its state REPAIRED (deleted owner
  *     removed from state.sources) but its content byte-for-byte UNCHANGED — the
  *     unchanged live owner is NOT recompiled (v1 limitation: no force-rebuild).
+ *  4. When a review policy is active, a refreshed page that trips policy is held
+ *     as a candidate (not written to wiki/) and the command reports it as held,
+ *     NOT as "refreshed".
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { writeFile, readFile, rm } from "fs/promises";
+import { mkdir, writeFile, readFile, rm } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { compileAndReport } from "../src/compiler/index.js";
 import { resolveStaleRefresh } from "../src/compiler/refresh-plan.js";
+import refreshCommand from "../src/commands/refresh.js";
+import { listCandidates } from "../src/compiler/candidates.js";
 import { AnthropicProvider } from "../src/providers/anthropic.js";
 import { readStateClassified } from "../src/utils/state.js";
 import { CONCEPTS_DIR } from "../src/utils/constants.js";
@@ -28,14 +33,24 @@ import { writeSourceState, writeSourceFile, sha256Hex } from "./fixtures/state-j
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-/** Minimal extraction JSON for one concept. */
-function extractionFor(title: string): string {
-  return JSON.stringify({
-    concepts: [{ concept: title, summary: `Summary of ${title}.`, is_new: true }],
-  });
+/** Minimal extraction JSON for one concept, optionally with confidence. */
+function extractionFor(title: string, confidence?: number): string {
+  const concept: Record<string, unknown> = { concept: title, summary: `Summary of ${title}.`, is_new: true };
+  if (confidence !== undefined) concept.confidence = confidence;
+  return JSON.stringify({ concepts: [concept] });
 }
 
 const STUB_BODY = "Stub body content. ^[a.md]";
+
+/** Write a low-confidence policy config to .llmwiki/config.json. */
+async function writeLowConfidencePolicy(root: string): Promise<void> {
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(
+    path.join(root, ".llmwiki", "config.json"),
+    JSON.stringify({ version: 1, review: { hold: ["low-confidence"], lowConfidenceThreshold: 0.5 } }),
+    "utf-8",
+  );
+}
 
 /**
  * Build a fresh temp project root with sources/ wiki/concepts/ .llmwiki/ dirs.
@@ -72,11 +87,25 @@ async function writeConceptPage(root: string, slug: string, title: string, sourc
 }
 
 /** Stub extraction and page-body calls on AnthropicProvider. Returns the extraction spy. */
-function stubProviderCalls(extractionTitle: string) {
+function stubProviderCalls(extractionTitle: string, confidence?: number) {
   const spy = vi.spyOn(AnthropicProvider.prototype, "toolCall")
-    .mockResolvedValue(extractionFor(extractionTitle));
+    .mockResolvedValue(extractionFor(extractionTitle, confidence));
   vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(STUB_BODY);
   return spy;
+}
+
+/**
+ * Seed a stale topic-a project: a.md in sources with a stale state hash,
+ * and an existing wiki page with "Old body.". Returns the actual a.md content.
+ */
+async function setupStaleTopicA(root: string): Promise<string> {
+  const aContent = "# Topic A\n\nAbout A.";
+  await writeSourceFile(root, "a.md", aContent);
+  await writeSourceState(root, {
+    "a.md": { hash: "stale-hash-not-matching-disk", concepts: ["topic-a"] },
+  });
+  await writeConceptPage(root, "topic-a", "Topic A", ["a.md"], "Old body.");
+  return aContent;
 }
 
 // ---------------------------------------------------------------------------
@@ -90,13 +119,7 @@ describe("refresh --stale (real run, stubbed provider)", () => {
     const root = await makeTmpRoot("stale");
 
     try {
-      const aContent = "# Topic A\n\nAbout A.";
-      await writeSourceFile(root, "a.md", aContent);
-      await writeSourceState(root, {
-        "a.md": { hash: "stale-hash-not-matching-disk", concepts: ["topic-a"] },
-      });
-      // Wiki page must exist on disk for resolveStaleRefresh to classify it as stale.
-      await writeConceptPage(root, "topic-a", "Topic A", ["a.md"], "Old body.");
+      const aContent = await setupStaleTopicA(root);
       // new.md on disk but NOT in state — refresh must skip it.
       await writeSourceFile(root, "new.md", "# New Topic\n\nBrand new.");
 
@@ -161,6 +184,57 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       expect(afterContent).toBe(originalContent);
       // a.md NOT extracted — unchanged live owner skipped in v1.
       expect(extractSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.restoreAllMocks();
+      delete process.env.LLMWIKI_PROVIDER;
+      delete process.env.ANTHROPIC_API_KEY;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: refresh + review policy — held pages reported as held, not refreshed
+  // -------------------------------------------------------------------------
+
+  it("reports a policy-held page as held for review, not as refreshed", async () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    const root = await makeTmpRoot("policy-held");
+
+    try {
+      await setupStaleTopicA(root);
+      // Low-confidence extraction triggers policy hold.
+      await writeLowConfidencePolicy(root);
+      stubProviderCalls("Topic A", 0.1);
+
+      const logLines: string[] = [];
+      vi.spyOn(console, "log").mockImplementation((...args) => {
+        logLines.push(args.join(" "));
+      });
+
+      // refreshCommand reads process.cwd() — chdir into the temp root.
+      const savedCwd = process.cwd();
+      process.chdir(root);
+      let exitCode: number;
+      try {
+        exitCode = await refreshCommand(
+          { stale: true },
+          () => { /* provider already set via env */ },
+        );
+      } finally {
+        process.chdir(savedCwd);
+      }
+
+      expect(exitCode).toBe(0);
+      // (a) page held as candidate — NOT overwritten in wiki/ (old body preserved)
+      const candidates = await listCandidates(root);
+      expect(candidates.some((c) => c.slug === "topic-a")).toBe(true);
+      const livePageContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-a.md"), "utf-8");
+      expect(livePageContent).toContain("Old body.");
+      // (b) output says "held for review", does NOT claim "Refreshed N page(s)"
+      const allOutput = logLines.join("\n");
+      expect(allOutput).toMatch(/held.*for review/i);
+      expect(allOutput).not.toMatch(/Refreshed \d+ page\(s\)/);
     } finally {
       vi.restoreAllMocks();
       delete process.env.LLMWIKI_PROVIDER;

--- a/test/review-candidate-durability.test.ts
+++ b/test/review-candidate-durability.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Durability tests for candidate persistence — Finding 2 & 3 from PR #97.
+ *
+ * Finding 2 (High): sanitizeCandidate must validate sourceStates at read time
+ * so that malformed candidate JSON can never corrupt .llmwiki/state.json on
+ * approval. Invalid entries (non-string hash, non-array concepts, path-traversal
+ * keys) are dropped; valid entries survive and still write normally.
+ *
+ * Finding 3 (Medium): deleteCandidateBySlug must delete ALL candidate files for
+ * a given slug, not just the first match. When duplicates exist (e.g. legacy or
+ * hand-dropped files) the direct-write reconcile path must leave zero remaining
+ * candidate files for that slug.
+ */
+
+import { describe, it, expect } from "vitest";
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+import {
+  deleteCandidateBySlug,
+  listCandidates,
+  readCandidate,
+} from "../src/compiler/candidates.js";
+import { listCandidateFileIds } from "../src/utils/candidate-store.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+const CANDIDATES_DIR = ".llmwiki/candidates";
+
+/** Write a raw object as JSON directly into the candidates dir (bypassing validation). */
+async function seedRawCandidate(dir: string, filename: string, content: object): Promise<void> {
+  const candidatesPath = path.join(dir, CANDIDATES_DIR);
+  await mkdir(candidatesPath, { recursive: true });
+  await writeFile(path.join(candidatesPath, filename), JSON.stringify(content), "utf-8");
+}
+
+/** Minimal valid base for candidate JSON seeded directly to disk. */
+function baseCandidate(id: string, slug: string): object {
+  return {
+    id,
+    title: slug,
+    slug,
+    summary: "S.",
+    sources: ["source.md"],
+    body: "B.",
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    reviewMode: "forced",
+    heldReasons: [{ code: "manual-review-requested" }],
+  };
+}
+
+/** Seed N candidate files for the same slug with distinct ids. */
+async function seedNDuplicates(dir: string, slug: string, count: number): Promise<string[]> {
+  const suffixes = ["aaaa0001", "bbbb0002", "cccc0003"];
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = `${slug}-${suffixes[i]}`;
+    await seedRawCandidate(dir, `${id}.json`, { ...baseCandidate(id, slug) });
+    ids.push(id);
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Finding 2: sourceStates validation in sanitizeCandidate
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper: seed a candidate with a single sourceStates entry where one field
+ * is invalid, read it back, and assert the entry was dropped.
+ */
+async function assertSourceStateEntryDropped(
+  dir: string,
+  id: string,
+  slug: string,
+  invalidEntry: Record<string, unknown>,
+): Promise<void> {
+  await seedRawCandidate(dir, `${id}.json`, {
+    ...baseCandidate(id, slug),
+    sourceStates: { "source.md": invalidEntry },
+  });
+  const candidate = await readCandidate(dir, id);
+  expect(candidate).not.toBeNull();
+  expect(candidate?.sourceStates?.["source.md"]).toBeUndefined();
+}
+
+describe("Finding 2 — sourceStates validation at candidate read time", () => {
+  it("drops sourceState entry whose hash is not a string", async () => {
+    await assertSourceStateEntryDropped(root.dir, "bad-hash-cand", "bad-hash", {
+      hash: 12345,
+      concepts: ["bad-hash"],
+      compiledAt: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("drops sourceState entry whose concepts is not an array", async () => {
+    await assertSourceStateEntryDropped(root.dir, "bad-concepts-cand", "bad-concepts", {
+      hash: "abc123",
+      concepts: "not-an-array",
+      compiledAt: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("drops sourceState entry whose compiledAt is not a string", async () => {
+    await assertSourceStateEntryDropped(root.dir, "bad-compiledat-cand", "bad-compiledat", {
+      hash: "abc123",
+      concepts: ["slug"],
+      compiledAt: 99999,
+    });
+  });
+
+  it("drops sourceState entry with a path-traversal key (../evil.md)", async () => {
+    const id = "traversal-key-cand";
+    await seedRawCandidate(root.dir, `${id}.json`, {
+      ...baseCandidate(id, "traversal-key"),
+      sourceStates: {
+        "../evil.md": { hash: "abc123", concepts: ["slug"], compiledAt: "2026-01-01T00:00:00.000Z" },
+      },
+    });
+    const candidate = await readCandidate(root.dir, id);
+    expect(candidate).not.toBeNull();
+    expect(candidate?.sourceStates?.["../evil.md"]).toBeUndefined();
+  });
+
+  it("drops sourceState entry with a path-separator key (dir/source.md)", async () => {
+    const id = "sep-key-cand";
+    await seedRawCandidate(root.dir, `${id}.json`, {
+      ...baseCandidate(id, "sep-key"),
+      sourceStates: {
+        "dir/source.md": { hash: "abc123", concepts: ["slug"], compiledAt: "2026-01-01T00:00:00.000Z" },
+      },
+    });
+    const candidate = await readCandidate(root.dir, id);
+    expect(candidate).not.toBeNull();
+    expect(candidate?.sourceStates?.["dir/source.md"]).toBeUndefined();
+  });
+
+  it("keeps a fully valid sourceState entry after read", async () => {
+    const id = "valid-state-cand";
+    await seedRawCandidate(root.dir, `${id}.json`, {
+      ...baseCandidate(id, "valid-state"),
+      sourceStates: {
+        "source.md": { hash: "abc123", concepts: ["valid-state"], compiledAt: "2026-01-01T00:00:00.000Z" },
+      },
+    });
+    const candidate = await readCandidate(root.dir, id);
+    expect(candidate?.sourceStates?.["source.md"]).toEqual({
+      hash: "abc123",
+      concepts: ["valid-state"],
+      compiledAt: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("treats sourceStates as absent when the field is not an object", async () => {
+    const id = "non-object-states-cand";
+    await seedRawCandidate(root.dir, `${id}.json`, {
+      ...baseCandidate(id, "non-object-states"),
+      sourceStates: "not-an-object",
+    });
+    const candidate = await readCandidate(root.dir, id);
+    expect(candidate).not.toBeNull();
+    expect(candidate?.sourceStates).not.toBe("not-an-object");
+    if (candidate?.sourceStates !== undefined) {
+      expect(typeof candidate.sourceStates).toBe("object");
+      expect(Object.keys(candidate.sourceStates)).toHaveLength(0);
+    }
+  });
+
+  it("valid entry survives while bad entry is dropped in same candidate", async () => {
+    const id = "mixed-states-cand";
+    await seedRawCandidate(root.dir, `${id}.json`, {
+      ...baseCandidate(id, "mixed-states"),
+      sourceStates: {
+        "bad.md": { hash: 99999, concepts: [id], compiledAt: "2026-01-01T00:00:00.000Z" },
+        "good.md": { hash: "goodhash", concepts: [id], compiledAt: "2026-01-01T00:00:00.000Z" },
+      },
+    });
+    const candidate = await readCandidate(root.dir, id);
+    expect(candidate?.sourceStates?.["bad.md"]).toBeUndefined();
+    expect(candidate?.sourceStates?.["good.md"]?.hash).toBe("goodhash");
+    // Only good.md reaches approval — bad.md can never corrupt state.json
+    expect(Object.keys(candidate?.sourceStates ?? {})).not.toContain("bad.md");
+    expect(Object.keys(candidate?.sourceStates ?? {})).toContain("good.md");
+  });
+
+  it("path-traversal key is absent from sourceStates alongside a valid key", async () => {
+    const badId = "mixed-traversal-cand";
+    const goodId = "mixed-good-cand";
+    await seedRawCandidate(root.dir, `${badId}.json`, {
+      ...baseCandidate(badId, "mixed-bad"),
+      sourceStates: { "../escape.md": { hash: "x", concepts: [], compiledAt: "now" } },
+    });
+    await seedRawCandidate(root.dir, `${goodId}.json`, {
+      ...baseCandidate(goodId, "mixed-good"),
+      sourceStates: { "good.md": { hash: "abc", concepts: ["mixed-good"], compiledAt: "2026-01-01T00:00:00.000Z" } },
+    });
+    const candidates = await listCandidates(root.dir);
+    const bad = candidates.find((c) => c.id === badId);
+    const good = candidates.find((c) => c.id === goodId);
+    expect(bad?.sourceStates?.["../escape.md"]).toBeUndefined();
+    expect(good?.sourceStates?.["good.md"]?.hash).toBe("abc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finding 3: deleteCandidateBySlug must delete ALL duplicates
+// ---------------------------------------------------------------------------
+
+describe("Finding 3 — deleteCandidateBySlug deletes all duplicate files for a slug", () => {
+  it("deletes both candidate files when two exist for the same slug", async () => {
+    await seedNDuplicates(root.dir, "dup-delete-slug", 2);
+    const candidatesDir = path.join(root.dir, CANDIDATES_DIR);
+    expect((await listCandidateFileIds(candidatesDir)).filter((id) => id.startsWith("dup-delete-slug"))).toHaveLength(2);
+
+    const deleted = await deleteCandidateBySlug(root.dir, "dup-delete-slug");
+    expect(deleted).toBe(true);
+    expect((await listCandidateFileIds(candidatesDir)).filter((id) => id.startsWith("dup-delete-slug"))).toHaveLength(0);
+  });
+
+  it("returns false when no candidate exists for the slug", async () => {
+    const result = await deleteCandidateBySlug(root.dir, "nonexistent-slug");
+    expect(result).toBe(false);
+  });
+
+  it("leaves zero candidates in listCandidates after deletion of duplicates", async () => {
+    await seedNDuplicates(root.dir, "zero-after-slug", 2);
+    await deleteCandidateBySlug(root.dir, "zero-after-slug");
+    const remaining = await listCandidates(root.dir);
+    expect(remaining.filter((c) => c.slug === "zero-after-slug")).toHaveLength(0);
+  });
+
+  it("does not affect candidates for other slugs", async () => {
+    await seedNDuplicates(root.dir, "target-slug", 2);
+    await seedRawCandidate(root.dir, "other-slug-aaaa9999.json", {
+      ...baseCandidate("other-slug-aaaa9999", "other-slug"),
+    });
+
+    await deleteCandidateBySlug(root.dir, "target-slug");
+
+    const remaining = await listCandidates(root.dir);
+    expect(remaining.filter((c) => c.slug === "target-slug")).toHaveLength(0);
+    expect(remaining.filter((c) => c.slug === "other-slug")).toHaveLength(1);
+  });
+
+  it("three duplicate files: all three are deleted", async () => {
+    const slug = "triple-dup-slug";
+    await seedNDuplicates(root.dir, slug, 3);
+    const candidatesDir = path.join(root.dir, CANDIDATES_DIR);
+    expect((await listCandidateFileIds(candidatesDir)).filter((id) => id.startsWith(slug))).toHaveLength(3);
+
+    await deleteCandidateBySlug(root.dir, slug);
+
+    expect((await listCandidateFileIds(candidatesDir)).filter((id) => id.startsWith(slug))).toHaveLength(0);
+  });
+});

--- a/test/review-candidate-lifecycle.test.ts
+++ b/test/review-candidate-lifecycle.test.ts
@@ -3,10 +3,14 @@
  *
  * Policy-held candidates are durable state, so repeated compiles for the same
  * slug must update the pending candidate in place instead of appending a new
- * random-id JSON file each time.
+ * random-id JSON file each time. Also verifies that duplicate candidate files
+ * for the same slug are canonicalized to exactly one file when writeCandidate
+ * is called (Issue D).
  */
 
 import { describe, it, expect } from "vitest";
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
 import {
   deleteCandidateBySlug,
   listCandidates,
@@ -14,9 +18,12 @@ import {
   readCandidateBySlug,
   writeCandidate,
 } from "../src/compiler/candidates.js";
+import { listCandidateFileIds } from "../src/utils/candidate-store.js";
 import { useTempRoot } from "./fixtures/temp-root.js";
 
 const root = useTempRoot();
+
+const CANDIDATES_DIR = ".llmwiki/candidates";
 
 function draft(slug: string, body: string) {
   return {
@@ -47,6 +54,60 @@ describe("pending candidate lifecycle", () => {
     expect(await deleteCandidateBySlug(root.dir, "topic")).toBe(true);
     expect(await readCandidateBySlug(root.dir, "topic")).toBeNull();
     expect(await deleteCandidateBySlug(root.dir, "topic")).toBe(false);
+  });
+});
+
+describe("duplicate slug canonicalization (Issue D)", () => {
+  /** Seed two candidate files for the same slug with different ids directly to disk. */
+  async function seedDuplicates(dir: string, slug: string): Promise<{ firstId: string; secondId: string }> {
+    const candidatesPath = path.join(dir, CANDIDATES_DIR);
+    await mkdir(candidatesPath, { recursive: true });
+    const firstId = `${slug}-aaaa0001`;
+    const secondId = `${slug}-bbbb0002`;
+    const base = { title: slug, slug, summary: "S.", sources: ["s.md"], body: "B.",
+      generatedAt: "2026-01-01T00:00:00.000Z", reviewMode: "forced",
+      heldReasons: [{ code: "manual-review-requested" }] };
+    await writeFile(path.join(candidatesPath, `${firstId}.json`), JSON.stringify({ ...base, id: firstId }), "utf-8");
+    await writeFile(path.join(candidatesPath, `${secondId}.json`), JSON.stringify({ ...base, id: secondId }), "utf-8");
+    return { firstId, secondId };
+  }
+
+  it("removes duplicate candidate files when writeCandidate is called for an existing slug", async () => {
+    const { firstId } = await seedDuplicates(root.dir, "dup-slug");
+    const candidatesDir = path.join(root.dir, CANDIDATES_DIR);
+
+    // Sanity-check: two files exist before the call
+    const before = await listCandidateFileIds(candidatesDir);
+    expect(before.filter((id) => id.startsWith("dup-slug"))).toHaveLength(2);
+
+    // writeCandidate should pick the canonical id and delete the extra
+    const result = await writeCandidate(root.dir, draft("dup-slug", "new body"));
+
+    const after = await listCandidateFileIds(candidatesDir);
+    const remaining = after.filter((id) => id.startsWith("dup-slug"));
+    expect(remaining).toHaveLength(1);
+    expect(result.id).toBe(firstId);
+  });
+
+  it("listCandidates returns exactly one candidate per slug after canonicalization", async () => {
+    await seedDuplicates(root.dir, "canon-slug");
+
+    // writeCandidate triggers canonicalization
+    await writeCandidate(root.dir, draft("canon-slug", "updated body"));
+
+    const candidates = await listCandidates(root.dir);
+    const forSlug = candidates.filter((c) => c.slug === "canon-slug");
+    expect(forSlug).toHaveLength(1);
+    expect(forSlug[0]?.body).toBe("updated body");
+  });
+
+  it("preserves the earliest id (canonical) when duplicates exist", async () => {
+    const { firstId } = await seedDuplicates(root.dir, "early-slug");
+
+    await writeCandidate(root.dir, draft("early-slug", "body"));
+
+    const found = await readCandidateBySlug(root.dir, "early-slug");
+    expect(found?.id).toBe(firstId);
   });
 });
 

--- a/test/review-candidate-lifecycle.test.ts
+++ b/test/review-candidate-lifecycle.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for durable pending-candidate lifecycle helpers.
+ *
+ * Policy-held candidates are durable state, so repeated compiles for the same
+ * slug must update the pending candidate in place instead of appending a new
+ * random-id JSON file each time.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  deleteCandidateBySlug,
+  listCandidates,
+  listPendingCandidateSlugs,
+  readCandidateBySlug,
+  writeCandidate,
+} from "../src/compiler/candidates.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+function draft(slug: string, body: string) {
+  return {
+    title: slug,
+    slug,
+    summary: `Summary for ${slug}.`,
+    sources: ["source.md"],
+    body,
+  };
+}
+
+describe("pending candidate lifecycle", () => {
+  it("supersedes an existing slug while preserving candidate id", async () => {
+    const first = await writeCandidate(root.dir, draft("topic", "first body"));
+    const second = await writeCandidate(root.dir, draft("topic", "second body"));
+    const all = await listCandidates(root.dir);
+
+    expect(second.id).toBe(first.id);
+    expect(all).toHaveLength(1);
+    expect(all[0]?.body).toBe("second body");
+  });
+
+  it("lists and deletes pending candidates by slug", async () => {
+    const candidate = await writeCandidate(root.dir, draft("topic", "body"));
+    expect(await readCandidateBySlug(root.dir, "topic")).toMatchObject({ id: candidate.id });
+    expect(await listPendingCandidateSlugs(root.dir)).toEqual(new Set(["topic"]));
+
+    expect(await deleteCandidateBySlug(root.dir, "topic")).toBe(true);
+    expect(await readCandidateBySlug(root.dir, "topic")).toBeNull();
+    expect(await deleteCandidateBySlug(root.dir, "topic")).toBe(false);
+  });
+});
+

--- a/test/review-candidate-metadata.test.ts
+++ b/test/review-candidate-metadata.test.ts
@@ -41,7 +41,7 @@ describe("review candidate metadata", () => {
     });
     const loaded = await readCandidate(root.dir, candidate.id);
     expect(loaded?.reviewMode).toBe("forced");
-    expect(loaded?.heldReasons?.map((r) => r.code)).toEqual(["manual-review-requested"]);
+    expect(loaded?.heldReasons.map((r) => r.code)).toEqual(["manual-review-requested"]);
   });
 
   it("round-trips policy metadata and displays it in list/show", async () => {

--- a/test/review-candidate-metadata.test.ts
+++ b/test/review-candidate-metadata.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for policy-aware review candidate metadata.
+ *
+ * Candidate records now explain why they exist: either forced by `--review` or
+ * held by project policy. These tests keep the persistence and display surface
+ * pinned without expanding the already-full review.test.ts file.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { writeCandidate, readCandidate } from "../src/compiler/candidates.js";
+import reviewListCommand from "../src/commands/review-list.js";
+import reviewShowCommand from "../src/commands/review-show.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+const BODY = [
+  "---",
+  "title: Policy Held",
+  "summary: Held by policy.",
+  "sources: []",
+  'createdAt: "2026-01-01T00:00:00.000Z"',
+  'updatedAt: "2026-01-01T00:00:00.000Z"',
+  "---",
+  "",
+  "Body.",
+].join("\n");
+
+function collectLogOutput(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((args) => args.join(" ")).join("\n");
+}
+
+describe("review candidate metadata", () => {
+  it("defaults writeCandidate metadata to forced manual review", async () => {
+    const candidate = await writeCandidate(root.dir, {
+      title: "Policy Held",
+      slug: "policy-held",
+      summary: "Held by policy.",
+      sources: [],
+      body: BODY,
+    });
+    const loaded = await readCandidate(root.dir, candidate.id);
+    expect(loaded?.reviewMode).toBe("forced");
+    expect(loaded?.heldReasons?.map((r) => r.code)).toEqual(["manual-review-requested"]);
+  });
+
+  it("round-trips policy metadata and displays it in list/show", async () => {
+    const candidate = await writeCandidate(root.dir, {
+      title: "Policy Held",
+      slug: "policy-held",
+      summary: "Held by policy.",
+      sources: [],
+      body: BODY,
+      reviewMode: "policy",
+      heldReasons: [{ code: "low-confidence", detail: "confidence 0.2 < 0.5" }],
+      confidence: 0.2,
+      contradicted: false,
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await reviewListCommand();
+    await reviewShowCommand(candidate.id);
+
+    const output = collectLogOutput(logSpy);
+    expect(output).toContain("policy: low-confidence");
+    expect(output).toContain("confidence 0.2 < 0.5");
+    expect(output).toContain("confidence: 0.2");
+    expect(output).toContain("contradicted: false");
+  });
+});
+

--- a/test/review-candidate-validation.test.ts
+++ b/test/review-candidate-validation.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for defensive candidate JSON validation at the IO boundary.
+ *
+ * Candidate files are durable and user-editable. This test suite verifies that
+ * malformed, truncated, or partially-invalid candidate files are skipped with a
+ * warning rather than crashing `review list`, `review show`, or `listCandidates`.
+ * Valid candidates co-existing with malformed ones must still be returned.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+import {
+  listCandidates,
+  readCandidate,
+  writeCandidate,
+} from "../src/compiler/candidates.js";
+import reviewListCommand from "../src/commands/review-list.js";
+import reviewShowCommand from "../src/commands/review-show.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+const CANDIDATES_DIR = ".llmwiki/candidates";
+
+/** Write a raw JSON string directly into the candidates dir (bypassing validation). */
+async function writeMalformedCandidate(dir: string, filename: string, content: string) {
+  const candidatesPath = path.join(dir, CANDIDATES_DIR);
+  await mkdir(candidatesPath, { recursive: true });
+  await writeFile(path.join(candidatesPath, filename), content, "utf-8");
+}
+
+/** Minimal valid candidate draft for seeding alongside malformed files. */
+function validDraft(slug: string) {
+  return {
+    title: slug,
+    slug,
+    summary: `Summary for ${slug}.`,
+    sources: ["source.md"],
+    body: "Body.",
+  };
+}
+
+describe("candidate JSON validation (Issue C)", () => {
+  it("skips truncated/unparseable JSON and still lists valid candidates", async () => {
+    await writeMalformedCandidate(root.dir, "bad-truncated.json", '{"id":"bad-trunc","title":"T","slug":"bad-trunc","body":"B","sources":[');
+    const valid = await writeCandidate(root.dir, validDraft("good-slug"));
+
+    const candidates = await listCandidates(root.dir);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.id).toBe(valid.id);
+  });
+
+  it("skips a candidate missing required fields (id) without throwing", async () => {
+    const noId = { title: "T", slug: "no-id", body: "B", sources: [] };
+    await writeMalformedCandidate(root.dir, "no-id.json", JSON.stringify(noId));
+
+    const candidates = await listCandidates(root.dir);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("defaults generatedAt when it is a number (non-string)", async () => {
+    const badDate = {
+      id: "bad-date-cand",
+      title: "T",
+      slug: "bad-date",
+      body: "B",
+      sources: [],
+      generatedAt: 12345,
+      reviewMode: "forced",
+      heldReasons: [{ code: "manual-review-requested" }],
+    };
+    await writeMalformedCandidate(root.dir, "bad-date-cand.json", JSON.stringify(badDate));
+
+    const candidate = await readCandidate(root.dir, "bad-date-cand");
+    expect(candidate).not.toBeNull();
+    expect(typeof candidate?.generatedAt).toBe("string");
+  });
+
+  it("defaults reviewMode when value is not a valid ReviewMode", async () => {
+    const bogusMode = {
+      id: "bogus-mode-cand",
+      title: "T",
+      slug: "bogus-mode",
+      body: "B",
+      sources: [],
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      reviewMode: "bogus",
+      heldReasons: [{ code: "manual-review-requested" }],
+    };
+    await writeMalformedCandidate(root.dir, "bogus-mode-cand.json", JSON.stringify(bogusMode));
+
+    const candidate = await readCandidate(root.dir, "bogus-mode-cand");
+    expect(candidate?.reviewMode).toBe("forced");
+  });
+
+  it("drops unknown heldReasons entries and defaults to manual-review-requested when missing", async () => {
+    const noReasons = {
+      id: "no-reasons-cand",
+      title: "T",
+      slug: "no-reasons",
+      body: "B",
+      sources: [],
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      reviewMode: "forced",
+    };
+    await writeMalformedCandidate(root.dir, "no-reasons-cand.json", JSON.stringify(noReasons));
+
+    const candidate = await readCandidate(root.dir, "no-reasons-cand");
+    expect(candidate?.heldReasons).toEqual([{ code: "manual-review-requested" }]);
+  });
+
+  it("drops heldReasons entries with unknown codes", async () => {
+    const unknownCode = {
+      id: "unk-code-cand",
+      title: "T",
+      slug: "unk-code",
+      body: "B",
+      sources: [],
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      reviewMode: "forced",
+      heldReasons: [
+        { code: "unknown-code" },
+        { code: "low-confidence" },
+        { notACode: true },
+      ],
+    };
+    await writeMalformedCandidate(root.dir, "unk-code-cand.json", JSON.stringify(unknownCode));
+
+    const candidate = await readCandidate(root.dir, "unk-code-cand");
+    expect(candidate?.heldReasons.map((r) => r.code)).toEqual(["low-confidence"]);
+  });
+
+  it("review list does not throw when malformed files are present", async () => {
+    await writeMalformedCandidate(root.dir, "crash-bait.json", "not-json-at-all!!!");
+    await writeCandidate(root.dir, validDraft("safe-slug"));
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await expect(reviewListCommand()).resolves.not.toThrow();
+    const out = logSpy.mock.calls.map((a) => a.join(" ")).join("\n");
+    expect(out).toContain("safe-slug");
+  });
+
+  it("review show does not throw for a valid candidate even when malformed files exist", async () => {
+    await writeMalformedCandidate(root.dir, "another-bad.json", '{"broken":}');
+    const good = await writeCandidate(root.dir, validDraft("show-safe-slug"));
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await expect(reviewShowCommand(good.id)).resolves.not.toThrow();
+    const out = logSpy.mock.calls.map((a) => a.join(" ")).join("\n");
+    expect(out).toContain("show-safe-slug");
+  });
+
+  it("heldReasons defaults to manual-review-requested when array is empty after filtering", async () => {
+    const allBadReasons = {
+      id: "all-bad-reasons",
+      title: "T",
+      slug: "all-bad",
+      body: "B",
+      sources: [],
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      reviewMode: "forced",
+      heldReasons: [{ code: "totally-invalid" }, { notCode: "missing" }],
+    };
+    await writeMalformedCandidate(root.dir, "all-bad-reasons.json", JSON.stringify(allBadReasons));
+
+    const candidate = await readCandidate(root.dir, "all-bad-reasons");
+    expect(candidate?.heldReasons).toEqual([{ code: "manual-review-requested" }]);
+  });
+});

--- a/test/review-config.test.ts
+++ b/test/review-config.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the fail-closed review config loader.
+ *
+ * Missing config is the legitimate "policy off" path. A present but corrupt
+ * or invalid `.llmwiki/config.json` must abort instead of silently disabling
+ * review policy.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { loadReviewPolicy, normalizeReviewPolicy, ReviewConfigError } from "../src/review/config.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+async function writeConfig(value: unknown): Promise<void> {
+  await mkdir(path.join(root.dir, ".llmwiki"), { recursive: true });
+  const body = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  await writeFile(path.join(root.dir, ".llmwiki", "config.json"), body, "utf-8");
+}
+
+describe("loadReviewPolicy", () => {
+  it("treats missing config as policy off", async () => {
+    const policy = await loadReviewPolicy(root.dir);
+    expect(policy.hold).toEqual([]);
+    expect(policy.lowConfidenceThreshold).toBe(0.5);
+    expect(policy.treatMissingConfidenceAs).toBe("low");
+  });
+
+  it("loads a valid policy config", async () => {
+    await writeConfig({
+      version: 1,
+      review: {
+        hold: ["low-confidence", "contradicted"],
+        lowConfidenceThreshold: 0.7,
+        treatMissingConfidenceAs: "ok",
+      },
+    });
+    await expect(loadReviewPolicy(root.dir)).resolves.toMatchObject({
+      hold: ["low-confidence", "contradicted"],
+      lowConfidenceThreshold: 0.7,
+      treatMissingConfidenceAs: "ok",
+    });
+  });
+
+  it("throws on corrupt JSON", async () => {
+    await writeConfig("{ broken");
+    await expect(loadReviewPolicy(root.dir)).rejects.toBeInstanceOf(ReviewConfigError);
+  });
+});
+
+describe("normalizeReviewPolicy", () => {
+  it("accepts absent review, empty hold, and explicit off as off", () => {
+    expect(normalizeReviewPolicy({ version: 1 }).hold).toEqual([]);
+    expect(normalizeReviewPolicy({ version: 1, review: { hold: [] } }).hold).toEqual([]);
+    expect(normalizeReviewPolicy({ version: 1, review: { hold: ["off"] } }).hold).toEqual([]);
+  });
+
+  it("rejects unknown modes and bad all/off combinations", () => {
+    expect(() => normalizeReviewPolicy({ review: { hold: ["low_confidence"] } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ review: { hold: ["off", "contradicted"] } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ review: { hold: ["all", "contradicted"] } })).toThrow(ReviewConfigError);
+  });
+
+  it("validates threshold and missing-confidence policy", () => {
+    expect(() => normalizeReviewPolicy({ review: { hold: ["low-confidence"], lowConfidenceThreshold: -0.1 } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ review: { hold: ["low-confidence"], lowConfidenceThreshold: Number.NaN } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ review: { hold: ["low-confidence"], treatMissingConfidenceAs: "maybe" } })).toThrow(ReviewConfigError);
+  });
+
+  it("accepts inert threshold and rejects unsupported version", () => {
+    expect(normalizeReviewPolicy({ version: 1, review: { hold: ["contradicted"], lowConfidenceThreshold: 0.2 } }).lowConfidenceThreshold).toBe(0.2);
+    expect(() => normalizeReviewPolicy({ version: 2, review: { hold: [] } })).toThrow(ReviewConfigError);
+  });
+});
+

--- a/test/review-config.test.ts
+++ b/test/review-config.test.ts
@@ -58,20 +58,25 @@ describe("normalizeReviewPolicy", () => {
   });
 
   it("rejects unknown modes and bad all/off combinations", () => {
-    expect(() => normalizeReviewPolicy({ review: { hold: ["low_confidence"] } })).toThrow(ReviewConfigError);
-    expect(() => normalizeReviewPolicy({ review: { hold: ["off", "contradicted"] } })).toThrow(ReviewConfigError);
-    expect(() => normalizeReviewPolicy({ review: { hold: ["all", "contradicted"] } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ version: 1, review: { hold: ["low_confidence"] } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ version: 1, review: { hold: ["off", "contradicted"] } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ version: 1, review: { hold: ["all", "contradicted"] } })).toThrow(ReviewConfigError);
   });
 
   it("validates threshold and missing-confidence policy", () => {
-    expect(() => normalizeReviewPolicy({ review: { hold: ["low-confidence"], lowConfidenceThreshold: -0.1 } })).toThrow(ReviewConfigError);
-    expect(() => normalizeReviewPolicy({ review: { hold: ["low-confidence"], lowConfidenceThreshold: Number.NaN } })).toThrow(ReviewConfigError);
-    expect(() => normalizeReviewPolicy({ review: { hold: ["low-confidence"], treatMissingConfidenceAs: "maybe" } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ version: 1, review: { hold: ["low-confidence"], lowConfidenceThreshold: -0.1 } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ version: 1, review: { hold: ["low-confidence"], lowConfidenceThreshold: Number.NaN } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ version: 1, review: { hold: ["low-confidence"], treatMissingConfidenceAs: "maybe" } })).toThrow(ReviewConfigError);
   });
 
   it("accepts inert threshold and rejects unsupported version", () => {
     expect(normalizeReviewPolicy({ version: 1, review: { hold: ["contradicted"], lowConfidenceThreshold: 0.2 } }).lowConfidenceThreshold).toBe(0.2);
     expect(() => normalizeReviewPolicy({ version: 2, review: { hold: [] } })).toThrow(ReviewConfigError);
+  });
+
+  it("missing version is a hard error", () => {
+    expect(() => normalizeReviewPolicy({ review: { hold: [] } })).toThrow(ReviewConfigError);
+    expect(() => normalizeReviewPolicy({ review: { hold: [] } })).toThrow('"version": 1');
   });
 });
 

--- a/test/review-integration.test.ts
+++ b/test/review-integration.test.ts
@@ -56,6 +56,8 @@ function mergeCandidateDefaults(overrides: Partial<ReviewCandidate>): ReviewCand
     sources: overrides.sources ?? ["source-a.md"],
     body: overrides.body ?? buildValidPageBody(text.title, text.summary),
     generatedAt: overrides.generatedAt ?? new Date().toISOString(),
+    reviewMode: overrides.reviewMode ?? "forced",
+    heldReasons: overrides.heldReasons ?? [{ code: "manual-review-requested" }],
   };
 }
 

--- a/test/review-lock.test.ts
+++ b/test/review-lock.test.ts
@@ -194,11 +194,11 @@ describe("review reject — lock discipline", () => {
 describe("sequential approvals — source-state persistence under lock", () => {
   /**
    * Two candidates from the same source approved in sequence (simulating what
-   * concurrent approvals would serialize to under lock). The first approval
-   * must NOT persist source state while the sibling is still pending. The
-   * second approval must persist it.
+   * concurrent approvals would serialize to under lock). Each approval immediately
+   * union-adds its own slug — no deferral until last sibling. Both approvals must
+   * result in a defined source-state entry with the correct hash.
    */
-  it("persists source state only after the last sibling candidate is approved", async () => {
+  it("persists source state immediately on each approval, accumulating both slugs", async () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     const { default: reviewApproveCommand } = await import(
@@ -216,16 +216,20 @@ describe("sequential approvals — source-state persistence under lock", () => {
     const alpha = await writeSampleCandidate(root.dir, "Alpha", "alpha", sourceStates);
     const beta = await writeSampleCandidate(root.dir, "Beta", "beta", sourceStates);
 
-    // First approval: sibling beta is still pending → source state NOT written.
+    // First approval: immediately union-adds alpha's slug to source state.
     await reviewApproveCommand(alpha.id);
     const stateAfterFirst = await readStateFile(root.dir);
-    expect(stateAfterFirst?.sources[SHARED_SOURCE]).toBeUndefined();
+    expect(stateAfterFirst?.sources[SHARED_SOURCE]).toBeDefined();
+    expect(stateAfterFirst?.sources[SHARED_SOURCE].hash).toBe("abc123");
+    expect(stateAfterFirst?.sources[SHARED_SOURCE].concepts).toContain("alpha");
 
-    // Second approval: no remaining sibling → source state IS written.
+    // Second approval: union-adds beta's slug — both alpha and beta are now recorded.
     await reviewApproveCommand(beta.id);
     const stateAfterSecond = await readStateFile(root.dir);
     expect(stateAfterSecond?.sources[SHARED_SOURCE]).toBeDefined();
     expect(stateAfterSecond?.sources[SHARED_SOURCE].hash).toBe("abc123");
+    expect(stateAfterSecond?.sources[SHARED_SOURCE].concepts).toContain("alpha");
+    expect(stateAfterSecond?.sources[SHARED_SOURCE].concepts).toContain("beta");
   });
 });
 

--- a/test/review-policy-cli.test.ts
+++ b/test/review-policy-cli.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Subprocess coverage for compile-time review policy.
+ *
+ * The CLI path is exercised with aimock rather than a live LLM. This pins the
+ * user-facing contract that policy-held pages are reported loudly during a
+ * normal `llmwiki compile` run.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, readFile, readdir, writeFile } from "fs/promises";
+import path from "path";
+import { mockClaudeEnv, useAimockLifecycle } from "./fixtures/aimock-helper.js";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+import type { ReviewCandidate } from "../src/utils/types.js";
+
+const aimock = useAimockLifecycle("review-policy-cli");
+
+async function writePolicyConfig(cwd: string): Promise<void> {
+  await mkdir(path.join(cwd, ".llmwiki"), { recursive: true });
+  await writeFile(
+    path.join(cwd, ".llmwiki", "config.json"),
+    JSON.stringify({ version: 1, review: { hold: ["low-confidence"] } }),
+    "utf-8",
+  );
+}
+
+async function readFirstCandidate(cwd: string): Promise<ReviewCandidate> {
+  const dir = path.join(cwd, ".llmwiki", "candidates");
+  const [file] = (await readdir(dir)).filter((candidate) => candidate.endsWith(".json"));
+  const raw = await readFile(path.join(dir, file), "utf-8");
+  return JSON.parse(raw) as ReviewCandidate;
+}
+
+function stubPolicyCompile(handle: Awaited<ReturnType<typeof aimock.start>>): void {
+  handle.mock.onToolCall("extract_concepts", {
+    toolCalls: [
+      {
+        name: "extract_concepts",
+        arguments: {
+          concepts: [
+            { concept: "Alpha", summary: "Alpha summary.", is_new: true, confidence: 0.2 },
+            { concept: "Beta", summary: "Beta summary.", is_new: true, confidence: 0.9 },
+          ],
+        },
+      },
+    ],
+  });
+  handle.mock.onMessage(/.*/, { content: "Generated body from aimock for review policy." });
+}
+
+describe("review policy CLI", () => {
+  it("reports policy-held pages in normal compile output", async () => {
+    const handle = await aimock.start();
+    stubPolicyCompile(handle);
+    const cwd = await aimock.makeWorkspace("# Source\n\nAlpha and Beta.\n");
+    await writePolicyConfig(cwd);
+
+    const result = await runCLI(["compile"], cwd, mockClaudeEnv(handle));
+    expectCLIExit(result, 0);
+
+    expect(result.stdout).toContain("Wrote 1 page(s), held 1 for review");
+    expect(result.stdout).toContain("llmwiki review list");
+    const candidate = await readFirstCandidate(cwd);
+    expect(candidate.slug).toBe("alpha");
+    expect(candidate.reviewMode).toBe("policy");
+    expect(candidate.heldReasons?.map((r) => r.code)).toEqual(["low-confidence"]);
+  }, 30_000);
+});

--- a/test/review-policy-cli.test.ts
+++ b/test/review-policy-cli.test.ts
@@ -63,6 +63,35 @@ describe("review policy CLI", () => {
     const candidate = await readFirstCandidate(cwd);
     expect(candidate.slug).toBe("alpha");
     expect(candidate.reviewMode).toBe("policy");
-    expect(candidate.heldReasons?.map((r) => r.code)).toEqual(["low-confidence"]);
+    expect(candidate.heldReasons.map((r) => r.code)).toEqual(["low-confidence"]);
+  }, 30_000);
+
+  // Test #6: subprocess review list / review show surface reviewMode and reasons
+  // Shared setup: run a policy compile and return the cwd + first candidate id.
+  async function setupPolicyCompile(): Promise<{ cwd: string; candidateId: string }> {
+    const handle = await aimock.start();
+    stubPolicyCompile(handle);
+    const cwd = await aimock.makeWorkspace("# Source\n\nAlpha and Beta.\n");
+    await writePolicyConfig(cwd);
+    await runCLI(["compile"], cwd, mockClaudeEnv(handle));
+    const candidate = await readFirstCandidate(cwd);
+    return { cwd, candidateId: candidate.id };
+  }
+
+  it("review list subprocess shows reviewMode and reason codes", async () => {
+    const { cwd } = await setupPolicyCompile();
+    const listResult = await runCLI(["review", "list"], cwd);
+    expectCLIExit(listResult, 0);
+    expect(listResult.stdout).toContain("policy");
+    expect(listResult.stdout).toContain("low-confidence");
+  }, 30_000);
+
+  it("review show subprocess surfaces confidence and reviewMode", async () => {
+    const { cwd, candidateId } = await setupPolicyCompile();
+    const showResult = await runCLI(["review", "show", candidateId], cwd);
+    expectCLIExit(showResult, 0);
+    expect(showResult.stdout).toContain("policy");
+    expect(showResult.stdout).toContain("low-confidence");
+    expect(showResult.stdout).toContain("confidence");
   }, 30_000);
 });

--- a/test/review-policy-cli.test.ts
+++ b/test/review-policy-cli.test.ts
@@ -7,11 +7,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { mkdir, readFile, readdir, writeFile } from "fs/promises";
+import { access, mkdir, readFile, readdir, writeFile } from "fs/promises";
 import path from "path";
 import { mockClaudeEnv, useAimockLifecycle } from "./fixtures/aimock-helper.js";
 import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
 import type { ReviewCandidate } from "../src/utils/types.js";
+import type { WikiState } from "../src/utils/types.js";
 
 const aimock = useAimockLifecycle("review-policy-cli");
 
@@ -94,4 +95,44 @@ describe("review policy CLI", () => {
     expect(showResult.stdout).toContain("low-confidence");
     expect(showResult.stdout).toContain("confidence");
   }, 30_000);
+
+  // Test: full approve lifecycle — policy compile holds a candidate, then approve lands it.
+  it("approve promotes held candidate to wiki/ and records slug in state", async () => {
+    const handle = await aimock.start();
+    stubPolicyCompile(handle);
+    const cwd = await aimock.makeWorkspace("# Source\n\nAlpha and Beta.\n");
+    await writePolicyConfig(cwd);
+
+    // Step 1: compile with low-confidence policy — alpha should be HELD.
+    const compileResult = await runCLI(["compile"], cwd, mockClaudeEnv(handle));
+    expectCLIExit(compileResult, 0);
+    const candidatesDir = path.join(cwd, ".llmwiki", "candidates");
+    const candidateFiles = (await readdir(candidatesDir)).filter((f) => f.endsWith(".json"));
+    expect(candidateFiles.length).toBeGreaterThanOrEqual(1);
+    const conceptPage = path.join(cwd, "wiki", "concepts", "alpha.md");
+    await expect(access(conceptPage)).rejects.toThrow();
+
+    // Step 2: read the held candidate id.
+    const candidate = await readFirstCandidate(cwd);
+    const { id: candidateId, slug } = candidate;
+
+    // Step 3: approve via subprocess (embeddings may warn but exit 0 is guaranteed).
+    const approveResult = await runCLI(["review", "approve", candidateId], cwd, mockClaudeEnv(handle));
+    expectCLIExit(approveResult, 0);
+
+    // Step 4a: concept page is now live.
+    await expect(access(path.join(cwd, "wiki", "concepts", `${slug}.md`))).resolves.toBeUndefined();
+
+    // Step 4b: candidate file is cleared from the pending area.
+    const remaining = await readdir(candidatesDir).catch(() => [] as string[]);
+    expect(remaining.filter((f) => f === `${candidateId}.json`)).toHaveLength(0);
+
+    // Step 4c: state.sources records the approved slug (requires sourceStates in candidate).
+    if (candidate.sourceStates) {
+      const stateRaw = await readFile(path.join(cwd, ".llmwiki", "state.json"), "utf-8");
+      const state = JSON.parse(stateRaw) as WikiState;
+      const allConcepts = Object.values(state.sources).flatMap((s) => s.concepts);
+      expect(allConcepts).toContain(slug);
+    }
+  }, 60_000);
 });

--- a/test/review-policy-compile.test.ts
+++ b/test/review-policy-compile.test.ts
@@ -77,7 +77,11 @@ describe("compile review policy", () => {
     expect(candidates[0]?.heldReasons.map((r) => r.code)).toEqual(["low-confidence"]);
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "beta.md"))).toBe(true);
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "alpha.md"))).toBe(false);
-    expect(state.sources["sample.md"]).toBeUndefined();
+    // New semantics: source is recorded with only live concepts (beta), not undefined.
+    // Alpha is held → excluded from state. Beta is live → included.
+    expect(state.sources["sample.md"]).toBeDefined();
+    expect(state.sources["sample.md"]?.concepts).toContain("beta");
+    expect(state.sources["sample.md"]?.concepts).not.toContain("alpha");
   });
 
   it("approval persists deferred source state and prevents unchanged re-extraction", async () => {
@@ -145,8 +149,12 @@ describe("compile review policy", () => {
     expect(second.candidates![0]).toBe(id1);
   });
 
-  // Test #3: reject → source re-proposes on next compile
-  it("rejected candidate is re-held on next compile when source still trips policy", async () => {
+  // Test #3: reject suppresses until source changes (new semantics)
+  // Reject records no source-state change — the rejected concept is simply not
+  // recorded. Because the source IS recorded (with its live concepts) after the
+  // first compile, the source is seen as unchanged on the next compile and alpha
+  // is NOT re-proposed until the source content changes.
+  it("rejected candidate is suppressed until source content changes", async () => {
     await writeReviewConfig(["low-confidence"]);
     const spy = stubTwoConcepts();
     vi.spyOn(console, "log").mockImplementation(() => {});
@@ -163,10 +171,25 @@ describe("compile review policy", () => {
 
     spy.mockRestore();
     stubTwoConcepts();
-    const second = await compileAndReport(ctx.dir);
+    // Source unchanged — alpha is suppressed (not re-held)
+    const secondUnchanged = await compileAndReport(ctx.dir);
+    expect(secondUnchanged.compiled).toBe(0);
+    expect(secondUnchanged.candidates ?? []).toEqual([]);
+
+    // Source changes — alpha re-proposes on the next compile
+    await writeFile(
+      path.join(ctx.dir, "sources", "sample.md"),
+      "# Sample\n\nAlpha and Beta updated content after reject.\n",
+      "utf-8",
+    );
+    spy.mockRestore();
+    vi.restoreAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    stubTwoConcepts();
+    const secondChanged = await compileAndReport(ctx.dir);
 
     const candidates = await listCandidates(ctx.dir);
-    expect(second.candidates!.length).toBeGreaterThan(0);
+    expect(secondChanged.candidates!.length).toBeGreaterThan(0);
     expect(candidates.some((c) => c.slug === "alpha" && c.reviewMode === "policy")).toBe(true);
   });
 

--- a/test/review-policy-compile.test.ts
+++ b/test/review-policy-compile.test.ts
@@ -14,6 +14,7 @@ import { existsSync } from "fs";
 import { compileAndReport } from "../src/compiler/index.js";
 import { listCandidates } from "../src/compiler/candidates.js";
 import reviewApproveCommand from "../src/commands/review-approve.js";
+import reviewRejectCommand from "../src/commands/review-reject.js";
 import { AnthropicProvider } from "../src/providers/anthropic.js";
 import { readStateClassified } from "../src/utils/state.js";
 import { CONCEPTS_DIR } from "../src/utils/constants.js";
@@ -73,7 +74,7 @@ describe("compile review policy", () => {
     expect(result.pages).toEqual(["beta"]);
     expect(result.concepts).toEqual(["Alpha", "Beta"]);
     expect(candidates[0]?.reviewMode).toBe("policy");
-    expect(candidates[0]?.heldReasons?.map((r) => r.code)).toEqual(["low-confidence"]);
+    expect(candidates[0]?.heldReasons.map((r) => r.code)).toEqual(["low-confidence"]);
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "beta.md"))).toBe(true);
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "alpha.md"))).toBe(false);
     expect(state.sources["sample.md"]).toBeUndefined();
@@ -119,5 +120,131 @@ describe("compile review policy", () => {
     expect(result.review).toBeUndefined();
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "alpha.md"))).toBe(true);
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "beta.md"))).toBe(true);
+  });
+
+  // Test #1: candidate id preserved across a real recompile with changed source
+  it("preserves candidate id when the source changes and re-trips policy", async () => {
+    await writeReviewConfig(["low-confidence"]);
+    stubTwoConcepts();
+
+    const first = await compileAndReport(ctx.dir);
+    const id1 = first.candidates![0]!;
+
+    // Mutate the source file so the content/hash changes
+    await writeFile(
+      path.join(ctx.dir, "sources", "sample.md"),
+      "# Sample\n\nAlpha and Beta are now different content.\n",
+      "utf-8",
+    );
+    stubTwoConcepts();
+    const second = await compileAndReport(ctx.dir);
+
+    const candidates = await listCandidates(ctx.dir);
+    const alphaSlugCandidates = candidates.filter((c) => c.slug === "alpha");
+    expect(alphaSlugCandidates).toHaveLength(1);
+    expect(second.candidates![0]).toBe(id1);
+  });
+
+  // Test #3: reject → source re-proposes on next compile
+  it("rejected candidate is re-held on next compile when source still trips policy", async () => {
+    await writeReviewConfig(["low-confidence"]);
+    const spy = stubTwoConcepts();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const first = await compileAndReport(ctx.dir);
+    const heldId = first.candidates![0]!;
+    const cwd = process.cwd();
+    process.chdir(ctx.dir);
+    try {
+      await reviewRejectCommand(heldId);
+    } finally {
+      process.chdir(cwd);
+    }
+
+    spy.mockRestore();
+    stubTwoConcepts();
+    const second = await compileAndReport(ctx.dir);
+
+    const candidates = await listCandidates(ctx.dir);
+    expect(second.candidates!.length).toBeGreaterThan(0);
+    expect(candidates.some((c) => c.slug === "alpha" && c.reviewMode === "policy")).toBe(true);
+  });
+
+  // Test #4: direct-write reconcile (L1) — policy off + changed source removes pending candidate
+  it("removes pending candidate when policy is off and source changes force a direct write", async () => {
+    await writeReviewConfig(["low-confidence"]);
+    stubTwoConcepts();
+    await compileAndReport(ctx.dir);
+
+    const before = await listCandidates(ctx.dir);
+    expect(before.some((c) => c.slug === "alpha")).toBe(true);
+
+    // Turn policy off AND change the source so the short-circuit is bypassed
+    await writeReviewConfig([]);
+    await writeFile(
+      path.join(ctx.dir, "sources", "sample.md"),
+      "# Sample\n\nAlpha and Beta changed content for direct write.\n",
+      "utf-8",
+    );
+    stubTwoConcepts();
+    await compileAndReport(ctx.dir);
+
+    const after = await listCandidates(ctx.dir);
+    expect(after.some((c) => c.slug === "alpha")).toBe(false);
+    expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "alpha.md"))).toBe(true);
+  });
+
+  // Test #5: --review compile produces reviewMode "forced" + manual-review-requested
+  it("--review compile produces forced reviewMode with manual-review-requested reason", async () => {
+    stubTwoConcepts();
+
+    const result = await compileAndReport(ctx.dir, { review: true });
+
+    const candidates = await listCandidates(ctx.dir);
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const candidate of candidates) {
+      expect(candidate.reviewMode).toBe("forced");
+      expect(candidate.heldReasons.map((r) => r.code)).toContain("manual-review-requested");
+    }
+    expect(result.review?.forced.length).toBeGreaterThan(0);
+  });
+});
+
+// Test #2: seed pages bypass policy (separate describe to isolate LLM stub strategy)
+describe("seed pages bypass review policy", () => {
+  const seedCtx = useCompileProject({ dirSuffix: "seed-policy", sourceFile: "empty.md", sourceContent: "" });
+
+  async function writeSchemaWithSeedPage(rootDir: string): Promise<void> {
+    const schema = {
+      version: 1, defaultKind: "concept", kinds: {},
+      seedPages: [{ title: "My Overview", kind: "overview", summary: "Top-level overview." }],
+    };
+    await writeFile(path.join(rootDir, ".llmwiki", "schema.json"), JSON.stringify(schema), "utf-8");
+  }
+
+  async function writeLowConfidencePolicy(rootDir: string): Promise<void> {
+    await writeFile(
+      path.join(rootDir, ".llmwiki", "config.json"),
+      JSON.stringify({ version: 1, review: { hold: ["low-confidence"] } }),
+      "utf-8",
+    );
+  }
+
+  it("writes seed pages directly even when low-confidence policy is active", async () => {
+    await writeSchemaWithSeedPage(seedCtx.dir);
+    await writeLowConfidencePolicy(seedCtx.dir);
+    const llm = await import("../src/utils/llm.js");
+    vi.spyOn(llm, "callClaude").mockImplementation(async ({ tools }) => {
+      if (tools && tools.length > 0) return JSON.stringify({ concepts: [] });
+      return "## My Overview\n\nThis is a seed page body.\n";
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await compileAndReport(seedCtx.dir);
+
+    const seedPath = path.join(seedCtx.dir, CONCEPTS_DIR, "my-overview.md");
+    expect(existsSync(seedPath)).toBe(true);
+    const candidates = await listCandidates(seedCtx.dir);
+    expect(candidates.some((c) => c.slug === "my-overview")).toBe(false);
   });
 });

--- a/test/review-policy-compile.test.ts
+++ b/test/review-policy-compile.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Compile integration tests for review policy.
+ *
+ * These use the repo's normal stubbed-provider convention: extraction and page
+ * generation are deterministic, offline, and exercise the real compile
+ * pipeline. The mixed-source test locks the critical source-state rule: a
+ * source that feeds any held candidate is not marked compiled until approval.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { existsSync } from "fs";
+import { compileAndReport } from "../src/compiler/index.js";
+import { listCandidates } from "../src/compiler/candidates.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { readStateClassified } from "../src/utils/state.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const ctx = useCompileProject({
+  dirSuffix: "review-policy",
+  sourceFile: "sample.md",
+  sourceContent: "# Sample\n\nAlpha and Beta are related.",
+});
+
+const PAGE_BODY = "Generated page body with enough content to be valid.";
+
+async function writeReviewConfig(hold: string[]): Promise<void> {
+  await mkdir(path.join(ctx.dir, ".llmwiki"), { recursive: true });
+  await writeFile(
+    path.join(ctx.dir, ".llmwiki", "config.json"),
+    JSON.stringify({ version: 1, review: { hold, lowConfidenceThreshold: 0.5 } }),
+    "utf-8",
+  );
+}
+
+function stubTwoConcepts(): ReturnType<typeof vi.spyOn> {
+  const extraction = JSON.stringify({
+    concepts: [
+      { concept: "Alpha", summary: "Alpha summary.", is_new: true, confidence: 0.2 },
+      { concept: "Beta", summary: "Beta summary.", is_new: true, confidence: 0.9 },
+    ],
+  });
+  const spy = vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(extraction);
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(PAGE_BODY);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return spy;
+}
+
+async function approveInProject(candidateId: string): Promise<void> {
+  const cwd = process.cwd();
+  process.chdir(ctx.dir);
+  try {
+    await reviewApproveCommand(candidateId);
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+describe("compile review policy", () => {
+  it("holds only pages that trip policy and defers source state for mixed sources", async () => {
+    await writeReviewConfig(["low-confidence"]);
+    stubTwoConcepts();
+
+    const result = await compileAndReport(ctx.dir);
+    const candidates = await listCandidates(ctx.dir);
+    const { state } = await readStateClassified(ctx.dir);
+
+    expect(result.review?.held.map((c) => c.slug)).toEqual(["alpha"]);
+    expect(result.candidates).toEqual([candidates[0]?.id]);
+    expect(result.pages).toEqual(["beta"]);
+    expect(result.concepts).toEqual(["Alpha", "Beta"]);
+    expect(candidates[0]?.reviewMode).toBe("policy");
+    expect(candidates[0]?.heldReasons?.map((r) => r.code)).toEqual(["low-confidence"]);
+    expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "beta.md"))).toBe(true);
+    expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "alpha.md"))).toBe(false);
+    expect(state.sources["sample.md"]).toBeUndefined();
+  });
+
+  it("approval persists deferred source state and prevents unchanged re-extraction", async () => {
+    await writeReviewConfig(["low-confidence"]);
+    const extractSpy = stubTwoConcepts();
+
+    const first = await compileAndReport(ctx.dir);
+    await approveInProject(first.candidates![0]!);
+    const second = await compileAndReport(ctx.dir);
+    const { state } = await readStateClassified(ctx.dir);
+
+    expect(state.sources["sample.md"]).toBeDefined();
+    expect(second.compiled).toBe(0);
+    expect(second.candidates ?? []).toEqual([]);
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not duplicate or re-extract an unchanged pending candidate", async () => {
+    await writeReviewConfig(["low-confidence"]);
+    const extractSpy = stubTwoConcepts();
+
+    const first = await compileAndReport(ctx.dir);
+    const firstId = first.candidates![0]!;
+    const second = await compileAndReport(ctx.dir);
+    const candidates = await listCandidates(ctx.dir);
+
+    expect(second.compiled).toBe(0);
+    expect(second.candidates ?? []).toEqual([]);
+    expect(candidates.map((c) => c.id)).toEqual([firstId]);
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("policy off preserves normal direct-write behavior", async () => {
+    await writeReviewConfig([]);
+    stubTwoConcepts();
+
+    const result = await compileAndReport(ctx.dir);
+
+    expect(result.candidates ?? []).toEqual([]);
+    expect(result.review).toBeUndefined();
+    expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "alpha.md"))).toBe(true);
+    expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "beta.md"))).toBe(true);
+  });
+});

--- a/test/review-policy-compile.test.ts
+++ b/test/review-policy-compile.test.ts
@@ -119,11 +119,16 @@ describe("compile review policy", () => {
     stubTwoConcepts();
 
     const result = await compileAndReport(ctx.dir);
+    const { state } = await readStateClassified(ctx.dir);
 
     expect(result.candidates ?? []).toEqual([]);
     expect(result.review).toBeUndefined();
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "alpha.md"))).toBe(true);
     expect(existsSync(path.join(ctx.dir, CONCEPTS_DIR, "beta.md"))).toBe(true);
+    // Regression guard: live-concept filter must not drop concepts when nothing is held.
+    // Both alpha and beta must appear in state even with policy off.
+    expect(state.sources["sample.md"]?.concepts).toContain("alpha");
+    expect(state.sources["sample.md"]?.concepts).toContain("beta");
   });
 
   // Test #1: candidate id preserved across a real recompile with changed source
@@ -230,6 +235,21 @@ describe("compile review policy", () => {
       expect(candidate.heldReasons.map((r) => r.code)).toContain("manual-review-requested");
     }
     expect(result.review?.forced.length).toBeGreaterThan(0);
+  });
+
+  // Test #6: held candidate ordering is stable and matches extraction (source) order
+  it("held candidates appear in extraction order, not parallel-completion order", async () => {
+    await writeReviewConfig(["all"]);
+    stubTwoConcepts();
+
+    const result = await compileAndReport(ctx.dir);
+
+    // Both alpha and beta are held. They must appear in the order the LLM extracted them
+    // (alpha first, beta second) — not in parallel-completion order.
+    expect(result.review?.held.map((c) => c.slug)).toEqual(["alpha", "beta"]);
+    expect(result.candidates).toHaveLength(2);
+    expect(result.candidates![0]).toBe(result.review?.held[0]?.id);
+    expect(result.candidates![1]).toBe(result.review?.held[1]?.id);
   });
 });
 

--- a/test/review-policy-source-state.test.ts
+++ b/test/review-policy-source-state.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Source-state integrity tests for the review-policy feature.
+ *
+ * Covers two data-integrity bugs in the live-concept recording model:
+ *
+ *   H1 (merge integrity): a source feeding a held page AND a live merged page
+ *   must be recorded in state with the live concept slug so that a later change
+ *   to the co-contributor correctly pulls the doc.md source back into the batch.
+ *
+ *   #4 (reject leakage): approving one candidate from a source that had multiple
+ *   held concepts must add only the approved slug to state, never the rejected sibling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import path from "path";
+import os from "os";
+import { compileAndReport } from "../src/compiler/index.js";
+import { listCandidates } from "../src/compiler/candidates.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import reviewRejectCommand from "../src/commands/review-reject.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { readStateClassified } from "../src/utils/state.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+
+/** Write a review policy config with the given hold modes into a project root. */
+async function writeReviewConfig(rootDir: string, hold: string[]): Promise<void> {
+  await writeFile(
+    path.join(rootDir, ".llmwiki", "config.json"),
+    JSON.stringify({ version: 1, review: { hold, lowConfidenceThreshold: 0.5 } }),
+    "utf-8",
+  );
+}
+
+/**
+ * Run a review command (approve/reject) scoped to a project dir so the
+ * command's cwd-based root discovery works.
+ */
+async function runReviewCommand(
+  rootDir: string,
+  fn: (id: string) => Promise<void>,
+  id: string,
+): Promise<void> {
+  const cwd = process.cwd();
+  process.chdir(rootDir);
+  try {
+    await fn(id);
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+/** Create a minimal llmwiki project root with the required directory structure. */
+async function makeProjectRoot(suffix: string): Promise<string> {
+  const rootDir = path.join(os.tmpdir(), `llmwiki-${suffix}-${Date.now()}`);
+  await mkdir(path.join(rootDir, "sources"), { recursive: true });
+  await mkdir(path.join(rootDir, "wiki", "concepts"), { recursive: true });
+  await mkdir(path.join(rootDir, ".llmwiki"), { recursive: true });
+  return rootDir;
+}
+
+/** Set up env vars for the stubbed provider and suppress console output. */
+function setupTestEnv(): void {
+  process.env.LLMWIKI_PROVIDER = "anthropic";
+  process.env.ANTHROPIC_API_KEY = "test-key";
+  vi.spyOn(console, "log").mockImplementation(() => {});
+}
+
+/** Remove env vars set by setupTestEnv. */
+function teardownTestEnv(): void {
+  delete process.env.LLMWIKI_PROVIDER;
+  delete process.env.ANTHROPIC_API_KEY;
+}
+
+// ---------------------------------------------------------------------------
+// H1: merge-integrity — two-source scenario
+// ---------------------------------------------------------------------------
+
+/** Sentinel string only present in page content when doc.md is in the compile batch. */
+const DOC_SENTINEL = "DOC_MD_EXCLUSIVE_CONTENT_SENTINEL";
+
+/** Extraction JSON for doc.md: Alpha (low-conf) + Beta (high-conf). */
+const DOC_EXTRACTION = JSON.stringify({
+  concepts: [
+    { concept: "Alpha", summary: "Alpha summary.", is_new: true, confidence: 0.2 },
+    { concept: "Beta", summary: "Beta summary.", is_new: true, confidence: 0.9 },
+  ],
+});
+
+/** Extraction JSON for other.md: Beta (high-conf) only. */
+const OTHER_EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Beta", summary: "Beta summary.", is_new: false, confidence: 0.9 }],
+});
+
+/** Stub extraction so doc.md produces Alpha+Beta and other.md produces Beta. */
+function stubH1Extraction(): void {
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(
+    async (system: string) => system.includes("Other") ? OTHER_EXTRACTION : DOC_EXTRACTION,
+  );
+}
+
+/** Stub page generation: include sentinel whenever doc.md context is present. */
+function stubH1Generation(): void {
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockImplementation(
+    async (system: string) =>
+      system.includes("Doc") || system.includes("doc.md")
+        ? `Beta page body. ${DOC_SENTINEL} ^[doc.md]`
+        : "Beta page body from other source. ^[other.md]",
+  );
+}
+
+describe("H1 — merge integrity: mixed-source state preserves co-contributor", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    setupTestEnv();
+    rootDir = await makeProjectRoot("h1");
+    await writeFile(path.join(rootDir, "sources", "doc.md"), "# Doc\n\nDoc content about Alpha and Beta.", "utf-8");
+    await writeFile(path.join(rootDir, "sources", "other.md"), "# Other\n\nOther content about Beta.", "utf-8");
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    teardownTestEnv();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("records doc.md state with live concept beta so it is pulled into merged recompile", async () => {
+    await writeReviewConfig(rootDir, ["low-confidence"]);
+    stubH1Extraction();
+    stubH1Generation();
+
+    await compileAndReport(rootDir);
+
+    const { state } = await readStateClassified(rootDir);
+    // doc.md must be in state with live concept "beta" — not undefined (the bug).
+    expect(state.sources["doc.md"]).toBeDefined();
+    expect(state.sources["doc.md"]?.concepts).toContain("beta");
+    expect(state.sources["doc.md"]?.concepts).not.toContain("alpha");
+  });
+
+  it("beta page lists doc.md as source after other.md changes (H1 merge guard)", async () => {
+    await writeReviewConfig(rootDir, ["low-confidence"]);
+    stubH1Extraction();
+    stubH1Generation();
+    await compileAndReport(rootDir);
+
+    // Prerequisite: doc.md must already be in state (proven by H1 test 1).
+    const { state: stateAfterFirst } = await readStateClassified(rootDir);
+    expect(stateAfterFirst.sources["doc.md"]).toBeDefined();
+
+    // Mutate other.md so a recompile is triggered.
+    await writeFile(path.join(rootDir, "sources", "other.md"), "# Other\n\nOther changed content.", "utf-8");
+    vi.restoreAllMocks();
+    setupTestEnv();
+    // Second compile: other.md changed → doc.md pulled as affected source.
+    vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(
+      async (system: string) => system.includes("Other changed") ? OTHER_EXTRACTION : DOC_EXTRACTION,
+    );
+    stubH1Generation();
+
+    await compileAndReport(rootDir);
+
+    // doc.md must be listed in beta.md sources — it was re-merged as co-contributor.
+    const betaContent = await readFile(path.join(rootDir, CONCEPTS_DIR, "beta.md"), "utf-8");
+    expect(betaContent).toContain("doc.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4: reject leakage — one source, multiple held concepts
+// ---------------------------------------------------------------------------
+
+describe("#4 — reject leakage: approving alpha does not record rejected beta", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    setupTestEnv();
+    rootDir = await makeProjectRoot("reject-leak");
+    await writeFile(path.join(rootDir, "sources", "source.md"), "# Source\n\nAlpha and Beta content.", "utf-8");
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    teardownTestEnv();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  function stubBothHeld(): ReturnType<typeof vi.spyOn> {
+    // Both alpha and beta are low-confidence → both held
+    const extraction = JSON.stringify({
+      concepts: [
+        { concept: "Alpha", summary: "Alpha summary.", is_new: true, confidence: 0.2 },
+        { concept: "Beta", summary: "Beta summary.", is_new: true, confidence: 0.3 },
+      ],
+    });
+    const spy = vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(extraction);
+    vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Page body. ^[source.md]");
+    return spy;
+  }
+
+  /** Compile, find the alpha and beta candidates, reject beta, approve alpha. */
+  async function compileAndRejectBetaApproveAlpha(): Promise<void> {
+    await compileAndReport(rootDir);
+    const candidates = await listCandidates(rootDir);
+    const alphaCandidate = candidates.find((c) => c.slug === "alpha");
+    const betaCandidate = candidates.find((c) => c.slug === "beta");
+    expect(alphaCandidate).toBeDefined();
+    expect(betaCandidate).toBeDefined();
+    await runReviewCommand(rootDir, reviewRejectCommand, betaCandidate!.id);
+    await runReviewCommand(rootDir, reviewApproveCommand, alphaCandidate!.id);
+  }
+
+  it("after rejecting beta and approving alpha, state has alpha but not beta", async () => {
+    await writeReviewConfig(rootDir, ["low-confidence"]);
+    stubBothHeld();
+
+    await compileAndRejectBetaApproveAlpha();
+
+    const { state } = await readStateClassified(rootDir);
+    expect(state.sources["source.md"]?.concepts).toContain("alpha");
+    expect(state.sources["source.md"]?.concepts).not.toContain("beta");
+  });
+
+  it("after rejecting beta and approving alpha, a recompile does not re-offer beta", async () => {
+    await writeReviewConfig(rootDir, ["low-confidence"]);
+    const spy = stubBothHeld();
+
+    await compileAndRejectBetaApproveAlpha();
+
+    spy.mockRestore();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    // Source unchanged — beta must not re-appear
+    const second = await compileAndReport(rootDir);
+
+    expect(second.compiled).toBe(0);
+    expect((second.candidates ?? []).length).toBe(0);
+    const afterCandidates = await listCandidates(rootDir);
+    expect(afterCandidates.some((c) => c.slug === "beta")).toBe(false);
+  });
+});

--- a/test/review-policy-source-state.test.ts
+++ b/test/review-policy-source-state.test.ts
@@ -1,7 +1,7 @@
 /**
  * Source-state integrity tests for the review-policy feature.
  *
- * Covers two data-integrity bugs in the live-concept recording model:
+ * Covers three data-integrity scenarios in the live-concept recording model:
  *
  *   H1 (merge integrity): a source feeding a held page AND a live merged page
  *   must be recorded in state with the live concept slug so that a later change
@@ -9,6 +9,11 @@
  *
  *   #4 (reject leakage): approving one candidate from a source that had multiple
  *   held concepts must add only the approved slug to state, never the rejected sibling.
+ *
+ *   #5 (sibling drop): when a source produces two held candidates and both are
+ *   approved (in either order), both slugs must appear in state. The old deferral
+ *   model dropped the first-approved slug because addApprovedSlugToSourceState was
+ *   skipped while any sibling was still pending.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -237,5 +242,84 @@ describe("#4 — reject leakage: approving alpha does not record rejected beta",
     expect((second.candidates ?? []).length).toBe(0);
     const afterCandidates = await listCandidates(rootDir);
     expect(afterCandidates.some((c) => c.slug === "beta")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5: sibling drop — both held candidates approved, both slugs must land in state
+// ---------------------------------------------------------------------------
+
+describe("#5 — sibling drop: approving two siblings from one source records both slugs", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    setupTestEnv();
+    rootDir = await makeProjectRoot("sibling-drop");
+    await writeFile(
+      path.join(rootDir, "sources", "topic.md"),
+      "# Topic\n\nAlpha and Beta content.",
+      "utf-8",
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    teardownTestEnv();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** Stub extraction: topic.md produces alpha + beta, both low-confidence (held). */
+  function stubBothHeld(): void {
+    const extraction = JSON.stringify({
+      concepts: [
+        { concept: "Alpha", summary: "Alpha summary.", is_new: true, confidence: 0.2 },
+        { concept: "Beta", summary: "Beta summary.", is_new: true, confidence: 0.3 },
+      ],
+    });
+    vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(extraction);
+    vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Page body. ^[topic.md]");
+  }
+
+  /**
+   * Compile topic.md and return the alpha and beta candidates.
+   * Asserts both are present so callers can proceed without extra guards.
+   */
+  async function compileBothHeld(): Promise<{ alpha: { id: string }; beta: { id: string } }> {
+    await compileAndReport(rootDir);
+    const candidates = await listCandidates(rootDir);
+    const alpha = candidates.find((c) => c.slug === "alpha");
+    const beta = candidates.find((c) => c.slug === "beta");
+    expect(alpha).toBeDefined();
+    expect(beta).toBeDefined();
+    return { alpha: alpha!, beta: beta! };
+  }
+
+  /** Assert that topic.md state contains both alpha and beta slugs. */
+  async function assertBothSlugsInState(): Promise<void> {
+    const { state } = await readStateClassified(rootDir);
+    expect(state.sources["topic.md"]?.concepts).toContain("alpha");
+    expect(state.sources["topic.md"]?.concepts).toContain("beta");
+  }
+
+  it("approve alpha then beta: state contains both slugs", async () => {
+    await writeReviewConfig(rootDir, ["low-confidence"]);
+    stubBothHeld();
+    const { alpha, beta } = await compileBothHeld();
+
+    await runReviewCommand(rootDir, reviewApproveCommand, alpha.id);
+    await runReviewCommand(rootDir, reviewApproveCommand, beta.id);
+
+    await assertBothSlugsInState();
+  });
+
+  it("approve beta then alpha: state contains both slugs", async () => {
+    await writeReviewConfig(rootDir, ["low-confidence"]);
+    stubBothHeld();
+    const { alpha, beta } = await compileBothHeld();
+
+    await runReviewCommand(rootDir, reviewApproveCommand, beta.id);
+    await runReviewCommand(rootDir, reviewApproveCommand, alpha.id);
+
+    await assertBothSlugsInState();
   });
 });

--- a/test/review-policy.test.ts
+++ b/test/review-policy.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the pure review-policy evaluator.
+ *
+ * These cover the page-level decision logic without running compile or touching
+ * the filesystem. Compile integration tests later verify that the signals fed
+ * into this function come from the final generated page artifact.
+ */
+
+import { describe, it, expect } from "vitest";
+import { evaluatePolicy, isPolicyOff, type PolicySignals, type ReviewPolicy } from "../src/review/policy.js";
+import type { LintResult } from "../src/linter/types.js";
+
+const CLEAN_SIGNALS: PolicySignals = {
+  confidence: 0.9,
+  contradicted: false,
+  schemaViolations: [],
+  provenanceViolations: [],
+};
+
+const DEFAULT_POLICY: ReviewPolicy = {
+  hold: [],
+  lowConfidenceThreshold: 0.5,
+  treatMissingConfidenceAs: "low",
+};
+
+const VIOLATION: LintResult = {
+  rule: "sample-rule",
+  severity: "warning",
+  file: "wiki/concepts/a.md",
+  message: "sample violation",
+};
+
+function policy(hold: ReviewPolicy["hold"], extra: Partial<ReviewPolicy> = {}): ReviewPolicy {
+  return { ...DEFAULT_POLICY, hold, ...extra };
+}
+
+describe("evaluatePolicy", () => {
+  it("returns no reasons for off or empty policy", () => {
+    expect(isPolicyOff(policy([]))).toBe(true);
+    expect(isPolicyOff(policy(["off"]))).toBe(true);
+    expect(evaluatePolicy(CLEAN_SIGNALS, policy([]))).toEqual([]);
+    expect(evaluatePolicy(CLEAN_SIGNALS, policy(["off"]))).toEqual([]);
+  });
+
+  it("supports all mode as an unconditional hold", () => {
+    expect(evaluatePolicy(CLEAN_SIGNALS, policy(["all"]))).toEqual([{ code: "all" }]);
+  });
+
+  it("fires low-confidence below threshold, not at or above threshold", () => {
+    const low = { ...CLEAN_SIGNALS, confidence: 0.49 };
+    const atThreshold = { ...CLEAN_SIGNALS, confidence: 0.5 };
+    expect(evaluatePolicy(low, policy(["low-confidence"]))[0]?.code).toBe("low-confidence");
+    expect(evaluatePolicy(atThreshold, policy(["low-confidence"]))).toEqual([]);
+  });
+
+  it("treats missing confidence according to config", () => {
+    const missing = { ...CLEAN_SIGNALS, confidence: undefined };
+    expect(evaluatePolicy(missing, policy(["low-confidence"]))[0]?.detail).toBe("confidence missing");
+    expect(evaluatePolicy(missing, policy(["low-confidence"], { treatMissingConfidenceAs: "ok" }))).toEqual([]);
+  });
+
+  it("fires contradicted, schema, and provenance reasons", () => {
+    const signals: PolicySignals = {
+      confidence: 0.9,
+      contradicted: true,
+      schemaViolations: [VIOLATION],
+      provenanceViolations: [VIOLATION],
+    };
+    const reasons = evaluatePolicy(signals, policy([
+      "contradicted",
+      "schema-violating",
+      "provenance-violating",
+    ]));
+    expect(reasons.map((r) => r.code)).toEqual([
+      "contradicted",
+      "schema-violating",
+      "provenance-violating",
+    ]);
+  });
+
+  it("unions multiple matching modes", () => {
+    const signals = { ...CLEAN_SIGNALS, confidence: 0.1, contradicted: true };
+    const reasons = evaluatePolicy(signals, policy(["low-confidence", "contradicted"]));
+    expect(reasons.map((r) => r.code)).toEqual(["low-confidence", "contradicted"]);
+  });
+});
+

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -272,16 +272,15 @@ describe("compile --review pipeline integration", () => {
   });
 
   /**
-   * Regression test for the multi-candidate-per-source bug.
+   * Regression test for the multi-candidate-per-source scenario.
    *
-   * When a single source yields multiple concepts (and therefore multiple
-   * candidates), approving the first candidate must NOT mark the source as
-   * fully compiled — otherwise the remaining pending candidates can never
-   * be regenerated, because the next compile sees the source as unchanged.
-   * Source-state is only persisted when the LAST candidate from that source
-   * is approved.
+   * When a single source yields multiple candidates, each approval immediately
+   * union-adds its own slug to the source's state entry. A pending sibling does
+   * NOT block the write — addApprovedSlugToSourceState reads current state and
+   * appends, so earlier-approved slugs are preserved when the sibling is later
+   * approved. After all candidates are approved the followup compile is a no-op.
    */
-  it("defers source-state persistence until every candidate from a source is approved", async () => {
+  it("records each approval immediately so no slug is dropped when siblings exist", async () => {
     await writeFile(
       path.join(root.dir, "sources", "topic.md"),
       "# Topic\nA brief article covering two related concepts.",
@@ -294,7 +293,8 @@ describe("compile --review pipeline integration", () => {
 
     const [firstId, secondId] = first.candidates!;
     await reviewApproveCommand(firstId);
-    expect(await readSourceState(root.dir, "topic.md")).toBeUndefined();
+    // First approval immediately records its slug — no longer deferred.
+    expect(await readSourceState(root.dir, "topic.md")).toBeDefined();
 
     await reviewApproveCommand(secondId);
     expect(await readSourceState(root.dir, "topic.md")).toBeDefined();

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -221,6 +221,7 @@ describe("compile --review pipeline integration", () => {
     const result = await compileAndReport(root.dir, { review: true });
     expect(callSpy).toHaveBeenCalled();
     expect(result.candidates ?? []).toHaveLength(1);
+    expect(result.pages).toEqual([]);
 
     // Pages on disk: only the candidate, never the wiki page.
     const conceptsDir = path.join(root.dir, CONCEPTS_DIR);

--- a/test/schema-subprocess.test.ts
+++ b/test/schema-subprocess.test.ts
@@ -124,6 +124,8 @@ describe("schema subprocess tests", () => {
         sources: ["source.md"],
         body: buildValidBody("Overview Page"),
         generatedAt: new Date().toISOString(),
+        reviewMode: "forced",
+        heldReasons: [{ code: "manual-review-requested" }],
         schemaViolations: [violation],
       };
 
@@ -152,6 +154,8 @@ describe("schema subprocess tests", () => {
         sources: ["source.md"],
         body: buildValidBody("Clean Page"),
         generatedAt: new Date().toISOString(),
+        reviewMode: "forced",
+        heldReasons: [{ code: "manual-review-requested" }],
         // schemaViolations intentionally omitted — block must not appear
       };
 


### PR DESCRIPTION
Adds compile-time review policy so risky generated pages can be held as review candidates during a normal `llmwiki compile`, while safe pages continue to write directly to `wiki/`.

## What Changed

- Adds `.llmwiki/config.json` review policy loading with fail-closed validation.
- Adds a pure policy engine for `low-confidence`, `contradicted`, `schema-violating`, `provenance-violating`, `all`, and `off` modes.
- Evaluates policy against the final generated page frontmatter and diagnostics at compile time.
- Holds policy-tripped pages as candidates with structured `heldReasons`, `reviewMode`, `confidence`, and `contradicted` metadata.
- Keeps `--review` behavior as a forced-review path with `manual-review-requested` metadata.
- Supersedes pending candidates by slug instead of appending duplicates.
- Skips re-extraction when a source is unchanged and only has an unchanged pending candidate.
- Reconciles stale candidates when a slug is later written directly.

## User-Facing Behavior

- Normal compile reports held pages explicitly: `Wrote N page(s), held M for review`.
- `review list` and `review show` display candidate mode and held reasons.
- Wikilinks to pending candidate slugs are reported as informational `pending-target` findings instead of failing as broken links.
- Health scoring does not penalize `pending-target` findings.

## Testing

- Policy engine table tests.
- Config loader validation tests, including fail-closed invalid config.
- Candidate lifecycle and metadata tests.
- Compile integration tests for mixed held/written output, approval source-state persistence, pending-candidate short-circuiting, and policy-off behavior.
- Aimock-backed CLI subprocess test for the `Wrote N, held M` compile output.
- Pending-target lint and health scoring regression test.

Validated locally and via pre-push: `npx tsc --noEmit`, `npm run build`, `npm test` (1494 passed, 3 skipped), `npx fallow`, and `npx fallow dupes --mode mild --changed-since main`.
