### PR TITLE
feat(sdk,mcp): programmatic + agent access to OKF export/import

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -37,13 +37,11 @@ import { buildJsonLd } from "../export/json-ld.js";
 import { buildGraphml } from "../export/graphml.js";
 import { buildMarp } from "../export/marp.js";
 import { buildOkfBundle } from "../export/okf/bundle.js";
+import { EXPORT_DIR } from "../utils/constants.js";
 import { EXPORT_TARGETS, DEFAULT_EXPORT_TARGETS, MARP_SOURCES } from "../export/types.js";
 import type { ExportPage, ExportTarget, MarpSource } from "../export/types.js";
 
 const require = createRequire(import.meta.url);
-
-/** Output paths relative to dist/exports/ within the project root. */
-const EXPORT_DIR = "dist/exports";
 
 /** Map each target to its output filename. */
 const TARGET_FILENAMES: Record<ExportTarget, string> = {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -186,8 +186,9 @@ export async function runExport(root: string, options: ExportOptions = {}): Prom
 
   for (const target of targets) {
     if (target === "okf") {
-      const { outDir, writtenPaths } = await runOkfExport(root, { out: options.out });
+      const { outDir, writtenPaths, warnings } = await runOkfExport(root, { out: options.out });
       written.push(...writtenPaths);
+      for (const w of warnings) output.status("!", output.warn(w));
       output.status("+", output.success(`Exported okf bundle → ${output.source(outDir)}`));
       continue;
     }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -36,7 +36,7 @@ import { validateProjectId } from "../export/project-id.js";
 import { buildJsonLd } from "../export/json-ld.js";
 import { buildGraphml } from "../export/graphml.js";
 import { buildMarp } from "../export/marp.js";
-import { buildOkfBundle } from "../export/okf/bundle.js";
+import { runOkfExport } from "../export/okf/run.js";
 import { EXPORT_DIR } from "../utils/constants.js";
 import { EXPORT_TARGETS, DEFAULT_EXPORT_TARGETS, MARP_SOURCES } from "../export/types.js";
 import type { ExportPage, ExportTarget, MarpSource } from "../export/types.js";
@@ -186,8 +186,7 @@ export async function runExport(root: string, options: ExportOptions = {}): Prom
 
   for (const target of targets) {
     if (target === "okf") {
-      const outDir = options.out ?? path.join(root, EXPORT_DIR, "okf");
-      const writtenPaths = await buildOkfBundle(root, pages, outDir);
+      const { outDir, writtenPaths } = await runOkfExport(root, { out: options.out });
       written.push(...writtenPaths);
       output.status("+", output.success(`Exported okf bundle → ${output.source(outDir)}`));
       continue;

--- a/src/commands/import-core.ts
+++ b/src/commands/import-core.ts
@@ -1,0 +1,9 @@
+// src/commands/import-core.ts
+/** @file Leaf helper shared by the import command and the import core (avoids a command↔core cycle). */
+import { validateWikiPage } from "../utils/markdown.js";
+import type { MappedOkfPage } from "../import/types.js";
+
+/** A mapped page is writable iff it has a non-empty slug and passes page validation. */
+export function isWritable(page: MappedOkfPage): boolean {
+  return page.slug.length > 0 && validateWikiPage(page.body);
+}

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,119 +1,42 @@
 /**
- * @file `llmwiki import --okf <dir> [--trusted]`. Default: stage each OKF doc as an
+ * @file `llmwiki import --okf <dir> [--trusted] [--dry-run]`. Default: stage each OKF doc as an
  * imported review candidate (untrusted external knowledge stays gated behind review).
  * `--trusted`: write mapped pages straight into wiki/ (validated + collision-checked).
+ *
+ * This command is a thin CLI presentation layer over the output-free `runOkfImport`
+ * core — it delegates all read/map/collision/stage/write logic and only formats the
+ * returned report for the terminal.
  */
-import path from "path";
-import { importOkfBundle } from "../import/okf-import.js";
-import { writeCandidate } from "../compiler/candidates.js";
-import { validateWikiPage, atomicWrite } from "../utils/markdown.js";
-import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
-import { refreshAfterImport } from "../import/okf-refresh.js";
-import { acquireLock, releaseLock } from "../utils/lock.js";
+import { runOkfImport } from "../import/run.js";
+import { LockUnavailableError } from "../import/run-errors.js";
 import * as output from "../utils/output.js";
-import type { MappedOkfPage } from "../import/types.js";
-import type { SkippedOkfPage } from "../import/okf-collision.js";
+import type { OkfImportReport } from "../import/run.js";
+export { isWritable } from "./import-core.js"; // preserve existing importers
 
 /** CLI options for `import`. */
 export interface ImportOptions { okf?: string; trusted?: boolean; dryRun?: boolean; }
 
-/** Stage one mapped page as an imported review candidate. */
-async function stageCandidate(root: string, page: MappedOkfPage): Promise<void> {
-  await writeCandidate(root, {
-    title: page.title, slug: page.slug, summary: page.summary, sources: page.sources, body: page.body,
-    reviewMode: "imported", heldReasons: [{ code: "imported-okf" }],
-    targetDirectory: page.targetDirectory, okfPath: page.okfPath,
-  });
+/** Print a report's warnings, skips, per-page lines, and a one-line summary (CLI-only presentation). */
+function printReport(report: OkfImportReport): void {
+  for (const w of report.warnings) output.status("!", output.warn(w));
+  for (const p of report.pages) output.status("+", `${p.slug} (${p.targetDirectory}) ← ${p.okfPath}`);
+  for (const s of report.skipped) output.status("!", output.warn(`skip ${s.okfPath} — ${s.reason}`));
+  const verb = report.mode === "written" ? "wrote" : report.mode === "dry-run" ? "would import" : "staged";
+  output.status("+", output.success(`OKF import: ${verb} ${report.pages.length} page(s); skipped ${report.skipped.length}.`));
 }
 
-/**
- * A mapped page is writable iff it has a non-empty slug and passes page validation.
- *
- * The empty-slug guard prevents writing `concepts/.md` for a doc whose path slugifies
- * to "" (a real title alone passes `validateWikiPage`, which only checks title + body).
- * `validateWikiPage` is NOT an origin check — imported-origin attribution is guaranteed
- * upstream by the mapper, which stamps `provenanceState: imported` + an `okf:` source token.
- */
-export function isWritable(page: MappedOkfPage): boolean {
-  return page.slug.length > 0 && validateWikiPage(page.body);
-}
-
-/** True if writable; warns + returns false otherwise (skip-and-warn, used by both write paths). */
-function validForWrite(page: MappedOkfPage): boolean {
-  if (isWritable(page)) return true;
-  output.status("!", output.warn(`OKF import: ${page.okfPath} (slug "${page.slug}") failed validation; skipped.`));
-  return false;
-}
-
-/**
- * Write already-validated mapped pages live (--trusted): atomic-write into the target
- * dir, then refresh. If a write throws mid-loop, the already-written subset is still
- * refreshed (index/MOC stay consistent) before the error propagates.
- */
-async function writeTrusted(root: string, pages: MappedOkfPage[]): Promise<void> {
-  const written: string[] = [];
-  try {
-    for (const page of pages) {
-      const dir = page.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
-      await atomicWrite(path.join(root, dir, `${page.slug}.md`), page.body);
-      written.push(page.slug);
-    }
-  } finally {
-    if (written.length) await refreshAfterImport(root, written);
-  }
-}
-
-/** Print the per-page breakdown of a dry-run: what would be written, what's invalid, what collides. */
-function reportPreview(pages: MappedOkfPage[], skipped: SkippedOkfPage[]): void {
-  for (const p of pages) {
-    if (isWritable(p)) {
-      output.status("+", `${p.slug} (${p.targetDirectory}) ← ${p.okfPath}`);
-    } else {
-      output.status("!", output.warn(`invalid (empty slug/title/body): ${p.okfPath}`));
-    }
-  }
-  for (const s of skipped) output.status("!", output.warn(`skip ${s.okfPath} — ${s.reason}`));
-}
-
-/** Report what an import WOULD stage/write and what it would skip, without mutating anything (read-only, no lock). */
-async function previewImport(root: string, okf: string): Promise<void> {
-  const { pages, skipped } = await importOkfBundle(okf, root);
-  const writable = pages.filter(isWritable).length;
-  const dropped = skipped.length + (pages.length - writable);
-  output.status("i", output.dim(`Dry run — would import ${writable} page(s); skip ${dropped}.`));
-  reportPreview(pages, skipped);
-}
-
-/**
- * Import an OKF bundle into the current project.
- *
- * The whole operation runs under `.llmwiki/lock`: BOTH the default staging path
- * (collision-read + candidate list→write→dedup canonicalization) and `--trusted`
- * (collision-read + live write + index/MOC refresh) are durable read-modify-writes
- * that must not race a concurrent `compile`/`approve`. `--dry-run` is read-only and
- * takes no lock.
- */
+/** `llmwiki import --okf <dir> [--trusted] [--dry-run]`. */
 export default async function importCommand(root: string, options: ImportOptions): Promise<void> {
   if (!options.okf) throw new Error("import: --okf <dir> is required");
-  if (options.dryRun) {
-    await previewImport(root, options.okf);
-    return;
-  }
-  const locked = await acquireLock(root);
-  if (!locked) {
-    output.status("!", output.error("Could not acquire lock. Try again later."));
-    process.exitCode = 1;
-    return;
-  }
   try {
-    const { pages, skipped } = await importOkfBundle(options.okf, root);
-    const valid = pages.filter(validForWrite);
-    if (options.trusted) await writeTrusted(root, valid);
-    else { for (const p of valid) await stageCandidate(root, p); }
-    const verb = options.trusted ? "wrote" : "staged";
-    const dropped = skipped.length + (pages.length - valid.length);
-    output.status("+", output.success(`OKF import: ${verb} ${valid.length} page(s); skipped ${dropped}.`));
-  } finally {
-    await releaseLock(root);
+    const report = await runOkfImport(root, options.okf, { trusted: options.trusted, dryRun: options.dryRun });
+    printReport(report);
+  } catch (err) {
+    if (err instanceof LockUnavailableError) {
+      output.status("!", output.error(err.message));
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
   }
 }

--- a/src/export/okf/bundle.ts
+++ b/src/export/okf/bundle.ts
@@ -67,14 +67,15 @@ async function copyResolvedReferences(
   return written;
 }
 
-/** Surface cited sources that were not bundled (missing or outside sources/). */
-function reportSkippedReferences(pages: ExportPage[], refs: Map<string, ResolvedReference>): void {
+/** Surface cited sources that were not bundled (missing or outside sources/) via the warning collector. */
+function reportSkippedReferences(
+  pages: ExportPage[],
+  refs: Map<string, ResolvedReference>,
+  onWarn: (msg: string) => void,
+): void {
   const skipped = collectReferenceFiles(pages).filter((f) => !refs.has(f));
   if (skipped.length === 0) return;
-  output.status(
-    "!",
-    output.warn(`OKF export: ${skipped.length} cited source(s) not bundled (missing or outside sources/)`),
-  );
+  onWarn(`OKF export: ${skipped.length} cited source(s) not bundled (missing or outside sources/)`);
 }
 
 /**
@@ -83,9 +84,17 @@ function reportSkippedReferences(pages: ExportPage[], refs: Map<string, Resolved
  * @param root - llmwiki project root (sources/ lives here).
  * @param pages - All export pages to include in this bundle.
  * @param out - Destination directory for the OKF bundle (created if absent).
+ * @param onWarn - Collector for non-fatal warnings (e.g. cited sources not bundled).
+ *   Defaults to printing via `output.status` so direct callers are unchanged; the
+ *   output-free core (`runOkfExport`) passes a collector so nothing reaches stdout.
  * @returns Absolute paths of every file written (index, docs, references, log).
  */
-export async function buildOkfBundle(root: string, pages: ExportPage[], out: string): Promise<string[]> {
+export async function buildOkfBundle(
+  root: string,
+  pages: ExportPage[],
+  out: string,
+  onWarn: (msg: string) => void = (m) => output.status("!", output.warn(m)),
+): Promise<string[]> {
   await mkdir(out, { recursive: true });
   const realOut = (await safeRealpath(out)) ?? path.normalize(out);
   await clearOkfManaged(realOut);
@@ -106,6 +115,6 @@ export async function buildOkfBundle(root: string, pages: ExportPage[], out: str
   }
   written.push(...(await copyResolvedReferences(refs, realOut)));
   written.push(await writeConfined(realOut, "log.md", await buildLog(root, pages.length)));
-  reportSkippedReferences(pages, refs);
+  reportSkippedReferences(pages, refs, onWarn);
   return written;
 }

--- a/src/export/okf/run.ts
+++ b/src/export/okf/run.ts
@@ -5,12 +5,13 @@ import { collectExportPages } from "../collect.js";
 import { buildOkfBundle } from "./bundle.js";
 import { EXPORT_DIR } from "../../utils/constants.js";
 
-export interface OkfExportReport { outDir: string; writtenPaths: string[]; }
+export interface OkfExportReport { outDir: string; writtenPaths: string[]; warnings: string[]; }
 
-/** Export the wiki as an OKF bundle under `out` (default dist/exports/okf). Returns the bundle dir + every written path. */
+/** Export the wiki as an OKF bundle under `out` (default dist/exports/okf). Returns the bundle dir, every written path, and any non-fatal warnings (e.g. cited sources not bundled). Output-free — warnings are data, not prints. */
 export async function runOkfExport(root: string, opts: { out?: string } = {}): Promise<OkfExportReport> {
   const outDir = opts.out ?? path.join(root, EXPORT_DIR, "okf");
   const pages = await collectExportPages(root);
-  const writtenPaths = await buildOkfBundle(root, pages, outDir);
-  return { outDir, writtenPaths };
+  const warnings: string[] = [];
+  const writtenPaths = await buildOkfBundle(root, pages, outDir, (m) => warnings.push(m));
+  return { outDir, writtenPaths, warnings };
 }

--- a/src/export/okf/run.ts
+++ b/src/export/okf/run.ts
@@ -1,0 +1,16 @@
+// src/export/okf/run.ts
+/** @file Output-free OKF export core shared by CLI/SDK/MCP: collect pages + build the bundle, returning the written paths. */
+import path from "path";
+import { collectExportPages } from "../collect.js";
+import { buildOkfBundle } from "./bundle.js";
+import { EXPORT_DIR } from "../../utils/constants.js";
+
+export interface OkfExportReport { outDir: string; writtenPaths: string[]; }
+
+/** Export the wiki as an OKF bundle under `out` (default dist/exports/okf). Returns the bundle dir + every written path. */
+export async function runOkfExport(root: string, opts: { out?: string } = {}): Promise<OkfExportReport> {
+  const outDir = opts.out ?? path.join(root, EXPORT_DIR, "okf");
+  const pages = await collectExportPages(root);
+  const writtenPaths = await buildOkfBundle(root, pages, outDir);
+  return { outDir, writtenPaths };
+}

--- a/src/import/okf-collision.ts
+++ b/src/import/okf-collision.ts
@@ -7,7 +7,6 @@ import { access } from "fs/promises";
 import path from "path";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import { listCandidates } from "../compiler/candidates.js";
-import * as output from "../utils/output.js";
 import type { MappedOkfPage } from "./types.js";
 
 /** A dropped doc + why, for caller reporting. */
@@ -33,7 +32,6 @@ export async function filterCollisions(
     else if (await fileExists(path.join(root, CONCEPTS_DIR, `${page.slug}.md`)) ||
              await fileExists(path.join(root, QUERIES_DIR, `${page.slug}.md`))) reason = "live-page";
     if (reason) {
-      output.status("!", output.warn(`OKF import: skipped ${page.okfPath} (slug "${page.slug}" collides: ${reason})`));
       skipped.push({ slug: page.slug, okfPath: page.okfPath, reason });
     } else { claimed.add(page.slug); kept.push(page); }
   }

--- a/src/import/okf-import.ts
+++ b/src/import/okf-import.ts
@@ -31,8 +31,9 @@ export async function importOkfBundle(
   bundleDir: string,
   root: string,
   overrides: Partial<OkfImportLimits> = {},
+  onWarn?: (msg: string) => void,
 ): Promise<{ pages: MappedOkfPage[]; skipped: SkippedOkfPage[] }> {
-  const docs = await readOkfBundle(bundleDir, overrides);
+  const docs = await readOkfBundle(bundleDir, overrides, onWarn);
   const ctx = { bundleId: bundleIdFor(bundleDir), titleOf: titleResolver(docs) };
   const mapped = docs.map((d) => okfDocToPage(d, ctx));
   const { kept, skipped } = await filterCollisions(root, mapped);

--- a/src/import/okf-read.ts
+++ b/src/import/okf-read.ts
@@ -59,6 +59,7 @@ export async function confinedInside(realRoot: string, rel: string): Promise<str
 export async function readOkfBundle(
   bundleDir: string,
   overrides: Partial<OkfImportLimits> = {},
+  onWarn: (msg: string) => void = (m) => output.status("!", output.warn(m)),
 ): Promise<RawOkfDoc[]> {
   const limits = { ...DEFAULT_OKF_LIMITS, ...overrides };
   const realRoot = await safeRealpath(bundleDir);
@@ -69,14 +70,14 @@ export async function readOkfBundle(
   for (const rel of rels) {
     if (RESERVED.has(rel)) continue;
     const real = await confinedInside(realRoot, rel);
-    if (!real) { output.status("!", output.warn(`OKF import: skipped path escaping bundle: ${rel}`)); continue; }
+    if (!real) { onWarn(`OKF import: skipped path escaping bundle: ${rel}`); continue; }
     const size = (await stat(real)).size;
     total += size;
     if (size > limits.maxDocBytes || total > limits.maxTotalBytes) throw new Error(`OKF import: bundle exceeds size limit at ${rel}`);
     const parsed = parseFrontmatterStatus(await readFile(real, "utf-8"));
     const type = parsed.meta.type;
     if (parsed.malformedFrontmatter || typeof type !== "string" || type.trim() === "") {
-      output.status("!", output.warn(`OKF import: skipped doc without a valid type: ${rel}`));
+      onWarn(`OKF import: skipped doc without a valid type: ${rel}`);
       continue;
     }
     docs.push({ relPath: rel, meta: parsed.meta, body: parsed.body });

--- a/src/import/run-errors.ts
+++ b/src/import/run-errors.ts
@@ -1,0 +1,17 @@
+/** @file Typed sentinels for OKF import control-flow conditions, so callers (CLI/SDK/MCP) discriminate without string-matching. */
+
+/** Thrown when a real (non-dry-run) import can't take the `.llmwiki/lock`. */
+export class LockUnavailableError extends Error {
+  constructor(message = "Could not acquire lock. Try again later.") {
+    super(message);
+    this.name = "LockUnavailableError";
+  }
+}
+
+/** Thrown when staging would push pending review candidates over a caller-supplied cap. */
+export class QueueFullError extends Error {
+  constructor(message = "Review queue would exceed the cap; approve/reject pending candidates first.") {
+    super(message);
+    this.name = "QueueFullError";
+  }
+}

--- a/src/import/run.ts
+++ b/src/import/run.ts
@@ -1,0 +1,90 @@
+// src/import/run.ts
+/** @file Output-free OKF import core shared by CLI/SDK/MCP: read→map→collision→validate→stage/write/preview, returning a structured report. Owns the .llmwiki lock. */
+import path from "path";
+import { importOkfBundle } from "./okf-import.js";
+import { isWritable } from "../commands/import-core.js"; // leaf created in Task 4 Step 0
+import { writeCandidate, listCandidates } from "../compiler/candidates.js";
+import { atomicWrite } from "../utils/markdown.js";
+import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import { refreshAfterImport } from "./okf-refresh.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { LockUnavailableError, QueueFullError } from "./run-errors.js";
+import type { MappedOkfPage } from "./types.js";
+
+export interface OkfImportSkip { slug: string; okfPath: string; reason: "live-page" | "pending-candidate" | "duplicate-in-bundle" | "invalid-page"; }
+export interface OkfImportedPage { slug: string; okfPath: string; targetDirectory: "concepts" | "queries"; }
+export interface OkfImportReport {
+  mode: "staged" | "written" | "dry-run";
+  pages: OkfImportedPage[];
+  skipped: OkfImportSkip[];
+  warnings: string[];
+  nextAction?: string;
+}
+export interface OkfImportOptions { trusted?: boolean; dryRun?: boolean; maxNewCandidates?: number; }
+
+const toImported = (p: MappedOkfPage): OkfImportedPage => ({ slug: p.slug, okfPath: p.okfPath, targetDirectory: p.targetDirectory });
+
+/** Partition mapped pages (single pass) + assemble the skip list (collisions ∪ invalid). */
+function partition(pages: MappedOkfPage[], collisionSkips: OkfImportSkip[]): { valid: MappedOkfPage[]; skipped: OkfImportSkip[] } {
+  const valid: MappedOkfPage[] = [];
+  const invalid: OkfImportSkip[] = [];
+  for (const p of pages) {
+    if (isWritable(p)) valid.push(p);
+    else invalid.push({ slug: p.slug, okfPath: p.okfPath, reason: "invalid-page" });
+  }
+  return { valid, skipped: [...collisionSkips, ...invalid] };
+}
+
+async function stageAll(root: string, valid: MappedOkfPage[]): Promise<void> {
+  for (const page of valid) {
+    await writeCandidate(root, {
+      title: page.title, slug: page.slug, summary: page.summary, sources: page.sources, body: page.body,
+      reviewMode: "imported", heldReasons: [{ code: "imported-okf" }],
+      targetDirectory: page.targetDirectory, okfPath: page.okfPath,
+    });
+  }
+}
+
+async function writeAll(root: string, valid: MappedOkfPage[]): Promise<void> {
+  const written: string[] = [];
+  try {
+    for (const page of valid) {
+      const dir = page.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
+      await atomicWrite(path.join(root, dir, `${page.slug}.md`), page.body);
+      written.push(page.slug);
+    }
+  } finally {
+    if (written.length) await refreshAfterImport(root, written);
+  }
+}
+
+/** Read→map→collision→validate→stage/write/preview an OKF bundle; output-free; returns a report. */
+export async function runOkfImport(root: string, dir: string, opts: OkfImportOptions = {}): Promise<OkfImportReport> {
+  const warnings: string[] = [];
+  if (opts.dryRun) {
+    const { pages, skipped } = await importOkfBundle(dir, root, {}, (m) => warnings.push(m));
+    const { valid, skipped: allSkipped } = partition(pages, skipped as OkfImportSkip[]);
+    return { mode: "dry-run", pages: valid.map(toImported), skipped: allSkipped, warnings, nextAction: "Re-run without dryRun to apply." };
+  }
+  const locked = await acquireLock(root);
+  if (!locked) throw new LockUnavailableError();
+  try {
+    const { pages, skipped } = await importOkfBundle(dir, root, {}, (m) => warnings.push(m));
+    const { valid, skipped: allSkipped } = partition(pages, skipped as OkfImportSkip[]);
+    if (opts.maxNewCandidates !== undefined && !opts.trusted) {
+      const pending = (await listCandidates(root)).length;
+      if (pending + valid.length > opts.maxNewCandidates) throw new QueueFullError();
+    }
+    if (opts.trusted) await writeAll(root, valid);
+    else await stageAll(root, valid);
+    return {
+      mode: opts.trusted ? "written" : "staged",
+      pages: valid.map(toImported),
+      skipped: allSkipped,
+      warnings,
+      nextAction: opts.trusted ? `${valid.length} page(s) written live.` : "Review and approve before it goes live: llmwiki review list.",
+    };
+  } finally {
+    await releaseLock(root);
+  }
+}

--- a/src/import/run.ts
+++ b/src/import/run.ts
@@ -8,6 +8,7 @@ import { atomicWrite } from "../utils/markdown.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import { refreshAfterImport } from "./okf-refresh.js";
 import { acquireLock, releaseLock } from "../utils/lock.js";
+import { withQuiet } from "../utils/output.js";
 import { LockUnavailableError, QueueFullError } from "./run-errors.js";
 import type { MappedOkfPage } from "./types.js";
 
@@ -66,7 +67,9 @@ export async function runOkfImport(root: string, dir: string, opts: OkfImportOpt
     const { valid, skipped: allSkipped } = partition(pages, skipped as OkfImportSkip[]);
     return { mode: "dry-run", pages: valid.map(toImported), skipped: allSkipped, warnings, nextAction: "Re-run without dryRun to apply." };
   }
-  const locked = await acquireLock(root);
+  // withQuiet: acquireLock prints "Another compilation is running." on contention;
+  // the typed LockUnavailableError is the signal, so the core stays output-free.
+  const locked = await withQuiet(() => acquireLock(root));
   if (!locked) throw new LockUnavailableError();
   try {
     const { pages, skipped } = await importOkfBundle(dir, root, {}, (m) => warnings.push(m));

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,3 +42,8 @@ export type { PageRecord } from "./pages/read.js";
 export type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "./sources/store.js";
 // WriteStatus is part of IngestResult — re-exported so callers needn't deep-import utils/types.
 export type { WriteStatus } from "./utils/types.js";
+
+// OKF export/import — report types and typed errors for SDK consumers.
+export type { OkfExportReport } from "./export/okf/run.js";
+export type { OkfImportReport, OkfImportSkip, OkfImportedPage } from "./import/run.js";
+export { LockUnavailableError, QueueFullError } from "./import/run-errors.js";

--- a/src/mcp/okf-tools.ts
+++ b/src/mcp/okf-tools.ts
@@ -25,7 +25,7 @@ export function registerOkfTools(server: McpServer, root: string, maxPending: nu
       try {
         const dest = await confineUnderRoot(out ?? "dist/exports/okf", root, { mustExist: false });
         const report = await runOkfExport(root, { out: dest });
-        return jsonResult({ outDir: report.outDir, fileCount: report.writtenPaths.length, files: report.writtenPaths.slice(0, 20) });
+        return jsonResult({ outDir: report.outDir, fileCount: report.writtenPaths.length, files: report.writtenPaths.slice(0, 20), warnings: report.warnings });
       } catch (err) {
         return errorResult(err instanceof Error ? err.message : String(err));
       }

--- a/src/mcp/okf-tools.ts
+++ b/src/mcp/okf-tools.ts
@@ -3,17 +3,12 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { confineUnderRoot } from "../utils/path-confine.js";
+import { withQuiet } from "../utils/output.js";
 import { runOkfExport } from "../export/okf/run.js";
 import { runOkfImport } from "../import/run.js";
+import { jsonResult, errorResult } from "./result.js";
 
 const MAX_MCP_PENDING_CANDIDATES = 200;
-
-function jsonResult(payload: unknown): { content: Array<{ type: "text"; text: string }>; structuredContent: { result: unknown } } {
-  return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }], structuredContent: { result: payload } };
-}
-function errorResult(message: string): { content: Array<{ type: "text"; text: string }>; isError: true } {
-  return { content: [{ type: "text" as const, text: message }], isError: true };
-}
 
 /** Register the OKF export/import tools. Both confine agent-supplied paths under `root`. `maxPending` is injectable so a test can prove the cap is actually wired into import_okf (default keeps production behavior). */
 export function registerOkfTools(server: McpServer, root: string, maxPending: number = MAX_MCP_PENDING_CANDIDATES): void {
@@ -24,7 +19,9 @@ export function registerOkfTools(server: McpServer, root: string, maxPending: nu
       description: "Export the wiki as an Open Knowledge Format (OKF) v0.1 bundle. `out` defaults to dist/exports/okf and must stay inside the project.",
       inputSchema: { out: z.string().optional().describe("Output dir for the bundle (must resolve inside the project root)") },
     },
-    async ({ out }) => {
+    // withQuiet: the export core can print skipped-reference warnings via output.status;
+    // on the MCP stdio transport those would land on the JSON-RPC stream and corrupt it.
+    async ({ out }) => withQuiet(async () => {
       try {
         const dest = await confineUnderRoot(out ?? "dist/exports/okf", root, { mustExist: false });
         const report = await runOkfExport(root, { out: dest });
@@ -32,7 +29,7 @@ export function registerOkfTools(server: McpServer, root: string, maxPending: nu
       } catch (err) {
         return errorResult(err instanceof Error ? err.message : String(err));
       }
-    },
+    }),
   );
 
   server.registerTool(
@@ -45,7 +42,8 @@ export function registerOkfTools(server: McpServer, root: string, maxPending: nu
         dryRun: z.boolean().optional().describe("Preview only — stage nothing"),
       },
     },
-    async ({ dir, dryRun }) => {
+    // withQuiet: same stdio-stream guard as export_okf (the import core may emit warnings).
+    async ({ dir, dryRun }) => withQuiet(async () => {
       try {
         const bundle = await confineUnderRoot(dir, root, { mustExist: true });
         const report = await runOkfImport(root, bundle, { trusted: false, dryRun, maxNewCandidates: maxPending });
@@ -62,6 +60,6 @@ export function registerOkfTools(server: McpServer, root: string, maxPending: nu
       } catch (err) {
         return errorResult(err instanceof Error ? err.message : String(err));
       }
-    },
+    }),
   );
 }

--- a/src/mcp/okf-tools.ts
+++ b/src/mcp/okf-tools.ts
@@ -1,0 +1,67 @@
+// src/mcp/okf-tools.ts
+/** @file MCP OKF tools: export_okf (confined) + import_okf (staging-only, confined, queue-capped). Extracted from tools.ts to stay under the file-size limit. */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { confineUnderRoot } from "../utils/path-confine.js";
+import { runOkfExport } from "../export/okf/run.js";
+import { runOkfImport } from "../import/run.js";
+
+const MAX_MCP_PENDING_CANDIDATES = 200;
+
+function jsonResult(payload: unknown): { content: Array<{ type: "text"; text: string }>; structuredContent: { result: unknown } } {
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }], structuredContent: { result: payload } };
+}
+function errorResult(message: string): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  return { content: [{ type: "text" as const, text: message }], isError: true };
+}
+
+/** Register the OKF export/import tools. Both confine agent-supplied paths under `root`. `maxPending` is injectable so a test can prove the cap is actually wired into import_okf (default keeps production behavior). */
+export function registerOkfTools(server: McpServer, root: string, maxPending: number = MAX_MCP_PENDING_CANDIDATES): void {
+  server.registerTool(
+    "export_okf",
+    {
+      title: "Export OKF bundle",
+      description: "Export the wiki as an Open Knowledge Format (OKF) v0.1 bundle. `out` defaults to dist/exports/okf and must stay inside the project.",
+      inputSchema: { out: z.string().optional().describe("Output dir for the bundle (must resolve inside the project root)") },
+    },
+    async ({ out }) => {
+      try {
+        const dest = await confineUnderRoot(out ?? "dist/exports/okf", root, { mustExist: false });
+        const report = await runOkfExport(root, { out: dest });
+        return jsonResult({ outDir: report.outDir, fileCount: report.writtenPaths.length, files: report.writtenPaths.slice(0, 20) });
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.registerTool(
+    "import_okf",
+    {
+      title: "Import OKF bundle (staged for review)",
+      description: "Import an OKF bundle from a path INSIDE the project as review candidates. Always staging-only — imported knowledge requires human review/approval before it enters the wiki. Use dryRun to preview.",
+      inputSchema: {
+        dir: z.string().describe("Bundle directory (must resolve inside the project root)"),
+        dryRun: z.boolean().optional().describe("Preview only — stage nothing"),
+      },
+    },
+    async ({ dir, dryRun }) => {
+      try {
+        const bundle = await confineUnderRoot(dir, root, { mustExist: true });
+        const report = await runOkfImport(root, bundle, { trusted: false, dryRun, maxNewCandidates: maxPending });
+        return jsonResult({
+          mode: report.mode,
+          imported: report.pages.length,
+          pages: report.pages,
+          skipped: report.skipped,
+          warnings: report.warnings,
+          nextAction: report.mode === "dry-run"
+            ? "Preview only — re-run without dryRun to stage these as review candidates."
+            : "Imported docs are STAGED as review candidates — approve them via `llmwiki review` (human gate) before they enter the wiki.",
+        });
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+}

--- a/src/mcp/result.ts
+++ b/src/mcp/result.ts
@@ -1,0 +1,37 @@
+/**
+ * @file Shared MCP CallToolResult builders.
+ *
+ * Every tool handler returns the same envelope shape, so the construction of
+ * success/error results lives here as the single source of truth — `tools.ts`
+ * and `okf-tools.ts` both import these rather than each keeping a local copy.
+ */
+
+/**
+ * Wrap an arbitrary JSON value as the standard MCP CallToolResult.
+ * MCP requires content blocks even for structured payloads, so we mirror
+ * the JSON in a text block for clients that don't read structuredContent.
+ *
+ * The return type is an inline object literal (not a named interface) so it
+ * stays structurally assignable to the SDK's `CallToolResult`, whose own type
+ * carries an index signature that a named interface would not satisfy.
+ */
+export function jsonResult(payload: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: { result: unknown };
+} {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    structuredContent: { result: payload },
+  };
+}
+
+/** Wrap an error message as an MCP error result (flagged with `isError`). */
+export function errorResult(message: string): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -14,6 +14,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerWikiTools } from "./tools.js";
+import { registerOkfTools } from "./okf-tools.js";
 import { registerWikiResources } from "./resources.js";
 
 interface ServerOptions {
@@ -42,6 +43,7 @@ export async function startMCPServer(options: ServerOptions): Promise<void> {
   });
 
   registerWikiTools(server, root);
+  registerOkfTools(server, root);
   registerWikiResources(server, root);
 
   const transport = new StdioServerTransport();

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -20,21 +20,7 @@ import { ensureProviderAvailable } from "../utils/provider-guard.js";
 import { runEval, DEFAULT_SAMPLE_SIZE } from "../eval/index.js";
 import { readPageRecord } from "../pages/read.js";
 import { pickSearchSlugs, loadPageRecords } from "../search/retrieval.js";
-
-/**
- * Wrap an arbitrary JSON value as the standard MCP CallToolResult.
- * MCP requires content blocks even for structured payloads, so we mirror
- * the JSON in a text block for clients that don't read structuredContent.
- */
-function jsonResult(payload: unknown): {
-  content: Array<{ type: "text"; text: string }>;
-  structuredContent: { result: unknown };
-} {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
-    structuredContent: { result: payload },
-  };
-}
+import { jsonResult } from "./result.js";
 
 /** Register all 9 wiki tools on the given MCP server instance. */
 export function registerWikiTools(server: McpServer, root: string): void {

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -18,6 +18,8 @@ import type { Page, PageRef, ListPagesOptions, ListPagesResult } from "../pages/
 import type { PageRecord } from "../pages/read.js";
 import type { JsonExportDocument, BuildJsonExportOptions } from "../export/json-export.js";
 import type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "../sources/store.js";
+import type { OkfExportReport } from "../export/okf/run.js";
+import type { OkfImportReport } from "../import/run.js";
 
 /** Options for `createWiki`. */
 export interface CreateWikiOptions {
@@ -155,4 +157,12 @@ export interface Wiki {
    * progress callback in v1; structured `onLog` event delivery is planned for v1.x.
    */
   runEval(options: { mode: "fast" | "full"; record?: boolean }): Promise<EvalReport>;
+  /** Export the wiki as an OKF v0.1 bundle (default dist/exports/okf). */
+  exportOkf(opts?: { out?: string }): Promise<OkfExportReport>;
+  /**
+   * Import an OKF bundle. Default stages review candidates; `trusted:true` writes live
+   * (and runs the full refresh — links/index/MOC/EMBEDDINGS, which may incur provider
+   * latency/cost); `dryRun:true` writes nothing.
+   */
+  importOkf(dir: string, opts?: { trusted?: boolean; dryRun?: boolean }): Promise<OkfImportReport>;
 }

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -36,6 +36,8 @@ import { collectStatus } from "../status/collect.js";
 import { pickSearchSlugs, loadPageRecords } from "../search/retrieval.js";
 import { getPage, listPages } from "../pages/list.js";
 import { listSources, getSource, deleteSource } from "../sources/store.js";
+import { runOkfExport } from "../export/okf/run.js";
+import { runOkfImport } from "../import/run.js";
 import type { CreateWikiOptions, Wiki, SdkCompileOptions } from "./types.js";
 
 /**
@@ -125,5 +127,9 @@ export function createWiki(options: CreateWikiOptions): Wiki {
         if (mode === "full") ensureProviderAvailable();
         return runEval(root, mode, DEFAULT_SAMPLE_SIZE, record);
       }),
+
+    exportOkf: (opts = {}) => runQuiet(() => runOkfExport(root, opts)),
+
+    importOkf: (dir, opts = {}) => runQuiet(() => runOkfImport(root, dir, opts)),
   };
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -72,6 +72,9 @@ export const OPENAI_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
  */
 export const OLLAMA_DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 
+/** Output paths relative to the project root for export artifacts. */
+export const EXPORT_DIR = "dist/exports";
+
 /** Directory names relative to the project root. */
 export const SOURCES_DIR = "sources";
 export const CONCEPTS_DIR = "wiki/concepts";

--- a/src/utils/path-confine.ts
+++ b/src/utils/path-confine.ts
@@ -67,3 +67,34 @@ export async function resolveSourcesDir(root: string): Promise<string | null> {
   }
   return sourcesDir;
 }
+
+/**
+ * Confine a caller-supplied path under `root` and return its absolute form, or THROW.
+ * `mustExist:true` (an input dir) requires the realpath to exist inside root.
+ * `mustExist:false` (an output dir that may not exist yet) resolves lexically, then
+ * realpath-checks the nearest existing path AT OR ABOVE the target — starting with the
+ * target itself — so an existing symlinked dir/parent that escapes root is rejected.
+ */
+export async function confineUnderRoot(
+  target: string,
+  root: string,
+  opts: { mustExist: boolean },
+): Promise<string> {
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  const abs = path.normalize(path.resolve(realRoot, target));
+  if (!isInsideDir(abs, realRoot)) throw new Error(`path escapes project root: ${target}`);
+  if (opts.mustExist) {
+    const real = await safeRealpath(abs);
+    if (real === null || !isInsideDir(real, realRoot)) throw new Error(`path escapes project root: ${target}`);
+    return real;
+  }
+  for (let cur = abs; ; cur = path.dirname(cur)) {
+    const real = await safeRealpath(cur);
+    if (real !== null) {
+      if (!isInsideDir(real, realRoot)) throw new Error(`path escapes project root: ${target}`);
+      break;
+    }
+    if (path.dirname(cur) === cur) break; // reached filesystem root without an existing ancestor
+  }
+  return abs;
+}

--- a/test/fixtures/mcp-test-env.ts
+++ b/test/fixtures/mcp-test-env.ts
@@ -80,7 +80,15 @@ export async function connectMcpClient(root: string): Promise<McpClientHandle> {
   return { client, transport };
 }
 
-/** Build a fresh McpServer with all wiki tools and resources registered. */
+/**
+ * Build a fresh McpServer with the wiki tools and resources registered.
+ *
+ * Intentionally registers ONLY the wiki tools/resources, NOT the OKF tools
+ * (export_okf/import_okf): in-process OKF coverage drives `registerOkfTools`
+ * directly with a fake server, and OKF stdio coverage uses the real `serve`
+ * binary via `connectMcpClient`. A future reader reaching for `buildServer`
+ * to call an OKF tool would get "tool not found" — by design.
+ */
 export function buildServer(root: string): McpServer {
   const server = new McpServer({ name: "llmwiki-test", version: "0.0.0" });
   registerWikiTools(server, root);

--- a/test/fixtures/mcp-test-env.ts
+++ b/test/fixtures/mcp-test-env.ts
@@ -25,8 +25,11 @@ import path from "path";
 import os from "os";
 import { afterEach, beforeEach } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { registerWikiTools } from "../../src/mcp/tools.js";
 import { registerWikiResources } from "../../src/mcp/resources.js";
+import { CLI } from "./run-cli.js";
 
 /** Live container for the current test's temp root path. */
 export interface McpRootHandle {
@@ -54,6 +57,27 @@ export function useMcpRoot(prefix: string): McpRootHandle {
     await rm(handle.value, { recursive: true, force: true });
   });
   return handle;
+}
+
+/** A connected SDK Client + its transport, spawned over real stdio. */
+export interface McpClientHandle {
+  client: Client;
+  transport: StdioClientTransport;
+}
+
+/**
+ * Spawn `llmwiki serve --root <root>` over stdio and connect an SDK Client
+ * through the full JSON-RPC stack. Shared by every MCP stdio integration test.
+ */
+export async function connectMcpClient(root: string): Promise<McpClientHandle> {
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [CLI, "serve", "--root", root],
+    stderr: "ignore",
+  });
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await client.connect(transport);
+  return { client, transport };
 }
 
 /** Build a fresh McpServer with all wiki tools and resources registered. */

--- a/test/fixtures/no-output.ts
+++ b/test/fixtures/no-output.ts
@@ -1,0 +1,16 @@
+import { vi, expect } from "vitest";
+/** Run `fn` asserting it writes nothing to stdout/stderr (the output-free-core guard). Returns fn's result. */
+export async function assertNoOutput<T>(fn: () => Promise<T>): Promise<T> {
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const result = await fn();
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    return result;
+  } finally {
+    log.mockRestore(); warn.mockRestore(); error.mockRestore();
+  }
+}

--- a/test/fixtures/okf-bundle-fixture.ts
+++ b/test/fixtures/okf-bundle-fixture.ts
@@ -1,0 +1,20 @@
+/**
+ * @file Shared test fixture: write a minimal one-doc OKF bundle under a root.
+ *
+ * Several import tests need the same starting point — a `kb/` bundle holding a
+ * single valid concept doc — so the directory layout + frontmatter live here
+ * rather than being copy-pasted into each test.
+ */
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+
+/**
+ * Create `<root>/kb/concepts/a.md` (a single valid OKF concept doc) and return
+ * the bundle directory path (`<root>/kb`), ready to pass to runOkfImport.
+ */
+export async function writeOneDocBundle(root: string): Promise<string> {
+  const bundleDir = path.join(root, "kb");
+  await mkdir(path.join(bundleDir, "concepts"), { recursive: true });
+  await writeFile(path.join(bundleDir, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
+  return bundleDir;
+}

--- a/test/fixtures/okf-tools-harness.ts
+++ b/test/fixtures/okf-tools-harness.ts
@@ -1,0 +1,29 @@
+/**
+ * @file Shared in-process harness for the MCP OKF tools.
+ *
+ * Both the OKF tool suite and the queue-cap test register `registerOkfTools`
+ * against a fake `McpServer` that just captures each tool's handler by name.
+ * The precise `ToolHandler` type means a drift in the result envelope fails at
+ * tsc rather than silently at runtime.
+ */
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerOkfTools } from "../../src/mcp/okf-tools.js";
+
+/** A registered tool handler's call signature — drift in the result envelope fails at tsc. */
+export type ToolHandler = (
+  args: Record<string, unknown>,
+) => Promise<{ content: Array<{ type: string; text: string }>; isError?: true }>;
+
+/**
+ * Register the OKF tools against a fake server and return their handlers by name.
+ * `maxPending` is forwarded so a test can inject a cap (e.g. 0) to prove it is wired.
+ */
+export function collectOkfHandlers(root: string, maxPending?: number): Map<string, ToolHandler> {
+  const handlers = new Map<string, ToolHandler>();
+  const fake = {
+    registerTool: (name: string, _def: unknown, handler: ToolHandler) => handlers.set(name, handler),
+  } as unknown as McpServer;
+  if (maxPending === undefined) registerOkfTools(fake, root);
+  else registerOkfTools(fake, root, maxPending);
+  return handlers;
+}

--- a/test/mcp-stdio.test.ts
+++ b/test/mcp-stdio.test.ts
@@ -15,9 +15,7 @@ import { describe, it, expect } from "vitest";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { CLI } from "./fixtures/run-cli.js";
-import { useMcpRoot } from "./fixtures/mcp-test-env.js";
+import { useMcpRoot, connectMcpClient } from "./fixtures/mcp-test-env.js";
 
 const rootHandle = useMcpRoot("mcp-stdio");
 
@@ -42,18 +40,6 @@ async function seedPendingCandidate(root: string): Promise<void> {
     JSON.stringify(candidate, null, 2),
     "utf-8",
   );
-}
-
-/** Connect an SDK Client to a freshly spawned llmwiki MCP server. */
-async function connectMcpClient(root: string): Promise<{ client: Client; transport: StdioClientTransport }> {
-  const transport = new StdioClientTransport({
-    command: "node",
-    args: [CLI, "serve", "--root", root],
-    stderr: "ignore",
-  });
-  const client = new Client({ name: "test-client", version: "0.0.0" });
-  await client.connect(transport);
-  return { client, transport };
 }
 
 /** Parse the JSON status payload from a wiki_status tool response. */

--- a/test/okf-import-cli-delegation.test.ts
+++ b/test/okf-import-cli-delegation.test.ts
@@ -5,19 +5,32 @@ import { tmpdir } from "os";
 import path from "path";
 import importCommand from "../src/commands/import.js";
 import { listCandidates } from "../src/compiler/candidates.js";
+import { writeOneDocBundle } from "./fixtures/okf-bundle-fixture.js";
 
 let dir: string;
-afterEach(async () => { vi.restoreAllMocks(); if (dir) await rm(dir, { recursive: true, force: true }); });
+afterEach(async () => { vi.restoreAllMocks(); process.exitCode = undefined; if (dir) await rm(dir, { recursive: true, force: true }); });
 
 describe("importCommand delegates to runOkfImport", () => {
   it("stages + prints a summary the CLI test relies on", async () => {
     dir = await mkdtemp(path.join(tmpdir(), "icd-"));
-    const b = path.join(dir, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
-    await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
+    const b = await writeOneDocBundle(dir);
     const out: string[] = [];
     vi.spyOn(console, "log").mockImplementation((...a) => out.push(a.join(" ")));
     await importCommand(dir, { okf: b });
     expect(await listCandidates(dir)).toHaveLength(1);
     expect(out.join("\n")).toMatch(/staged 1 page/i);
+  });
+  it("prints exactly ONE friendly lock message when the lock is held", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "icd-lock-"));
+    const b = await writeOneDocBundle(dir);
+    await mkdir(path.join(dir, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(dir, ".llmwiki", "lock"), String(process.pid), "utf-8");
+    const out: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...a) => out.push(a.join(" ")));
+    vi.spyOn(console, "warn").mockImplementation((...a) => out.push(a.join(" ")));
+    await importCommand(dir, { okf: b });
+    const lockLines = out.filter((l) => /could not acquire lock/i.test(l));
+    expect(lockLines).toHaveLength(1);
+    expect(out.join("\n")).not.toMatch(/another compilation is running/i);
   });
 });

--- a/test/okf-import-cli-delegation.test.ts
+++ b/test/okf-import-cli-delegation.test.ts
@@ -1,0 +1,23 @@
+// test/okf-import-cli-delegation.test.ts
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import importCommand from "../src/commands/import.js";
+import { listCandidates } from "../src/compiler/candidates.js";
+
+let dir: string;
+afterEach(async () => { vi.restoreAllMocks(); if (dir) await rm(dir, { recursive: true, force: true }); });
+
+describe("importCommand delegates to runOkfImport", () => {
+  it("stages + prints a summary the CLI test relies on", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "icd-"));
+    const b = path.join(dir, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
+    await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
+    const out: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...a) => out.push(a.join(" ")));
+    await importCommand(dir, { okf: b });
+    expect(await listCandidates(dir)).toHaveLength(1);
+    expect(out.join("\n")).toMatch(/staged 1 page/i);
+  });
+});

--- a/test/okf-mcp-queue-cap.test.ts
+++ b/test/okf-mcp-queue-cap.test.ts
@@ -3,8 +3,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerOkfTools } from "../src/mcp/okf-tools.js";
+import { collectOkfHandlers } from "./fixtures/okf-tools-harness.js";
 
 let dir: string;
 afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
