### PR TITLE
docs: update OKF SDK, MCP, and round-trip behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Do not use llmwiki as a general static-site generator, a heavy ontology database
 - **Review policy.** Generated pages can be auto-held for review when confidence, contradiction, schema, or provenance rules trip.
 - **Freshness repair.** `llmwiki lint` and `llmwiki next` surface stale/orphaned pages; `llmwiki refresh --stale` repairs changed knowledge without compiling unrelated new sources.
 - **Eval harness.** `llmwiki eval` reports health score, citation coverage/precision, corpus stats, regression deltas, and optional judge-model citation support.
-- **MCP server.** `llmwiki serve` exposes ingest, compile, query, lint, read, status, eval, and context-pack tools to MCP-compatible agents.
-- **SDK.** `createWiki({ root })` drives ingest, compile, query, context, status, export, and eval from TypeScript without shelling out.
+- **MCP server.** `llmwiki serve` exposes ingest, compile, query, lint, read, status, eval, context-pack, and OKF exchange tools to MCP-compatible agents.
+- **SDK.** `createWiki({ root })` drives ingest, compile, query, context, status, export, eval, and OKF import/export from TypeScript without shelling out.
 - **Open Knowledge Format exchange.** Export and import OKF bundles for portable, markdown-native knowledge exchange. External OKF imports are staged through the review queue by default; trusted bundles can be written live explicitly.
 - **Other portable exports.** Export JSON, JSON-LD, GraphML, Marp slides, and `llms.txt` for downstream systems.
 - **Provider portable.** Anthropic, Claude Agent SDK local login, OpenAI-compatible servers, Ollama, GitHub Copilot, and local OpenAI-compatible runtimes.
@@ -135,7 +135,7 @@ llmwiki import --okf ./dist/okf --dry-run
 llmwiki import --okf ./dist/okf
 ```
 
-OKF import is intentionally review-first: untrusted bundles become review candidates, not live wiki pages. The importer preserves foreign OKF metadata, stores llmwiki provenance under `x-llmwiki`, and re-exports imported pages honestly after local edits.
+OKF import is intentionally review-first: untrusted bundles become review candidates, not live wiki pages. The importer preserves foreign OKF metadata, stores llmwiki provenance under `x-llmwiki`, and re-exports imported pages honestly after local edits, including safe original nested paths.
 
 See [`docs/guides/open-knowledge-format.mdx`](docs/guides/open-knowledge-format.mdx), [`docs/cli/export.mdx`](docs/cli/export.mdx), and [`docs/cli/import.mdx`](docs/cli/import.mdx).
 
@@ -171,7 +171,7 @@ Run:
 llmwiki serve --root /path/to/wiki-project
 ```
 
-MCP clients can ingest sources, compile, query, search pages, read pages, lint, run eval, inspect status, and request context packs. Read-only tools work without provider credentials; LLM-backed tools validate provider credentials at call time.
+MCP clients can ingest sources, compile, query, search pages, read pages, lint, run eval, inspect status, request context packs, and exchange OKF bundles. Read-only tools work without provider credentials; LLM-backed tools validate provider credentials at call time.
 
 See [`docs/guides/mcp-agent-integration.mdx`](docs/guides/mcp-agent-integration.mdx).
 

--- a/docs/cli/export.mdx
+++ b/docs/cli/export.mdx
@@ -172,19 +172,21 @@ dist/exports/okf/
   index.md
   concepts/<slug>.md
   queries/<slug>.md
