### PR TITLE
chore: prepare 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-06-16
+
+Extends Open Knowledge Format support beyond the CLI: in-process SDK and MCP access to the OKF round-trip, and faithful reconstruction of an imported foreign bundle's original nested paths on re-export.
+
+### Added
+
+- **OKF SDK access** — `createWiki().exportOkf({ out? })` and `importOkf(dir, { dryRun?, trusted? })` run the OKF export/import round-trip in-process and return structured reports, with warnings and skips surfaced as data rather than console output. `OkfExportReport` and `OkfImportReport` are exported from the package types.
+- **OKF MCP tools** — `llmwiki serve` now registers `export_okf` and a staging-only `import_okf`, bringing the server to 11 tools. `import_okf` previews a bundle with `dryRun` or stages it as review candidates; it exposes no trusted live-write path to agents, and its bundle path is confined under the project root.
+- **Nested-path reconstruction on OKF re-export** — imported foreign OKF pages re-export at their original bundle-relative path (for example `tables/customers.md`) instead of `concepts/<slug>.md`, and native-to-foreign links round-trip. Paths that are unsafe, URL-unsafe, non-`.md`, reserved, escaping, or contested fall back to the slug path with a warning.
+
+### Changed
+
+- OKF link reversal now restores `[[wikilinks]]` from any bundle-relative `.md` link that resolves to a known imported page, not only `concepts/` and `queries/` slug links.
+- OKF export refuses dangerous output targets — the filesystem root, the project root, directories inside `.git`, and non-empty directories that are not already OKF bundles — before writing, and wholesale-clears a recognized prior bundle while refusing any nested `.git`. All bundle writes are realpath-confined to the output directory.
+
+### Contributors
+
+No external contributors in this release.
+
 ## [0.10.0] - 2026-06-14
 
 Adds a review-policy gate for generated knowledge, a full Open Knowledge Format (OKF) export/import round-trip, and a Mintlify documentation site.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # llmwiki
 
 <p align="center">
-  <img src="docs/images/okf-readme-banner.svg" alt="Breaking News: llmwiki 0.10.0 supports Open Knowledge Format" width="900">
+  <img src="docs/images/okf-readme-banner.svg" alt="Breaking News: llmwiki supports Open Knowledge Format" width="900">
 </p>
 
 **Breaking News:** llmwiki is now an **Open Knowledge Format (OKF)** producer and consumer, aligning compiled agent knowledge with Google Cloud's emerging standard for portable knowledge sharing. Export compiled wikis with `llmwiki export --target okf`, import external bundles with `llmwiki import --okf`, and stage untrusted knowledge through review before it becomes live agent context.
@@ -261,7 +261,7 @@ volta run --node 24 npx mint dev --port 3001
 
 ## Current release
 
-Version `0.10.0` includes review policy, source-freshness repair, Open Knowledge Format import/export/re-export support, the Claude Agent SDK provider, and the Mintlify docs site. See [`CHANGELOG.md`](CHANGELOG.md) for release history.
+Version `0.11.0` adds in-process SDK (`createWiki().exportOkf`/`importOkf`) and MCP (`export_okf`/`import_okf`) access to the Open Knowledge Format round-trip, plus faithful nested-path reconstruction when re-exporting imported foreign bundles. It builds on the 0.10.0 review policy, source-freshness repair, OKF CLI round-trip, and Mintlify docs site. See [`CHANGELOG.md`](CHANGELOG.md) for release history.
 
 ## Companion: Atomic Memory
 

--- a/docs/images/okf-docs-banner.svg
+++ b/docs/images/okf-docs-banner.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="330" viewBox="0 0 1400 330" role="img" aria-labelledby="title desc">
-  <title id="title">Breaking News: llmwiki 0.10.0 supports Open Knowledge Format</title>
+  <title id="title">Breaking News: llmwiki supports Open Knowledge Format</title>
   <desc id="desc">llmwiki is now an OKF producer and consumer aligned with Google Cloud's emerging standard for portable knowledge sharing.</desc>
   <defs>
     <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
@@ -17,7 +17,7 @@
   </text>
 
   <text x="700" y="145" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="38" font-weight="800" fill="#F8FAFC">
-    llmwiki 0.10.0 supports Open Knowledge Format
+    llmwiki supports Open Knowledge Format
   </text>
   <text x="700" y="190" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="600" fill="#CBD5E1">
     A producer and consumer for Google Cloud's emerging standard for portable knowledge sharing

--- a/docs/images/okf-readme-banner.svg
+++ b/docs/images/okf-readme-banner.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="330" viewBox="0 0 1400 330" role="img" aria-labelledby="title desc">
-  <title id="title">Breaking News: llmwiki 0.10.0 supports Open Knowledge Format</title>
+  <title id="title">Breaking News: llmwiki supports Open Knowledge Format</title>
   <desc id="desc">llmwiki is now an OKF producer and consumer aligned with Google Cloud's emerging standard for portable knowledge sharing.</desc>
   <defs>
     <linearGradient id="bubble" x1="0" y1="0" x2="1" y2="1">
@@ -20,7 +20,7 @@
   </text>
 
   <text x="700" y="145" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="38" font-weight="800" fill="#0F172A">
-    llmwiki 0.10.0 supports Open Knowledge Format
+    llmwiki supports Open Knowledge Format
   </text>
   <text x="700" y="190" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="600" fill="#334155">
     A producer and consumer for Google Cloud's emerging standard for portable knowledge sharing

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -5,7 +5,7 @@ description: "llmwiki turns URLs, files, and session exports into a persistent, 
 ---
 
 <p align="center">
-  <img src="/images/okf-docs-banner.svg" alt="Breaking News: llmwiki 0.10.0 supports Open Knowledge Format" width="900" />
+  <img src="/images/okf-docs-banner.svg" alt="Breaking News: llmwiki supports Open Knowledge Format" width="900" />
 </p>
 
 llmwiki is a knowledge compiler. You point it at your sources - research papers, documentation sites, notes, session exports - and it uses an LLM pipeline to compile them into a structured, interlinked wiki that you can browse, search, query, and connect to AI agents. Unlike retrieval-augmented generation (RAG), llmwiki compiles your knowledge once into a durable artifact that compounds over time: concepts get their own typed pages, links form a navigable graph, and every claim traces back to its source.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Prepares the 0.11.0 release. No source changes — this ships the already-merged OKF SDK/MCP access (#105) and nested-path reconstruction (#106) to npm.

- `package.json` 0.10.0 → 0.11.0
- `CHANGELOG.md` 0.11.0 entry (Added: OKF SDK `exportOkf`/`importOkf`, MCP `export_okf`/staging-only `import_okf`, nested-path restoration; Changed: generalized link reversal + output-dir safety)
- README current-release line bumped to 0.11.0
- OKF banners made versionless ("llmwiki supports Open Knowledge Format") so they don't rot each release