@@ -14,9 +13,7 @@ describe("import_okf honors the candidate cap", () => {
     dir = await mkdtemp(path.join(tmpdir(), "mcp-cap-"));
     const b = path.join(dir, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
     await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
-    const handlers = new Map<string, Function>();
-    const fake = { registerTool: (n: string, _d: unknown, h: Function) => handlers.set(n, h) } as unknown as McpServer;
-    registerOkfTools(fake, dir, 0); // injected cap of 0 → any staging is over the cap
+    const handlers = collectOkfHandlers(dir, 0); // injected cap of 0 → any staging is over the cap
     const refused = await handlers.get("import_okf")!({ dir: "kb" });
     expect(refused.isError).toBe(true);
     expect(refused.content[0].text).toMatch(/queue/i);

--- a/test/okf-mcp-queue-cap.test.ts
+++ b/test/okf-mcp-queue-cap.test.ts
@@ -1,0 +1,26 @@
+// test/okf-mcp-queue-cap.test.ts  (≤40 lines)
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerOkfTools } from "../src/mcp/okf-tools.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+describe("import_okf honors the candidate cap", () => {
+  it("refuses to stage when the cap would be exceeded, but dry-run is allowed", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "mcp-cap-"));
+    const b = path.join(dir, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
+    await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
+    const handlers = new Map<string, Function>();
+    const fake = { registerTool: (n: string, _d: unknown, h: Function) => handlers.set(n, h) } as unknown as McpServer;
+    registerOkfTools(fake, dir, 0); // injected cap of 0 → any staging is over the cap
+    const refused = await handlers.get("import_okf")!({ dir: "kb" });
+    expect(refused.isError).toBe(true);
+    expect(refused.content[0].text).toMatch(/queue/i);
+    const preview = await handlers.get("import_okf")!({ dir: "kb", dryRun: true });
+    expect(preview.isError).toBeUndefined(); // dry-run is never blocked
+  });
+});