+  <foreign/path>.md
   references/<source-file>.md
   log.md
 ```
 
 - `index.md` is the bundle table of contents and carries `okf_version: "0.1"` in frontmatter.
-- `concepts/` and `queries/` contain one OKF markdown document per exported wiki page.
+- Native llmwiki pages export under `concepts/` and `queries/`.
+- Imported foreign pages re-export at their original bundle-relative `.md` path when that path is safe, URL-safe, non-reserved, and uncontested. Unsafe or colliding paths fall back to the native slug path with a warning.
 - `references/` contains cited source files that still exist under `sources/` and resolve inside that directory. Missing or unsafe references are listed as plain text in citations instead of becoming dangling links.
 - `log.md` translates llmwiki's activity journal into an OKF-style date-grouped log.
 
 Each page document includes standard OKF fields (`type`, `title`, `description`, `tags`, `timestamp`) plus an `x-llmwiki` block with compiler metadata such as source files, citations, freshness, provenance, and a canonical content hash. Imported foreign OKF pages preserve their foreign `type` and producer-specific keys on re-export while refreshing the current llmwiki metadata.
 
 <Note>
-  `export --target okf` writes pages by llmwiki slug under `concepts/` or `queries/`. If a foreign bundle originally used nested paths, the original path is preserved as imported provenance, but re-exported documents are placed by the llmwiki slug.
+  `export --target okf` refuses dangerous output targets such as the filesystem root, the project root, directories inside `.git`, and non-empty directories that are not already OKF bundles. Re-exporting into an existing OKF bundle clears stale bundle files before writing the new bundle.
 </Note>
 
 See [Open Knowledge Format guide](/guides/open-knowledge-format) for the import/export round-trip workflow.

--- a/docs/cli/import.mdx
+++ b/docs/cli/import.mdx
@@ -87,9 +87,9 @@ Every non-reserved `.md` file in the bundle is treated as an OKF document if it 
 - Standard OKF `description` maps to llmwiki `summary`.
 - Standard OKF `tags` map to llmwiki `tags`.
 - Imported pages carry `provenanceState: imported` and an `okf:<bundle>` source token.
-- Native llmwiki OKF links are converted back to `[[wikilinks]]` when they resolve to a known imported page.
+- OKF links are converted back to `[[wikilinks]]` when their target path resolves to a known imported page.
 
-Foreign producer-specific frontmatter is preserved under `x-okf.originalFrontmatter`. If you later export with `llmwiki export --target okf`, llmwiki preserves foreign producer keys and raw foreign `type` values while refreshing current standard fields and `x-llmwiki` metadata.
+Foreign producer-specific frontmatter is preserved under `x-okf.originalFrontmatter`, and the original bundle-relative path is preserved under `x-okf.okfPath`. If you later export with `llmwiki export --target okf`, llmwiki preserves foreign producer keys and raw foreign `type` values while refreshing current standard fields and `x-llmwiki` metadata.
 
 ---
 
@@ -132,5 +132,4 @@ Round-trip behavior is designed to be honest rather than magical:
 
 - Page content, citations, imported provenance, and foreign producer keys are preserved.
 - Current llmwiki standard fields (`title`, `description`, `tags`, `timestamp`) are used on re-export, so local edits are reflected.
-- Documents are re-exported under llmwiki slug paths such as `concepts/<slug>.md` or `queries/<slug>.md`. The original OKF path is kept as imported provenance for diagnostics.
-
+- Safe original nested paths are restored on re-export. If the original path is unsafe, non-`.md`, URL-unsafe, reserved, or collides with another page, llmwiki falls back to slug paths such as `concepts/<slug>.md` or `queries/<slug>.md` and reports a warning.

--- a/docs/cli/serve.mdx
+++ b/docs/cli/serve.mdx
@@ -49,7 +49,7 @@ For Claude Desktop this goes in `claude_desktop_config.json`. For Cursor, add it
 
 ## MCP tools
 
-The server registers 9 tools. Read-only tools work without credentials; tools that invoke the LLM pipeline validate provider configuration on each call.
+The server registers 11 tools. Read-only tools work without credentials; tools that invoke the LLM pipeline validate provider configuration on each call.
 
 | Tool | What it does | LLM credentials needed? |
 |------|-------------|------------------------|
@@ -62,6 +62,8 @@ The server registers 9 tools. Read-only tools work without credentials; tools th
 | `wiki_status` | Summarize the wiki: page count, source count, last compile time, stale/orphaned pages, `stateStatus`, and `pendingCandidates` queue depth. Lists are capped at 100 entries; `*Count` fields give true totals. | No |
 | `get_context_pack` | Build an agent-ready evidence pack: primary pages, semantic chunks, graph neighbors, citations, per-page freshness, warnings, and suggested actions. Same v1 JSON envelope as `llmwiki context --json`. | No (uses lexical fallback when embeddings are unavailable) |
 | `run_eval` | Score wiki quality. `fast` suite checks health and citation coverage without LLM calls. `full` suite also LLM-judges a sample of citations. Set `record: true` to persist results to eval history. | `full` suite only |
+| `export_okf` | Export the wiki as an Open Knowledge Format bundle. The optional output directory is confined under the project root. | No |
+| `import_okf` | Preview or stage an Open Knowledge Format bundle as review candidates. The bundle directory must be inside the project root; no trusted live-write mode is exposed over MCP. | No |
 
 ### `get_context_pack` vs. `query_wiki`
 
@@ -91,6 +93,10 @@ Path confinement prevents reads outside the `sources/` directory, but only enabl
 ### Checking the review queue
 
 `wiki_status` includes a `pendingCandidates` field with the current count of pages waiting in the review queue. Agents can poll this field to decide whether to prompt the user to run `llmwiki review list` before continuing.
+
+### Importing OKF through MCP
+
+`import_okf` is intentionally staging-only. Agents can preview a bundle with `dryRun`, or stage it for human review, but cannot bypass review and write imported knowledge directly into `wiki/`. Use `llmwiki review list/show/approve` to inspect and approve staged imports.
 
 ---
 

--- a/docs/concepts/wiki-model.mdx
+++ b/docs/concepts/wiki-model.mdx
@@ -106,7 +106,7 @@ When multiple sources merge into one page, all contributing source filenames app
 
 Pages imported from Open Knowledge Format bundles are marked as imported knowledge. The mapped page frontmatter carries `provenanceState: imported`, an `okf:<bundle>` source token, and an `x-okf` provenance snapshot that records the original bundle path and original OKF frontmatter.
 
-This imported provenance is used for honest re-export: `llmwiki export --target okf` preserves foreign producer keys and raw foreign `type` values, while deriving standard OKF fields from the current llmwiki page so local edits are reflected.
+This imported provenance is used for honest re-export: `llmwiki export --target okf` preserves foreign producer keys and raw foreign `type` values, restores safe original bundle paths, and derives standard OKF fields from the current llmwiki page so local edits are reflected.
 
 <Note>
   OKF import is review-gated by default. External bundle content is staged as review candidates and does not become live wiki content until you approve it. Use `llmwiki import --okf <dir> --trusted` only for bundles you already trust.

--- a/docs/guides/mcp-agent-integration.mdx
+++ b/docs/guides/mcp-agent-integration.mdx
@@ -92,7 +92,7 @@ This guide walks you through starting the server, wiring it into Claude Desktop 
 
 ### Tools
 
-The server exposes nine tools. Read-only tools work without provider credentials; tools that invoke the LLM pipeline require a configured provider in the `env` block.
+The server exposes eleven tools. Read-only tools work without provider credentials; tools that invoke the LLM pipeline require a configured provider in the `env` block.
 
 | Tool | What it does | Credentials required |
 |------|--------------|:--------------------:|
@@ -105,6 +105,8 @@ The server exposes nine tools. Read-only tools work without provider credentials
 | `wiki_status` | Page and source counts, stale/orphaned pages, `stateStatus`, `pendingCandidates` | No |
 | `get_context_pack` | Build a token-budgeted evidence pack (primary pages, chunks, graph neighbors, citations, freshness, warnings, suggested actions) | No |
 | `run_eval` | Score wiki quality - fast suite is credential-free; full suite LLM-judges citation samples | Fast: No / Full: Yes |
+| `export_okf` | Export the wiki as an Open Knowledge Format bundle under a project-confined output path | No |
+| `import_okf` | Preview or stage an Open Knowledge Format bundle from a project-confined path as review candidates | No |
 
 **`get_context_pack` vs `query_wiki`:** these tools serve different purposes. `get_context_pack` *packages evidence* - it assembles a structured JSON envelope of relevant pages, semantic chunks, and citations that the agent uses for its own reasoning. `query_wiki` *generates an answer* - it calls the LLM and returns prose. Use `get_context_pack` when the agent needs grounded source material to reason over; use `query_wiki` when you want a finished answer.
 
@@ -126,7 +128,7 @@ Resources are passive read views of the wiki that agents can attach as context w
 
 The server starts without credentials. Provider credentials are read from the `env` block in your MCP config and forwarded to each pipeline call:
 
-- **Read-only tools** (`read_page`, `lint_wiki`, `wiki_status`, `ingest_source`) - always work, no credentials needed.
+- **Read-only and filesystem-only tools** (`read_page`, `lint_wiki`, `wiki_status`, `ingest_source`, `export_okf`, `import_okf`) - always work, no credentials needed.
 - **LLM-dependent tools** (`compile_wiki`, `query_wiki`, `search_pages`) - require a valid provider credential (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) in the environment at call time.
 - **`get_context_pack`** - credential-free by default. When embeddings are available and provider credentials are present, semantic retrieval is used. Without credentials or an embedding store, the tool falls back to lexical ranking and surfaces an `embedding-store-missing` or `query-embedding-unavailable` warning in the response - it does not fail.
 - **`run_eval`** - the `fast` suite (health score, citation coverage, corpus stats) runs without any credentials. The `full` suite adds LLM-judged citation scoring and requires a provider.
@@ -147,6 +149,14 @@ The server starts without credentials. Provider credentials are read from the `e
 ## Using `ingest_source` safely
 
 `ingest_source` accepts a URL or an absolute local file path. Because it performs a server-side fetch and local file read, it is a **trusted-input-only** primitive - pass only URLs and paths you control. For untrusted or user-supplied content, use the SDK's `ingestText` instead (see the [SDK guide](/guides/sdk)).
