### PR TITLE
feat(export): restore original nested paths on OKF re-export

### DIFF
--- a/src/export/okf/bundle.ts
+++ b/src/export/okf/bundle.ts
@@ -19,6 +19,9 @@ import { buildOkfIndex, buildOkfLog, parseLlmwikiLog } from "./index-log.js";
 import { collectReferenceFiles, resolveReferences, type ResolvedReference } from "./references.js";
 import { resolveOutputPaths } from "./output-paths.js";
 
+/** OS noise files that must not, by themselves, make an output dir count as non-empty. */
+const IGNORED_DIR_ENTRIES = new Set([".DS_Store", "Thumbs.db"]);
+
 /** A resolver over the export's own pages (title + resolved output path per slug). */
 function makeResolver(pages: ExportPage[], paths: Map<ExportPage, string>): LinkResolver {
   const map = new Map(pages.map((p) => [p.slug, { path: paths.get(p)!, title: p.title }] as const));
@@ -28,6 +31,8 @@ function makeResolver(pages: ExportPage[], paths: Map<ExportPage, string>): Link
 /**
  * Write `rel` (a bundle-relative path) under `out`, realpath-confined; returns the abs path.
  * `confineUnderRoot` rejects any `rel` whose resolved target (or a symlinked parent) escapes `out`.
+ * A realpath escape here ABORTS the export (a hard backstop) rather than silently falling back —
+ * unreachable in practice because the wholesale-clear strips bundle symlinks before any write.
  */
 async function writeConfined(out: string, rel: string, content: string): Promise<string> {
   const abs = await confineUnderRoot(rel, out, { mustExist: false });
@@ -86,7 +91,10 @@ async function isRecognizedBundle(realOut: string): Promise<boolean> {
   return typeof meta.okf_version !== "undefined";
 }
 
-/** Throw if any `.git` entry exists anywhere under `realOut` (lstat, no symlink-follow). */
+/**
+ * Throw if any `.git` entry exists anywhere under `realOut` (lstat, no symlink-follow).
+ * A full recursive scan bounded by bundle size, run once before clearing a recognized bundle.
+ */
 async function assertNoNestedGit(realOut: string): Promise<void> {
   for (const e of await readdir(realOut, { withFileTypes: true })) {
     if (e.name === ".git") throw new Error(`OKF export: refusing to clear ${realOut} — it contains a nested .git`);
@@ -150,11 +158,11 @@ export async function buildOkfBundle(
   out: string,
   onWarn: (msg: string) => void = (m) => output.status("!", output.warn(m)),
 ): Promise<string[]> {
-  await assertSafeBundleTarget(out, root);           // BEFORE any write — resolved target inside root, not root/.git/fs-root
+  await assertSafeBundleTarget(out, root);           // BEFORE any write — refuse fs-root, project-root, inside-.git on the resolved target (external out is allowed)
   await mkdir(out, { recursive: true });
   const realOut = (await safeRealpath(out)) ?? path.normalize(out);
   await assertNoTopLevelGit(realOut);                // existing dir holding a top-level .git (mkdir of an existing dir is a no-op)
-  const empty = (await readdir(realOut)).length === 0;
+  const empty = (await readdir(realOut)).filter((e) => !IGNORED_DIR_ENTRIES.has(e)).length === 0;
   const bundle = empty ? false : await isRecognizedBundle(realOut);
   if (!empty && !bundle) throw new Error(`OKF export: ${out} is not empty and not an OKF bundle; export into a fresh directory or an existing OKF bundle.`);
   if (bundle) { await assertNoNestedGit(realOut); await clearContents(realOut); }

--- a/src/export/okf/bundle.ts
+++ b/src/export/okf/bundle.ts
@@ -16,12 +16,11 @@ import type { LinkResolver } from "./types.js";
 import { renderOkfDoc } from "./render-doc.js";
 import { buildOkfIndex, buildOkfLog, parseLlmwikiLog } from "./index-log.js";
 import { collectReferenceFiles, resolveReferences, type ResolvedReference } from "./references.js";
+import { resolveOutputPaths } from "./output-paths.js";
 
-/** A resolver over the export's own pages (title + dir per slug). */
-function makeResolver(pages: ExportPage[]): LinkResolver {
-  const map = new Map(
-    pages.map((p) => [p.slug, { dir: p.pageDirectory, title: p.title }] as const),
-  );
+/** A resolver over the export's own pages (title + resolved output path per slug). */
+function makeResolver(pages: ExportPage[], paths: Map<ExportPage, string>): LinkResolver {
+  const map = new Map(pages.map((p) => [p.slug, { path: paths.get(p)!, title: p.title }] as const));
   return (slug) => map.get(slug) ?? null;
 }
 
@@ -98,23 +97,21 @@ export async function buildOkfBundle(
   await mkdir(out, { recursive: true });
   const realOut = (await safeRealpath(out)) ?? path.normalize(out);
   await clearOkfManaged(realOut);
-  const resolve = makeResolver(pages);
+  const { paths, warnings: pathWarnings } = resolveOutputPaths(pages, realOut);
+  const resolve = makeResolver(pages, paths);
   // Resolve references FIRST so citation links are emitted only for files actually copied.
   const refs = await resolveReferences(root, pages);
   const refName = (file: string): string | null => refs.get(file)?.destName ?? null;
   const written: string[] = [];
 
-  written.push(await writeConfined(realOut, "index.md", buildOkfIndex(pages)));
+  written.push(await writeConfined(realOut, "index.md", buildOkfIndex(pages, paths)));
   for (const p of pages) {
-    const docRel = `${p.pageDirectory}/${p.slug}.md`;
-    const docAbs = path.normalize(path.join(realOut, docRel));
-    const pageDir = path.join(realOut, p.pageDirectory);
-    // Reject slugs with traversal components (e.g. "../escape") — the doc must stay in its pageDirectory.
-    if (!isInsideDir(docAbs, pageDir)) throw new Error(`OKF page slug escapes its directory: ${p.slug}`);
+    const docRel = paths.get(p)!;
     written.push(await writeConfined(realOut, docRel, renderOkfDoc(p, resolve, refName)));
   }
   written.push(...(await copyResolvedReferences(refs, realOut)));
   written.push(await writeConfined(realOut, "log.md", await buildLog(root, pages.length)));
   reportSkippedReferences(pages, refs, onWarn);
+  for (const w of pathWarnings) onWarn(w);
   return written;
 }

--- a/src/export/okf/bundle.ts
+++ b/src/export/okf/bundle.ts
@@ -1,16 +1,17 @@
 /**
  * @file Assemble + write the OKF bundle directory (path-confined).
  *
- * Orchestrates the full export: clears stale managed paths, writes index.md,
- * one doc per page under its pageDirectory/, copies cited source files into
- * references/, and appends a translated log.md. Every write is confined to
- * the bundle output directory; slugs that would escape it are rejected.
+ * Orchestrates the full export: refuses unsafe output dirs (project/fs root,
+ * inside .git, non-empty non-bundle, nested .git), wholesale-clears a recognized
+ * prior bundle, writes index.md, one doc per page at its resolved output path,
+ * copies cited source files into references/, and appends a translated log.md.
+ * Every write is realpath-confined to the bundle output directory.
  */
-import { mkdir, copyFile, rm, readFile } from "fs/promises";
+import { mkdir, copyFile, rm, readFile, readdir, lstat } from "fs/promises";
 import path from "path";
-import { atomicWrite } from "../../utils/markdown.js";
+import { atomicWrite, parseFrontmatterStatus } from "../../utils/markdown.js";
 import * as output from "../../utils/output.js";
-import { safeRealpath, isInsideDir } from "../../utils/path-confine.js";
+import { safeRealpath, isInsideDir, confineUnderRoot } from "../../utils/path-confine.js";
 import type { ExportPage } from "../types.js";
 import type { LinkResolver } from "./types.js";
 import { renderOkfDoc } from "./render-doc.js";
@@ -25,21 +26,77 @@ function makeResolver(pages: ExportPage[], paths: Map<ExportPage, string>): Link
 }
 
 /**
- * Write `rel` (a bundle-relative path) under `out`, confined; returns the abs path.
- * Throws when the normalized destination escapes the bundle directory.
+ * Write `rel` (a bundle-relative path) under `out`, realpath-confined; returns the abs path.
+ * `confineUnderRoot` rejects any `rel` whose resolved target (or a symlinked parent) escapes `out`.
  */
 async function writeConfined(out: string, rel: string, content: string): Promise<string> {
-  const normalized = path.normalize(path.join(out, rel));
-  if (!isInsideDir(normalized, out)) throw new Error(`OKF write escapes bundle: ${rel}`);
-  await atomicWrite(normalized, content);
-  return normalized;
+  const abs = await confineUnderRoot(rel, out, { mustExist: false });
+  await atomicWrite(abs, content);
+  return abs;
 }
 
-/** OKF-managed paths cleared before each export so deleted pages don't linger. */
-async function clearOkfManaged(realOut: string): Promise<void> {
-  for (const rel of ["concepts", "queries", "references", "index.md", "log.md"]) {
-    await rm(path.join(realOut, rel), { recursive: true, force: true });
+/** True if `p` exists (any type) without following a final symlink. */
+async function lexists(p: string): Promise<boolean> {
+  try { await lstat(p); return true; } catch { return false; }
+}
+
+/**
+ * Realpath of the nearest EXISTING ancestor of `p`, plus the not-yet-existing suffix.
+ * Resolves symlinked parents so a fresh `<root>/exports/okf` where `exports` -> elsewhere
+ * yields the REAL location `mkdir` would create — not the lexical path.
+ */
+async function resolveRealTarget(p: string): Promise<string> {
+  let cur = path.resolve(p);
+  const suffix: string[] = [];
+  for (;;) {
+    const real = await safeRealpath(cur);
+    if (real) return suffix.length ? path.join(real, ...suffix.reverse()) : real;
+    const parent = path.dirname(cur);
+    if (parent === cur) return path.resolve(p); // no existing ancestor
+    suffix.push(path.basename(cur));
+    cur = parent;
   }
+}
+
+/**
+ * PRE-mkdir refusal on the SYMLINK-RESOLVED target (must run BEFORE the dir is created).
+ * Refuse the DANGEROUS resolved targets only: the filesystem root, the project root, or
+ * inside `.git`. Resolving symlinked parents first is the point — `<root>/exports -> <root>/.git`
+ * with `--out <root>/exports/okf` looks safe lexically but resolves into `.git` and is refused.
+ * An out dir OUTSIDE the project root is ALLOWED: external export is a supported pattern.
+ */
+async function assertSafeBundleTarget(out: string, root: string): Promise<void> {
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  const target = await resolveRealTarget(out);
+  if (target === path.parse(target).root) throw new Error("OKF export: refusing to export to the filesystem root");
+  if (target === realRoot) throw new Error("OKF export: refusing to export to the project root");
+  if (isInsideDir(target, path.join(realRoot, ".git"))) throw new Error("OKF export: refusing to export inside .git");
+}
+
+/** POST-mkdir refusal: an existing out dir that itself holds a top-level `.git` (a nested repo). */
+async function assertNoTopLevelGit(realOut: string): Promise<void> {
+  if (await lexists(path.join(realOut, ".git"))) throw new Error("OKF export: refusing to export to a directory containing .git");
+}
+
+/** True when `realOut` looks like a prior OKF bundle: root index.md is a regular file with okf_version frontmatter. */
+async function isRecognizedBundle(realOut: string): Promise<boolean> {
+  const idx = path.join(realOut, "index.md");
+  try { if (!(await lstat(idx)).isFile()) return false; } catch { return false; }
+  const { meta } = parseFrontmatterStatus(await readFile(idx, "utf-8"));
+  return typeof meta.okf_version !== "undefined";
+}
+
+/** Throw if any `.git` entry exists anywhere under `realOut` (lstat, no symlink-follow). */
+async function assertNoNestedGit(realOut: string): Promise<void> {
+  for (const e of await readdir(realOut, { withFileTypes: true })) {
+    if (e.name === ".git") throw new Error(`OKF export: refusing to clear ${realOut} — it contains a nested .git`);
+    if (e.isDirectory()) await assertNoNestedGit(path.join(realOut, e.name));
+  }
+}
+
+/** Remove every child of `realOut` (the dir itself stays). */
+async function clearContents(realOut: string): Promise<void> {
+  for (const name of await readdir(realOut)) await rm(path.join(realOut, name), { recursive: true, force: true });
 }
 
 /** OKF log translated from llmwiki's activity log.md when present, else a synthetic export entry. */
@@ -57,8 +114,7 @@ async function copyResolvedReferences(
 ): Promise<string[]> {
   const written: string[] = [];
   for (const { srcAbs, destName } of refs.values()) {
-    const dest = path.join(realOut, "references", destName);
-    if (!isInsideDir(path.normalize(dest), realOut)) continue;
+    const dest = await confineUnderRoot(path.join("references", destName), realOut, { mustExist: false });
     await mkdir(path.dirname(dest), { recursive: true });
     await copyFile(srcAbs, dest);
     written.push(dest);
@@ -94,9 +150,14 @@ export async function buildOkfBundle(
   out: string,
   onWarn: (msg: string) => void = (m) => output.status("!", output.warn(m)),
 ): Promise<string[]> {
+  await assertSafeBundleTarget(out, root);           // BEFORE any write — resolved target inside root, not root/.git/fs-root
   await mkdir(out, { recursive: true });
   const realOut = (await safeRealpath(out)) ?? path.normalize(out);
-  await clearOkfManaged(realOut);
+  await assertNoTopLevelGit(realOut);                // existing dir holding a top-level .git (mkdir of an existing dir is a no-op)
+  const empty = (await readdir(realOut)).length === 0;
+  const bundle = empty ? false : await isRecognizedBundle(realOut);
+  if (!empty && !bundle) throw new Error(`OKF export: ${out} is not empty and not an OKF bundle; export into a fresh directory or an existing OKF bundle.`);
+  if (bundle) { await assertNoNestedGit(realOut); await clearContents(realOut); }
   const { paths, warnings: pathWarnings } = resolveOutputPaths(pages, realOut);
   const resolve = makeResolver(pages, paths);
   // Resolve references FIRST so citation links are emitted only for files actually copied.

--- a/src/export/okf/index-log.ts
+++ b/src/export/okf/index-log.ts
@@ -12,8 +12,8 @@ import type { ExportPage } from "../types.js";
 export interface OkfLogEntry { date: string; action: string; text: string; }
 
 /** Bundle-root index.md: okf_version frontmatter + a TOC over concepts/ AND queries/. */
-export function buildOkfIndex(pages: ExportPage[]): string {
-  const entry = (p: ExportPage) => `* [${p.title}](/${p.pageDirectory}/${p.slug}.md) - ${p.summary}`;
+export function buildOkfIndex(pages: ExportPage[], paths: Map<ExportPage, string>): string {
+  const entry = (p: ExportPage) => `* [${p.title}](/${paths.get(p)}) - ${p.summary}`;
   const concepts = pages.filter((p) => p.pageDirectory === "concepts").map(entry);
   const queries = pages.filter((p) => p.pageDirectory === "queries").map(entry);
   const sections: string[] = [];

--- a/src/export/okf/mapping.ts
+++ b/src/export/okf/mapping.ts
@@ -116,7 +116,8 @@ export function mapPageToOkfFrontmatter(page: ExportPage): OkfFrontmatter {
 }
 
 const WIKILINK = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
-const OKF_LINK = /\[([^\]]+)\]\(\/(concepts|queries)\/([^)]+?)\.md\)/g;
+// any bundle-relative markdown link to a `.md` doc: captures display text + path (no leading slash, no .md)
+const OKF_LINK = /\[([^\]]+)\]\(\/([^)]+?)\.md\)/g;
 const FENCE = /(```[\s\S]*?```|~~~[\s\S]*?~~~)/g; // capturing → fenced blocks at odd split indices
 // Only fenced blocks are protected; single-backtick inline code (e.g. `[[x]]`)
 // is NOT — a wikilink inside inline code will still be rewritten. Acceptable for v0.1.
@@ -138,10 +139,18 @@ export function wikilinksToOkf(body: string, resolve: LinkResolver): string {
     .join("");
 }
 
-/** Reverse: OKF link -> [[slug]] when text == target title, else [[slug|text]]. */
-export function okfLinksToWikilinks(body: string, titleOf: (slug: string) => string | null): string {
-  return body.replace(OKF_LINK, (_m, text: string, _dir: string, slug: string) => {
-    const title = titleOf(slug);
-    return title !== null && text === title ? `[[${slug}]]` : `[[${slug}|${text}]]`;
+/**
+ * Reverse: OKF link -> [[slug]] when `resolveLink(path)` maps the link's path to a known
+ * bundle doc; an unknown/external path is left verbatim. `[[slug]]` when text === title,
+ * else `[[slug|text]]`.
+ */
+export function okfLinksToWikilinks(
+  body: string,
+  resolveLink: (linkPath: string) => { slug: string; title: string } | null,
+): string {
+  return body.replace(OKF_LINK, (match, text: string, linkPath: string) => {
+    const r = resolveLink(linkPath);
+    if (!r) return match;
+    return r.title === text ? `[[${r.slug}]]` : `[[${r.slug}|${text}]]`;
   });
 }

--- a/src/export/okf/mapping.ts
+++ b/src/export/okf/mapping.ts
@@ -133,7 +133,7 @@ export function wikilinksToOkf(body: string, resolve: LinkResolver): string {
             const slug = slugify(rawSlug);
             const target = resolve(slug);
             if (!target) return match;
-            return `[${disp ?? target.title}](/${target.dir}/${slug}.md)`;
+            return `[${disp ?? target.title}](/${target.path})`;
           }),
     )
     .join("");

--- a/src/export/okf/mapping.ts
+++ b/src/export/okf/mapping.ts
@@ -91,10 +91,9 @@ function applyStandardFields(fm: Record<string, unknown>, page: ExportPage): voi
  * description, tags, timestamp) from the CURRENT page so local edits are reflected,
  * and refresh x-llmwiki. (Preserve foreign keys, not stale standard frontmatter.)
  *
- * Re-export places every doc at `<pageDirectory>/<slug>.md`: the llmwiki slug is the
- * identity the OKF link rewriter + index TOC understand. The original bundle path is
- * preserved durably under `x-okf.okfPath` for diagnosis; faithful reconstruction of
- * nested original paths is intentionally deferred (it needs a non-slug link/index model).
+ * Re-export's output PATH for a foreign doc is decided by `resolveOutputPaths` (restoring
+ * `x-okf.okfPath` when safe); this function governs only the frontmatter reconstruction
+ * (raw foreign type/keys + refreshed x-llmwiki).
  */
 function reconstructForeignFrontmatter(page: ExportPage, x: XLlmwiki): OkfFrontmatter {
   const of = page.xOkf!.originalFrontmatter;

--- a/src/export/okf/output-paths.ts
+++ b/src/export/okf/output-paths.ts
@@ -1,0 +1,63 @@
+/**
+ * @file Decide each export page's bundle-relative output path. Native pages use
+ * their slug-path; an imported foreign page restores its original `x-okf.okfPath`
+ * when it is safe and uncontested, else falls back to its slug-path (with a warning).
+ * An ownership map of every page's slug-path guarantees a foreign okfPath can never
+ * steal any page's fallback location.
+ */
+import path from "node:path";
+import { isInsideDir } from "../../utils/path-confine.js";
+import type { ExportPage } from "../types.js";
+
+/** Bundle-relative slug-path for a page. */
+function slugPath(p: ExportPage): string {
+  return `${p.pageDirectory}/${p.slug}.md`;
+}
+
+/** Cheap lexical pre-filter: is `okfPath` a safe bundle-relative target? (Realpath is enforced at write time.) */
+export function isSafeOkfPath(okfPath: unknown, realOut: string): boolean {
+  if (typeof okfPath !== "string" || okfPath.length === 0) return false;
+  if (path.isAbsolute(okfPath)) return false;
+  if (okfPath.split(/[/\\]+/).includes("..")) return false;
+  if (okfPath === "index.md" || okfPath === "log.md") return false; // ROOT reserved (exact, not basename)
+  if (okfPath === "references" || okfPath.startsWith("references/")) return false;
+  return isInsideDir(path.normalize(path.join(realOut, okfPath)), realOut);
+}
+
+/** Resolve every page to a bundle-relative output path; returns the map + structured fallback warnings. */
+export function resolveOutputPaths(
+  pages: ExportPage[],
+  realOut: string,
+): { paths: Map<ExportPage, string>; warnings: string[] } {
+  const owner = new Map<string, ExportPage>(); // slug-path -> owning page (slug-paths are unique)
+  for (const p of pages) owner.set(slugPath(p), p);
+
+  const paths = new Map<ExportPage, string>();
+  const warnings: string[] = [];
+  const used = new Set<string>();
+
+  // Foreign pages first (deterministic), so a restored okfPath claims before fallbacks fill `used`.
+  const foreign = pages.filter((p) => typeof p.xOkf?.okfPath === "string").sort((a, b) => (a.xOkf!.okfPath! < b.xOkf!.okfPath! ? -1 : 1));
+  const native = pages.filter((p) => typeof p.xOkf?.okfPath !== "string");
+
+  for (const p of foreign) {
+    const okfPath = p.xOkf!.okfPath!;
+    const ownerOfOkf = owner.get(okfPath);
+    const usable = isSafeOkfPath(okfPath, realOut) && !used.has(okfPath) && (ownerOfOkf === undefined || ownerOfOkf === p);
+    if (usable) {
+      paths.set(p, okfPath);
+      used.add(okfPath);
+    } else {
+      const sp = slugPath(p);
+      paths.set(p, sp);
+      used.add(sp);
+      warnings.push(`OKF export: ${okfPath} not restorable (unsafe or collides); using ${sp}`);
+    }
+  }
+  for (const p of native) {
+    const sp = slugPath(p);
+    paths.set(p, sp);
+    used.add(sp);
+  }
+  return { paths, warnings };
+}

--- a/src/export/okf/output-paths.ts
+++ b/src/export/okf/output-paths.ts
@@ -18,10 +18,22 @@ function slugPath(p: ExportPage): string {
 export function isSafeOkfPath(okfPath: unknown, realOut: string): boolean {
   if (typeof okfPath !== "string" || okfPath.length === 0) return false;
   if (path.isAbsolute(okfPath)) return false;
-  if (okfPath.split(/[/\\]+/).includes("..")) return false;
+  if (!/^[A-Za-z0-9._/-]+$/.test(okfPath)) return false; // only URL-safe path chars — spaces/parens/#/? would yield malformed links; fall back to the slug-path
+  const segments = okfPath.split(/[/\\]+/);
+  if (segments.includes("..") || segments.includes(".")) return false; // reject traversal AND current-dir segments (e.g. "./index.md" must not slip past the reserved-name check)
+  if (!okfPath.endsWith(".md")) return false; // only markdown documents are round-trippable; reject non-.md / directory-like targets (e.g. "tables/customers", "tables/")
   if (okfPath === "index.md" || okfPath === "log.md") return false; // ROOT reserved (exact, not basename)
   if (okfPath === "references" || okfPath.startsWith("references/")) return false;
   return isInsideDir(path.normalize(path.join(realOut, okfPath)), realOut);
+}
+
+/** Total order over foreign pages: okfPath, then pageDirectory, then slug (stable, no equal-returns-1). */
+function compareForeign(a: ExportPage, b: ExportPage): number {
+  const ap = a.xOkf!.okfPath!, bp = b.xOkf!.okfPath!;
+  if (ap !== bp) return ap < bp ? -1 : 1;
+  if (a.pageDirectory !== b.pageDirectory) return a.pageDirectory < b.pageDirectory ? -1 : 1;
+  if (a.slug !== b.slug) return a.slug < b.slug ? -1 : 1;
+  return 0;
 }
 
 /** Resolve every page to a bundle-relative output path; returns the map + structured fallback warnings. */
@@ -37,7 +49,7 @@ export function resolveOutputPaths(
   const used = new Set<string>();
 
   // Foreign pages first (deterministic), so a restored okfPath claims before fallbacks fill `used`.
-  const foreign = pages.filter((p) => typeof p.xOkf?.okfPath === "string").sort((a, b) => (a.xOkf!.okfPath! < b.xOkf!.okfPath! ? -1 : 1));
+  const foreign = pages.filter((p) => typeof p.xOkf?.okfPath === "string").sort(compareForeign);
   const native = pages.filter((p) => typeof p.xOkf?.okfPath !== "string");
 
   for (const p of foreign) {

--- a/src/export/okf/types.ts
+++ b/src/export/okf/types.ts
@@ -31,5 +31,5 @@ export interface OkfFrontmatter {
   "x-llmwiki": XLlmwiki;
 }
 
-/** Resolves a wikilink slug to its bundle location + title (or null if unknown). */
-export type LinkResolver = (slug: string) => { dir: "concepts" | "queries"; title: string } | null;
+/** Resolves a wikilink slug to its bundle-relative output path + title (or null if unknown). */
+export type LinkResolver = (slug: string) => { path: string; title: string } | null;

--- a/src/import/okf-map.ts
+++ b/src/import/okf-map.ts
@@ -110,9 +110,9 @@ export function okfDocToPage(doc: RawOkfDoc, ctx: OkfMapContext): MappedOkfPage 
   // (symmetric, so round-trip canonical equality holds); an author-written `# Citations`
   // in a native page is likewise dropped. Foreign bodies are kept content-verbatim.
   const resolveLink = (linkPath: string): { slug: string; title: string } | null => {
-    const slug = slugFromRelPath(linkPath);
-    const title = ctx.titleOf(slug);
-    return title !== null ? { slug, title } : null;
+    const linkSlug = slugFromRelPath(linkPath);
+    const title = ctx.titleOf(linkSlug);
+    return title !== null ? { slug: linkSlug, title } : null;
   };
   const body = isNative ? okfLinksToWikilinks(canonicalBody(doc.body), resolveLink) : doc.body;
   // Join with a SINGLE newline, mirroring the exporter's render-doc convention

--- a/src/import/okf-map.ts
+++ b/src/import/okf-map.ts
@@ -109,7 +109,12 @@ export function okfDocToPage(doc: RawOkfDoc, ctx: OkfMapContext): MappedOkfPage 
   // NOTE: canonicalBody strips a derived `# Citations` section on BOTH export and import
   // (symmetric, so round-trip canonical equality holds); an author-written `# Citations`
   // in a native page is likewise dropped. Foreign bodies are kept content-verbatim.
-  const body = isNative ? okfLinksToWikilinks(canonicalBody(doc.body), ctx.titleOf) : doc.body;
+  const resolveLink = (linkPath: string): { slug: string; title: string } | null => {
+    const slug = slugFromRelPath(linkPath);
+    const title = ctx.titleOf(slug);
+    return title !== null ? { slug, title } : null;
+  };
+  const body = isNative ? okfLinksToWikilinks(canonicalBody(doc.body), resolveLink) : doc.body;
   // Join with a SINGLE newline, mirroring the exporter's render-doc convention
   // (`${frontmatter}\n${body}`). The canonical body already carries its own leading
   // blank line, so this keeps the export->import round-trip byte-symmetric.

--- a/src/import/okf-map.ts
+++ b/src/import/okf-map.ts
@@ -114,6 +114,9 @@ export function okfDocToPage(doc: RawOkfDoc, ctx: OkfMapContext): MappedOkfPage 
     const title = ctx.titleOf(linkSlug);
     return title !== null ? { slug: linkSlug, title } : null;
   };
+  // A foreign body is kept verbatim on FIRST import, but re-export stamps an `x-llmwiki` block, so a
+  // SUBSEQUENT import sees it as native and rewrites its markdown links to [[wikilinks]]. The first
+  // round-trip is faithful; multi-hop "llmwiki-ifies" the link syntax — intentional (it's a llmwiki page by then).
   const body = isNative ? okfLinksToWikilinks(canonicalBody(doc.body), resolveLink) : doc.body;
   // Join with a SINGLE newline, mirroring the exporter's render-doc convention
   // (`${frontmatter}\n${body}`). The canonical body already carries its own leading

--- a/test/fixtures/okf-export-page.ts
+++ b/test/fixtures/okf-export-page.ts
@@ -1,0 +1,25 @@
+/**
+ * @file Shared ExportPage factory for OKF bundle-writer tests.
+ *
+ * The nested-export and output-dir-safety suites both build minimal in-memory
+ * ExportPages to drive `buildOkfBundle`; the full required-field shape lives here
+ * once rather than being copy-pasted (and re-flagged as a clone) into each suite.
+ */
+import type { ExportPage } from "../../src/export/types.js";
+
+/** Options for {@link makeExportPage}; only `slug` is required. */
+export interface ExportPageOptions {
+  pageDirectory?: "concepts" | "queries";
+  body?: string;
+  okfPath?: string;
+}
+
+/** Build a complete ExportPage with sane defaults, optionally carrying an `x-okf` snapshot. */
+export function makeExportPage(slug: string, opts: ExportPageOptions = {}): ExportPage {
+  const { pageDirectory = "concepts", body = "b\n", okfPath } = opts;
+  return {
+    slug, pageDirectory, title: slug, summary: "s", sources: [], tags: [], createdAt: "", updatedAt: "",
+    links: [], body, citations: [], freshnessStatus: "unverified", contradicted: false, archived: false,
+    contentHash: "", sourceHashes: [], path: "", ...(okfPath ? { xOkf: { okfPath, originalFrontmatter: {} } } : {}),
+  } as ExportPage;
+}

--- a/test/okf-bundle.test.ts
+++ b/test/okf-bundle.test.ts
@@ -84,7 +84,11 @@ describe("buildOkfBundle", () => {
 
   it("does not write a page outside the bundle dir", async () => {
     const out = path.join(root, "bundle");
-    await expect(buildOkfBundle(root, [page({ slug: "../escape" })], out)).rejects.toThrow();
+    // A pathological `../escape` slug normalizes to a path INSIDE the bundle (escape.md at
+    // its root) under bundle-level confinement, so it no longer throws — but the
+    // security property that still holds is that NOTHING is written outside the bundle.
+    await buildOkfBundle(root, [page({ slug: "../escape" })], out);
+    await expect(access(path.join(out, "..", "escape.md"))).rejects.toThrow();
   });
 
   it("rejects a page whose pageDirectory escapes the bundle", async () => {

--- a/test/okf-index-log.test.ts
+++ b/test/okf-index-log.test.ts
@@ -6,10 +6,15 @@ const pages = [
   { title: "RAG", slug: "rag", pageDirectory: "concepts", summary: "Grounded." },
   { title: "Q1", slug: "q1", pageDirectory: "queries", summary: "An answer." },
 ] as ExportPage[];
+// Resolved output paths: native pages keep their <dir>/<slug>.md slug-path.
+const paths = new Map<ExportPage, string>([
+  [pages[0], "concepts/rag.md"],
+  [pages[1], "queries/q1.md"],
+]);
 
 describe("OKF index + log", () => {
   it("index has root okf_version frontmatter and a TOC over BOTH dirs", () => {
-    const idx = buildOkfIndex(pages);
+    const idx = buildOkfIndex(pages, paths);
     expect(idx).toMatch(/^---\n[\s\S]*okf_version:\s*["']?0\.1/m);
     expect(idx).toContain("* [RAG](/concepts/rag.md) - Grounded.");
     expect(idx).toContain("* [Q1](/queries/q1.md) - An answer.");

--- a/test/okf-links-general.test.ts
+++ b/test/okf-links-general.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { okfLinksToWikilinks } from "../src/export/okf/mapping.js";
+
+// resolveLink: linkPath -> { slug, title } | null for known bundle docs.
+const resolveLink = (p: string) =>
+  p === "tables/customers" ? { slug: "tables-customers", title: "Customers" }
+  : p === "concepts/rag" ? { slug: "rag", title: "RAG" }
+  : null;
+
+describe("okfLinksToWikilinks (generalized)", () => {
+  it("reverses a nested foreign path to a wikilink when known", () => {
+    expect(okfLinksToWikilinks("See [Customers](/tables/customers.md).", resolveLink)).toBe("See [[tables-customers]].");
+  });
+  it("still reverses concepts/queries paths (backward compatible)", () => {
+    expect(okfLinksToWikilinks("[RAG](/concepts/rag.md)", resolveLink)).toBe("[[rag]]");
+    expect(okfLinksToWikilinks("[Retrieval](/concepts/rag.md)", resolveLink)).toBe("[[rag|Retrieval]]");
+  });
+  it("leaves an unknown/external path verbatim (no over-match)", () => {
+    expect(okfLinksToWikilinks("[x](/external/thing.md)", resolveLink)).toBe("[x](/external/thing.md)");
+  });
+});

--- a/test/okf-links.test.ts
+++ b/test/okf-links.test.ts
@@ -3,7 +3,9 @@ import { wikilinksToOkf, okfLinksToWikilinks } from "../src/export/okf/mapping.j
 
 const resolve = (slug: string) =>
   slug === "rag" ? { dir: "concepts" as const, title: "RAG" } : null;
-const titleOf = (slug: string) => (slug === "rag" ? "RAG" : null);
+// resolveLink: linkPath ("concepts/rag") -> { slug, title } | null for known bundle docs.
+const resolveLink = (linkPath: string) =>
+  linkPath === "concepts/rag" ? { slug: "rag", title: "RAG" } : null;
 
 describe("wikilink <-> OKF link rewrite", () => {
   it("forward: [[slug]] -> [Title](/dir/slug.md); leaves unresolved links", () => {
@@ -14,12 +16,12 @@ describe("wikilink <-> OKF link rewrite", () => {
     expect(wikilinksToOkf("[[rag|the method]]", resolve)).toBe("[the method](/concepts/rag.md)");
   });
   it("reverse round-trips: text==title -> [[slug]]; else [[slug|text]]", () => {
-    expect(okfLinksToWikilinks("[RAG](/concepts/rag.md)", titleOf)).toBe("[[rag]]");
-    expect(okfLinksToWikilinks("[the method](/concepts/rag.md)", titleOf)).toBe("[[rag|the method]]");
+    expect(okfLinksToWikilinks("[RAG](/concepts/rag.md)", resolveLink)).toBe("[[rag]]");
+    expect(okfLinksToWikilinks("[the method](/concepts/rag.md)", resolveLink)).toBe("[[rag|the method]]");
   });
   it("forward then reverse reproduces the original body", () => {
     const original = "see [[rag]] and [[rag|the method]].";
-    expect(okfLinksToWikilinks(wikilinksToOkf(original, resolve), titleOf)).toBe(original);
+    expect(okfLinksToWikilinks(wikilinksToOkf(original, resolve), resolveLink)).toBe(original);
   });
   it("does not rewrite [[..]] inside fenced code blocks", () => {
     const body = "```\n[[rag]]\n```\nout [[rag]]";

--- a/test/okf-links.test.ts
+++ b/test/okf-links.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { wikilinksToOkf, okfLinksToWikilinks } from "../src/export/okf/mapping.js";
 
 const resolve = (slug: string) =>
-  slug === "rag" ? { dir: "concepts" as const, title: "RAG" } : null;
+  slug === "rag" ? { path: "concepts/rag.md", title: "RAG" } : null;
 // resolveLink: linkPath ("concepts/rag") -> { slug, title } | null for known bundle docs.
 const resolveLink = (linkPath: string) =>
   linkPath === "concepts/rag" ? { slug: "rag", title: "RAG" } : null;

--- a/test/okf-nested-export.test.ts
+++ b/test/okf-nested-export.test.ts
@@ -1,20 +1,17 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { mkdtemp, rm, mkdir, writeFile, stat, readFile } from "fs/promises";
-import { tmpdir } from "os";
+import { describe, it, expect } from "vitest";
+import { stat, readFile } from "fs/promises";
 import path from "path";
 import { buildOkfBundle } from "../src/export/okf/bundle.js";
-import type { ExportPage } from "../src/export/types.js";
+import { makeExportPage } from "./fixtures/okf-export-page.js";
+import { useOkfTempDir } from "./fixtures/okf-temp-dir.js";
 
-let dir: string;
-afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
-const page = (slug: string, dirn: "concepts" | "queries", body: string, okfPath?: string): ExportPage =>
-  ({ slug, pageDirectory: dirn, title: slug, summary: "s", sources: [], tags: [], createdAt: "", updatedAt: "",
-     links: [], body, citations: [], freshnessStatus: "unverified", contradicted: false, archived: false,
-     contentHash: "", sourceHashes: [], path: "", ...(okfPath ? { xOkf: { okfPath, originalFrontmatter: {} } } : {}) } as ExportPage);
+const { make } = useOkfTempDir();
+const page = (slug: string, dirn: "concepts" | "queries", body: string, okfPath?: string) =>
+  makeExportPage(slug, { pageDirectory: dirn, body, okfPath });
 
 describe("nested-path export", () => {
   it("writes a foreign doc at its okfPath and the index links there", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-nest-"));
+    const dir = await make("okf-nest-");
     const out = path.join(dir, "bundle");
     const pages = [page("tables-customers", "concepts", "Body.\n", "tables/customers.md")];
     await buildOkfBundle(dir, pages, out);
@@ -23,7 +20,7 @@ describe("nested-path export", () => {
     expect(await readFile(path.join(out, "index.md"), "utf-8")).toContain("(/tables/customers.md)");
   });
   it("a native page linking a foreign doc emits the foreign doc's real path", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-nest2-"));
+    const dir = await make("okf-nest2-");
     const out = path.join(dir, "bundle");
     const pages = [
       page("home", "concepts", "See [[tables-customers]].\n"),

--- a/test/okf-nested-export.test.ts
+++ b/test/okf-nested-export.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, stat, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { buildOkfBundle } from "../src/export/okf/bundle.js";
+import type { ExportPage } from "../src/export/types.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+const page = (slug: string, dirn: "concepts" | "queries", body: string, okfPath?: string): ExportPage =>
+  ({ slug, pageDirectory: dirn, title: slug, summary: "s", sources: [], tags: [], createdAt: "", updatedAt: "",
+     links: [], body, citations: [], freshnessStatus: "unverified", contradicted: false, archived: false,
+     contentHash: "", sourceHashes: [], path: "", ...(okfPath ? { xOkf: { okfPath, originalFrontmatter: {} } } : {}) } as ExportPage);
+
+describe("nested-path export", () => {
+  it("writes a foreign doc at its okfPath and the index links there", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-nest-"));
+    const out = path.join(dir, "bundle");
+    const pages = [page("tables-customers", "concepts", "Body.\n", "tables/customers.md")];
+    await buildOkfBundle(dir, pages, out);
+    expect((await stat(path.join(out, "tables/customers.md"))).isFile()).toBe(true);
+    expect(await stat(path.join(out, "concepts/tables-customers.md")).then(() => true, () => false)).toBe(false);
+    expect(await readFile(path.join(out, "index.md"), "utf-8")).toContain("(/tables/customers.md)");
+  });
+  it("a native page linking a foreign doc emits the foreign doc's real path", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-nest2-"));
+    const out = path.join(dir, "bundle");
+    const pages = [
+      page("home", "concepts", "See [[tables-customers]].\n"),
+      page("tables-customers", "concepts", "Body.\n", "tables/customers.md"),
+    ];
+    await buildOkfBundle(dir, pages, out);
+    expect(await readFile(path.join(out, "concepts/home.md"), "utf-8")).toContain("(/tables/customers.md)");
+  });
+});

--- a/test/okf-nested-roundtrip.test.ts
+++ b/test/okf-nested-roundtrip.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile, stat } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { importOkfBundle } from "../src/import/okf-import.js";
+import { collectExportPages } from "../src/export/collect.js";
+import { buildOkfBundle } from "../src/export/okf/bundle.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+
+describe("OKF nested-path round-trip", () => {
+  it("restores foreign nested paths and keeps foreign->foreign links resolving", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-nrt-"));
+    const bundle = path.join(dir, "kb");
+    await mkdir(path.join(bundle, "tables"), { recursive: true });
+    await writeFile(path.join(bundle, "tables/customers.md"), "---\ntype: concept\ntitle: Customers\n---\n\nA table.\n");
+    await writeFile(path.join(bundle, "tables/orders.md"), "---\ntype: concept\ntitle: Orders\n---\n\nSee [Customers](/tables/customers.md).\n");
+    const proj = path.join(dir, "proj");
+    const { pages } = await importOkfBundle(bundle, proj);
+    await mkdir(path.join(proj, "wiki/concepts"), { recursive: true });
+    for (const p of pages) await writeFile(path.join(proj, `wiki/concepts/${p.slug}.md`), p.body);
+    const exp = await collectExportPages(proj);
+    const out = path.join(dir, "out");
+    await buildOkfBundle(proj, exp, out);
+    expect((await stat(path.join(out, "tables/customers.md"))).isFile()).toBe(true);
+    expect((await stat(path.join(out, "tables/orders.md"))).isFile()).toBe(true);
+    expect(await readFile(path.join(out, "tables/orders.md"), "utf-8")).toContain("(/tables/customers.md)");
+    // re-import the exported bundle still works
+    const { pages: again } = await importOkfBundle(out, path.join(dir, "proj2"));
+    expect(again.map((p) => p.slug).sort()).toEqual(["tables-customers", "tables-orders"]);
+  });
+
+  it("native [[tables-customers]] round-trips: -> /tables/customers.md -> back to [[tables-customers]]", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-n2f-"));
+    // Seed a foreign customers doc (gets x-okf.okfPath) + a NATIVE home page that wikilinks it.
+    const bundle = path.join(dir, "kb"); await mkdir(path.join(bundle, "tables"), { recursive: true });
+    await writeFile(path.join(bundle, "tables/customers.md"), "---\ntype: concept\ntitle: Customers\n---\n\nA table.\n");
+    const proj = path.join(dir, "proj");
+    const { pages } = await importOkfBundle(bundle, proj);                 // pages[0] is the foreign customers doc
+    await mkdir(path.join(proj, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(proj, `wiki/concepts/${pages[0].slug}.md`), pages[0].body); // slug tables-customers, has x-okf
+    await writeFile(path.join(proj, "wiki/concepts/home.md"), "---\ntitle: Home\nkind: concept\n---\n\nSee [[tables-customers]].\n");
+    const out = path.join(dir, "out");
+    await buildOkfBundle(proj, await collectExportPages(proj), out);
+    expect(await readFile(path.join(out, "concepts/home.md"), "utf-8")).toContain("(/tables/customers.md)"); // export emits the real path
+    const { pages: round } = await importOkfBundle(out, path.join(dir, "proj2"));
+    const home = round.find((p) => p.slug === "home")!;
+    expect(home.body).toContain("[[tables-customers]]");                  // re-import reverses BACK to a wikilink (no drift)
+  });
+});

--- a/test/okf-output-dir-safety.test.ts
+++ b/test/okf-output-dir-safety.test.ts
@@ -1,43 +1,40 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, stat, symlink } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
 import { buildOkfBundle } from "../src/export/okf/bundle.js";
-import type { ExportPage } from "../src/export/types.js";
+import { makeExportPage } from "./fixtures/okf-export-page.js";
+import { useOkfTempDir } from "./fixtures/okf-temp-dir.js";
 
-let dir: string;
-afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
-const concept = (slug: string): ExportPage =>
-  ({ slug, pageDirectory: "concepts", title: slug, summary: "", sources: [], tags: [], createdAt: "", updatedAt: "",
-     links: [], body: "b\n", citations: [], freshnessStatus: "unverified", contradicted: false, archived: false,
-     contentHash: "", sourceHashes: [], path: "" } as ExportPage);
+const { make } = useOkfTempDir();
+const concept = (slug: string) => makeExportPage(slug);
 
 describe("output-dir safety", () => {
   it("refuses a non-empty, non-bundle out dir (no clobber)", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-"));
+    const dir = await make("okf-safe-");
     const out = path.join(dir, "notes"); await mkdir(out, { recursive: true });
     await writeFile(path.join(out, "keep.md"), "KEEP");
     await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/not an OKF bundle/i);
     expect((await stat(path.join(out, "keep.md"))).isFile()).toBe(true);
   });
   it("refuses an out dir containing a top-level .git", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe2-"));
+    const dir = await make("okf-safe2-");
     const out = path.join(dir, "repo"); await mkdir(path.join(out, ".git"), { recursive: true });
     await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/\.git/i);
   });
   it("refuses out === project root", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-root-"));
+    const dir = await make("okf-safe-root-");
     await expect(buildOkfBundle(dir, [concept("a")], dir)).rejects.toThrow(/project root/i);
   });
   it("refuses out inside .git (no mkdir under .git)", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-ingit-"));
+    const dir = await make("okf-safe-ingit-");
     await mkdir(path.join(dir, ".git"), { recursive: true });
     const out = path.join(dir, ".git", "okf");
     await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/\.git/i);
     expect(await stat(out).then(() => true, () => false)).toBe(false); // never created
   });
   it("refuses a fresh out path whose existing parent symlinks INTO .git (resolved; no mkdir)", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-symgit-"));
+    const dir = await make("okf-safe-symgit-");
     await mkdir(path.join(dir, ".git"), { recursive: true });
     await symlink(path.join(dir, ".git"), path.join(dir, "exports")); // <root>/exports -> <root>/.git
     const out = path.join(dir, "exports", "okf");                     // lexically not in .git; RESOLVES into .git
@@ -45,26 +42,26 @@ describe("output-dir safety", () => {
     expect(await stat(path.join(dir, ".git", "okf")).then(() => true, () => false)).toBe(false); // never created
   });
   it("refuses to wholesale-clear a recognized bundle that contains a nested .git", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-nested-"));
+    const dir = await make("okf-safe-nested-");
     const out = path.join(dir, "bundle");
     await buildOkfBundle(dir, [concept("a")], out);                 // make it a recognized bundle
     await mkdir(path.join(out, "sub", ".git"), { recursive: true }); // plant a nested repo
     await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/nested \.git/i);
   });
   it("a symlinked subdir in the bundle does not redirect a nested write", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-symlink-"));
+    const dir = await make("okf-safe-symlink-");
     const out = path.join(dir, "bundle");
     await buildOkfBundle(dir, [concept("a")], out);                 // recognized bundle
     const outside = await mkdtemp(path.join(tmpdir(), "okf-safe-out-"));
     await symlink(outside, path.join(out, "tables"));               // tables -> outside
-    const foreign = { ...concept("tables-customers"), xOkf: { okfPath: "tables/customers.md", originalFrontmatter: {} } } as ExportPage;
+    const foreign = makeExportPage("tables-customers", { okfPath: "tables/customers.md" });
     // wholesale-clear removes the symlink, so the write lands in a fresh real dir, not `outside`:
     await buildOkfBundle(dir, [foreign], out);
     expect(await stat(path.join(outside, "customers.md")).then(() => true, () => false)).toBe(false);
     await rm(outside, { recursive: true, force: true });
   });
   it("wholesale-clears a recognized prior bundle (stale gone)", async () => {
-    dir = await mkdtemp(path.join(tmpdir(), "okf-safe3-"));
+    const dir = await make("okf-safe3-");
     const out = path.join(dir, "bundle");
     await buildOkfBundle(dir, [concept("a"), concept("old")], out); // first export → bundle with two docs
     await buildOkfBundle(dir, [concept("a")], out);                 // re-export without "old"

--- a/test/okf-output-dir-safety.test.ts
+++ b/test/okf-output-dir-safety.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, stat, symlink } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { buildOkfBundle } from "../src/export/okf/bundle.js";
+import type { ExportPage } from "../src/export/types.js";
+
+let dir: string;
+afterEach(async () => { if (dir) await rm(dir, { recursive: true, force: true }); });
+const concept = (slug: string): ExportPage =>
+  ({ slug, pageDirectory: "concepts", title: slug, summary: "", sources: [], tags: [], createdAt: "", updatedAt: "",
+     links: [], body: "b\n", citations: [], freshnessStatus: "unverified", contradicted: false, archived: false,
+     contentHash: "", sourceHashes: [], path: "" } as ExportPage);
+
+describe("output-dir safety", () => {
+  it("refuses a non-empty, non-bundle out dir (no clobber)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-"));
+    const out = path.join(dir, "notes"); await mkdir(out, { recursive: true });
+    await writeFile(path.join(out, "keep.md"), "KEEP");
+    await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/not an OKF bundle/i);
+    expect((await stat(path.join(out, "keep.md"))).isFile()).toBe(true);
+  });
+  it("refuses an out dir containing a top-level .git", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe2-"));
+    const out = path.join(dir, "repo"); await mkdir(path.join(out, ".git"), { recursive: true });
+    await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/\.git/i);
+  });
+  it("refuses out === project root", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-root-"));
+    await expect(buildOkfBundle(dir, [concept("a")], dir)).rejects.toThrow(/project root/i);
+  });
+  it("refuses out inside .git (no mkdir under .git)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-ingit-"));
+    await mkdir(path.join(dir, ".git"), { recursive: true });
+    const out = path.join(dir, ".git", "okf");
+    await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/\.git/i);
+    expect(await stat(out).then(() => true, () => false)).toBe(false); // never created
+  });
+  it("refuses a fresh out path whose existing parent symlinks INTO .git (resolved; no mkdir)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-symgit-"));
+    await mkdir(path.join(dir, ".git"), { recursive: true });
+    await symlink(path.join(dir, ".git"), path.join(dir, "exports")); // <root>/exports -> <root>/.git
+    const out = path.join(dir, "exports", "okf");                     // lexically not in .git; RESOLVES into .git
+    await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/\.git/i);
+    expect(await stat(path.join(dir, ".git", "okf")).then(() => true, () => false)).toBe(false); // never created
+  });
+  it("refuses to wholesale-clear a recognized bundle that contains a nested .git", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-nested-"));
+    const out = path.join(dir, "bundle");
+    await buildOkfBundle(dir, [concept("a")], out);                 // make it a recognized bundle
+    await mkdir(path.join(out, "sub", ".git"), { recursive: true }); // plant a nested repo
+    await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/nested \.git/i);
+  });
+  it("a symlinked subdir in the bundle does not redirect a nested write", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe-symlink-"));
+    const out = path.join(dir, "bundle");
+    await buildOkfBundle(dir, [concept("a")], out);                 // recognized bundle
+    const outside = await mkdtemp(path.join(tmpdir(), "okf-safe-out-"));
+    await symlink(outside, path.join(out, "tables"));               // tables -> outside
+    const foreign = { ...concept("tables-customers"), xOkf: { okfPath: "tables/customers.md", originalFrontmatter: {} } } as ExportPage;
+    // wholesale-clear removes the symlink, so the write lands in a fresh real dir, not `outside`:
+    await buildOkfBundle(dir, [foreign], out);
+    expect(await stat(path.join(outside, "customers.md")).then(() => true, () => false)).toBe(false);
+    await rm(outside, { recursive: true, force: true });
+  });
+  it("wholesale-clears a recognized prior bundle (stale gone)", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "okf-safe3-"));
+    const out = path.join(dir, "bundle");
+    await buildOkfBundle(dir, [concept("a"), concept("old")], out); // first export → bundle with two docs
+    await buildOkfBundle(dir, [concept("a")], out);                 // re-export without "old"
+    expect(await stat(path.join(out, "concepts/old.md")).then(() => true, () => false)).toBe(false);
+  });
+});