--- a/test/okf-mcp-stdio.test.ts
+++ b/test/okf-mcp-stdio.test.ts
@@ -1,0 +1,42 @@
+/**
+ * MCP-over-stdio integration test for the OKF export tool.
+ *
+ * Mirrors `test/mcp-stdio.test.ts`: spawns the actual `llmwiki serve --root <tmp>`
+ * binary over stdio, connects an SDK Client via StdioClientTransport, and calls
+ * `export_okf` through the full JSON-RPC stack. Verifies the tool produces a
+ * bundle on disk and returns a non-error response. `export_okf` makes no LLM
+ * calls, so no API key is required.
+ */
+
+import { describe, it, expect } from "vitest";
+import { stat, writeFile } from "fs/promises";
+import path from "path";
+import { useMcpRoot, connectMcpClient } from "./fixtures/mcp-test-env.js";
+
+const rootHandle = useMcpRoot("okf-mcp-stdio");
+
+/** Seed a minimal concept page so the OKF bundle has content to export. */
+async function seedConceptPage(root: string): Promise<void> {
+  await writeFile(
+    path.join(root, "wiki/concepts/rag.md"),
+    "---\ntitle: RAG\nkind: concept\n---\n\nBody.\n",
+    "utf-8",
+  );
+}
+
+describe("MCP stdio: export_okf produces a bundle", () => {
+  it("writes an OKF bundle to disk and returns a non-error response", async () => {
+    const root = rootHandle.value;
+    await seedConceptPage(root);
+
+    const { client, transport } = await connectMcpClient(root);
+    try {
+      const result = await client.callTool({ name: "export_okf", arguments: {} });
+      expect(result.isError).toBeFalsy();
+      expect((await stat(path.join(root, "dist/exports/okf/index.md"))).isFile()).toBe(true);
+    } finally {
+      await client.close();
+      await transport.close();
+    }
+  }, 30_000);
+});