+
+## OKF tools
+
+`export_okf` and `import_okf` give agents structured Open Knowledge Format access without parsing CLI output.
+
+- `export_okf` writes an OKF bundle. Its optional `out` path is confined under the project root.
+- `import_okf` reads an OKF bundle from a project-confined `dir`. It supports `dryRun` and is always staging-only; MCP does not expose the trusted live-write import path.
+- After `import_okf` stages pages, approve them with `llmwiki review list`, `llmwiki review show`, and `llmwiki review approve`.
 
 <Tip>
   After an agent calls `compile_wiki`, check `wiki_status` and look at the `pendingCandidates` field. If your wiki has a review policy configured in `.llmwiki/config.json`, some pages may be held for human review rather than written directly. A non-zero `pendingCandidates` means the agent has queued work that needs your approval before those pages go live - run `llmwiki review list` to inspect them.

--- a/docs/guides/open-knowledge-format.mdx
+++ b/docs/guides/open-knowledge-format.mdx
@@ -8,7 +8,8 @@ Open Knowledge Format (OKF) is a markdown-bundle shape for sharing compiled know
 
 - `llmwiki export --target okf` writes a portable OKF bundle from your compiled wiki.
 - `llmwiki import --okf <dir>` reads an OKF bundle and stages its documents for review by default.
