### PR TITLE
feat(embeddings): Add batch API, binary vector store, and modularize pipeline

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -30,9 +30,9 @@ import {
 import {
   findRelevantPages,
   findRelevantChunks,
-  updateEmbeddings,
   type ChunkEmbeddingEntry,
 } from "../utils/embeddings.js";
+import { updateEmbeddingsDispatched as updateEmbeddings } from "../utils/embeddings-dispatch.js";
 import { rerankWithBm25 } from "../utils/retrieval.js";
 import { appendLog, formatWikilinkList } from "../utils/activity-log.js";
 import type { ChunkCitation, QueryResult, RetrievalDebug } from "../utils/types.js";

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -25,7 +25,7 @@ import {
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
-import { updateEmbeddings } from "../utils/embeddings.js";
+import { updateEmbeddingsDispatched as updateEmbeddings } from "../utils/embeddings-dispatch.js";
 import { updateSourceState } from "../utils/state.js";
 import { CONCEPTS_DIR } from "../utils/constants.js";
 import * as output from "../utils/output.js";

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -47,7 +47,7 @@ import { generateIndex } from "./indexgen.js";
 import { buildBudgetedCombinedContent, type SourceSlice } from "./prompt-budget.js";
 import { addObsidianMeta, generateMOC } from "./obsidian.js";
 import { addModelProvenanceMeta } from "./provenance.js";
-import { updateEmbeddings } from "../utils/embeddings.js";
+import { updateEmbeddingsDispatched as updateEmbeddings } from "../utils/embeddings-dispatch.js";
 import { writeCandidate } from "./candidates.js";
 import { appendLog, formatList, formatWikilinkList } from "../utils/activity-log.js";
 import {

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -7,7 +7,7 @@
 
 import Anthropic, { type ClientOptions } from "@anthropic-ai/sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { voyageEmbed } from "./voyage-embed.js";
+import { voyageEmbed, voyageEmbedBatch } from "./voyage-embed.js";
 
 /**
  * Builds the client options for the Anthropic SDK.
@@ -138,5 +138,10 @@ export class AnthropicProvider implements LLMProvider {
    */
   async embed(text: string): Promise<number[]> {
     return voyageEmbed(text);
+  }
+
+  /** Produce embedding vectors for multiple texts via a single Voyage API call. */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return voyageEmbedBatch(texts);
   }
 }

--- a/src/providers/claude-agent.ts
+++ b/src/providers/claude-agent.ts
@@ -16,7 +16,7 @@
 
 import { query, createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { voyageEmbed } from "./voyage-embed.js";
+import { voyageEmbed, voyageEmbedBatch } from "./voyage-embed.js";
 import { jsonSchemaToZodShape } from "./json-schema-to-zod.js";
 
 /** Name for the throwaway in-process MCP server used to host a tool. */
@@ -211,6 +211,11 @@ export class ClaudeAgentProvider implements LLMProvider {
   /** Produce a single embedding vector via Voyage (Anthropic has no endpoint). */
   async embed(text: string): Promise<number[]> {
     return voyageEmbed(text);
+  }
+
+  /** Produce embedding vectors for multiple texts via a single Voyage API call. */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return voyageEmbedBatch(texts);
   }
 }
 

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -32,4 +32,13 @@ export class CopilotProvider extends OpenAIProvider {
       "    export OPENAI_API_KEY=sk-...",
     );
   }
+
+  override async embedBatch(_texts: string[]): Promise<number[][]> {
+    throw new Error(
+      "GitHub Copilot does not support embeddings.\n" +
+      "  For semantic search (llmwiki query), switch to the OpenAI provider:\n" +
+      "    export LLMWIKI_PROVIDER=openai\n" +
+      "    export OPENAI_API_KEY=sk-...",
+    );
+  }
 }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -171,6 +171,28 @@ export class OpenAIProvider implements LLMProvider {
     return vector;
   }
 