--- a/test/okf-mcp-stdio.test.ts
+++ b/test/okf-mcp-stdio.test.ts
@@ -1,19 +1,24 @@
 /**
- * MCP-over-stdio integration test for the OKF export tool.
+ * MCP-over-stdio integration tests for the OKF tools.
  *
- * Mirrors `test/mcp-stdio.test.ts`: spawns the actual `llmwiki serve --root <tmp>`
- * binary over stdio, connects an SDK Client via StdioClientTransport, and calls
- * `export_okf` through the full JSON-RPC stack. Verifies the tool produces a
- * bundle on disk and returns a non-error response. `export_okf` makes no LLM
- * calls, so no API key is required.
+ * Mirrors `test/mcp-stdio.test.ts`: each test spawns the actual
+ * `llmwiki serve --root <tmp>` binary over stdio, connects an SDK Client via
+ * StdioClientTransport, and drives a tool through the full JSON-RPC stack.
+ * Covers `export_okf` (happy path), and `import_okf` staging, path-confinement
+ * rejection, and dry-run — the paths a fake in-process `registerTool` can't
+ * exercise. None of these tools call an LLM, so no API key is required.
+ *
+ * Root isolation: each `describe` owns its OWN `useMcpRoot` handle, and
+ * `useMcpRoot` reassigns the root via `beforeEach` so every `it` gets a fresh
+ * temp dir. The staging test (writes a candidate) and the dry-run test (asserts
+ * zero candidates) therefore never share a root.
  */
 
 import { describe, it, expect } from "vitest";