-- Re-export preserves foreign producer keys and raw foreign types while refreshing llmwiki's own metadata.
+- Re-export preserves foreign producer keys, raw foreign types, and safe original bundle paths while refreshing llmwiki's own metadata.
+- SDK and MCP callers can export/import OKF without shelling out; MCP import is staging-only.
 
 Use OKF when you want to exchange compiled knowledge with another tool or project. Use JSON export when you are feeding a programmatic importer that expects llmwiki's JSON bridge contract.
 
@@ -28,9 +29,12 @@ knowledge-bundle/
   index.md
   concepts/<slug>.md
   queries/<slug>.md
+  <foreign/path>.md
   references/<source-file>.md
   log.md
 ```
+
+Native llmwiki pages export under `concepts/<slug>.md` or `queries/<slug>.md`. Imported foreign pages re-export to their original bundle-relative `.md` path when that path is safe, URL-safe, non-reserved, and uncontested. If the original path is unsafe or collides, llmwiki falls back to the slug path and returns a warning.
 
 Each page document includes OKF standard frontmatter plus an `x-llmwiki` block with compiler metadata:
 
@@ -109,12 +113,29 @@ When you import a foreign OKF bundle, llmwiki stores the original OKF frontmatte
 - Current llmwiki standard fields (`title`, `description`, `tags`, `timestamp`) are derived from the current page, so local edits are reflected.
 - `x-llmwiki` is regenerated from current llmwiki state.
 - `x-okf` is not emitted; it is an internal imported-provenance record.
+- Safe original nested paths are restored, so foreign bundle layouts can round-trip.
+- Native `[[wikilinks]]` to imported foreign pages are exported to that page's restored OKF path.
 
 This keeps the bundle honest: foreign metadata is not discarded, but stale standard fields are not blindly replayed after local edits.
 
 <Note>
-  Re-export places documents by llmwiki slug under `concepts/` or `queries/`. If a foreign bundle originally used nested paths, that original path is preserved as provenance for diagnostics, but the exported document path follows llmwiki's slug model.
+  Path restoration is conservative. Non-`.md`, URL-unsafe, reserved, escaping, or colliding foreign paths fall back to `concepts/<slug>.md` or `queries/<slug>.md` with a warning.
 </Note>
+
+---
+
+## Programmatic and agent access
+
+Use the SDK when your application owns the trust decision:
+
+```ts
+const bundle = await wiki.exportOkf({ out: "./dist/okf" });
+const preview = await wiki.importOkf("./partner-bundle", { dryRun: true });
+const staged = await wiki.importOkf("./partner-bundle");
+const written = await wiki.importOkf("./internal-bundle", { trusted: true });
+```
+
+Use MCP when an agent needs structured OKF access. The MCP server exposes `export_okf` and `import_okf`; `import_okf` is always staging-only and supports `dryRun`, so imported knowledge still requires review approval before it enters the live wiki.
 
 ---
 
@@ -129,4 +150,3 @@ This keeps the bundle honest: foreign metadata is not discarded, but stale stand
 | Share a human-readable portable bundle | OKF |
 
 See [Export](/cli/export) for every export target and [Import](/cli/import) for the full OKF import reference.
-

--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -169,6 +169,24 @@ Both methods return `IngestResult` with `filename`, `chars`, and `truncated` fie
   **Performance note:** same per-call corpus-hashing cost as `status()` and `lint()`. Avoid hot loops.
 </ParamField>
 
+<ParamField body="wiki.exportOkf(options?)" type="Promise<OkfExportReport>">
+  Export the compiled wiki as an Open Knowledge Format bundle - the same bundle written by `llmwiki export --target okf`. No credentials required.
+
+  - `options.out` - optional output directory. Defaults to `dist/exports/okf` under the wiki root.
+
+  The report includes the output directory, written paths, and warnings such as cited sources that could not be bundled. Imported foreign pages re-export at their original safe bundle paths when possible.
+</ParamField>
+
+<ParamField body="wiki.importOkf(dir, options?)" type="Promise<OkfImportReport>">
+  Import an Open Knowledge Format bundle without calling an LLM. By default, imported pages are staged as review candidates, matching `llmwiki import --okf`.
+
+  - `dir` - path to the OKF bundle directory.
+  - `options.dryRun` - preview pages, skips, and warnings without writing.
+  - `options.trusted` - write live pages directly. Use only for bundles whose content and provenance you already trust.
+
+  The report includes `mode`, imported page details, skipped pages, warnings, and a `nextAction` string when review approval is required.
+</ParamField>
+
 ## Error handling
 
 Methods that require an LLM provider throw `ProviderUnavailableError` when no credentials are configured. If the provider name is not recognized, they throw `UnknownProviderError`. Both are exported from the package:
@@ -203,6 +221,8 @@ import type {
   WikiStatus,
   ContextPack,
   EvalReport,
+  OkfExportReport,
+  OkfImportReport,
 } from "llm-wiki-compiler";
 ```
 
