### PR TITLE
docs: polish README and docs intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # llmwiki
 
-![Breaking News: llmwiki 0.10.0 supports Open Knowledge Format](docs/images/okf-readme-banner.svg)
+<p align="center">
+  <img src="docs/images/okf-readme-banner.svg" alt="Breaking News: llmwiki 0.10.0 supports Open Knowledge Format" width="900">
+</p>
 
 **Breaking News:** llmwiki is now an **Open Knowledge Format (OKF)** producer and consumer, aligning compiled agent knowledge with Google Cloud's emerging standard for portable knowledge sharing. Export compiled wikis with `llmwiki export --target okf`, import external bundles with `llmwiki import --okf`, and stage untrusted knowledge through review before it becomes live agent context.
 
@@ -272,7 +274,7 @@ Use them independently or together. The [`@atomicmemory/llmwiki`](https://github
 
 ## Contributing
 
-Good first contributions are usually docs, provider setup improvements, importer/exporter polish, eval fixtures, or focused CLI ergonomics. Larger feature work should start with an issue or design discussion.
+Contributions are welcome. If llmwiki is missing something you need, open an issue or PR and describe the workflow you are trying to support — need-driven improvements are often the best ones. If you want to contribute more generally, roadmap items are a good place to start. For larger changes to core compile, review, import/export, or retrieval semantics, please start with an issue or design discussion so we can align on the contract first.
 
 Before committing code changes, run:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "name": "llmwiki",
+  "description": "llmwiki compiles raw sources into persistent, citation-traceable markdown wikis that agents and humans can browse, query, lint, export, import, and reuse.",
   "theme": "luma",
   "colors": {
     "primary": "#5B6AD0",

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,6 +4,10 @@ sidebarTitle: "Introduction"
 description: "llmwiki turns URLs, files, and session exports into a persistent, citation-traced markdown wiki with semantic search and MCP agent integration."
 ---
 
+<p align="center">
+  <img src="/images/okf-readme-banner.svg" alt="Breaking News: llmwiki 0.10.0 supports Open Knowledge Format" width="900" />
+</p>
+
 llmwiki is a knowledge compiler. You point it at your sources — research papers, documentation sites, notes, session exports — and it uses an LLM pipeline to compile them into a structured, interlinked wiki that you can browse, search, query, and connect to AI agents. Unlike retrieval-augmented generation (RAG), llmwiki compiles your knowledge once into a durable artifact that compounds over time: concepts get their own typed pages, links form a navigable graph, and every claim traces back to its source.
 
 llmwiki also supports [Google Cloud's Open Knowledge Format initiative](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/). You can export a compiled wiki as an OKF bundle, import OKF bundles from other tools through the review queue, and re-export foreign bundles while preserving producer metadata and llmwiki provenance.


### PR DESCRIPTION
## What
- Centers and constrains the README OKF banner so it renders cleanly on GitHub.
- Adds the same OKF banner to the Mintlify introduction page.
- Adds a top-level docs description so generated agent-facing docs indexes have a useful site summary.
- Updates README contributing copy to welcome need-driven issues and PRs as well as roadmap-driven contributions.

## Validation
- npx tsc --noEmit
- npm run build
- npm test
- npx fallow
- npm run release:check-docs:current