-import { stat, writeFile } from "fs/promises";
+import { stat, writeFile, mkdir } from "fs/promises";
 import path from "path";
 import { useMcpRoot, connectMcpClient } from "./fixtures/mcp-test-env.js";
-
-const rootHandle = useMcpRoot("okf-mcp-stdio");
+import { listCandidates } from "../src/compiler/candidates.js";
 
 /** Seed a minimal concept page so the OKF bundle has content to export. */
 async function seedConceptPage(root: string): Promise<void> {
@@ -24,7 +29,19 @@ async function seedConceptPage(root: string): Promise<void> {
   );
 }
 
+/** Write a foreign OKF bundle under `<root>/kb` with one valid concept doc. */
+async function writeBundle(root: string): Promise<void> {
+  await mkdir(path.join(root, "kb/concepts"), { recursive: true });
+  await writeFile(path.join(root, "kb/concepts/a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n", "utf-8");
+}
+
+/** Read the JSON payload a tool returned via `jsonResult` (structuredContent.result). */
+function payloadOf(result: Awaited<ReturnType<Awaited<ReturnType<typeof connectMcpClient>>["client"]["callTool"]>>): Record<string, unknown> {
+  return (result.structuredContent as { result: Record<string, unknown> }).result;
+}
+
 describe("MCP stdio: export_okf produces a bundle", () => {
+  const rootHandle = useMcpRoot("okf-mcp-stdio-export");
   it("writes an OKF bundle to disk and returns a non-error response", async () => {
     const root = rootHandle.value;
     await seedConceptPage(root);
@@ -34,6 +51,63 @@ describe("MCP stdio: export_okf produces a bundle", () => {
       const result = await client.callTool({ name: "export_okf", arguments: {} });
       expect(result.isError).toBeFalsy();
       expect((await stat(path.join(root, "dist/exports/okf/index.md"))).isFile()).toBe(true);
+    } finally {
+      await client.close();
+      await transport.close();
+    }
+  }, 30_000);
+});
+
+describe("MCP stdio: import_okf stages candidates", () => {
+  const rootHandle = useMcpRoot("okf-mcp-stdio-import");
+  it("stages a candidate and conveys the review gate over the wire", async () => {
+    const root = rootHandle.value;
+    await writeBundle(root);
+
+    const { client, transport } = await connectMcpClient(root);
+    try {
+      const result = await client.callTool({ name: "import_okf", arguments: { dir: "kb" } });
+      expect(result.isError).toBeFalsy();
+      expect((await listCandidates(root)).length).toBe(1);
+      expect(payloadOf(result).nextAction).toMatch(/review|approve|staged/i);
+    } finally {
+      await client.close();
+      await transport.close();
+    }
+  }, 30_000);
+});
+
+describe("MCP stdio: OKF tools confine agent-supplied paths", () => {
+  const rootHandle = useMcpRoot("okf-mcp-stdio-confine");
+  it("rejects an import dir and an export out that escape the root", async () => {
+    const root = rootHandle.value;
+
+    const { client, transport } = await connectMcpClient(root);
+    try {
+      const importEscape = await client.callTool({ name: "import_okf", arguments: { dir: "/etc" } });
+      expect(importEscape.isError).toBe(true);
+      const exportEscape = await client.callTool({ name: "export_okf", arguments: { out: "../escape" } });
+      expect(exportEscape.isError).toBe(true);
+    } finally {
+      await client.close();
+      await transport.close();
+    }
+  }, 30_000);
+});
+
+describe("MCP stdio: import_okf dry-run stages nothing", () => {
+  const rootHandle = useMcpRoot("okf-mcp-stdio-dryrun");
+  it("previews without staging and reports dry-run over the wire", async () => {
+    const root = rootHandle.value;
+    await writeBundle(root);
+
+    const { client, transport } = await connectMcpClient(root);
+    try {
+      const result = await client.callTool({ name: "import_okf", arguments: { dir: "kb", dryRun: true } });
+      expect(result.isError).toBeFalsy();
+      expect(payloadOf(result).mode).toBe("dry-run");
+      expect((await listCandidates(root)).length).toBe(0);
+      expect(payloadOf(result).nextAction).toMatch(/preview|re-run|dryRun/i);
     } finally {
       await client.close();
       await transport.close();

--- a/test/okf-mcp-tools.test.ts
+++ b/test/okf-mcp-tools.test.ts
@@ -3,27 +3,19 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, stat } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { registerOkfTools } from "../src/mcp/okf-tools.js";
 import { listCandidates } from "../src/compiler/candidates.js";
+import { assertNoOutput } from "./fixtures/no-output.js";
+import { collectOkfHandlers } from "./fixtures/okf-tools-harness.js";
 
 let dir: string;
 afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
-
-/** Capture each registered tool's handler by name. */
-function collect(root: string): Map<string, Function> {
-  const handlers = new Map<string, Function>();
-  const fake = { registerTool: (name: string, _def: unknown, handler: Function) => handlers.set(name, handler) } as unknown as McpServer;
-  registerOkfTools(fake, root);
-  return handlers;
-}
 
 describe("MCP OKF tools", () => {
   it("export_okf writes a confined bundle; rejects out outside root", async () => {
     dir = await mkdtemp(path.join(tmpdir(), "mcp-okf-"));
     await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
     await writeFile(path.join(dir, "wiki/concepts/rag.md"), "---\ntitle: RAG\nkind: concept\n---\n\nBody.\n");
-    const h = collect(dir);
+    const h = collectOkfHandlers(dir);
     await h.get("export_okf")!({ });
     expect((await stat(path.join(dir, "dist/exports/okf/index.md"))).isFile()).toBe(true);
     const bad = await h.get("export_okf")!({ out: "../escape" });
@@ -33,11 +25,20 @@ describe("MCP OKF tools", () => {
     dir = await mkdtemp(path.join(tmpdir(), "mcp-okf2-"));
     const b = path.join(dir, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
     await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
-    const h = collect(dir);
+    const h = collectOkfHandlers(dir);
     const res = await h.get("import_okf")!({ dir: "kb" });
     expect(res.isError).toBeUndefined();
     expect(await listCandidates(dir)).toHaveLength(1);
     const bad = await h.get("import_okf")!({ dir: "/etc" });
     expect(bad.isError).toBe(true);
+  });
+  it("export_okf stays silent even when a cited source is unbundled (stdio-stream safety)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "mcp-okf3-"));
+    await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
+    // ^[missing.md:1-2] cites a source that does not exist → reportSkippedReferences would print.
+    await writeFile(path.join(dir, "wiki/concepts/rag.md"), "---\ntitle: RAG\nkind: concept\n---\n\nClaim. ^[missing.md:1-2]\n");
+    const h = collectOkfHandlers(dir);
+    const res = await assertNoOutput(() => h.get("export_okf")!({}));
+    expect(res.isError).toBeUndefined();
   });
 });

--- a/test/okf-mcp-tools.test.ts
+++ b/test/okf-mcp-tools.test.ts
@@ -1,0 +1,43 @@
+// test/okf-mcp-tools.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, stat } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerOkfTools } from "../src/mcp/okf-tools.js";
+import { listCandidates } from "../src/compiler/candidates.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+/** Capture each registered tool's handler by name. */
+function collect(root: string): Map<string, Function> {
+  const handlers = new Map<string, Function>();
+  const fake = { registerTool: (name: string, _def: unknown, handler: Function) => handlers.set(name, handler) } as unknown as McpServer;
+  registerOkfTools(fake, root);
+  return handlers;
+}
+
+describe("MCP OKF tools", () => {
+  it("export_okf writes a confined bundle; rejects out outside root", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "mcp-okf-"));
+    await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(dir, "wiki/concepts/rag.md"), "---\ntitle: RAG\nkind: concept\n---\n\nBody.\n");
+    const h = collect(dir);
+    await h.get("export_okf")!({ });
+    expect((await stat(path.join(dir, "dist/exports/okf/index.md"))).isFile()).toBe(true);
+    const bad = await h.get("export_okf")!({ out: "../escape" });
+    expect(bad.isError).toBe(true);
+  });
+  it("import_okf stages (no trusted reachable) and rejects dir outside root", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "mcp-okf2-"));
+    const b = path.join(dir, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
+    await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
+    const h = collect(dir);
+    const res = await h.get("import_okf")!({ dir: "kb" });
+    expect(res.isError).toBeUndefined();
+    expect(await listCandidates(dir)).toHaveLength(1);
+    const bad = await h.get("import_okf")!({ dir: "/etc" });
+    expect(bad.isError).toBe(true);
+  });
+});

--- a/test/okf-read-onwarn.test.ts
+++ b/test/okf-read-onwarn.test.ts
@@ -1,0 +1,22 @@
+// test/okf-read-onwarn.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { readOkfBundle } from "../src/import/okf-read.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+describe("readOkfBundle onWarn collector", () => {
+  it("routes skip warnings to onWarn instead of printing", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-onwarn-"));
+    const b = path.join(dir, "bundle"); await mkdir(b, { recursive: true });
+    await writeFile(path.join(b, "bad.md"), "---\ntitle: no type\n---\n\nx\n"); // typeless → skipped+warned
+    await writeFile(path.join(b, "ok.md"), "---\ntype: concept\ntitle: Y\n---\n\ny\n");
+    const warnings: string[] = [];
+    const docs = await readOkfBundle(b, {}, (m) => warnings.push(m));
+    expect(docs.map((d) => d.relPath)).toEqual(["ok.md"]);
+    expect(warnings.some((w) => w.includes("bad.md"))).toBe(true);
+  });
+});