@@ -213,6 +233,7 @@ Several methods hash the full source corpus on every call with no cross-call cac
 - `status()` - O(total source bytes) per call
 - `lint()` - O(total source bytes) per call
 - `exportJson()` - O(total source bytes) per call
+- `exportOkf()` - O(total source bytes) per call
 
 Avoid calling these methods in tight loops or on every request in a server. An mtime-keyed cache is planned for a future release.
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -10,7 +10,7 @@ description: "llmwiki turns URLs, files, and session exports into a persistent, 
 
 llmwiki is a knowledge compiler. You point it at your sources - research papers, documentation sites, notes, session exports - and it uses an LLM pipeline to compile them into a structured, interlinked wiki that you can browse, search, query, and connect to AI agents. Unlike retrieval-augmented generation (RAG), llmwiki compiles your knowledge once into a durable artifact that compounds over time: concepts get their own typed pages, links form a navigable graph, and every claim traces back to its source.
 
-llmwiki also supports [Google Cloud's Open Knowledge Format initiative](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/). You can export a compiled wiki as an OKF bundle, import OKF bundles from other tools through the review queue, and re-export foreign bundles while preserving producer metadata and llmwiki provenance.
+llmwiki also supports [Google Cloud's Open Knowledge Format initiative](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/). You can export a compiled wiki as an OKF bundle, import OKF bundles from other tools through the review queue, and re-export foreign bundles while preserving producer metadata, llmwiki provenance, and safe original nested paths.
 
 <CardGroup cols={2}>
   <Card title="Quick Start" icon="rocket" href="/quickstart">
@@ -38,11 +38,11 @@ llmwiki also supports [Google Cloud's Open Knowledge Format initiative](https://
 
 **A local web viewer.** `llmwiki view` opens your compiled wiki in a browser - sidebar navigation, full-text search, a force-directed page graph, and provenance chips on every paragraph.
 
-**Agent-ready via MCP.** `llmwiki serve` exposes the full pipeline to Claude Desktop, Cursor, Claude Code, and any MCP-compatible agent. Agents can ingest sources, compile, query, lint, and retrieve context packs without touching the CLI.
+**Agent-ready via MCP.** `llmwiki serve` exposes the full pipeline to Claude Desktop, Cursor, Claude Code, and any MCP-compatible agent. Agents can ingest sources, compile, query, lint, retrieve context packs, and exchange OKF bundles without touching the CLI.
 
-**Open Knowledge Format round-trip.** `llmwiki export --target okf` writes a Google OKF-style bundle with page docs, references, and an activity log. `llmwiki import --okf` stages external bundles for review by default, so third-party knowledge does not touch your live wiki until you approve it.
+**Open Knowledge Format round-trip.** `llmwiki export --target okf` writes a Google OKF-style bundle with page docs, references, and an activity log. `llmwiki import --okf` stages external bundles for review by default, so third-party knowledge does not touch your live wiki until you approve it. Imported foreign pages re-export at their safe original paths when possible.
 
-**Programmatic control via SDK.** `createWiki({ root })` drives the entire pipeline in-process - no shelling out, no console noise, fully typed.
+**Programmatic control via SDK.** `createWiki({ root })` drives the entire pipeline in-process - no shelling out, no console noise, fully typed, including OKF import/export.
 
 ## Who uses llmwiki
 


### PR DESCRIPTION
## What

Updates public docs for the current Open Knowledge Format support after the latest OKF work landed.

- Documents safe nested-path restoration on OKF re-export, plus fallback warnings for unsafe or colliding paths
- Adds SDK `exportOkf` / `importOkf` coverage
- Adds MCP `export_okf` / staging-only `import_okf` coverage and trust-boundary notes
- Refreshes README, introduction, CLI export/import/serve, SDK, MCP, and wiki model docs

## Validation

- `volta run npm run release:check-docs`
- `volta run npx mint validate`
- `volta run npx mint broken-links`
- `volta run npx tsc --noEmit`
- `volta run npm run build`
- `volta run npm test`
- `volta run npm run fallow:ci`

Pre-push build and full test suite also passed.