+  /** Produce embedding vectors for multiple texts via a single OpenAI API call. */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const response = await this.embeddingsClient.embeddings.create({
+      model: this.embeddingModel(),
+      input: texts,
+    });
+
+    const data = response.data;
+    if (!Array.isArray(data)) {
+      throw new Error("OpenAI embeddings response did not include a data array.");
+    }
+    return data.map((item, i) => {
+      const vector = item.embedding;
+      if (!Array.isArray(vector)) {
+        throw new Error(`OpenAI embeddings response item ${i} did not include a vector.`);
+      }
+      return vector;
+    });
+  }
+
   /** Default embedding model for this provider. Subclasses may override. */
   protected embeddingModel(): string {
     return this.configuredEmbeddingModel ?? EMBEDDING_MODELS.openai;

--- a/src/providers/voyage-embed.ts
+++ b/src/providers/voyage-embed.ts
@@ -11,6 +11,38 @@ import { EMBEDDING_MODELS } from "../utils/constants.js";
 
 const VOYAGE_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
 
+function resolveApiKey(): string {
+  const key = process.env.VOYAGE_API_KEY?.trim();
+  if (!key) {
+    throw new Error(
+      "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
+    );
+  }
+  return key;
+}
+
+/**
+ * Call the Voyage embeddings API with the given input.
+ * Single texts and arrays share the same request shape — Voyage normalises both.
+ */
+async function callVoyageApi(input: string | string[], model: string): Promise<unknown> {
+  const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${resolveApiKey()}`,
+    },
+    body: JSON.stringify({ input, model }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Voyage embeddings request failed (${response.status}): ${detail}`);
+  }
+
+  return response.json();
+}
+
 /**
  * Produce a single embedding vector for the given text via the Voyage API.
  *
@@ -23,31 +55,33 @@ export async function voyageEmbed(
   text: string,
   model: string = EMBEDDING_MODELS.anthropic,
 ): Promise<number[]> {
-  const apiKey = process.env.VOYAGE_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error(
-      "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
-    );
-  }
-
-  const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({ input: text, model }),
-  });
-
-  if (!response.ok) {
-    const detail = await response.text();
-    throw new Error(`Voyage embeddings request failed (${response.status}): ${detail}`);
-  }
-
-  const json = (await response.json()) as { data?: Array<{ embedding?: number[] }> };
+  const json = (await callVoyageApi(text, model)) as { data?: Array<{ embedding?: number[] }> };
   const vector = json.data?.[0]?.embedding;
   if (!Array.isArray(vector)) {
     throw new Error("Voyage embeddings response did not include a vector.");
   }
   return vector;
+}
+
+/**
+ * Produce embedding vectors for multiple texts via a single Voyage API call.
+ * Voyage accepts input as a string array; batching reduces round-trips.
+ */
+export async function voyageEmbedBatch(
+  texts: string[],
+  model: string = EMBEDDING_MODELS.anthropic,
+): Promise<number[][]> {
+  if (texts.length === 0) return [];
+
+  const json = (await callVoyageApi(texts, model)) as { data?: Array<{ embedding?: number[] }> };
+  if (!Array.isArray(json.data)) {
+    throw new Error("Voyage embeddings response did not include a data array.");
+  }
+  return json.data.map((item, i) => {
+    const vector = item.embedding;
+    if (!Array.isArray(vector)) {
+      throw new Error(`Voyage embeddings response item ${i} did not include a vector.`);
+    }
+    return vector;
+  });
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -100,6 +100,9 @@ export const LOG_DESCRIPTION_MAX_CHARS = 200;
  */
 export const LOG_MAX_PAGE_LINKS = 20;
 export const EMBEDDINGS_FILE = ".llmwiki/embeddings.json";
+
+/** Binary vector storage for embedding stores using LLMWIKI_BINARY_EMBEDDINGS. */
+export const EMBEDDINGS_BIN_FILE = ".llmwiki/embeddings.bin";
 export const LAST_LINT_FILE = ".llmwiki/last-lint.json";
 
 /** Supported image file extensions for vision-based ingest. */
@@ -132,6 +135,12 @@ export const RULE_CANDIDATES_ARCHIVE_DIR = ".llmwiki/rule-candidates/archive";
 
 /** Number of most similar pages to return from embedding-based pre-filter. */
 export const EMBEDDING_TOP_K = 15;
+
+/** Max pages per embedding API call when batching. */
+export const EMBEDDING_BATCH_SIZE = 20;
+
+/** Max chunks per embedding API call when batching. Defaults higher than pages since chunks are more numerous and shorter. */
+export const EMBEDDING_CHUNK_BATCH_SIZE = 50;
 
 /** Number of chunk candidates to retain after the semantic-similarity step. */
 export const CHUNK_TOP_K = 30;

--- a/src/utils/embeddings-batch.ts
+++ b/src/utils/embeddings-batch.ts
@@ -1,0 +1,254 @@
+/**
+ * Batched variant of the embedding update pipeline.
+ *
+ * Unlike the default {@link updateEmbeddings} which embeds pages one at a time
+ * and persists only at the end, this version batches multiple texts per API
+ * call and writes the store after each batch so an interrupted run can resume.
+ */
+
+import { getProvider } from "./provider.js";
+import type { LLMProvider } from "./provider.js";
+import { EMBEDDING_BATCH_SIZE, EMBEDDING_CHUNK_BATCH_SIZE } from "./constants.js";
+import { hashChunkText, splitIntoChunks } from "./retrieval.js";
+import {
+  type EmbeddingEntry,
+  type ChunkEmbeddingEntry,
+  type EmbeddingStore,
+  type PageRecord,
+  STORE_VERSION,
+  writeEmbeddingStore,
+  resolveEmbeddingState,
+  buildEmbeddingText,
+  hashPageText,
+  mergeEntries,
+  isStoreEmpty,
+  shouldRunEmbedding,
+} from "./embeddings.js";
+import { indexChunksByKey, chunkKey, pickReusableChunk } from "./embeddings-chunks.js";
+import * as output from "./output.js";
+
+function batchSize(): number {
+  const fromEnv = Number(process.env.LLMWIKI_EMBEDDING_BATCH_SIZE);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : EMBEDDING_BATCH_SIZE;
+}
+
+function chunkBatchSize(): number {
+  const fromEnv = Number(process.env.LLMWIKI_CHUNK_BATCH_SIZE);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : EMBEDDING_CHUNK_BATCH_SIZE;
+}
+
+/**
+ * Call provider.embedBatch when available, falling back to sequential embed()
+ * calls so providers that only implement the single-text method are supported.
+ */
+async function safeEmbedBatch(provider: LLMProvider, texts: string[]): Promise<number[][]> {
+  if (provider.embedBatch) {
+    return provider.embedBatch(texts);
+  }
+  const out: number[][] = [];
+  for (const text of texts) out.push(await provider.embed(text));
+  return out;
+}
+
+/**
+ * Determine which slugs to embed based on changed slugs, cold starts, model
+ * changes, and interrupted-run resume detection.
+ */
+function collectSlugsToEmbed(
+  records: PageRecord[],
+  changedSlugs: string[],
+  liveSlugs: Set<string>,
+  existingStore: EmbeddingStore | null,
+  modelChanged: boolean,
+  previousEntries: EmbeddingEntry[],
+): Set<string> {
+  const toEmbed = new Set(changedSlugs.filter((slug) => liveSlugs.has(slug)));
+
+  const emptyStore = !existingStore || isStoreEmpty(existingStore);
+  if (!existingStore || modelChanged || (emptyStore && liveSlugs.size > 0)) {
+    for (const record of records) toEmbed.add(record.slug);
+  }
+
+  addMissingFromResume(toEmbed, records, previousEntries);
+  return toEmbed;
+}
+
+/** Add slugs whose pages were never embedded (interrupted-run recovery). */
+function addMissingFromResume(
+  toEmbed: Set<string>,
+  records: PageRecord[],
+  previousEntries: EmbeddingEntry[],
+): void {
+  if (toEmbed.size >= records.length) return;
+  const embeddedSlugs = new Set(previousEntries.map((e) => e.slug));
+  for (const record of records) {
+    if (!embeddedSlugs.has(record.slug)) toEmbed.add(record.slug);
+  }
+}
+
+/**
+ * Embed pages in batches, writing the store after each batch so an
+ * interrupted run can resume from the last persisted batch.
+ */
+async function embedPagesInBatches(
+  pagesToEmbed: PageRecord[],
+  previousEntries: EmbeddingEntry[],
+  previousChunks: ChunkEmbeddingEntry[],
+  liveSlugs: Set<string>,
+  provider: LLMProvider,
+  now: string,
+  bs: number,
+  embeddingModel: string,
+  root: string,
+): Promise<EmbeddingEntry[]> {
+  const freshEntries: EmbeddingEntry[] = [];
+  for (let i = 0; i < pagesToEmbed.length; i += bs) {
+    const batch = pagesToEmbed.slice(i, i + bs);
+    const vectors = await safeEmbedBatch(provider, batch.map((r) => buildEmbeddingText(r)));
+
+    for (let j = 0; j < batch.length; j++) {
+      const record = batch[j];
+      freshEntries.push({
+        slug: record.slug,
+        title: record.title,
+        summary: record.summary,
+        vector: vectors[j],
+        contentHash: hashPageText(record),
+        updatedAt: now,
+      });
+    }
+
+    output.status("*", output.dim(`${Math.min(i + bs, pagesToEmbed.length)}/${pagesToEmbed.length} pages`));
+    const merged = mergeEntries(previousEntries, freshEntries, liveSlugs);
+    await writeIncrementalStore(root, embeddingModel, merged, previousChunks);
+  }
+  return freshEntries;
+}
+
+/**
+ * Collect all chunks across all pages, batch-embed them, and write the
+ * store after each batch. Chunks whose contentHash matches an existing
+ * entry are reused without an API call.
+ */
+async function collectAndEmbedChunks(
+  records: PageRecord[],
+  previousChunks: ChunkEmbeddingEntry[],
+  liveSlugs: Set<string>,
+  modelChanged: boolean,
+  provider: LLMProvider,
+  now: string,
+  bs: number,
+  embeddingModel: string,
+  root: string,
+  entries: EmbeddingEntry[],
+): Promise<void> {
+  const existingByKey = indexChunksByKey(previousChunks.filter((c) => liveSlugs.has(c.slug)));
+
+  type ChunkToEmbed = { record: PageRecord; chunkIndex: number; text: string; contentHash: string };
+  const chunksToEmbed: ChunkToEmbed[] = [];
+  const validKeys = new Set<string>();
+
+  for (const record of records) {
+    const chunkTexts = splitIntoChunks(record.body);
+    for (let i = 0; i < chunkTexts.length; i++) {
+      const text = chunkTexts[i];
+      const h = hashChunkText(text);
+      const key = chunkKey(record.slug, i);
+      validKeys.add(key);
+      const reused = pickReusableChunk(existingByKey, record.slug, i, h, modelChanged);
+      if (reused) {
+        existingByKey.set(key, { ...reused, title: record.title });
+      } else {
+        chunksToEmbed.push({ record, chunkIndex: i, text, contentHash: h });
+      }
+    }
+  }
+
+  const pagesWithNewChunks = new Set<string>();
+  for (let i = 0; i < chunksToEmbed.length; i += bs) {
+    const batch = chunksToEmbed.slice(i, i + bs);
+    const vectors = await safeEmbedBatch(provider, batch.map((b) => b.text));
+
+    for (let j = 0; j < batch.length; j++) {
+      const { record, chunkIndex, text, contentHash } = batch[j];
+      const entry: ChunkEmbeddingEntry = {
+        slug: record.slug,
+        title: record.title,
+        chunkIndex,
+        contentHash,
+        text,
+        vector: vectors[j],
+        updatedAt: now,
+      };
+      existingByKey.set(chunkKey(record.slug, chunkIndex), entry);
+      pagesWithNewChunks.add(record.slug);
+    }
+
+    output.status("*", output.dim(`chunks: ${Math.min(i + bs, chunksToEmbed.length)}/${chunksToEmbed.length} across ${records.length} pages`));
+    const chunks = Array.from(existingByKey.values());
+    await writeIncrementalStore(root, embeddingModel, entries, chunks);
+  }
+
+  for (const key of existingByKey.keys()) {
+    if (!validKeys.has(key)) existingByKey.delete(key);
+  }
+
+  const chunks = Array.from(existingByKey.values());
+  output.status("*", output.dim(`Embeddings updated (${entries.length} pages, ${chunks.length} chunks across ${pagesWithNewChunks.size} pages).`));
+  await writeIncrementalStore(root, embeddingModel, entries, chunks);
+}
+
+/**
+ * Re-embed changed slugs with batched API calls and incremental disk writes.
+ * Interrupted runs can resume: pages whose contentHash matches the on-disk
+ * entry are skipped on re-run.
+ */
+export async function updateEmbeddingsBatched(root: string, changedSlugs: string[]): Promise<void> {
+  const { records, liveSlugs, embeddingModel, existingStore, modelChanged, previousEntries, previousChunks } = await resolveEmbeddingState(root);
+  const toEmbed = collectSlugsToEmbed(records, changedSlugs, liveSlugs, existingStore, modelChanged, previousEntries);
+
+  if (!modelChanged && toEmbed.size === 0 && shouldRunEmbedding(modelChanged, toEmbed, previousEntries, previousChunks, liveSlugs) === false) {
+    output.status("*", output.dim("Embeddings up to date."));
+    return;
+  }
+
+  const provider = getProvider();
+  const now = new Date().toISOString();
+  const bs = batchSize();
+
+  const previousBySlug = new Map<string, EmbeddingEntry>();
+  for (const e of previousEntries) previousBySlug.set(e.slug, e);
+
+  const pagesToEmbed = records.filter((r) => {
+    if (!toEmbed.has(r.slug)) return false;
+    const existing = previousBySlug.get(r.slug);
+    if (existing && existing.contentHash === hashPageText(r)) return false;
+    return true;
+  });
+
+  const skipped = toEmbed.size - pagesToEmbed.length;
+  output.status("*", output.dim(`Embedding ${pagesToEmbed.length} pages in batches of ${bs}${skipped > 0 ? ` (${skipped} skipped — unchanged)` : ""}.`));
+
+  const freshEntries = await embedPagesInBatches(pagesToEmbed, previousEntries, previousChunks, liveSlugs, provider, now, bs, embeddingModel, root);
+  const entries = mergeEntries(previousEntries, freshEntries, liveSlugs);
+  await collectAndEmbedChunks(records, previousChunks, liveSlugs, modelChanged, provider, now, chunkBatchSize(), embeddingModel, root, entries);
+}
+
+/** Write the store mid-batch for incremental progress. */
+async function writeIncrementalStore(
+  root: string,
+  model: string,
+  entries: EmbeddingEntry[],
+  chunks: ChunkEmbeddingEntry[],
+): Promise<void> {
+  const dimensions = entries[0]?.vector.length ?? chunks[0]?.vector.length ?? 0;
+  const store: EmbeddingStore = {
+    version: STORE_VERSION,
+    model,
+    dimensions,
+    entries,
+    chunks,
+  };
+  await writeEmbeddingStore(root, store);
+}
+

--- a/src/utils/embeddings-binary.ts
+++ b/src/utils/embeddings-binary.ts
@@ -1,0 +1,65 @@
+/**
+ * Binary vector I/O for embedding stores.
+ *
+ * When LLMWIKI_BINARY_EMBEDDINGS is set, vectors are packed into a contiguous
+ * Float32 binary buffer and stored in .llmwiki/embeddings.bin instead of
+ * inside the JSON store. This avoids JSON.stringify blowing past Node's
+ * string-length limit (~268 MB) on wikis with many pages and chunks.
+ */
+
+import type { EmbeddingStore } from "./embeddings.js";
+
+/**
+ * Pack vectors from entries and chunks into a contiguous Float32 binary buffer.
+ * Returns the buffer and a JSON-safe store with vectors stripped.
+ */
+export function serializeBinaryStore(store: EmbeddingStore): { store: EmbeddingStore; buffer: Buffer } {
+  const allVectors: number[][] = [
+    ...store.entries.map((e) => e.vector),
+    ...(store.chunks ?? []).map((c) => c.vector),
+  ];
+  const totalFloats = allVectors.reduce((sum, v) => sum + v.length, 0);
+  const buf = Buffer.allocUnsafe(totalFloats * 4);
+  const floats = new Float32Array(buf.buffer, buf.byteOffset, totalFloats);
+  let offset = 0;
+  for (const v of allVectors) {
+    floats.set(v, offset);
+    offset += v.length;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const strippedEntries = store.entries.map(({ vector: _v, ...rest }: any) => rest);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const strippedChunks = store.chunks?.map(({ vector: _v, ...rest }: any) => rest);
+
+  return {
+    store: { ...store, binaryVectors: true, entries: strippedEntries, chunks: strippedChunks },
+    buffer: buf,
+  };
+}
+
+/**
+ * Restore vectors from a contiguous binary buffer into a store whose entries
+ * and chunks were stripped of their vector fields.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function deserializeBinaryStore(raw: any, buffer: Buffer): EmbeddingStore {
+  const dimensions: number = raw.dimensions;
+  const entryCount: number = raw.entries.length;
+  const chunkCount: number = raw.chunks?.length ?? 0;
+  const bytesPerVector = dimensions * 4;
+
+  const entries = raw.entries.map((e: any, i: number) => {
+    const start = i * bytesPerVector;
+    const floats = new Float32Array(buffer.buffer, buffer.byteOffset + start, dimensions);
+    return { ...e, vector: Array.from(floats) };
+  });
+
+  const chunks = (raw.chunks ?? []).map((c: any, i: number) => {
+    const start = (entryCount + i) * bytesPerVector;
+    const floats = new Float32Array(buffer.buffer, buffer.byteOffset + start, dimensions);
+    return { ...c, vector: Array.from(floats) };
+  });
+
+  return { ...raw, entries, chunks: chunkCount > 0 ? chunks : undefined };
+}

--- a/src/utils/embeddings-chunks.ts
+++ b/src/utils/embeddings-chunks.ts
@@ -1,0 +1,90 @@
+/**
+ * Chunk-level embedding helpers.
+ *
+ * Handles embedding (or reusing) paragraph-level chunks for a page, plus the
+ * index-key and content-hash-aware reuse lookup utilities shared by both the
+ * sequential and batched update pipelines.
+ */
+
+import { getProvider } from "./provider.js";
+import { hashChunkText, splitIntoChunks } from "./retrieval.js";
+import type { ChunkEmbeddingEntry } from "./embeddings.js";
+import type { PageRecord } from "../pages/read.js";
+
+/**
+ * Refresh chunk embeddings for the given pages, reusing existing chunk vectors
+ * whose contentHash still matches. Pages absent from `records` are pruned.
+ */
+export async function refreshChunkEmbeddings(
+  records: PageRecord[],
+  existing: ChunkEmbeddingEntry[],
+  forceAll: boolean,
+): Promise<ChunkEmbeddingEntry[]> {
+  const liveSlugs = new Set(records.map((r) => r.slug));
+  const existingByKey = indexChunksByKey(existing.filter((c) => liveSlugs.has(c.slug)));
+  const now = new Date().toISOString();
+  const fresh: ChunkEmbeddingEntry[] = [];
+
+  for (const record of records) {
+    const pageChunks = await embedRecordChunks(record, existingByKey, forceAll, now);
+    fresh.push(...pageChunks);
+  }
+  return fresh;
+}
+
+/**
+ * Embed (or reuse) every chunk for a single page, in order. Reused chunks have
+ * their `title` refreshed so a renamed page propagates to the chunk metadata.
+ */
+async function embedRecordChunks(
+  record: PageRecord,
+  existingByKey: Map<string, ChunkEmbeddingEntry>,
+  forceAll: boolean,
+  now: string,
+): Promise<ChunkEmbeddingEntry[]> {
+  const provider = getProvider();
+  const chunkTexts = splitIntoChunks(record.body);
+  const out: ChunkEmbeddingEntry[] = [];
+
+  for (let i = 0; i < chunkTexts.length; i++) {
+    const text = chunkTexts[i];
+    const contentHash = hashChunkText(text);
+    const reused = pickReusableChunk(existingByKey, record.slug, i, contentHash, forceAll);
+    if (reused) {
+      out.push({ ...reused, title: record.title });
+      continue;
+    }
+    const vector = await provider.embed(text);
+    out.push({
+      slug: record.slug, title: record.title, chunkIndex: i,
+      contentHash, text, vector, updatedAt: now,
+    });
+  }
+  return out;
+}
+
+/** Index existing chunks by `${slug}#${chunkIndex}` for O(1) reuse lookup. */
+export function indexChunksByKey(chunks: ChunkEmbeddingEntry[]): Map<string, ChunkEmbeddingEntry> {
+  const byKey = new Map<string, ChunkEmbeddingEntry>();
+  for (const chunk of chunks) byKey.set(chunkKey(chunk.slug, chunk.chunkIndex), chunk);
+  return byKey;
+}
+
+/** Compose the index key for a chunk lookup. */
+export function chunkKey(slug: string, chunkIndex: number): string {
+  return `${slug}#${chunkIndex}`;
+}
+
+/** Return the existing chunk vector when its hash still matches and reuse is allowed. */
+export function pickReusableChunk(
+  byKey: Map<string, ChunkEmbeddingEntry>,
+  slug: string,
+  chunkIndex: number,
+  contentHash: string,
+  forceAll: boolean,
+): ChunkEmbeddingEntry | null {
+  if (forceAll) return null;
+  const existing = byKey.get(chunkKey(slug, chunkIndex));
+  if (!existing) return null;
+  return existing.contentHash === contentHash ? existing : null;
+}

--- a/src/utils/embeddings-dispatch.ts
+++ b/src/utils/embeddings-dispatch.ts
@@ -1,0 +1,17 @@
+/**
+ * Thin dispatch wrapper that selects between the default and batched embedding
+ * update pipelines based on LLMWIKI_BATCH_EMBEDDINGS.
+ *
+ * This file exists to break a circular import: embeddings.ts ↔ embeddings-batch.ts.
+ * Callers import from here instead of embedding the dispatch inside embeddings.ts.
+ */
+
+import { updateEmbeddings } from "./embeddings.js";
+
+export async function updateEmbeddingsDispatched(root: string, changedSlugs: string[]): Promise<void> {
+  if (process.env.LLMWIKI_BATCH_EMBEDDINGS === "true") {
+    const { updateEmbeddingsBatched } = await import("./embeddings-batch.js");
+    return updateEmbeddingsBatched(root, changedSlugs);
+  }
+  return updateEmbeddings(root, changedSlugs);
+}

--- a/src/utils/embeddings-similarity.ts
+++ b/src/utils/embeddings-similarity.ts
@@ -1,0 +1,56 @@
+/**
+ * Cosine similarity and top-K ranking helpers for embedding vectors.
+ *
+ * Pure functions with zero dependencies on the store I/O layer, so they can be
+ * imported by embeddings.ts without creating a circular dependency.
+ */
+
+import type { EmbeddingStore, EmbeddingEntry, ChunkEmbeddingEntry } from "./embeddings.js";
+
+/**
+ * Cosine similarity between two equal-length vectors.
+ * Returns 0 when either vector has zero magnitude (safer than NaN for ranking).
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+
+  if (magA === 0 || magB === 0) return 0;
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}
+
+/** Return the top-K entries most similar to the query vector, sorted descending. */
+export function findTopK(
+  queryVec: number[],
+  store: EmbeddingStore,
+  k: number,
+): EmbeddingEntry[] {
+  const scored = store.entries.map((entry) => ({
+    entry,
+    score: cosineSimilarity(queryVec, entry.vector),
+  }));
+  scored.sort((left, right) => right.score - left.score);
+  return scored.slice(0, k).map((item) => item.entry);
+}
+
+/** Score and sort chunk entries by cosine similarity, returning the top-K. */
+export function findTopKChunks(
+  queryVec: number[],
+  chunks: ChunkEmbeddingEntry[],
+  k: number,
+): Array<{ chunk: ChunkEmbeddingEntry; score: number }> {
+  const scored = chunks.map((chunk) => ({
+    chunk,
+    score: cosineSimilarity(queryVec, chunk.vector),
+  }));
+  scored.sort((left, right) => right.score - left.score);
+  return scored.slice(0, k);
+}

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -16,8 +16,9 @@
  *     and reranking before final page selection.
  */
 
-import { readFile, readdir } from "fs/promises";
+import { readFile, readdir, writeFile, rename, rm } from "fs/promises";
 import { existsSync } from "fs";
+import { createHash } from "crypto";
 import path from "path";
 import { getProvider, getActiveProviderName } from "./provider.js";
 import { atomicWrite, safeReadFile, parseFrontmatter } from "./markdown.js";
@@ -25,14 +26,20 @@ import {
   CONCEPTS_DIR,
   QUERIES_DIR,
   EMBEDDINGS_FILE,
+  EMBEDDINGS_BIN_FILE,
   EMBEDDING_TOP_K,
   EMBEDDING_MODELS,
 } from "./constants.js";
-import { hashChunkText, splitIntoChunks } from "./retrieval.js";
+import { serializeBinaryStore, deserializeBinaryStore } from "./embeddings-binary.js";
+import { findTopK, findTopKChunks } from "./embeddings-similarity.js";
+import { refreshChunkEmbeddings } from "./embeddings-chunks.js";
+import type { PageRecord } from "../pages/read.js";
 import * as output from "./output.js";
 
+export { cosineSimilarity, findTopK, findTopKChunks } from "./embeddings-similarity.js";
+
 /** Current store version; bumped from 1 → 2 when chunk entries were added. */
-const STORE_VERSION = 2 as const;
+export const STORE_VERSION = 2 as const;
 
 /** A single embedded page record. */
 export interface EmbeddingEntry {
@@ -41,6 +48,8 @@ export interface EmbeddingEntry {
   summary: string;
   vector: number[];
   updatedAt: string;
+  /** SHA256 hex (first 16 chars) of buildEmbeddingText output; absent in stores built by older versions. */
+  contentHash?: string;
 }
 
 /** A single embedded chunk drawn from a page body. */
@@ -62,76 +71,43 @@ export interface EmbeddingStore {
   entries: EmbeddingEntry[];
   /** Optional in v2 stores; absent in v1 stores. */
   chunks?: ChunkEmbeddingEntry[];
+  /** When true, vectors are stored in .llmwiki/embeddings.bin instead of JSON. */
+  binaryVectors?: boolean;
 }
 
-/** A retrievable page record on disk (concepts/ or queries/). */
-interface PageRecord {
-  slug: string;
-  title: string;
-  summary: string;
-  body: string;
-}
-
-/**
- * Cosine similarity between two equal-length vectors.
- * Returns 0 when either vector has zero magnitude (safer than NaN for ranking).
- */
-export function cosineSimilarity(a: number[], b: number[]): number {
-  if (a.length !== b.length || a.length === 0) return 0;
-
-  let dot = 0;
-  let magA = 0;
-  let magB = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    magA += a[i] * a[i];
-    magB += b[i] * b[i];
-  }
-
-  if (magA === 0 || magB === 0) return 0;
-  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
-}
-
-/** Return the top-K entries most similar to the query vector, sorted descending. */
-export function findTopK(
-  queryVec: number[],
-  store: EmbeddingStore,
-  k: number,
-): EmbeddingEntry[] {
-  const scored = store.entries.map((entry) => ({
-    entry,
-    score: cosineSimilarity(queryVec, entry.vector),
-  }));
-  scored.sort((left, right) => right.score - left.score);
-  return scored.slice(0, k).map((item) => item.entry);
-}
-
-/** Score and sort chunk entries by cosine similarity, returning the top-K. */
-export function findTopKChunks(
-  queryVec: number[],
-  chunks: ChunkEmbeddingEntry[],
-  k: number,
-): Array<{ chunk: ChunkEmbeddingEntry; score: number }> {
-  const scored = chunks.map((chunk) => ({
-    chunk,
-    score: cosineSimilarity(queryVec, chunk.vector),
-  }));
-  scored.sort((left, right) => right.score - left.score);
-  return scored.slice(0, k);
-}
+export type { PageRecord };
 
 /** Read .llmwiki/embeddings.json, returning null if it does not exist. */
 export async function readEmbeddingStore(root: string): Promise<EmbeddingStore | null> {
   const filePath = path.join(root, EMBEDDINGS_FILE);
   if (!existsSync(filePath)) return null;
   const raw = await readFile(filePath, "utf-8");
-  return JSON.parse(raw) as EmbeddingStore;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const store: any = JSON.parse(raw);
+  if (store.binaryVectors) {
+    const binPath = path.join(root, EMBEDDINGS_BIN_FILE);
+    if (!existsSync(binPath)) return null;
+    const binBuffer = await readFile(binPath);
+    return deserializeBinaryStore(store, binBuffer);
+  }
+  return store as EmbeddingStore;
 }
 
 /** Atomically persist the embedding store. */
 export async function writeEmbeddingStore(root: string, store: EmbeddingStore): Promise<void> {
   const filePath = path.join(root, EMBEDDINGS_FILE);
-  await atomicWrite(filePath, JSON.stringify(store, null, 2));
+  if (process.env.LLMWIKI_BINARY_EMBEDDINGS === "true") {
+    const binPath = path.join(root, EMBEDDINGS_BIN_FILE);
+    const serialized = serializeBinaryStore(store);
+    await atomicWrite(filePath, JSON.stringify(serialized.store, null, 2));
+    const tmpBinPath = binPath + ".tmp";
+    await writeFile(tmpBinPath, serialized.buffer);
+    await rename(tmpBinPath, binPath);
+  } else {
+    await atomicWrite(filePath, JSON.stringify(store, null, 2));
+    const binPath = path.join(root, EMBEDDINGS_BIN_FILE);
+    await rm(binPath, { force: true });
+  }
 }
 
 /**
@@ -220,11 +196,22 @@ async function readPageRecord(absDir: string, file: string): Promise<PageRecord 
 }
 
 /** Build the text that represents a page in the embedding space. */
-function buildEmbeddingText(record: PageRecord): string {
+export function buildEmbeddingText(record: PageRecord): string {
   return record.summary
     ? `${record.title}\n\n${record.summary}`
     : record.title;
 }
+
+/** Produce a short content hash for embedding text so callers can detect staleness. */
+function hashEmbeddingText(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+/** Hash the text used for page-level embeddings. */
+export function hashPageText(record: PageRecord): string {
+  return hashEmbeddingText(buildEmbeddingText(record));
+}
+
 
 /**
  * Embed every page in `records` whose slug appears in `slugsToEmbed`,
@@ -246,6 +233,7 @@ async function embedPages(
       title: record.title,
       summary: record.summary,
       vector,
+      contentHash: hashPageText(record),
       updatedAt: now,
     });
   }
@@ -285,7 +273,7 @@ export function resolveEmbeddingModel(): string {
 }
 
 /** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */
-function mergeEntries(
+export function mergeEntries(
   existing: EmbeddingEntry[],
   fresh: EmbeddingEntry[],
   liveSlugs: Set<string>,
@@ -300,82 +288,32 @@ function mergeEntries(
   return Array.from(bySlug.values());
 }
 
-/**
- * Refresh chunk embeddings for the given pages, reusing existing chunk vectors
- * whose contentHash still matches. Pages absent from `records` are pruned.
- */
-async function refreshChunkEmbeddings(
-  records: PageRecord[],
-  existing: ChunkEmbeddingEntry[],
-  forceAll: boolean,
-): Promise<ChunkEmbeddingEntry[]> {
+/** Shared state loaded by both updateEmbeddings variants. */
+interface EmbeddingState {
+  records: PageRecord[];
+  liveSlugs: Set<string>;
+  embeddingModel: string;
+  existingStore: EmbeddingStore | null;
+  modelChanged: boolean;
+  previousEntries: EmbeddingEntry[];
+  previousChunks: ChunkEmbeddingEntry[];
+}
+
+export async function resolveEmbeddingState(root: string): Promise<EmbeddingState> {
+  const records = await collectPageRecords(root);
   const liveSlugs = new Set(records.map((r) => r.slug));
-  const existingByKey = indexChunksByKey(existing.filter((c) => liveSlugs.has(c.slug)));
-  const now = new Date().toISOString();
-  const fresh: ChunkEmbeddingEntry[] = [];
-
-  for (const record of records) {
-    const pageChunks = await embedRecordChunks(record, existingByKey, forceAll, now);
-    fresh.push(...pageChunks);
-  }
-  return fresh;
-}
-
-/**
- * Embed (or reuse) every chunk for a single page, in order. Reused chunks have
- * their `title` refreshed so a renamed page propagates to the chunk metadata.
- */
-async function embedRecordChunks(
-  record: PageRecord,
-  existingByKey: Map<string, ChunkEmbeddingEntry>,
-  forceAll: boolean,
-  now: string,
-): Promise<ChunkEmbeddingEntry[]> {
-  const provider = getProvider();
-  const chunkTexts = splitIntoChunks(record.body);
-  const out: ChunkEmbeddingEntry[] = [];
-
-  for (let i = 0; i < chunkTexts.length; i++) {
-    const text = chunkTexts[i];
-    const contentHash = hashChunkText(text);
-    const reused = pickReusableChunk(existingByKey, record.slug, i, contentHash, forceAll);
-    if (reused) {
-      out.push({ ...reused, title: record.title });
-      continue;
-    }
-    const vector = await provider.embed(text);
-    out.push({
-      slug: record.slug, title: record.title, chunkIndex: i,
-      contentHash, text, vector, updatedAt: now,
-    });
-  }
-  return out;
-}
-
-/** Index existing chunks by `${slug}#${chunkIndex}` for O(1) reuse lookup. */
-function indexChunksByKey(chunks: ChunkEmbeddingEntry[]): Map<string, ChunkEmbeddingEntry> {
-  const byKey = new Map<string, ChunkEmbeddingEntry>();
-  for (const chunk of chunks) byKey.set(chunkKey(chunk.slug, chunk.chunkIndex), chunk);
-  return byKey;
-}
-
-/** Compose the index key for a chunk lookup. */
-function chunkKey(slug: string, chunkIndex: number): string {
-  return `${slug}#${chunkIndex}`;
-}
-
-/** Return the existing chunk vector when its hash still matches and reuse is allowed. */
-function pickReusableChunk(
-  byKey: Map<string, ChunkEmbeddingEntry>,
-  slug: string,
-  chunkIndex: number,
-  contentHash: string,
-  forceAll: boolean,
-): ChunkEmbeddingEntry | null {
-  if (forceAll) return null;
-  const existing = byKey.get(chunkKey(slug, chunkIndex));
-  if (!existing) return null;
-  return existing.contentHash === contentHash ? existing : null;
+  const embeddingModel = resolveEmbeddingModel();
+  const existingStore = await readEmbeddingStore(root);
+  const modelChanged = Boolean(existingStore && existingStore.model !== embeddingModel);
+  return {
+    records,
+    liveSlugs,
+    embeddingModel,
+    existingStore,
+    modelChanged,
+    previousEntries: modelChanged ? [] : existingStore?.entries ?? [],
+    previousChunks: modelChanged ? [] : existingStore?.chunks ?? [],
+  };
 }
 
 /**
@@ -383,19 +321,11 @@ function pickReusableChunk(
  * exist on disk. Changed slugs not present as live pages are silently skipped.
  */
 export async function updateEmbeddings(root: string, changedSlugs: string[]): Promise<void> {
-  const records = await collectPageRecords(root);
-  const liveSlugs = new Set(records.map((r) => r.slug));
-  const embeddingModel = resolveEmbeddingModel();
-  const existingStore = await readEmbeddingStore(root);
-  const modelChanged = Boolean(existingStore && existingStore.model !== embeddingModel);
+  const { records, liveSlugs, embeddingModel, existingStore, modelChanged, previousEntries, previousChunks } = await resolveEmbeddingState(root);
+
   const toEmbed = new Set(changedSlugs.filter((slug) => liveSlugs.has(slug)));
-  const previousEntries = modelChanged ? [] : existingStore?.entries ?? [];
-  const previousChunks = modelChanged ? [] : existingStore?.chunks ?? [];
 
   // Cold start: embed every page so the store is immediately useful.
-  // Also treat an empty on-disk store as a cold start so that a project
-  // with no ingested pages yet (or a wiped store) gets populated the next
-  // time `compile` runs without needing an explicit slug change.
   const isEmptyStore = isStoreEmpty(existingStore);
   if (!existingStore || modelChanged || (isEmptyStore && liveSlugs.size > 0)) {
     for (const record of records) toEmbed.add(record.slug);
@@ -435,13 +365,13 @@ async function persistRefreshedStore(
 }
 
 /** Return true when a store exists on disk but has neither page nor chunk entries. */
-function isStoreEmpty(store: EmbeddingStore | null): boolean {
+export function isStoreEmpty(store: EmbeddingStore | null): boolean {
   if (!store) return false;
   return store.entries.length === 0 && (!store.chunks || store.chunks.length === 0);
 }
 
 /** Decide whether updateEmbeddings has work to do beyond a no-op. */
-function shouldRunEmbedding(
+export function shouldRunEmbedding(
   modelChanged: boolean,
   toEmbed: Set<string>,
   previousEntries: EmbeddingEntry[],

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -49,6 +49,8 @@ export interface LLMProvider {
   ): Promise<string>;
   /** Return a single embedding vector for the given text. */
   embed(text: string): Promise<number[]>;
+  /** Return embedding vectors for multiple texts in a single batch call. Providers that don't implement this fall back to sequential embed() calls. */
+  embedBatch?(texts: string[]): Promise<number[][]>;
 }
 
 const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "claude-agent", "openai", "ollama", "minimax", "copilot"]);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -96,6 +96,8 @@ describe("CLI smoke tests", () => {
           ...process.env,
           ANTHROPIC_API_KEY: "",
           ANTHROPIC_AUTH_TOKEN: "",
+          OPENAI_API_KEY: "",
+          LLMWIKI_PROVIDER: "anthropic",
           LLMWIKI_CLAUDE_SETTINGS_PATH: workspace.settingsPath,
         },
       });
@@ -118,6 +120,8 @@ describe("CLI smoke tests", () => {
           ...process.env,
           ANTHROPIC_API_KEY: "",
           ANTHROPIC_AUTH_TOKEN: "",
+          OPENAI_API_KEY: "",
+          LLMWIKI_PROVIDER: "anthropic",
           LLMWIKI_CLAUDE_SETTINGS_PATH: workspace.settingsPath,
         },
       });

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the batched embedding pipeline (updateEmbeddingsBatched) and
+ * store persistence. The OpenAI provider is stubbed so no real network
+ * calls are made.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import path from "path";
+import {
+  readEmbeddingStore,
+  resetStaleEmbeddingWarnings,
+  writeEmbeddingStore,
+  type EmbeddingStore,
+} from "../src/utils/embeddings.js";
+import { updateEmbeddingsBatched } from "../src/utils/embeddings-batch.js";
+import { OpenAIProvider } from "../src/providers/openai.js";
+import { EMBEDDING_BATCH_SIZE } from "../src/utils/constants.js";
+import {
+  STORE_PATH,
+  makeEntry,
+  makeRoot,
+  writeConceptPage,
+  writeConcept,
+} from "./helpers/embedding-store.js";
+
+async function setupBatchTest(): Promise<{ root: string; embedBatch: ReturnType<typeof vi.fn> }> {
+  const root = await makeRoot();
+  process.env.LLMWIKI_PROVIDER = "openai";
+  process.env.OPENAI_API_KEY = "test-key";
+  process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
+  delete process.env.LLMWIKI_BINARY_EMBEDDINGS;
+  delete process.env.LLMWIKI_EMBEDDING_BATCH_SIZE;
+  delete process.env.LLMWIKI_CHUNK_BATCH_SIZE;
+  const embedBatch = vi.fn();
+  vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(embedBatch);
+  return { root, embedBatch };
+}
+
+afterEach(() => {
+  delete process.env.LLMWIKI_PROVIDER;
+  delete process.env.LLMWIKI_EMBEDDING_MODEL;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.LLMWIKI_BINARY_EMBEDDINGS;
+  delete process.env.LLMWIKI_EMBEDDING_BATCH_SIZE;
+  delete process.env.LLMWIKI_CHUNK_BATCH_SIZE;
+  resetStaleEmbeddingWarnings();
+  vi.restoreAllMocks();
+});
+
+describe("store persistence", () => {
+  it("roundtrips a store as number[] vectors on disk", async () => {
+    delete process.env.LLMWIKI_BINARY_EMBEDDINGS;
+    const root = await makeRoot();
+    const original: EmbeddingStore = {
+      version: 2,
+      model: "test-model",
+      dimensions: 2,
+      entries: [
+        makeEntry("alpha", [0.1, 0.2]),
+        makeEntry("beta", [0.4, 0.5]),
+      ],
+    };
+
+    await writeEmbeddingStore(root, original);
+    const loaded = await readEmbeddingStore(root);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.model).toBe(original.model);
+    expect(loaded!.entries).toHaveLength(2);
+    expect(loaded!.entries[0].slug).toBe("alpha");
+    expect(loaded!.entries[0].vector[0]).toBeCloseTo(0.1);
+    expect(loaded!.entries[1].slug).toBe("beta");
+    expect(loaded!.entries[1].vector[1]).toBeCloseTo(0.5);
+
+    const { readFile } = await import("fs/promises");
+    const raw = await readFile(path.join(root, STORE_PATH), "utf-8");
+    const onDisk = JSON.parse(raw);
+    expect(onDisk.version).toBe(2);
+    expect(Array.isArray(onDisk.entries[0].vector)).toBe(true);
+    expect(Array.isArray(onDisk.entries[1].vector)).toBe(true);
+  });
+});
+
+describe("updateEmbeddingsBatched", () => {
+  it("skips pages whose contentHash already matches the on-disk store", async () => {
+    const { root, embedBatch } = await setupBatchTest();
+
+    await writeConceptPage(root, "alpha");
+    await writeConceptPage(root, "beta");
+
+    embedBatch.mockImplementation((texts: string[]) =>
+      Promise.resolve(texts.map(() => [0.1, 0.2]))
+    );
+    await updateEmbeddingsBatched(root, ["alpha", "beta"]);
+    expect(embedBatch).toHaveBeenCalled();
+
+    embedBatch.mockClear();
+    await updateEmbeddingsBatched(root, ["alpha", "beta"]);
+    expect(embedBatch).toHaveBeenCalledTimes(0);
+  });
+
+  it("batches page embeddings into groups of EMBEDDING_BATCH_SIZE", async () => {
+    const { root, embedBatch } = await setupBatchTest();
+
+    for (let i = 0; i < 25; i++) {
+      await writeConceptPage(root, `page-${i}`);
+    }
+    const slugs = Array.from({ length: 25 }, (_, i) => `page-${i}`);
+
+    embedBatch.mockImplementation((texts: string[]) =>
+      Promise.resolve(texts.map(() => [0.1, 0.2]))
+    );
+
+    await updateEmbeddingsBatched(root, slugs);
+
+    expect(embedBatch).toHaveBeenCalled();
+    expect(embedBatch.mock.calls[0][0]).toHaveLength(EMBEDDING_BATCH_SIZE);
+    expect(embedBatch.mock.calls[1][0]).toHaveLength(5);
+  });
+
+  it("batch-embeds chunks across a single page", async () => {
+    const { root, embedBatch } = await setupBatchTest();
+
+    let body = "";
+    for (let i = 0; i < 50; i++) {
+      body += `Paragraph ${i} with enough text to form chunks. `.repeat(20) + "\n\n";
+    }
+    await writeConcept(root, "big-page", body);
+
+    embedBatch.mockImplementation((texts: string[]) =>
+      Promise.resolve(texts.map(() => [0.5, 0.5]))
+    );
+
+    await updateEmbeddingsBatched(root, ["big-page"]);
+    const store = await readEmbeddingStore(root);
+
+    expect(embedBatch).toHaveBeenCalled();
+    expect(store?.chunks?.length).toBeGreaterThan(0);
+    for (const chunk of store?.chunks ?? []) {
+      expect(chunk.contentHash).toMatch(/^[a-f0-9]{16}$/);
+    }
+  });
+});

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -4,9 +4,8 @@
  */
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { mkdtemp, writeFile, mkdir } from "fs/promises";
+import { writeFile } from "fs/promises";
 import path from "path";
-import os from "os";
 import {
   cosineSimilarity,
   findTopK,
@@ -16,49 +15,22 @@ import {
   resolveEmbeddingModel,
   updateEmbeddings,
   writeEmbeddingStore,
-  type EmbeddingStore,
-  type EmbeddingEntry,
 } from "../src/utils/embeddings.js";
 import { OpenAIProvider } from "../src/providers/openai.js";
 import { EMBEDDING_MODELS } from "../src/utils/constants.js";
-
-const STORE_PATH = ".llmwiki/embeddings.json";
-
-function makeEntry(slug: string, vector: number[]): EmbeddingEntry {
-  return {
-    slug,
-    title: slug,
-    summary: `Summary for ${slug}`,
-    vector,
-    updatedAt: "2026-01-01T00:00:00.000Z",
-  };
-}
-
-function makeStore(entries: EmbeddingEntry[]): EmbeddingStore {
-  return {
-    version: 1,
-    model: "test-model",
-    dimensions: entries[0]?.vector.length ?? 0,
-    entries,
-  };
-}
-
-async function makeRoot(): Promise<string> {
-  const root = await mkdtemp(path.join(os.tmpdir(), "llmwiki-embed-"));
-  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
-  return root;
-}
-
-async function writeConceptPage(root: string, slug: string): Promise<void> {
-  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
-  const content = `---\ntitle: ${slug}\nsummary: Summary for ${slug}\n---\n\nBody`;
-  await writeFile(path.join(root, "wiki/concepts", `${slug}.md`), content);
-}
+import {
+  STORE_PATH,
+  makeEntry,
+  makeStore,
+  makeRoot,
+  writeConceptPage,
+} from "./helpers/embedding-store.js";
 
 afterEach(() => {
   delete process.env.LLMWIKI_PROVIDER;
   delete process.env.LLMWIKI_EMBEDDING_MODEL;
   delete process.env.OPENAI_API_KEY;
+  delete process.env.LLMWIKI_BINARY_EMBEDDINGS;
   resetStaleEmbeddingWarnings();
   vi.restoreAllMocks();
 });

--- a/test/helpers/embedding-store.ts
+++ b/test/helpers/embedding-store.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared test utilities for embedding store tests.
+ */
+
+import { mkdtemp, writeFile, mkdir } from "fs/promises";
+import path from "path";
+import os from "os";
+import type { EmbeddingEntry, EmbeddingStore } from "../../src/utils/embeddings.js";
+
+export const STORE_PATH = ".llmwiki/embeddings.json";
+
+export function makeEntry(slug: string, vector: number[]): EmbeddingEntry {
+  return {
+    slug,
+    title: slug,
+    summary: `Summary for ${slug}`,
+    vector,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+export function makeStore(entries: EmbeddingEntry[], model = "test-model"): EmbeddingStore {
+  return {
+    version: 2,
+    model,
+    dimensions: entries[0]?.vector.length ?? 0,
+    entries,
+  };
+}
+
+export async function makeRoot(prefix = "llmwiki-test-"): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  return root;
+}
+
+export async function writeConceptPage(root: string, slug: string): Promise<void> {
+  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+  const content = `---\ntitle: ${slug}\nsummary: Summary for ${slug}\n---\n\nBody`;
+  await writeFile(path.join(root, "wiki/concepts", `${slug}.md`), content);
+}
+
+export async function writeConcept(root: string, slug: string, body: string): Promise<void> {
+  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+  const content = `---\ntitle: ${slug}\nsummary: Summary for ${slug}\n---\n\n${body}`;
+  await writeFile(path.join(root, "wiki/concepts", `${slug}.md`), content);
+}

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -380,9 +380,13 @@ async function withNoCredentials(root: string, fn: () => Promise<void>): Promise
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
     LLMWIKI_CLAUDE_SETTINGS_PATH: process.env.LLMWIKI_CLAUDE_SETTINGS_PATH,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    LLMWIKI_PROVIDER: process.env.LLMWIKI_PROVIDER,
   };
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.ANTHROPIC_AUTH_TOKEN;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.LLMWIKI_PROVIDER;
   process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = path.join(root, "no-such-settings.json");
   try {
     await fn();

--- a/test/provider-factory.test.ts
+++ b/test/provider-factory.test.ts
@@ -3,7 +3,7 @@
  * Verifies correct provider instantiation based on env vars.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -49,7 +49,7 @@ function expectClientBaseURL(provider: object, field: string, expected: string):
 }
 
 describe("getProvider", () => {
-  afterEach(() => {
+  function cleanEnv() {
     delete process.env.LLMWIKI_PROVIDER;
     delete process.env.LLMWIKI_MODEL;
     delete process.env.LLMWIKI_EMBEDDING_MODEL;
@@ -63,7 +63,14 @@ describe("getProvider", () => {
     delete process.env.OLLAMA_EMBEDDINGS_HOST;
     delete process.env[TEST_SETTINGS_PATH_ENV];
     delete process.env.MINIMAX_API_KEY;
+  }
 
+  beforeEach(() => {
+    cleanEnv();
+  });
+
+  afterEach(() => {
+    cleanEnv();
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/review-integration.test.ts
+++ b/test/review-integration.test.ts
@@ -142,6 +142,8 @@ describe("review integration tests", () => {
       const result = await runCLI(["compile", "--review"], cwd, {
         ANTHROPIC_API_KEY: "",
         ANTHROPIC_AUTH_TOKEN: "",
+        OPENAI_API_KEY: "",
+        LLMWIKI_PROVIDER: "anthropic",
       });
       expectCLIFailure(result);
       expect(result.stderr).toContain("Error:");


### PR DESCRIPTION
Split the embedding pipeline into focused modules and added two opt-in features behind env vars:
- `LLMWIKI_BATCH_EMBEDDINGS=true` — groups page and chunk texts into single API calls instead of embedding one-by-one
- `LLMWIKI_BINARY_EMBEDDINGS=true` — packs vectors into a compact Float32 .bin file instead of JSON to avoid Node's string-length ceiling

Both default to off, so the existing sequential pipeline and JSON store are unchanged.

---

I loved the project and I wanted to test it in my company's documentation repo. But it was over 900 markdown files, generating over 33000 chunks to compile. The compilation was taking ages, so I implemented batching and saving the embeddings as binary to avoid json string size limitations. These features are controlled with env vars and the code changes don't affect the current default behavior of the CLI.

It worked like a charm for my use case: compilation orders of magnitude faster and query, view and context commands working as expected.

I didn't do extensive manual testing, didn't test the MCP too, because I was mostly experimenting and messing around. But I figured I should open the PR because maybe this is something you or some other people with similar use cases might appreciate.

Issue: #99 