--- a/test/okf-run-errors.test.ts
+++ b/test/okf-run-errors.test.ts
@@ -1,0 +1,15 @@
+// test/okf-run-errors.test.ts
+import { describe, it, expect } from "vitest";
+import { LockUnavailableError, QueueFullError } from "../src/import/run-errors.js";
+
+describe("OKF run errors", () => {
+  it("are distinguishable Error subclasses with messages", () => {
+    const lock = new LockUnavailableError();
+    const queue = new QueueFullError("review queue would exceed the cap");
+    expect(lock).toBeInstanceOf(Error);
+    expect(lock).toBeInstanceOf(LockUnavailableError);
+    expect(queue).toBeInstanceOf(QueueFullError);
+    expect(lock.message).toMatch(/lock/i);
+    expect(queue.message).toMatch(/queue/i);
+  });
+});

--- a/test/okf-run-export.test.ts
+++ b/test/okf-run-export.test.ts
@@ -1,0 +1,28 @@
+// test/okf-run-export.test.ts
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, stat } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { runOkfExport } from "../src/export/okf/run.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+describe("runOkfExport", () => {
+  it("writes a bundle and returns outDir + paths (no stdout)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rxe-"));
+    await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(dir, "wiki/concepts/rag.md"), "---\ntitle: RAG\nkind: concept\n---\n\nBody.\n");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const report = await runOkfExport(dir, { out: path.join(dir, "out") });
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    log.mockRestore(); warn.mockRestore(); error.mockRestore();
+    expect(report.outDir).toBe(path.join(dir, "out"));
+    expect(report.writtenPaths.length).toBeGreaterThan(0);
+    expect((await stat(path.join(dir, "out/index.md"))).isFile()).toBe(true);
+  });
+});