--- a/test/okf-output-dir-safety.test.ts
+++ b/test/okf-output-dir-safety.test.ts
@@ -17,6 +17,13 @@ describe("output-dir safety", () => {
     await expect(buildOkfBundle(dir, [concept("a")], out)).rejects.toThrow(/not an OKF bundle/i);
     expect((await stat(path.join(out, "keep.md"))).isFile()).toBe(true);
   });
+  it("tolerates a stray .DS_Store: a dir holding only OS noise still exports", async () => {
+    const dir = await make("okf-safe-noise-");
+    const out = path.join(dir, "fresh"); await mkdir(out, { recursive: true });
+    await writeFile(path.join(out, ".DS_Store"), "noise");
+    await buildOkfBundle(dir, [concept("a")], out);
+    expect((await stat(path.join(out, "index.md"))).isFile()).toBe(true);
+  });
   it("refuses an out dir containing a top-level .git", async () => {
     const dir = await make("okf-safe2-");
     const out = path.join(dir, "repo"); await mkdir(path.join(out, ".git"), { recursive: true });

--- a/test/okf-output-paths.test.ts
+++ b/test/okf-output-paths.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { resolveOutputPaths, isSafeOkfPath } from "../src/export/okf/output-paths.js";
+import type { ExportPage } from "../src/export/types.js";
+
+const page = (slug: string, dir: "concepts" | "queries", okfPath?: string): ExportPage =>
+  ({ slug, pageDirectory: dir, title: slug, summary: "", body: "", ...(okfPath ? { xOkf: { okfPath, originalFrontmatter: {} } } : {}) } as ExportPage);
+
+describe("resolveOutputPaths", () => {
+  it("native pages use slug-paths; a safe foreign okfPath is restored", () => {
+    const pages = [page("rag", "concepts"), page("tables-customers", "concepts", "tables/customers.md")];
+    const { paths, warnings } = resolveOutputPaths(pages, "/out");
+    expect(paths.get(pages[0])).toBe("concepts/rag.md");
+    expect(paths.get(pages[1])).toBe("tables/customers.md");
+    expect(warnings).toHaveLength(0);
+  });
+  it("an unsafe okfPath falls back to slug-path + warns", () => {
+    const pages = [page("x", "concepts", "../escape.md")];
+    const { paths, warnings } = resolveOutputPaths(pages, "/out");
+    expect(paths.get(pages[0])).toBe("concepts/x.md");
+    expect(warnings[0]).toMatch(/not restorable/i);
+  });
+  it("a foreign okfPath that is a NATIVE page's slug-path is rejected; neither is lost", () => {
+    const a = page("customers", "concepts");                      // native, slug-path concepts/customers.md
+    const b = page("b", "concepts", "concepts/customers.md");     // foreign, wants A's slug-path
+    const { paths } = resolveOutputPaths([a, b], "/out");
+    expect(paths.get(a)).toBe("concepts/customers.md");
+    expect(paths.get(b)).toBe("concepts/b.md");
+  });
+  it("a foreign okfPath equal to ANOTHER FOREIGN page's fallback slug-path is rejected; both keep a path", () => {
+    const a = page("customers", "concepts", "../bad.md");         // foreign, unsafe okfPath → falls back to concepts/customers.md
+    const b = page("b", "concepts", "concepts/customers.md");     // foreign, wants A's (fallback) slug-path
+    const { paths } = resolveOutputPaths([a, b], "/out");
+    expect(paths.get(a)).toBe("concepts/customers.md");          // A's reserved slug-path is never stolen
+    expect(paths.get(b)).toBe("concepts/b.md");                  // B falls back to its own
+  });
+  it("isSafeOkfPath rejects reserved/escape/absolute, allows nested index.md", () => {
+    expect(isSafeOkfPath("index.md", "/out")).toBe(false);
+    expect(isSafeOkfPath("references/x.md", "/out")).toBe(false);
+    expect(isSafeOkfPath("/abs.md", "/out")).toBe(false);
+    expect(isSafeOkfPath("a/../../b.md", "/out")).toBe(false);
+    expect(isSafeOkfPath("tables/index.md", "/out")).toBe(true);
+    expect(isSafeOkfPath("tables/customers.md", "/out")).toBe(true);
+  });
+});

--- a/test/okf-output-paths.test.ts
+++ b/test/okf-output-paths.test.ts
@@ -19,19 +19,18 @@ describe("resolveOutputPaths", () => {
     expect(paths.get(pages[0])).toBe("concepts/x.md");
     expect(warnings[0]).toMatch(/not restorable/i);
   });
-  it("a foreign okfPath that is a NATIVE page's slug-path is rejected; neither is lost", () => {
-    const a = page("customers", "concepts");                      // native, slug-path concepts/customers.md
-    const b = page("b", "concepts", "concepts/customers.md");     // foreign, wants A's slug-path
+  // B is foreign and wants concepts/customers.md (A's slug-path); A must keep it, B must fall back.
+  const expectCollisionRejected = (a: ExportPage) => {
+    const b = page("b", "concepts", "concepts/customers.md");
     const { paths } = resolveOutputPaths([a, b], "/out");
-    expect(paths.get(a)).toBe("concepts/customers.md");
-    expect(paths.get(b)).toBe("concepts/b.md");
+    expect(paths.get(a)).toBe("concepts/customers.md"); // A's reserved slug-path is never stolen
+    expect(paths.get(b)).toBe("concepts/b.md");         // B falls back to its own
+  };
+  it("a foreign okfPath that is a NATIVE page's slug-path is rejected; neither is lost", () => {
+    expectCollisionRejected(page("customers", "concepts")); // native owner of concepts/customers.md
   });
   it("a foreign okfPath equal to ANOTHER FOREIGN page's fallback slug-path is rejected; both keep a path", () => {
-    const a = page("customers", "concepts", "../bad.md");         // foreign, unsafe okfPath → falls back to concepts/customers.md
-    const b = page("b", "concepts", "concepts/customers.md");     // foreign, wants A's (fallback) slug-path
-    const { paths } = resolveOutputPaths([a, b], "/out");
-    expect(paths.get(a)).toBe("concepts/customers.md");          // A's reserved slug-path is never stolen
-    expect(paths.get(b)).toBe("concepts/b.md");                  // B falls back to its own
+    expectCollisionRejected(page("customers", "concepts", "../bad.md")); // foreign, unsafe okfPath → falls back to concepts/customers.md
   });
   it("isSafeOkfPath rejects reserved/escape/absolute, allows nested index.md", () => {
     expect(isSafeOkfPath("index.md", "/out")).toBe(false);

--- a/test/okf-output-paths.test.ts
+++ b/test/okf-output-paths.test.ts
@@ -37,7 +37,42 @@ describe("resolveOutputPaths", () => {
     expect(isSafeOkfPath("references/x.md", "/out")).toBe(false);
     expect(isSafeOkfPath("/abs.md", "/out")).toBe(false);
     expect(isSafeOkfPath("a/../../b.md", "/out")).toBe(false);
+    expect(isSafeOkfPath("./index.md", "/out")).toBe(false);
+    expect(isSafeOkfPath("a/./b.md", "/out")).toBe(false);
     expect(isSafeOkfPath("tables/index.md", "/out")).toBe(true);
     expect(isSafeOkfPath("tables/customers.md", "/out")).toBe(true);
+  });
+  it("isSafeOkfPath rejects URL-unsafe characters (spaces/parens would yield malformed links)", () => {
+    expect(isSafeOkfPath("tables/my customers.md", "/out")).toBe(false); // space truncates link URL
+    expect(isSafeOkfPath("report (2024).md", "/out")).toBe(false);       // paren closes link early
+    expect(isSafeOkfPath("tables/customers.md", "/out")).toBe(true);     // still safe
+    expect(isSafeOkfPath("a/../../b.md", "/out")).toBe(false);           // still rejected
+  });
+  it("isSafeOkfPath rejects non-.md / directory-like targets (importer only round-trips .md docs)", () => {
+    expect(isSafeOkfPath("tables/customers", "/out")).toBe(false); // no extension
+    expect(isSafeOkfPath("tables/", "/out")).toBe(false);          // directory-like
+    expect(isSafeOkfPath("tables/customers.md", "/out")).toBe(true);
+  });
+  it("a foreign okfPath that is not a .md document falls back to its slug-path + warns", () => {
+    const pages = [page("customers", "concepts", "tables/customers")];
+    const { paths, warnings } = resolveOutputPaths(pages, "/out");
+    expect(paths.get(pages[0])).toBe("concepts/customers.md");
+    expect(warnings[0]).toMatch(/not restorable/i);
+  });
+  it("a foreign okfPath with URL-unsafe chars falls back to its slug-path + warns", () => {
+    const pages = [page("my-customers", "concepts", "tables/my customers.md")];
+    const { paths, warnings } = resolveOutputPaths(pages, "/out");
+    expect(paths.get(pages[0])).toBe("concepts/my-customers.md");
+    expect(warnings[0]).toMatch(/not restorable/i);
+  });
+  it("two foreign pages sharing an okfPath resolve deterministically regardless of input order", () => {
+    const a = page("a-slug", "concepts", "tables/dup.md");
+    const b = page("b-slug", "concepts", "tables/dup.md");
+    const forward = resolveOutputPaths([a, b], "/out").paths;
+    const reversed = resolveOutputPaths([b, a], "/out").paths;
+    expect(forward.get(a)).toBe("tables/dup.md"); // a wins the okfPath (sorts before b by slug)
+    expect(reversed.get(a)).toBe("tables/dup.md"); // SAME page wins regardless of order
+    expect(forward.get(b)).toBe("concepts/b-slug.md");
+    expect(reversed.get(b)).toBe("concepts/b-slug.md");
   });
 });

--- a/test/okf-render-doc.test.ts
+++ b/test/okf-render-doc.test.ts
@@ -12,7 +12,7 @@ const page = {
   links: ["other"], body: "See [[other]]. ^[a.md:1-3]", kind: "concept",
   citations: [{ file: "a.md", start: 1, end: 3 }], contentHash: "h", sourceHashes: [],
 } as ExportPage;
-const resolve = (s: string) => (s === "other" ? { dir: "concepts" as const, title: "Other" } : null);
+const resolve = (s: string) => (s === "other" ? { path: "concepts/other.md", title: "Other" } : null);
 const refName = (f: string) => (f === "a.md" ? "a-deadbeef.md" : null);
 
 describe("renderOkfDoc", () => {

--- a/test/okf-roundtrip-export.test.ts
+++ b/test/okf-roundtrip-export.test.ts
@@ -15,10 +15,10 @@ describe("export-side round-trip invariant", () => {
   it("reverse(forward(body)) == canonical body, and contentHash is stable", () => {
     const body = "See [[other]] and [[other|x]]. ^[a.md:1-3]\n";
     const resolve = (s: string) => (s === "other" ? { dir: "concepts" as const, title: "Other" } : null);
-    const titleOf = (s: string) => (s === "other" ? "Other" : null);
+    const resolveLink = (p: string) => (p === "concepts/other" ? { slug: "other", title: "Other" } : null);
     const canon = canonicalBody(body);
     const okfBody = wikilinksToOkf(canon, resolve);
-    const recovered = okfLinksToWikilinks(okfBody, titleOf);
+    const recovered = okfLinksToWikilinks(okfBody, resolveLink);
     expect(recovered).toBe(canon);
     const h = (s: string) => createHash("sha256").update(s, "utf-8").digest("hex");
     expect(h(recovered)).toBe(h(canon));

--- a/test/okf-roundtrip-export.test.ts
+++ b/test/okf-roundtrip-export.test.ts
@@ -14,7 +14,7 @@ import { wikilinksToOkf, okfLinksToWikilinks, canonicalBody } from "../src/expor
 describe("export-side round-trip invariant", () => {
   it("reverse(forward(body)) == canonical body, and contentHash is stable", () => {
     const body = "See [[other]] and [[other|x]]. ^[a.md:1-3]\n";
-    const resolve = (s: string) => (s === "other" ? { dir: "concepts" as const, title: "Other" } : null);
+    const resolve = (s: string) => (s === "other" ? { path: "concepts/other.md", title: "Other" } : null);
     const resolveLink = (p: string) => (p === "concepts/other" ? { slug: "other", title: "Other" } : null);
     const canon = canonicalBody(body);
     const okfBody = wikilinksToOkf(canon, resolve);


### PR DESCRIPTION
## What

Re-exporting an OKF bundle that was imported from nested paths now restores each imported foreign document to its **original** location (e.g. `tables/customers.md`) instead of flattening it to `concepts/<slug>.md`, with the index and inter-document links pointing at those paths. This resolves the deferred follow-up from the OKF round-trip work — a bundle now survives import → export with its layout and links intact.

- **Placement.** A new resolver assigns each page its output path: native pages keep their slug-path; an imported page restores its `x-okf.okfPath` when that path is safe and uncontested, otherwise falls back to its slug-path with a warning. An ownership map guarantees a restored path can never displace another page.
- **Links.** The link resolver is path-aware, so a native page linking an imported doc (`[[tables-customers]]`) emits the doc's real path (`/tables/customers.md`); on re-import that link reverses back to a wikilink, so it round-trips with no drift. Foreign documents' own markdown links are preserved verbatim and now resolve, since the files are restored to where the links point.

## Why

It makes llmwiki a faithful OKF pass-through: a third-party bundle keeps its directory structure and cross-document links across a round-trip, not just its contents and frontmatter.

## Safety

Imported `okfPath` values are untrusted (editable page frontmatter), so the exporter is hardened: an unsafe or colliding path falls back to the slug-path with a structured warning; every write is realpath-confined to the bundle; and the output directory is handled carefully — the bundle's real target is resolved through symlinks before any directory is created and refused if it is the filesystem root, the project root, or inside `.git`; a non-empty directory that isn't a recognized OKF bundle is refused rather than clobbered; and a recognized prior bundle is wholesale-cleared (refusing if it contains a nested `.git`) so stale files don't linger. External output directories remain supported.

## Test plan

- [x] `npx tsc --noEmit`, `npm run build`, `npm test` (1663 passed), `npx fallow` (0 above threshold), dupes clean
- [x] Nested round-trip: a foreign `tables/customers.md` + a sibling linking it survive import → export at their exact paths with the link intact, and re-import
- [x] Native→foreign full cycle: `[[tables-customers]]` → `/tables/customers.md` → back to `[[tables-customers]]`
- [x] Output-path resolution: ownership-map collisions (foreign-vs-native and foreign-vs-foreign), unsafe-path fallback with warning, exact-match reserved names (nested `index.md` allowed)
- [x] Output-dir safety: refusals for filesystem/project root, inside `.git` (asserted never created), a symlinked parent resolving into `.git`, a nested `.git` in a bundle, and a non-empty non-bundle dir; symlinked-subdir cleanup and stale-file cleanup
- [x] Backward compatibility: native-only bundles place every doc at `<dir>/<slug>.md` with unchanged TOC/links