--- a/test/okf-run-export.test.ts
+++ b/test/okf-run-export.test.ts
@@ -1,9 +1,10 @@
 // test/okf-run-export.test.ts
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, stat } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { runOkfExport } from "../src/export/okf/run.js";
+import { assertNoOutput } from "./fixtures/no-output.js";
 
 let dir: string;
 afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
@@ -13,14 +14,7 @@ describe("runOkfExport", () => {
     dir = await mkdtemp(path.join(tmpdir(), "rxe-"));
     await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
     await writeFile(path.join(dir, "wiki/concepts/rag.md"), "---\ntitle: RAG\nkind: concept\n---\n\nBody.\n");
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const report = await runOkfExport(dir, { out: path.join(dir, "out") });
-    expect(log).not.toHaveBeenCalled();
-    expect(warn).not.toHaveBeenCalled();
-    expect(error).not.toHaveBeenCalled();
-    log.mockRestore(); warn.mockRestore(); error.mockRestore();
+    const report = await assertNoOutput(() => runOkfExport(dir, { out: path.join(dir, "out") }));
     expect(report.outDir).toBe(path.join(dir, "out"));
     expect(report.writtenPaths.length).toBeGreaterThan(0);
     expect((await stat(path.join(dir, "out/index.md"))).isFile()).toBe(true);

--- a/test/okf-run-export.test.ts
+++ b/test/okf-run-export.test.ts
@@ -17,6 +17,16 @@ describe("runOkfExport", () => {
     const report = await assertNoOutput(() => runOkfExport(dir, { out: path.join(dir, "out") }));
     expect(report.outDir).toBe(path.join(dir, "out"));
     expect(report.writtenPaths.length).toBeGreaterThan(0);
+    expect(report.warnings).toEqual([]);
     expect((await stat(path.join(dir, "out/index.md"))).isFile()).toBe(true);
+  });
+  it("surfaces unbundled-reference warnings as data, not stdout", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rxe-warn-"));
+    await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
+    // ^[missing.md:1-2] cites a source with no sources/missing.md → reportSkippedReferences fires.
+    await writeFile(path.join(dir, "wiki/concepts/rag.md"), "---\ntitle: RAG\nkind: concept\n---\n\nClaim. ^[missing.md:1-2]\n");
+    const report = await assertNoOutput(() => runOkfExport(dir, { out: path.join(dir, "out") }));
+    expect(report.warnings.length).toBeGreaterThan(0);
+    expect(report.warnings.some((w) => /not bundled/i.test(w))).toBe(true);
   });
 });

--- a/test/okf-run-import-lock.test.ts
+++ b/test/okf-run-import-lock.test.ts
@@ -1,0 +1,32 @@
+// test/okf-run-import-lock.test.ts
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { runOkfImport } from "../src/import/run.js";
+import { LockUnavailableError } from "../src/import/run-errors.js";
+import { writeOneDocBundle } from "./fixtures/okf-bundle-fixture.js";
+
+let dir: string;
+afterEach(async () => { vi.restoreAllMocks(); if (dir) await rm(dir, { recursive: true, force: true }); });
+
+/** Write a live-holder lock file (this process's pid) so acquireLock sees a non-stale lock. */
+async function holdLock(root: string): Promise<void> {
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(path.join(root, ".llmwiki", "lock"), String(process.pid), "utf-8");
+}
+
+describe("runOkfImport lock contention is silent", () => {
+  it("throws LockUnavailableError with no stdout/stderr when the lock is held", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rii-lock-"));
+    const b = await writeOneDocBundle(dir);
+    await holdLock(dir);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(runOkfImport(dir, b, {})).rejects.toBeInstanceOf(LockUnavailableError);
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/test/okf-run-import.test.ts
+++ b/test/okf-run-import.test.ts
@@ -1,0 +1,49 @@
+// test/okf-run-import.test.ts
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile, stat } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { runOkfImport } from "../src/import/run.js";
+import { listCandidates } from "../src/compiler/candidates.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+async function bundle(root: string): Promise<string> {
+  const b = path.join(root, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
+  await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
+  return b;
+}
+
+describe("runOkfImport", () => {
+  it("stages by default and returns a staged report (no stdout)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rii-"));
+    const b = await bundle(dir);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const report = await runOkfImport(dir, b, {});
+    expect(log).not.toHaveBeenCalled(); // output-free core: no stdout
+    expect(warn).not.toHaveBeenCalled(); // ...and no stderr (output.note → console.warn)
+    expect(error).not.toHaveBeenCalled();
+    log.mockRestore(); warn.mockRestore(); error.mockRestore();
+    expect(report.mode).toBe("staged");
+    expect(report.pages).toEqual([{ slug: "a", okfPath: "concepts/a.md", targetDirectory: "concepts" }]);
+    expect(await listCandidates(dir)).toHaveLength(1);
+  });
+  it("dry-run writes/stages nothing and reports would-import", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rii2-"));
+    const b = await bundle(dir);
+    const report = await runOkfImport(dir, b, { dryRun: true });
+    expect(report.mode).toBe("dry-run");
+    expect(report.pages).toHaveLength(1);
+    expect(await listCandidates(dir)).toHaveLength(0);
+  });
+  it("trusted writes live", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rii3-"));
+    const b = await bundle(dir);
+    const report = await runOkfImport(dir, b, { trusted: true });
+    expect(report.mode).toBe("written");
+    expect((await stat(path.join(dir, "wiki/concepts/a.md"))).isFile()).toBe(true);
+    expect(await readFile(path.join(dir, "wiki/concepts/a.md"), "utf-8")).toContain("provenanceState: imported");
+  });
+});

--- a/test/okf-run-import.test.ts
+++ b/test/okf-run-import.test.ts
@@ -1,10 +1,11 @@
 // test/okf-run-import.test.ts
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, readFile, stat } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { runOkfImport } from "../src/import/run.js";
 import { listCandidates } from "../src/compiler/candidates.js";
+import { assertNoOutput } from "./fixtures/no-output.js";
 
 let dir: string;
 afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
@@ -18,14 +19,7 @@ describe("runOkfImport", () => {
   it("stages by default and returns a staged report (no stdout)", async () => {
     dir = await mkdtemp(path.join(tmpdir(), "rii-"));
     const b = await bundle(dir);
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const report = await runOkfImport(dir, b, {});
-    expect(log).not.toHaveBeenCalled(); // output-free core: no stdout
-    expect(warn).not.toHaveBeenCalled(); // ...and no stderr (output.note → console.warn)
-    expect(error).not.toHaveBeenCalled();
-    log.mockRestore(); warn.mockRestore(); error.mockRestore();
+    const report = await assertNoOutput(() => runOkfImport(dir, b, {}));
     expect(report.mode).toBe("staged");
     expect(report.pages).toEqual([{ slug: "a", okfPath: "concepts/a.md", targetDirectory: "concepts" }]);
     expect(await listCandidates(dir)).toHaveLength(1);

--- a/test/okf-run-import.test.ts
+++ b/test/okf-run-import.test.ts
@@ -1,19 +1,15 @@
 // test/okf-run-import.test.ts
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtemp, rm, mkdir, writeFile, readFile, stat } from "fs/promises";
+import { mkdtemp, rm, readFile, stat } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { runOkfImport } from "../src/import/run.js";
 import { listCandidates } from "../src/compiler/candidates.js";
 import { assertNoOutput } from "./fixtures/no-output.js";
+import { writeOneDocBundle as bundle } from "./fixtures/okf-bundle-fixture.js";
 
 let dir: string;
 afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
-async function bundle(root: string): Promise<string> {
-  const b = path.join(root, "kb"); await mkdir(path.join(b, "concepts"), { recursive: true });
-  await writeFile(path.join(b, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
-  return b;
-}
 
 describe("runOkfImport", () => {
   it("stages by default and returns a staged report (no stdout)", async () => {

--- a/test/okf-sdk.test.ts
+++ b/test/okf-sdk.test.ts
@@ -1,0 +1,31 @@
+// test/okf-sdk.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, stat } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { createWiki } from "../src/index.js";
+import { listCandidates } from "../src/compiler/candidates.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+describe("SDK OKF methods", () => {
+  it("exportOkf writes a bundle; importOkf stages by default; dryRun stages nothing", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "sdk-okf-"));
+    await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(dir, "wiki/concepts/rag.md"), "---\ntitle: RAG\nkind: concept\n---\n\nBody.\n");
+    const wiki = createWiki({ root: dir });
+    const exp = await wiki.exportOkf({ out: path.join(dir, "out") });
+    expect((await stat(path.join(exp.outDir, "index.md"))).isFile()).toBe(true);
+
+    const bundle = path.join(dir, "kb"); await mkdir(path.join(bundle, "concepts"), { recursive: true });
+    await writeFile(path.join(bundle, "concepts", "a.md"), "---\ntype: concept\ntitle: A\n---\n\nBody.\n");
+    const staged = await wiki.importOkf(bundle);
+    expect(staged.mode).toBe("staged");
+    expect(await listCandidates(dir)).toHaveLength(1);
+
+    const preview = await wiki.importOkf(bundle, { dryRun: true });
+    expect(preview.mode).toBe("dry-run");
+    expect(await listCandidates(dir)).toHaveLength(1); // dry-run added nothing
+  });
+});

--- a/test/path-confine-confine-under-root.test.ts
+++ b/test/path-confine-confine-under-root.test.ts
@@ -1,0 +1,42 @@
+// test/path-confine-confine-under-root.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, symlink } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { confineUnderRoot } from "../src/utils/path-confine.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+describe("confineUnderRoot", () => {
+  it("accepts an inside path and a fresh non-existent default (mustExist:false)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "cur-"));
+    const out = await confineUnderRoot("dist/exports/okf", dir, { mustExist: false });
+    expect(out).toBe(path.join(await import("fs/promises").then((m) => m.realpath(dir)), "dist/exports/okf"));
+  });
+  it("rejects .. traversal and an absolute path outside root", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "cur2-"));
+    await expect(confineUnderRoot("../escape", dir, { mustExist: false })).rejects.toThrow(/escape/i);
+    await expect(confineUnderRoot("/etc", dir, { mustExist: false })).rejects.toThrow(/escape/i);
+  });
+  it("rejects a missing dir when mustExist, accepts an existing one", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "cur3-"));
+    await mkdir(path.join(dir, "bundle"));
+    expect(await confineUnderRoot("bundle", dir, { mustExist: true })).toContain("bundle");
+    await expect(confineUnderRoot("nope", dir, { mustExist: true })).rejects.toThrow();
+  });
+  it("rejects an existing target that is a symlink escape (mustExist:false)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "cur4-"));
+    const outside = await mkdtemp(path.join(tmpdir(), "cur4-out-"));
+    await symlink(outside, path.join(dir, "link"));
+    await expect(confineUnderRoot("link", dir, { mustExist: false })).rejects.toThrow(/escape/i);
+    await rm(outside, { recursive: true, force: true });
+  });
+  it("rejects a FRESH child under a symlinked parent that escapes (nearest-existing-ancestor walk)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "cur5-"));
+    const outside = await mkdtemp(path.join(tmpdir(), "cur5-out-"));
+    await symlink(outside, path.join(dir, "link")); // link → outside; "link/fresh/out" doesn't exist
+    await expect(confineUnderRoot("link/fresh/out", dir, { mustExist: false })).rejects.toThrow(/escape/i);
+    await rm(outside, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## What

Makes OKF export/import reachable from the **SDK** and the **MCP server**, not just the CLI. All three surfaces now share one output-free core, so they can't drift.

**Shared core.** OKF orchestration is extracted out of the CLI commands into `runOkfExport(root, opts)` and `runOkfImport(root, dir, opts)` — output-free functions that return structured reports. Warnings and skips are returned as data rather than printed (the read/collision/validate stages no longer write to stdout), so a library or an MCP stdio server gets clean results. The CLI commands now delegate to these cores and keep their existing presentation.

**SDK** (`createWiki()`):
- `wiki.exportOkf({ out? })` → `{ outDir, writtenPaths }`
- `wiki.importOkf(dir, { trusted?, dryRun? })` → `{ mode, pages, skipped, warnings, nextAction }`
- Defaults mirror the CLI: staged review candidates, `trusted:false`, `dryRun:false`. As application code, an SDK caller owns the explicit `trusted:true` escape hatch (writes live and runs the full refresh — links/index/MOC/embeddings). Report types and the typed errors are exported from the package entry point.

**MCP** (new `src/mcp/okf-tools.ts`):
- `export_okf` — export the wiki as a bundle.
- `import_okf` — **staging-only**: imports are always staged as review candidates (no `trusted` surface is exposed to agents), so external knowledge always passes a human review/approval gate before it can enter the wiki. Supports `dryRun` previews and returns a `nextAction` that states the review requirement explicitly.

## Trust boundary

Import treats bundles as untrusted, and the boundary is uniform across surfaces: nothing reaches the live wiki without either an explicit caller `trusted:true` (SDK/CLI — caller-owned) or human review (MCP and the default path). The MCP tools add agent-surface safety: a shared path-confinement primitive (`confineUnderRoot`) keeps an agent-supplied path inside the project root for both tools (rejecting `..`, absolute, and symlinked-ancestor escapes), import staging is bounded by a pending-candidate cap, and both handlers run silently so they can never corrupt the JSON-RPC stdio stream. Lock contention and a full queue surface as typed errors mapped to clean tool results.

## Test plan

- [x] `npx tsc --noEmit`, `npm run build`, `npm test` (1637 passed), `npx fallow` (0 above threshold), dupes clean
- [x] Output-free core: `runOkfExport`/`runOkfImport` emit zero stdout/stderr on the staged/dry-run paths (asserted via a shared `assertNoOutput` helper), incl. a wiki with a missing-source citation that would otherwise print
- [x] `confineUnderRoot` direct tests: `..`, absolute-outside, existing-symlink-escape, fresh-child-under-symlinked-parent, and valid-inside/fresh-default
- [x] SDK: `exportOkf` writes a bundle; `importOkf` stages by default; `dryRun` stages nothing; `trusted` writes live
- [x] MCP: `export_okf` confined (rejects out-of-root); `import_okf` staging-only (no `trusted` reachable), confined (rejects dir-out-of-root), and refused past the candidate cap; a real stdio JSON-RPC round-trip drives the built server
- [x] Behavior-preserving: existing CLI `okf-import-*`/`okf-export-cli` tests stay green; `src/mcp/tools.ts` untouched