### PR TITLE
feat(profile): Phase 1b — profile-aware programmatic read surfaces

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -31,7 +31,9 @@ import {
   buildJsonExportDocument,
   type BuildJsonExportOptions,
   type JsonExportDocument,
+  type JsonExportProfileBlock,
 } from "../export/json-export.js";
+import { buildExportProfileBlock } from "../export/profile-block.js";
 import { validateProjectId } from "../export/project-id.js";
 import { buildJsonLd } from "../export/json-ld.js";
 import { buildGraphml } from "../export/graphml.js";
@@ -126,18 +128,35 @@ interface BuildContentInputs {
   marpSource: MarpSource;
   /** Optional bridge identifier; only consumed by the json target. */
   projectId?: string;
+  /** Pre-computed non-default profile block; only consumed by the json target. */
+  profile?: JsonExportProfileBlock;
+}
+
+/**
+ * Assemble the JSON-export options from the optional bridge id and the
+ * pre-computed profile block, omitting each key when absent so the default
+ * envelope is unchanged.
+ */
+function buildJsonOptions(
+  projectId: string | undefined,
+  profile: JsonExportProfileBlock | undefined,
+): BuildJsonExportOptions {
+  return {
+    ...(projectId !== undefined ? { projectId } : {}),
+    ...(profile !== undefined ? { profile } : {}),
+  };
 }
 
 /** Build the content string for a single target. */
 function buildContent(inputs: BuildContentInputs): string {
-  const { target, pages, projectTitle, marpSource, projectId } = inputs;
+  const { target, pages, projectTitle, marpSource, projectId, profile } = inputs;
   switch (target) {
     case "llms-txt":
       return buildLlmsTxt(pages, projectTitle);
     case "llms-full-txt":
       return buildLlmsFullTxt(pages, projectTitle);
     case "json":
-      return buildJsonExport(pages, projectId !== undefined ? { projectId } : {});
+      return buildJsonExport(pages, buildJsonOptions(projectId, profile));
     case "json-ld":
       return buildJsonLd(pages);
     case "graphml":
@@ -179,6 +198,7 @@ export async function runExport(root: string, options: ExportOptions = {}): Prom
     options.projectId !== undefined ? validateProjectId(options.projectId) : undefined;
   const pages = await collectExportPages(root);
   const projectTitle = resolveProjectTitle(root);
+  const profile = await buildExportProfileBlock(root);
 
   const targets = resolveTargets(options.target);
   const marpSource = resolveMarpSource(options.source);
@@ -192,7 +212,7 @@ export async function runExport(root: string, options: ExportOptions = {}): Prom
       output.status("+", output.success(`Exported okf bundle → ${output.source(outDir)}`));
       continue;
     }
-    const content = buildContent({ target, pages, projectTitle, marpSource, projectId });
+    const content = buildContent({ target, pages, projectTitle, marpSource, projectId, profile });
     const outPath = path.join(root, EXPORT_DIR, TARGET_FILENAMES[target]);
     await atomicWrite(outPath, content);
     written.push(outPath);
@@ -232,7 +252,8 @@ export async function exportJson(
   options: BuildJsonExportOptions = {},
 ): Promise<JsonExportDocument> {
   const pages = await collectExportPages(root);
-  return buildJsonExportDocument(pages, options);
+  const profile = await buildExportProfileBlock(root);
+  return buildJsonExportDocument(pages, profile ? { ...options, profile } : options);
 }
 
 /**

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -30,6 +30,7 @@ import {
   buildJsonExport,
   buildJsonExportDocument,
   type BuildJsonExportOptions,
+  type ExportJsonOptions,
   type JsonExportDocument,
   type JsonExportProfileBlock,
 } from "../export/json-export.js";
@@ -249,11 +250,18 @@ function resolveTargets(rawTarget: string | undefined): ExportTarget[] {
  */
 export async function exportJson(
   root: string,
-  options: BuildJsonExportOptions = {},
+  options: ExportJsonOptions = {},
 ): Promise<JsonExportDocument> {
   const pages = await collectExportPages(root);
   const profile = await buildExportProfileBlock(root);
-  return buildJsonExportDocument(pages, profile ? { ...options, profile } : options);
+  // Reconstruct build options from ONLY the public knob so a forged `profile`
+  // on the caller's object can never reach the document; the pipeline-computed
+  // `profile` is the sole source of the block.
+  const buildOptions: BuildJsonExportOptions = {
+    ...(options.projectId !== undefined ? { projectId: options.projectId } : {}),
+    ...(profile !== undefined ? { profile } : {}),
+  };
+  return buildJsonExportDocument(pages, buildOptions);
 }
 
 /**

--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -37,6 +37,13 @@ import type { EntityPageView } from "../profile/types.js";
 export const EXPORT_SCHEMA_VERSION = 1;
 
 /**
+ * Contract version of the additive `JsonExportProfileBlock`. Bump when the
+ * profile block's shape changes; independent of the document `schemaVersion` so
+ * a profile-block change never breaks the default (block-less) envelope.
+ */
+export const PROFILE_BLOCK_VERSION = 1;
+
+/**
  * Additive, non-default-profile entity block for the JSON export.
  *
  * Present ONLY for a non-default profile; ABSENT for the built-in default so
@@ -45,8 +52,17 @@ export const EXPORT_SCHEMA_VERSION = 1;
  * `filePath`) with its `body` INCLUDED — export wants page content — NOT the
  * freshness/hash-decorated `ExportPage`. The legacy `pages` array stays scoped
  * to concepts/queries.
+ *
+ * @experimental Shape may change in a future release.
  */
 export interface JsonExportProfileBlock {
+  /**
+   * Block-level contract version (a literal `1`). Distinct from the document
+   * `schemaVersion`: lets consumers detect future profile-block shape changes
+   * without a default-breaking document bump. Only appears for a non-default
+   * profile (the whole block is absent for the built-in default).
+   */
+  version: 1;
   profileId: string;
   entityPages: EntityPageView[];
   /** Human-readable collector problems; present ONLY when non-empty. */

--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -28,7 +28,7 @@
 
 import { validateProjectId } from "./project-id.js";
 import type { ExportPage } from "./types.js";
-import type { EntityPage } from "../profile/types.js";
+import type { EntityPageView } from "../profile/types.js";
 
 /**
  * Monotonically-incremented envelope version.
@@ -40,13 +40,15 @@ export const EXPORT_SCHEMA_VERSION = 1;
  * Additive, non-default-profile entity block for the JSON export.
  *
  * Present ONLY for a non-default profile; ABSENT for the built-in default so
- * the default export is byte-identical. `entityPages` carries the
- * content-bearing `EntityPage` shape directly — NOT the freshness/hash-decorated
- * `ExportPage`. The legacy `pages` array stays scoped to concepts/queries.
+ * the default export is byte-identical. `entityPages` carries the PUBLIC
+ * `EntityPageView` shape (project-relative `path`, never an absolute
+ * `filePath`) with its `body` INCLUDED — export wants page content — NOT the
+ * freshness/hash-decorated `ExportPage`. The legacy `pages` array stays scoped
+ * to concepts/queries.
  */
 export interface JsonExportProfileBlock {
   profileId: string;
-  entityPages: EntityPage[];
+  entityPages: EntityPageView[];
   /** Human-readable collector problems; present ONLY when non-empty. */
   problems?: string[];
 }
@@ -70,17 +72,36 @@ export interface JsonExportDocument {
   profile?: JsonExportProfileBlock;
 }
 
-/** Options accepted by {@link buildJsonExportDocument}. */
-export interface BuildJsonExportOptions {
+/**
+ * PUBLIC options for the JSON export, exposing ONLY the legitimate caller knob.
+ *
+ * Deliberately omits `profile`: the profile block is computed and injected by
+ * the export PIPELINE after it resolves the active profile, never accepted from
+ * caller input — otherwise a default-project caller could FORGE a `profile`
+ * block into the document. Callers (SDK `Wiki.exportJson`, the CLI export
+ * command) accept this type, not the internal {@link BuildJsonExportOptions}.
+ */
+export interface ExportJsonOptions {
   /**
    * Optional project identifier. Validated against the bridge contract
    * regex; throws if invalid so a malformed value never reaches disk.
    */
   projectId?: string;
+}
+
+/**
+ * INTERNAL build options for {@link buildJsonExportDocument}.
+ *
+ * Extends the public {@link ExportJsonOptions} with the pipeline-only `profile`
+ * block. The `profile` field is injected by the export pipeline (which holds
+ * `root` and computes the active profile); it is ABSENT for the built-in
+ * default so the default envelope gains no `profile` key. Never expose this
+ * type at a caller boundary — see {@link ExportJsonOptions}.
+ */
+export interface BuildJsonExportOptions extends ExportJsonOptions {
   /**
-   * Pre-computed non-default profile entity block. Supplied by the caller
-   * (which holds `root`); ABSENT for the built-in default so the default
-   * envelope gains no `profile` key.
+   * Pre-computed non-default profile entity block, injected by the pipeline;
+   * ABSENT for the built-in default.
    */
   profile?: JsonExportProfileBlock;
 }

--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -28,7 +28,7 @@
 
 import { validateProjectId } from "./project-id.js";
 import type { ExportPage } from "./types.js";
-import type { EntityPageView } from "../profile/types.js";
+import type { EntityPageView, EntityProblemView } from "../profile/types.js";
 
 /**
  * Monotonically-incremented envelope version.
@@ -65,8 +65,16 @@ export interface JsonExportProfileBlock {
   version: 1;
   profileId: string;
   entityPages: EntityPageView[];
-  /** Human-readable collector problems; present ONLY when non-empty. */
-  problems?: string[];
+  /**
+   * Structured collector problems, present ONLY when non-empty. An export is a
+   * COMPLETE snapshot, so this list is NEVER capped — every problem is retained
+   * (each `path` project-relative, never absolute; absent for directory-level
+   * problems). `problemTotal` mirrors `problems.length` for symmetry with the
+   * capped status/viewer surfaces.
+   */
+  problems?: EntityProblemView[];
+  /** Full problem count; equals `problems.length` (export is never capped). */
+  problemTotal?: number;
 }
 
 /** Top-level shape of the JSON export file. */

--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -28,12 +28,28 @@
 
 import { validateProjectId } from "./project-id.js";
 import type { ExportPage } from "./types.js";
+import type { EntityPage } from "../profile/types.js";
 
 /**
  * Monotonically-incremented envelope version.
  * Bump when a breaking field change lands; additive additions do not require a bump.
  */
 export const EXPORT_SCHEMA_VERSION = 1;
+
+/**
+ * Additive, non-default-profile entity block for the JSON export.
+ *
+ * Present ONLY for a non-default profile; ABSENT for the built-in default so
+ * the default export is byte-identical. `entityPages` carries the
+ * content-bearing `EntityPage` shape directly — NOT the freshness/hash-decorated
+ * `ExportPage`. The legacy `pages` array stays scoped to concepts/queries.
+ */
+export interface JsonExportProfileBlock {
+  profileId: string;
+  entityPages: EntityPage[];
+  /** Human-readable collector problems; present ONLY when non-empty. */
+  problems?: string[];
+}
 
 /** Top-level shape of the JSON export file. */
 export interface JsonExportDocument {
@@ -47,6 +63,11 @@ export interface JsonExportDocument {
   /** Optional bridge identifier. See `src/export/project-id.ts` for the validation rule. */
   projectId?: string;
   pages: ExportPage[];
+  /**
+   * Non-default profile entity pages, ADDITIVELY. ABSENT (undefined) for the
+   * built-in default so the default envelope is byte-identical.
+   */
+  profile?: JsonExportProfileBlock;
 }
 
 /** Options accepted by {@link buildJsonExportDocument}. */
@@ -56,6 +77,12 @@ export interface BuildJsonExportOptions {
    * regex; throws if invalid so a malformed value never reaches disk.
    */
   projectId?: string;
+  /**
+   * Pre-computed non-default profile entity block. Supplied by the caller
+   * (which holds `root`); ABSENT for the built-in default so the default
+   * envelope gains no `profile` key.
+   */
+  profile?: JsonExportProfileBlock;
 }
 
 /**
@@ -76,6 +103,9 @@ export function buildJsonExportDocument(
   };
   if (options.projectId !== undefined) {
     doc.projectId = validateProjectId(options.projectId);
+  }
+  if (options.profile !== undefined) {
+    doc.profile = options.profile;
   }
   return doc;
 }

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -10,6 +10,7 @@
  */
 
 import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
+import { toEntityPageView } from "../profile/types.js";
 import type { JsonExportProfileBlock } from "./json-export.js";
 
 /**
@@ -27,7 +28,7 @@ export async function buildExportProfileBlock(
   const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
   return {
     profileId: loaded.profile.profileId,
-    entityPages: pages,
+    entityPages: pages.map((page) => toEntityPageView(page, true)),
     ...(messages.length > 0 ? { problems: messages } : {}),
   };
 }

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -11,6 +11,7 @@
 
 import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
 import { toEntityPageView } from "../profile/types.js";
+import { PROFILE_BLOCK_VERSION } from "./json-export.js";
 import type { JsonExportProfileBlock } from "./json-export.js";
 
 /**
@@ -27,6 +28,7 @@ export async function buildExportProfileBlock(
   if (loaded === undefined) return undefined;
   const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
   return {
+    version: PROFILE_BLOCK_VERSION,
     profileId: loaded.profile.profileId,
     entityPages: pages.map((page) => toEntityPageView(page, true)),
     ...(messages.length > 0 ? { problems: messages } : {}),

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -1,0 +1,39 @@
+/**
+ * Additive profile entity block for the JSON export.
+ *
+ * Mirrors the `status`/`listPages` additive-block pattern: for the built-in
+ * default profile this returns `undefined` so the default export envelope is
+ * byte-identical, and ONLY for a non-default profile does it assemble a
+ * `JsonExportProfileBlock` carrying the content-bearing `EntityPage`s from the
+ * shared collector. The built-in is detected by `loadedFrom === null` (never by
+ * profileId), with a digest cross-check as defense-in-depth.
+ */
+
+import { loadProfile } from "../profile/load.js";
+import { collectEntityPages } from "../profile/collect.js";
+import { DEFAULT_PROFILE } from "../profile/default.js";
+import { profileDigest } from "../profile/digest.js";
+import type { JsonExportProfileBlock } from "./json-export.js";
+
+/**
+ * Build the additive JSON-export profile block for a project root.
+ *
+ * @param root - Absolute project root directory.
+ * @returns The profile block for a non-default profile, or `undefined` for the
+ *   built-in default so the export gains no `profile` key.
+ */
+export async function buildExportProfileBlock(
+  root: string,
+): Promise<JsonExportProfileBlock | undefined> {
+  const loaded = await loadProfile(root);
+  const isBuiltInDefault =
+    loaded.loadedFrom === null && loaded.digest === profileDigest(DEFAULT_PROFILE);
+  if (isBuiltInDefault) return undefined;
+  const { pages, problems } = await collectEntityPages(root, loaded.profile);
+  const messages = problems.map((p) => p.message);
+  return {
+    profileId: loaded.profile.profileId,
+    entityPages: pages,
+    ...(messages.length > 0 ? { problems: messages } : {}),
+  };
+}

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -5,14 +5,11 @@
  * default profile this returns `undefined` so the default export envelope is
  * byte-identical, and ONLY for a non-default profile does it assemble a
  * `JsonExportProfileBlock` carrying the content-bearing `EntityPage`s from the
- * shared collector. The built-in is detected by `loadedFrom === null` (never by
- * profileId), with a digest cross-check as defense-in-depth.
+ * shared collector. The built-in is gated through the shared
+ * {@link loadNonDefaultProfile} primitive.
  */
 
-import { loadProfile } from "../profile/load.js";
-import { collectEntityPages } from "../profile/collect.js";
-import { DEFAULT_PROFILE } from "../profile/default.js";
-import { profileDigest } from "../profile/digest.js";
+import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
 import type { JsonExportProfileBlock } from "./json-export.js";
 
 /**
@@ -25,12 +22,9 @@ import type { JsonExportProfileBlock } from "./json-export.js";
 export async function buildExportProfileBlock(
   root: string,
 ): Promise<JsonExportProfileBlock | undefined> {
-  const loaded = await loadProfile(root);
-  const isBuiltInDefault =
-    loaded.loadedFrom === null && loaded.digest === profileDigest(DEFAULT_PROFILE);
-  if (isBuiltInDefault) return undefined;
-  const { pages, problems } = await collectEntityPages(root, loaded.profile);
-  const messages = problems.map((p) => p.message);
+  const loaded = await loadNonDefaultProfile(root);
+  if (loaded === undefined) return undefined;
+  const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
   return {
     profileId: loaded.profile.profileId,
     entityPages: pages,

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -26,11 +26,11 @@ export async function buildExportProfileBlock(
 ): Promise<JsonExportProfileBlock | undefined> {
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
-  const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
+  const { pages, problems } = await collectEntityPagesWithMessages(root, loaded);
   return {
     version: PROFILE_BLOCK_VERSION,
     profileId: loaded.profile.profileId,
     entityPages: pages.map((page) => toEntityPageView(page, true)),
-    ...(messages.length > 0 ? { problems: messages } : {}),
+    ...(problems.length > 0 ? { problems, problemTotal: problems.length } : {}),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,14 @@ export type {
   PageDirectory,
   ListPagesOptions,
   ListPagesResult,
+  ListPagesProfileBlock,
 } from "./pages/list.js";
 
-export type { JsonExportDocument } from "./export/json-export.js";
+export type {
+  JsonExportDocument,
+  ExportJsonOptions,
+  JsonExportProfileBlock,
+} from "./export/json-export.js";
 
 export {
   ProviderUnavailableError,
@@ -53,6 +58,7 @@ export type {
   ProfilePack,
   EntityId,
   EntityPageRef,
+  EntityPageView,
   LoadedProfile,
   SlugSafe,
 } from "./profile/types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export type {
   EntityId,
   EntityPageRef,
   EntityPageView,
+  EntityProblemView,
   LoadedProfile,
   SlugSafe,
 } from "./profile/types.js";

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -24,6 +24,8 @@ import {
 import { loadSchema } from "../schema/index.js";
 import { buildFreshnessSnapshot } from "../freshness/index.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
+import { loadProfile } from "../profile/load.js";
+import { lintProfileEntities } from "../profile/lint.js";
 
 /** Rule-only lint checks that don't depend on the schema layer. */
 const RULES_WITHOUT_SCHEMA: LintRule[] = [
@@ -55,10 +57,34 @@ function countBySeverity(
   return results.filter((r) => r.severity === severity).length;
 }
 
+/** Build a summary from a flat result list, computing the severity counts. */
+function summarize(results: LintResult[]): LintSummary {
+  return {
+    errors: countBySeverity(results, "error"),
+    warnings: countBySeverity(results, "warning"),
+    info: countBySeverity(results, "info"),
+    results,
+  };
+}
+
+/**
+ * Append profile-aware entity findings when the project runs a NON-default
+ * profile. A default/built-in profile (`loadedFrom === null`) returns the
+ * default results UNCHANGED, so the default lint output stays byte-identical.
+ */
+async function appendProfileFindings(root: string, defaultResults: LintResult[]): Promise<LintResult[]> {
+  const { profile, loadedFrom } = await loadProfile(root);
+  if (loadedFrom === null) return defaultResults;
+  const profileResults = await lintProfileEntities(root, profile);
+  return [...defaultResults, ...profileResults];
+}
+
 /**
  * Run all lint rules concurrently against the wiki at the given root.
  * Loads the project schema (or defaults) so schema-aware rules can enforce
- * per-kind cross-link minimums alongside structural checks.
+ * per-kind cross-link minimums alongside structural checks. When the project
+ * declares a NON-default profile, profile-aware entity findings are appended;
+ * a default profile leaves the output byte-identical to the pre-profile linter.
  * @param root - Absolute path to the project root directory.
  * @returns A summary containing all diagnostics and severity counts.
  */
@@ -71,16 +97,10 @@ export async function lint(root: string): Promise<LintSummary> {
     Promise.all(RULES_WITH_FRESHNESS.map((rule) => rule(root, freshness))),
   ]);
 
-  const results = [...plainResults.flat(), ...schemaResults.flat(), ...freshnessResults.flat()];
-
-  const summary: LintSummary = {
-    errors: countBySeverity(results, "error"),
-    warnings: countBySeverity(results, "warning"),
-    info: countBySeverity(results, "info"),
-    results,
-  };
+  const defaultResults = [...plainResults.flat(), ...schemaResults.flat(), ...freshnessResults.flat()];
+  const results = await appendProfileFindings(root, defaultResults);
 
   // lint is intentionally not journaled to log.md — it is a read-only check,
   // and the MCP `lint_wiki` tool documents it as non-mutating.
-  return summary;
+  return summarize(results);
 }

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -269,20 +269,39 @@ export async function checkEmptyPages(root: string): Promise<LintResult[]> {
 
   for (const page of pages) {
     const { meta, body } = parseFrontmatter(page.content);
-    const hasTitle = typeof meta.title === "string" && meta.title.trim() !== "";
-    const isBodyEmpty = body.trim().length < MIN_BODY_LENGTH;
-
-    if (hasTitle && isBodyEmpty) {
-      results.push({
-        rule: "empty-page",
-        severity: "warning",
-        file: page.filePath,
-        message: `Page body is empty or too short (< ${MIN_BODY_LENGTH} chars)`,
-      });
-    }
+    const title = typeof meta.title === "string" ? meta.title : undefined;
+    results.push(...checkPageEmpty({ title, body, filePath: page.filePath }));
   }
 
   return results;
+}
+
+/**
+ * Pure per-page variant of {@link checkEmptyPages}: flag a titled page whose
+ * body is empty or shorter than {@link MIN_BODY_LENGTH}. Operates on an
+ * already-parsed `{ title, body, filePath }` so callers that hold a page's
+ * content in memory (e.g. the profile-aware entity-page linter) can reuse the
+ * exact same rule without re-reading or re-parsing frontmatter.
+ *
+ * @param page - The page's frontmatter title (if any), markdown body, and path.
+ * @returns A single `empty-page` warning, or an empty array when not empty.
+ */
+export function checkPageEmpty(page: {
+  title?: string;
+  body: string;
+  filePath: string;
+}): LintResult[] {
+  const hasTitle = typeof page.title === "string" && page.title.trim() !== "";
+  const isBodyEmpty = page.body.trim().length < MIN_BODY_LENGTH;
+  if (!hasTitle || !isBodyEmpty) return [];
+  return [
+    {
+      rule: "empty-page",
+      severity: "warning",
+      file: page.filePath,
+      message: `Page body is empty or too short (< ${MIN_BODY_LENGTH} chars)`,
+    },
+  ];
 }
 
 /** Strip an optional `:start-end` or `#Lstart-Lend` span suffix from a citation entry. */

--- a/src/linter/types.ts
+++ b/src/linter/types.ts
@@ -10,6 +10,13 @@ export interface LintResult {
   file: string;
   message: string;
   line?: number;
+  /**
+   * Declared entity type a finding belongs to, set only by profile-aware
+   * checks over non-default entity pages. Default-profile findings omit it,
+   * so the field is absent (not `undefined`) on the default lint output and
+   * the frozen parity golden stays byte-identical.
+   */
+  entityType?: string;
 }
 
 export interface LintSummary {

--- a/src/pages/list.ts
+++ b/src/pages/list.ts
@@ -26,7 +26,8 @@ import { extractWikilinkSlugs } from "../wiki/collect.js";
 import { assertSafeSlug } from "../viewer/path-safety.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
-import type { EntityPage } from "../profile/types.js";
+import { toEntityPageView } from "../profile/types.js";
+import type { EntityPageView } from "../profile/types.js";
 import type { PageDirectory } from "../export/types.js";
 
 export type { PageDirectory };
@@ -70,14 +71,15 @@ export interface ListPagesOptions {
  *
  * Present ONLY for a non-default profile; for the built-in default it is
  * ABSENT (`result.profile === undefined`) so the default envelope is unchanged.
- * `entityPages` carries the content-bearing `EntityPage`s; each page's `body`
- * is stripped when `includeBody` is false (mirroring the legacy `pages` block).
+ * `entityPages` carries the PUBLIC `EntityPageView`s (project-relative `path`,
+ * never an absolute `filePath`); each view's `body` is OMITTED when
+ * `includeBody` is false (mirroring how the legacy `pages` block omits bodies).
  *
  * Entity-section pagination is deferred — every entity page is returned in one
  * block, regardless of the legacy `cursor`/`limit` (which still scope `pages`).
  */
 export interface ListPagesProfileBlock {
-  entityPages: EntityPage[];
+  entityPages: EntityPageView[];
   /** Human-readable collector problems; present ONLY when non-empty. */
   problems?: string[];
 }
@@ -181,8 +183,10 @@ export async function listPages(
  * default so the legacy envelope is unchanged — gated through the shared
  * {@link loadNonDefaultProfile} primitive, exactly as `status` does.
  *
- * Honors `includeBody`: each entity page's `body` is stripped when bodies are
- * not requested, mirroring how the legacy `pages` block omits bodies.
+ * Honors `includeBody`: each view's `body` is OMITTED (key absent) when bodies
+ * are not requested, mirroring how the legacy `pages` block omits bodies. Maps
+ * the internal `EntityPage` to the public `EntityPageView` so the absolute
+ * `filePath` never reaches the surface.
  */
 async function collectProfileBlock(
   root: string,
@@ -191,16 +195,11 @@ async function collectProfileBlock(
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
   const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
-  const entityPages = includeBody ? pages : pages.map(stripBody);
+  const entityPages = pages.map((page) => toEntityPageView(page, includeBody));
   return {
     entityPages,
     ...(messages.length > 0 ? { problems: messages } : {}),
   };
-}
-
-/** Return a copy of an entity page with its `body` replaced by an empty string. */
-function stripBody(page: EntityPage): EntityPage {
-  return { ...page, body: "" };
 }
 
 /**

--- a/src/pages/list.ts
+++ b/src/pages/list.ts
@@ -27,7 +27,7 @@ import { assertSafeSlug } from "../viewer/path-safety.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
 import { toEntityPageView } from "../profile/types.js";
-import type { EntityPageView } from "../profile/types.js";
+import type { EntityPageView, EntityPage } from "../profile/types.js";
 import type { PageDirectory } from "../export/types.js";
 
 export type { PageDirectory };
@@ -64,6 +64,13 @@ export interface ListPagesOptions {
   includeBody?: boolean;
   includeArchived?: boolean;
   includeOrphaned?: boolean;
+  /**
+   * Opaque continuation cursor for the ADDITIVE profile entity section ONLY.
+   * Drives the entity window independently of the legacy `cursor` (which scopes
+   * `pages`), so the entity batch is never re-sliced or re-sent by legacy
+   * paging. Uses the SAME `limit` as the legacy section.
+   */
+  profileCursor?: string;
 }
 
 /**
@@ -75,16 +82,35 @@ export interface ListPagesOptions {
  * never an absolute `filePath`); each view's `body` is OMITTED when
  * `includeBody` is false (mirroring how the legacy `pages` block omits bodies).
  *
- * Entity-section pagination is deferred — every entity page is returned in one
- * block, regardless of the legacy `cursor`/`limit` (which still scope `pages`).
+ * The entity section is BOUNDED by `limit`: it returns at most `limit` views,
+ * deterministically sorted by `id`, with `total` reporting the full entity-page
+ * count and `cursor` carrying the offset of the NEXT batch (absent when
+ * exhausted). Drive the next batch via {@link ListPagesOptions.profileCursor},
+ * which is independent of the legacy `pages` cursor.
+ *
+ * @experimental Shape may change in a future release.
  */
 export interface ListPagesProfileBlock {
   entityPages: EntityPageView[];
+  /** Full count of entity pages across the whole non-default profile. */
+  total: number;
+  /**
+   * Opaque continuation cursor for the NEXT entity batch; absent when the
+   * entity section is exhausted. Pass back via `profileCursor`.
+   */
+  cursor?: string;
   /** Human-readable collector problems; present ONLY when non-empty. */
   problems?: string[];
 }
 
-/** Result returned by `listPages`. */
+/**
+ * Result returned by `listPages`.
+ *
+ * DX note: for a NON-DEFAULT profile the legacy `pages` array is scoped to
+ * concepts/queries (typically EMPTY for an entity-only project); the entity
+ * content lives in `profile.entityPages`. Read the entity section there, not
+ * from `pages`.
+ */
 export interface ListPagesResult {
   pages: Page[];
   /** Opaque cursor for the next page; absent when the listing is exhausted. */
@@ -92,7 +118,9 @@ export interface ListPagesResult {
   /**
    * Non-default profile entity pages, ADDITIVELY. ABSENT (undefined) for the
    * built-in default so the default envelope is byte-identical; the legacy
-   * `pages` block stays scoped to concepts/queries in both cases.
+   * `pages` block stays scoped to concepts/queries in both cases. For a
+   * non-default profile this is where the entity content lives — the legacy
+   * `pages` array is typically empty.
    */
   profile?: ListPagesProfileBlock;
 }
@@ -173,8 +201,21 @@ export async function listPages(
       a.pageDirectory.localeCompare(b.pageDirectory) || a.slug.localeCompare(b.slug),
   );
   const result = paginate(all, options);
-  const profile = await collectProfileBlock(root, options.includeBody === true);
+  const profile = await collectProfileBlock(root, options);
   return profile ? { ...result, profile } : result;
+}
+
+/**
+ * Resolve the entity-window offset from `profileCursor`. A non-integer or
+ * negative cursor is rejected rather than silently recycled (mirroring the
+ * legacy {@link paginate} cursor guard).
+ */
+function profileOffset(cursor: string | undefined): number {
+  const offset = cursor !== undefined ? Number(cursor) : 0;
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`invalid listPages profileCursor: ${cursor}`);
+  }
+  return offset;
 }
 
 /**
@@ -187,17 +228,46 @@ export async function listPages(
  * are not requested, mirroring how the legacy `pages` block omits bodies. Maps
  * the internal `EntityPage` to the public `EntityPageView` so the absolute
  * `filePath` never reaches the surface.
+ *
+ * BOUNDED + PAGINATED: entity pages are deterministically sorted by `id` (entity
+ * collection order is filesystem-dependent and unstable), then windowed by the
+ * SAME `limit` as the legacy section, offset by `profileCursor`. `total` reports
+ * the full count and `cursor` carries the next offset (absent when exhausted) —
+ * so a large profile no longer returns an unbounded, body-bearing payload.
  */
 async function collectProfileBlock(
   root: string,
-  includeBody: boolean,
+  options: ListPagesOptions,
 ): Promise<ListPagesProfileBlock | undefined> {
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
   const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
-  const entityPages = pages.map((page) => toEntityPageView(page, includeBody));
+  pages.sort((a, b) => a.id.localeCompare(b.id));
+  const includeBody = options.includeBody === true;
+  return windowEntityPages(pages, options, includeBody, messages);
+}
+
+/**
+ * Slice an already-sorted entity-page list into a bounded, cursor-paged block.
+ * A non-positive or absent limit is treated as unbounded (mirroring the legacy
+ * {@link paginate} contract); the next-batch `cursor` is the offset past the
+ * returned window, absent once the entity section is exhausted.
+ */
+function windowEntityPages(
+  pages: EntityPage[],
+  options: ListPagesOptions,
+  includeBody: boolean,
+  messages: string[],
+): ListPagesProfileBlock {
+  const offset = profileOffset(options.profileCursor);
+  const limit = options.limit && options.limit > 0 ? options.limit : pages.length;
+  const window = pages.slice(offset, offset + limit);
+  const nextOffset = offset + window.length;
+  const cursor = nextOffset < pages.length ? String(nextOffset) : undefined;
   return {
-    entityPages,
+    entityPages: window.map((page) => toEntityPageView(page, includeBody)),
+    total: pages.length,
+    ...(cursor !== undefined ? { cursor } : {}),
     ...(messages.length > 0 ? { problems: messages } : {}),
   };
 }

--- a/src/pages/list.ts
+++ b/src/pages/list.ts
@@ -25,10 +25,7 @@ import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
 import { extractWikilinkSlugs } from "../wiki/collect.js";
 import { assertSafeSlug } from "../viewer/path-safety.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
-import { loadProfile } from "../profile/load.js";
-import { collectEntityPages } from "../profile/collect.js";
-import { DEFAULT_PROFILE } from "../profile/default.js";
-import { profileDigest } from "../profile/digest.js";
+import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
 import type { EntityPage } from "../profile/types.js";
 import type { PageDirectory } from "../export/types.js";
 
@@ -181,8 +178,8 @@ export async function listPages(
 /**
  * For a NON-DEFAULT profile only, build the additive `profile` block from the
  * content-carrying entity collector. Returns `undefined` for the built-in
- * default so the legacy envelope is unchanged — the built-in is identified by
- * `loadedFrom === null` (never by profileId), exactly as `status` does.
+ * default so the legacy envelope is unchanged — gated through the shared
+ * {@link loadNonDefaultProfile} primitive, exactly as `status` does.
  *
  * Honors `includeBody`: each entity page's `body` is stripped when bodies are
  * not requested, mirroring how the legacy `pages` block omits bodies.
@@ -191,13 +188,10 @@ async function collectProfileBlock(
   root: string,
   includeBody: boolean,
 ): Promise<ListPagesProfileBlock | undefined> {
-  const loaded = await loadProfile(root);
-  const isBuiltInDefault =
-    loaded.loadedFrom === null && loaded.digest === profileDigest(DEFAULT_PROFILE);
-  if (isBuiltInDefault) return undefined;
-  const { pages, problems } = await collectEntityPages(root, loaded.profile);
+  const loaded = await loadNonDefaultProfile(root);
+  if (loaded === undefined) return undefined;
+  const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
   const entityPages = includeBody ? pages : pages.map(stripBody);
-  const messages = problems.map((p) => p.message);
   return {
     entityPages,
     ...(messages.length > 0 ? { problems: messages } : {}),

--- a/src/pages/list.ts
+++ b/src/pages/list.ts
@@ -27,7 +27,7 @@ import { assertSafeSlug } from "../viewer/path-safety.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
 import { toEntityPageView } from "../profile/types.js";
-import type { EntityPageView, EntityPage } from "../profile/types.js";
+import type { EntityPageView, EntityProblemView, EntityPage } from "../profile/types.js";
 import type { PageDirectory } from "../export/types.js";
 
 export type { PageDirectory };
@@ -71,6 +71,13 @@ export interface ListPagesOptions {
    * paging. Uses the SAME `limit` as the legacy section.
    */
   profileCursor?: string;
+  /**
+   * Opaque continuation cursor for the ADDITIVE profile `problems` section ONLY.
+   * Windows collector problems independently of `cursor`/`profileCursor`, using
+   * the SAME `limit`, so a partially-invalid profile never returns thousands of
+   * problems per page. Drive the next batch via {@link ListPagesProfileBlock.problemCursor}.
+   */
+  problemCursor?: string;
 }
 
 /**
@@ -99,8 +106,20 @@ export interface ListPagesProfileBlock {
    * entity section is exhausted. Pass back via `profileCursor`.
    */
   cursor?: string;
-  /** Human-readable collector problems; present ONLY when non-empty. */
-  problems?: string[];
+  /**
+   * Structured collector problems, WINDOWED by `limit` independently of
+   * `entityPages` (its own `problemCursor` offset). Present ONLY when the window
+   * is non-empty; each `path` is project-relative (never absolute) and absent
+   * for directory-level problems. See `problemTotal` for the full count.
+   */
+  problems?: EntityProblemView[];
+  /** Full count of collector problems across the profile; present ONLY when non-empty. */
+  problemTotal?: number;
+  /**
+   * Opaque continuation cursor for the NEXT `problems` batch; absent when the
+   * problem section is exhausted. Pass back via `problemCursor`.
+   */
+  problemCursor?: string;
 }
 
 /**
@@ -206,14 +225,15 @@ export async function listPages(
 }
 
 /**
- * Resolve the entity-window offset from `profileCursor`. A non-integer or
- * negative cursor is rejected rather than silently recycled (mirroring the
- * legacy {@link paginate} cursor guard).
+ * Resolve a window offset from an opaque cursor for an additive profile section.
+ * A non-integer or negative cursor is rejected rather than silently recycled
+ * (mirroring the legacy {@link paginate} cursor guard). `name` identifies the
+ * offending cursor option in the error so callers can tell which one was bad.
  */
-function profileOffset(cursor: string | undefined): number {
+function profileOffset(cursor: string | undefined, name: string): number {
   const offset = cursor !== undefined ? Number(cursor) : 0;
   if (!Number.isInteger(offset) || offset < 0) {
-    throw new Error(`invalid listPages profileCursor: ${cursor}`);
+    throw new Error(`invalid listPages ${name}: ${cursor}`);
   }
   return offset;
 }
@@ -241,34 +261,54 @@ async function collectProfileBlock(
 ): Promise<ListPagesProfileBlock | undefined> {
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
-  const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
+  const { pages, problems } = await collectEntityPagesWithMessages(root, loaded);
   pages.sort((a, b) => a.id.localeCompare(b.id));
   const includeBody = options.includeBody === true;
-  return windowEntityPages(pages, options, includeBody, messages);
+  return windowEntityPages(pages, options, includeBody, problems);
+}
+
+/** An offset window over a list: the slice plus the next-batch offset (absent when exhausted). */
+interface OffsetWindow<T> {
+  items: T[];
+  cursor?: string;
 }
 
 /**
- * Slice an already-sorted entity-page list into a bounded, cursor-paged block.
- * A non-positive or absent limit is treated as unbounded (mirroring the legacy
- * {@link paginate} contract); the next-batch `cursor` is the offset past the
- * returned window, absent once the entity section is exhausted.
+ * Slice an already-ordered list into a bounded window at `offset`, sized by the
+ * SAME `limit` contract as the legacy {@link paginate} (non-positive/absent limit
+ * = unbounded). The returned `cursor` is the offset past the window, absent once
+ * the list is exhausted. Shared by the entity-page and problem windows so the two
+ * never drift.
+ */
+function sliceWindow<T>(items: T[], offset: number, limit: number | undefined): OffsetWindow<T> {
+  const effectiveLimit = limit && limit > 0 ? limit : items.length;
+  const window = items.slice(offset, offset + effectiveLimit);
+  const nextOffset = offset + window.length;
+  return { items: window, ...(nextOffset < items.length ? { cursor: String(nextOffset) } : {}) };
+}
+
+/**
+ * Slice an already-sorted entity-page list into a bounded, cursor-paged block,
+ * windowing `problems` by the SAME `limit` under an INDEPENDENT `problemCursor`
+ * offset (with `problemTotal`/`problemCursor`) so a partially-invalid profile
+ * never returns thousands of problems per page. Entity `cursor` and problem
+ * `problemCursor` advance separately; the next-batch cursors are absent once
+ * each section is exhausted.
  */
 function windowEntityPages(
   pages: EntityPage[],
   options: ListPagesOptions,
   includeBody: boolean,
-  messages: string[],
+  problems: EntityProblemView[],
 ): ListPagesProfileBlock {
-  const offset = profileOffset(options.profileCursor);
-  const limit = options.limit && options.limit > 0 ? options.limit : pages.length;
-  const window = pages.slice(offset, offset + limit);
-  const nextOffset = offset + window.length;
-  const cursor = nextOffset < pages.length ? String(nextOffset) : undefined;
+  const pageWindow = sliceWindow(pages, profileOffset(options.profileCursor, "profileCursor"), options.limit);
+  const problemWindow = sliceWindow(problems, profileOffset(options.problemCursor, "problemCursor"), options.limit);
   return {
-    entityPages: window.map((page) => toEntityPageView(page, includeBody)),
+    entityPages: pageWindow.items.map((page) => toEntityPageView(page, includeBody)),
     total: pages.length,
-    ...(cursor !== undefined ? { cursor } : {}),
-    ...(messages.length > 0 ? { problems: messages } : {}),
+    ...(pageWindow.cursor !== undefined ? { cursor: pageWindow.cursor } : {}),
+    ...(problems.length > 0 ? { problems: problemWindow.items, problemTotal: problems.length } : {}),
+    ...(problemWindow.cursor !== undefined ? { problemCursor: problemWindow.cursor } : {}),
   };
 }
 

--- a/src/pages/list.ts
+++ b/src/pages/list.ts
@@ -25,6 +25,11 @@ import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
 import { extractWikilinkSlugs } from "../wiki/collect.js";
 import { assertSafeSlug } from "../viewer/path-safety.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import { loadProfile } from "../profile/load.js";
+import { collectEntityPages } from "../profile/collect.js";
+import { DEFAULT_PROFILE } from "../profile/default.js";
+import { profileDigest } from "../profile/digest.js";
+import type { EntityPage } from "../profile/types.js";
 import type { PageDirectory } from "../export/types.js";
 
 export type { PageDirectory };
@@ -63,11 +68,34 @@ export interface ListPagesOptions {
   includeOrphaned?: boolean;
 }
 
+/**
+ * Additive, non-default-profile entity-page block for `listPages`.
+ *
+ * Present ONLY for a non-default profile; for the built-in default it is
+ * ABSENT (`result.profile === undefined`) so the default envelope is unchanged.
+ * `entityPages` carries the content-bearing `EntityPage`s; each page's `body`
+ * is stripped when `includeBody` is false (mirroring the legacy `pages` block).
+ *
+ * Entity-section pagination is deferred — every entity page is returned in one
+ * block, regardless of the legacy `cursor`/`limit` (which still scope `pages`).
+ */
+export interface ListPagesProfileBlock {
+  entityPages: EntityPage[];
+  /** Human-readable collector problems; present ONLY when non-empty. */
+  problems?: string[];
+}
+
 /** Result returned by `listPages`. */
 export interface ListPagesResult {
   pages: Page[];
   /** Opaque cursor for the next page; absent when the listing is exhausted. */
   cursor?: string;
+  /**
+   * Non-default profile entity pages, ADDITIVELY. ABSENT (undefined) for the
+   * built-in default so the default envelope is byte-identical; the legacy
+   * `pages` block stays scoped to concepts/queries in both cases.
+   */
+  profile?: ListPagesProfileBlock;
 }
 
 /** Maps each PageDirectory to its project-relative path. */
@@ -145,7 +173,40 @@ export async function listPages(
     (a, b) =>
       a.pageDirectory.localeCompare(b.pageDirectory) || a.slug.localeCompare(b.slug),
   );
-  return paginate(all, options);
+  const result = paginate(all, options);
+  const profile = await collectProfileBlock(root, options.includeBody === true);
+  return profile ? { ...result, profile } : result;
+}
+
+/**
+ * For a NON-DEFAULT profile only, build the additive `profile` block from the
+ * content-carrying entity collector. Returns `undefined` for the built-in
+ * default so the legacy envelope is unchanged — the built-in is identified by
+ * `loadedFrom === null` (never by profileId), exactly as `status` does.
+ *
+ * Honors `includeBody`: each entity page's `body` is stripped when bodies are
+ * not requested, mirroring how the legacy `pages` block omits bodies.
+ */
+async function collectProfileBlock(
+  root: string,
+  includeBody: boolean,
+): Promise<ListPagesProfileBlock | undefined> {
+  const loaded = await loadProfile(root);
+  const isBuiltInDefault =
+    loaded.loadedFrom === null && loaded.digest === profileDigest(DEFAULT_PROFILE);
+  if (isBuiltInDefault) return undefined;
+  const { pages, problems } = await collectEntityPages(root, loaded.profile);
+  const entityPages = includeBody ? pages : pages.map(stripBody);
+  const messages = problems.map((p) => p.message);
+  return {
+    entityPages,
+    ...(messages.length > 0 ? { problems: messages } : {}),
+  };
+}
+
+/** Return a copy of an entity page with its `body` replaced by an empty string. */
+function stripBody(page: EntityPage): EntityPage {
+  return { ...page, body: "" };
 }
 
 /**

--- a/src/profile/block.ts
+++ b/src/profile/block.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared non-default-profile summary block (profileId, digest, per-type entity
+ * counts, problems).
+ *
+ * This is the single source of truth for the additive `profile` block that the
+ * `status` collector and the viewer snapshot both surface. Centralizing it
+ * keeps the two surfaces byte-identical to each other and prevents the gate
+ * logic (built-in-default detection, count seeding, problem mapping) from
+ * drifting between them.
+ *
+ * For the built-in default profile this returns `undefined` so each caller
+ * omits the `profile` key entirely and its default envelope is unchanged. The
+ * built-in is identified by `loadedFrom === null` (never by `profileId`), with
+ * a digest cross-check as defense-in-depth against a future loader change.
+ */
+
+import { loadProfile } from "./load.js";
+import { collectEntityPages } from "./collect.js";
+import { DEFAULT_PROFILE } from "./default.js";
+import { profileDigest } from "./digest.js";
+import type { ProfilePack, EntityPage, LoadedProfile } from "./types.js";
+
+/**
+ * Load the active profile and return it ONLY when it is a non-default profile;
+ * return `undefined` for the built-in default so every additive read surface
+ * can omit its `profile` key with one shared gate.
+ *
+ * The built-in is identified by `loadedFrom === null` (the loader sets null
+ * ONLY for the no-file/default path) — never by `profileId === "default"`,
+ * which a disk profile can no longer claim but which must not be the gate. The
+ * digest comparison is defense-in-depth against a future loader change.
+ *
+ * @param root - Absolute project root directory.
+ * @returns The loaded non-default profile, or `undefined` for the built-in default.
+ */
+export async function loadNonDefaultProfile(
+  root: string,
+): Promise<LoadedProfile | undefined> {
+  const loaded = await loadProfile(root);
+  const isBuiltInDefault =
+    loaded.loadedFrom === null && loaded.digest === profileDigest(DEFAULT_PROFILE);
+  return isBuiltInDefault ? undefined : loaded;
+}
+
+/** The additive profile summary shared by the status and viewer surfaces. */
+export interface ProfileSummaryBlock {
+  profileId: string;
+  digest: string;
+  entityCounts: Record<string, number>;
+  /**
+   * Human-readable collector problems. Present ONLY when non-empty, so a
+   * non-default project with a bad directory or page is never reported as
+   * silently healthy.
+   */
+  problems?: string[];
+}
+
+/**
+ * Tally entity pages per declared entity type for a non-default profile.
+ *
+ * Seeds every declared entity type at zero so a declared-but-empty type still
+ * reports `0` (rather than being absent), then tallies the collected pages.
+ */
+function countByEntityType(profile: ProfilePack, pages: EntityPage[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const entityType of Object.keys(profile.entities)) counts[entityType] = 0;
+  for (const page of pages) counts[page.entityType] = (counts[page.entityType] ?? 0) + 1;
+  return counts;
+}
+
+/**
+ * Collect a loaded non-default profile's entity pages alongside its problems
+ * already flattened to human-readable messages — the shared read-side step
+ * every additive profile block performs before shaping its own envelope.
+ *
+ * @param root - Absolute project root directory.
+ * @param loaded - A non-default profile (from {@link loadNonDefaultProfile}).
+ * @returns The collected entity pages and the flattened problem messages.
+ */
+export async function collectEntityPagesWithMessages(
+  root: string,
+  loaded: LoadedProfile,
+): Promise<{ pages: EntityPage[]; messages: string[] }> {
+  const { pages, problems } = await collectEntityPages(root, loaded.profile);
+  return { pages, messages: problems.map((p) => p.message) };
+}
+
+/**
+ * Resolve the active profile and, for a NON-DEFAULT profile only, build the
+ * shared summary block (profileId, digest, per-type entity counts, problems).
+ *
+ * @param root - Absolute project root directory.
+ * @returns The summary block for a non-default profile, or `undefined` for the
+ *   built-in default so the caller omits the `profile` key entirely.
+ */
+export async function collectProfileSummary(
+  root: string,
+): Promise<ProfileSummaryBlock | undefined> {
+  const loaded = await loadNonDefaultProfile(root);
+  if (loaded === undefined) return undefined;
+  const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
+  return {
+    profileId: loaded.profile.profileId,
+    digest: loaded.digest,
+    entityCounts: countByEntityType(loaded.profile, pages),
+    ...(messages.length > 0 ? { problems: messages } : {}),
+  };
+}

--- a/src/profile/block.ts
+++ b/src/profile/block.ts
@@ -16,9 +16,12 @@
 
 import { loadProfile } from "./load.js";
 import { collectEntityPages, collectEntitySummary } from "./collect.js";
+import type { EntityProblem } from "./collect.js";
 import { DEFAULT_PROFILE } from "./default.js";
 import { profileDigest } from "./digest.js";
-import type { EntityPage, LoadedProfile } from "./types.js";
+import { toEntityProblemView } from "./types.js";
+import type { EntityPage, EntityProblemView, LoadedProfile } from "./types.js";
+import { safeRealpath } from "../utils/path-confine.js";
 
 /**
  * Load the active profile and return it ONLY when it is a non-default profile;
@@ -42,34 +45,66 @@ export async function loadNonDefaultProfile(
   return isBuiltInDefault ? undefined : loaded;
 }
 
+/**
+ * The maximum number of structured `problems` the count-only status/viewer
+ * summary surfaces inline. A profile with thousands of invalid pages is never
+ * dumped wholesale into a status/viewer envelope; `problemTotal` always reports
+ * the full count so the cap is visible. Export keeps the COMPLETE list (it is a
+ * full snapshot), and `listPages` paginates instead of capping — only this
+ * count-only summary applies the cap.
+ */
+export const PROFILE_PROBLEM_CAP = 100;
+
 /** The additive profile summary shared by the status and viewer surfaces. */
 export interface ProfileSummaryBlock {
   profileId: string;
   digest: string;
   entityCounts: Record<string, number>;
   /**
-   * Human-readable collector problems. Present ONLY when non-empty, so a
-   * non-default project with a bad directory or page is never reported as
-   * silently healthy.
+   * Structured collector problems, CAPPED at {@link PROFILE_PROBLEM_CAP}.
+   * Present ONLY when non-empty, so a non-default project with a bad directory
+   * or page is never reported as silently healthy. Each problem's `path` is
+   * project-relative (never absolute) and absent for directory-level problems.
    */
-  problems?: string[];
+  problems?: EntityProblemView[];
+  /**
+   * Full count of collector problems (may exceed `problems.length` when capped).
+   * Present ONLY when there is at least one problem.
+   */
+  problemTotal?: number;
 }
 
 /**
- * Collect a loaded non-default profile's entity pages alongside its problems
- * already flattened to human-readable messages — the shared read-side step
- * every additive profile block performs before shaping its own envelope.
+ * Collect a loaded non-default profile's entity pages alongside its STRUCTURED
+ * problems (already mapped to public, path-safe {@link EntityProblemView}s) — the
+ * shared read-side step every additive profile block performs before shaping
+ * (windowing, capping, or passing through) its own problem envelope.
  *
  * @param root - Absolute project root directory.
  * @param loaded - A non-default profile (from {@link loadNonDefaultProfile}).
- * @returns The collected entity pages and the flattened problem messages.
+ * @returns The collected entity pages and the structured problem views.
  */
 export async function collectEntityPagesWithMessages(
   root: string,
   loaded: LoadedProfile,
-): Promise<{ pages: EntityPage[]; messages: string[] }> {
+): Promise<{ pages: EntityPage[]; problems: EntityProblemView[] }> {
   const { pages, problems } = await collectEntityPages(root, loaded.profile);
-  return { pages, messages: problems.map((p) => p.message) };
+  return { pages, problems: await toProblemViews(problems, root) };
+}
+
+/**
+ * Map structured collector problems to public, path-safe problem views,
+ * relativizing each `filePath` against the CANONICAL root. The collector
+ * resolves every `filePath` through `safeRealpath`, so a non-canonical input
+ * `root` (e.g. a `/var` path whose real form is `/private/var`) would otherwise
+ * yield a misleading `../…` traversal instead of a clean project-relative path.
+ */
+async function toProblemViews(
+  problems: EntityProblem[],
+  root: string,
+): Promise<EntityProblemView[]> {
+  const canonicalRoot = (await safeRealpath(root)) ?? root;
+  return problems.map((problem) => toEntityProblemView(problem, canonicalRoot));
 }
 
 /**
@@ -78,8 +113,10 @@ export async function collectEntityPagesWithMessages(
  *
  * Uses the COUNT-ONLY {@link collectEntitySummary} so the status/viewer surfaces
  * never build or retain content `EntityPage`s (with bodies) just to tally — the
- * counts and problem messages are identical to the content path, which shares
- * the same per-scan validation.
+ * counts and structured problems are identical to the content path, which shares
+ * the same per-scan validation. Problems are CAPPED at {@link PROFILE_PROBLEM_CAP}
+ * (with `problemTotal` reporting the full count) so a hugely invalid profile is
+ * never dumped wholesale into a status/viewer envelope.
  *
  * @param root - Absolute project root directory.
  * @returns The summary block for a non-default profile, or `undefined` for the
@@ -91,11 +128,11 @@ export async function collectProfileSummary(
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
   const { counts, problems } = await collectEntitySummary(root, loaded.profile);
-  const messages = problems.map((p) => p.message);
+  const views = await toProblemViews(problems, root);
   return {
     profileId: loaded.profile.profileId,
     digest: loaded.digest,
     entityCounts: counts,
-    ...(messages.length > 0 ? { problems: messages } : {}),
+    ...(views.length > 0 ? { problems: views.slice(0, PROFILE_PROBLEM_CAP), problemTotal: views.length } : {}),
   };
 }

--- a/src/profile/block.ts
+++ b/src/profile/block.ts
@@ -15,10 +15,10 @@
  */
 
 import { loadProfile } from "./load.js";
-import { collectEntityPages } from "./collect.js";
+import { collectEntityPages, collectEntitySummary } from "./collect.js";
 import { DEFAULT_PROFILE } from "./default.js";
 import { profileDigest } from "./digest.js";
-import type { ProfilePack, EntityPage, LoadedProfile } from "./types.js";
+import type { EntityPage, LoadedProfile } from "./types.js";
 
 /**
  * Load the active profile and return it ONLY when it is a non-default profile;
@@ -56,19 +56,6 @@ export interface ProfileSummaryBlock {
 }
 
 /**
- * Tally entity pages per declared entity type for a non-default profile.
- *
- * Seeds every declared entity type at zero so a declared-but-empty type still
- * reports `0` (rather than being absent), then tallies the collected pages.
- */
-function countByEntityType(profile: ProfilePack, pages: EntityPage[]): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const entityType of Object.keys(profile.entities)) counts[entityType] = 0;
-  for (const page of pages) counts[page.entityType] = (counts[page.entityType] ?? 0) + 1;
-  return counts;
-}
-
-/**
  * Collect a loaded non-default profile's entity pages alongside its problems
  * already flattened to human-readable messages — the shared read-side step
  * every additive profile block performs before shaping its own envelope.
@@ -89,6 +76,11 @@ export async function collectEntityPagesWithMessages(
  * Resolve the active profile and, for a NON-DEFAULT profile only, build the
  * shared summary block (profileId, digest, per-type entity counts, problems).
  *
+ * Uses the COUNT-ONLY {@link collectEntitySummary} so the status/viewer surfaces
+ * never build or retain content `EntityPage`s (with bodies) just to tally — the
+ * counts and problem messages are identical to the content path, which shares
+ * the same per-scan validation.
+ *
  * @param root - Absolute project root directory.
  * @returns The summary block for a non-default profile, or `undefined` for the
  *   built-in default so the caller omits the `profile` key entirely.
@@ -98,11 +90,12 @@ export async function collectProfileSummary(
 ): Promise<ProfileSummaryBlock | undefined> {
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
-  const { pages, messages } = await collectEntityPagesWithMessages(root, loaded);
+  const { counts, problems } = await collectEntitySummary(root, loaded.profile);
+  const messages = problems.map((p) => p.message);
   return {
     profileId: loaded.profile.profileId,
     digest: loaded.digest,
-    entityCounts: countByEntityType(loaded.profile, pages),
+    entityCounts: counts,
     ...(messages.length > 0 ? { problems: messages } : {}),
   };
 }

--- a/src/profile/collect.ts
+++ b/src/profile/collect.ts
@@ -87,12 +87,28 @@ function declaredSlug(frontmatter: Record<string, unknown>): string | undefined 
 }
 
 /**
+ * Compute the de-duplicated set of required field names for an entity type: the
+ * UNION of the entity-level `requiredFields` array and every field whose own
+ * `FieldDef.required === true`. Returned as a `Set` so a field declared required
+ * BOTH ways yields exactly one missing-field problem, never two.
+ */
+function requiredFieldNames(def: EntityTypeDef): Set<string> {
+  const names = new Set<string>(def.requiredFields ?? []);
+  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
+    if (fieldDef.required === true) names.add(name);
+  }
+  return names;
+}
+
+/**
  * Validate a slug-safe page against its entity type's declared field contract,
  * pushing a `field-violation` problem for each missing required field and, for
- * each PRESENT field value, every declared-type / enum / min-max mismatch. The
- * page is NOT dropped — a contract violation is surfaced, not fatal — and this
- * NEVER throws. Messages are PATH-FREE (the offending path lives only on the
- * structured `filePath` field).
+ * each PRESENT field value, every declared-type / enum / min-max mismatch. A
+ * field is required when it is in `def.requiredFields` OR carries
+ * `FieldDef.required === true` (the union, de-duplicated). The page is NOT
+ * dropped — a contract violation is surfaced, not fatal — and this NEVER throws.
+ * Messages are PATH-FREE (the offending path lives only on the structured
+ * `filePath` field).
  */
 function checkFieldContract(
   entityType: string,
@@ -101,7 +117,7 @@ function checkFieldContract(
   problems: EntityProblem[],
 ): void {
   const fm = scan.frontmatter;
-  for (const field of def.requiredFields ?? []) {
+  for (const field of requiredFieldNames(def)) {
     if (!(field in fm)) {
       problems.push({
         kind: "field-violation",
@@ -179,7 +195,7 @@ function isValidDate(value: unknown): boolean {
  */
 const TYPE_PREDICATES: Record<Exclude<FieldType, "enum">, (value: unknown) => boolean> = {
   string: (v) => typeof v === "string",
-  slug: (v) => typeof v === "string",
+  slug: (v) => typeof v === "string" && isSlugSafe(v),
   integer: (v) => Number.isInteger(v),
   number: (v) => typeof v === "number" && Number.isFinite(v),
   boolean: (v) => typeof v === "boolean",

--- a/src/profile/collect.ts
+++ b/src/profile/collect.ts
@@ -10,7 +10,7 @@
  *
  * Honest, graceful read path (problems, not throws):
  *   - the collector NEVER throws on page data — a bad page yields a problem
- *     record and is skipped, while its valid siblings still become refs;
+ *     record and is skipped, while its valid siblings still become pages;
  *   - an INVALID (symlinked / confinement-failed) entity directory is surfaced
  *     as an `invalid-directory` problem — never silently skipped, because the
  *     spec forbids presenting a partial project as healthy;
@@ -20,7 +20,7 @@
  *     `slug-mismatch` problem;
  *   - a valid page that violates the declared field contract (a missing
  *     required field, or an enum value outside its declared set) →
- *     `field-violation` problem; the ref is STILL produced.
+ *     `field-violation` problem; the page is STILL produced.
  *
  * The only thrown error is the `isDefaultProfile` guard — that is a programming
  * error (wrong collector), not page data. Default-profile collection NEVER comes
@@ -32,7 +32,7 @@ import { isDefaultProfile } from "./default.js";
 import { isSlugSafe, entityId, suggestSlugFromBasename } from "./identity.js";
 import type {
   ProfilePack,
-  EntityPageRef,
+  EntityPage,
   EntityTypeDef,
   FieldDef,
 } from "./types.js";
@@ -65,7 +65,7 @@ export interface EntityProblem {
 
 /** The graceful result of collecting one profile's entity pages. */
 export interface EntityCollectResult {
-  refs: EntityPageRef[];
+  pages: EntityPage[];
   problems: EntityProblem[];
 }
 
@@ -79,7 +79,7 @@ function declaredSlug(frontmatter: Record<string, unknown>): string | undefined 
  * Validate a slug-safe page against its entity type's declared field contract,
  * pushing a `field-violation` problem for each missing required field and each
  * enum field whose present value is outside its declared set. Basic by design:
- * required-present + enum-membership only (no deep type coercion). The ref is
+ * required-present + enum-membership only (no deep type coercion). The page is
  * NOT dropped — a contract violation is surfaced, not fatal.
  */
 function checkFieldContract(
@@ -128,17 +128,21 @@ function checkEnumMembership(
 }
 
 /**
- * Validate one scanned page. Returns an `EntityPageRef` for a valid (slug-safe,
- * slug-matching) page — and, when the page violates the declared field contract,
- * still returns the ref but appends `field-violation` problems. Returns `null`
- * (and appends a problem) for a non-slug-safe stem or a slug mismatch.
+ * Validate one scanned page. Returns an `EntityPage` (identity PLUS the scan's
+ * `frontmatter`/`body`/`title`) for a valid (slug-safe, slug-matching) page —
+ * and, when the page violates the declared field contract, still returns the
+ * page but appends `field-violation` problems. Returns `null` (and appends a
+ * problem) for a non-slug-safe stem or a slug mismatch.
+ *
+ * The `title` is the frontmatter title only when the scan flagged one present
+ * (`parseStatus.hasTitle`); otherwise it is `undefined`.
  */
-function refFromScan(
+function pageFromScan(
   def: EntityTypeDef,
   entityType: string,
   scan: RawEntityScan,
   problems: EntityProblem[],
-): EntityPageRef | null {
+): EntityPage | null {
   const stem = scan.stem;
   if (!isSlugSafe(stem)) {
     problems.push({
@@ -163,15 +167,25 @@ function refFromScan(
     return null;
   }
   checkFieldContract(entityType, def, scan, problems);
-  return { entityType, directory: def.directory, slug: stem, id: entityId(entityType, stem), filePath: scan.filePath };
+  const title = scan.parseStatus.hasTitle ? (scan.frontmatter.title as string) : undefined;
+  return {
+    entityType,
+    directory: def.directory,
+    slug: stem,
+    id: entityId(entityType, stem),
+    filePath: scan.filePath,
+    frontmatter: scan.frontmatter,
+    body: scan.body,
+    title,
+  };
 }
 
-/** Collect one entity type's pages, appending refs and problems in place. */
+/** Collect one entity type's pages, appending pages and problems in place. */
 async function collectOneEntity(
   root: string,
   entityType: string,
   def: EntityTypeDef,
-  refs: EntityPageRef[],
+  pages: EntityPage[],
   problems: EntityProblem[],
 ): Promise<void> {
   const { scans, dirStatus } = await scanEntityDir(root, def.directory);
@@ -186,22 +200,23 @@ async function collectOneEntity(
     return;
   }
   for (const scan of scans) {
-    const ref = refFromScan(def, entityType, scan, problems);
-    if (ref) refs.push(ref);
+    const page = pageFromScan(def, entityType, scan, problems);
+    if (page) pages.push(page);
   }
 }
 
 /**
- * Collect every entity page for a NON-DEFAULT profile as strict
- * `EntityPageRef`s with branded `EntityId`s, alongside any structured problems.
- * Iterates the profile's declared entity types, scanning each through the shared
- * `scanEntityDir`. One bad page or directory never stops the others.
+ * Collect every entity page for a NON-DEFAULT profile as content-carrying
+ * `EntityPage`s (branded `EntityId` identity PLUS frontmatter/body/title),
+ * alongside any structured problems. Iterates the profile's declared entity
+ * types, scanning each through the shared `scanEntityDir`. One bad page or
+ * directory never stops the others.
  *
  * @param root - Absolute project root directory.
  * @param profile - A non-default profile pack. Passing the default profile is a
  *   programming error and throws (the only thrown case).
- * @returns `{ refs, problems }` — one ref per valid page, plus a problem per
- *   invalid directory / bad page / field-contract violation.
+ * @returns `{ pages, problems }` — one page per valid page (with its content),
+ *   plus a problem per invalid directory / bad page / field-contract violation.
  * @throws {EntityCollectError} ONLY when the default profile is passed.
  */
 export async function collectEntityPages(
@@ -213,10 +228,10 @@ export async function collectEntityPages(
       "collectEntityPages is for non-default profiles only; use collectRawWikiPages for the default profile.",
     );
   }
-  const refs: EntityPageRef[] = [];
+  const pages: EntityPage[] = [];
   const problems: EntityProblem[] = [];
   for (const [entityType, def] of Object.entries(profile.entities) as [string, EntityTypeDef][]) {
-    await collectOneEntity(root, entityType, def, refs, problems);
+    await collectOneEntity(root, entityType, def, pages, problems);
   }
-  return { refs, problems };
+  return { pages, problems };
 }

--- a/src/profile/collect.ts
+++ b/src/profile/collect.ts
@@ -29,12 +29,13 @@
 
 import { scanEntityDir, type RawEntityScan } from "../wiki/collect.js";
 import { isDefaultProfile } from "./default.js";
-import { isSlugSafe, entityId, suggestSlugFromBasename } from "./identity.js";
+import { isSlugSafe, assertSlugSafe, entityId, suggestSlugFromBasename } from "./identity.js";
 import type {
   ProfilePack,
   EntityPage,
   EntityTypeDef,
   FieldDef,
+  FieldType,
 } from "./types.js";
 
 /** Error raised only for the programming-error default-profile guard. */
@@ -69,6 +70,16 @@ export interface EntityCollectResult {
   problems: EntityProblem[];
 }
 
+/**
+ * The count-only result of summarizing a profile's entity pages: per-type
+ * counts plus problems, with NO content `EntityPage[]` retained. Produced by
+ * {@link collectEntitySummary} for surfaces (status, viewer) that only tally.
+ */
+export interface EntitySummaryResult {
+  counts: Record<string, number>;
+  problems: EntityProblem[];
+}
+
 /** Read a declared frontmatter `slug` field as a string, or undefined. */
 function declaredSlug(frontmatter: Record<string, unknown>): string | undefined {
   const value = frontmatter.slug;
@@ -77,10 +88,11 @@ function declaredSlug(frontmatter: Record<string, unknown>): string | undefined 
 
 /**
  * Validate a slug-safe page against its entity type's declared field contract,
- * pushing a `field-violation` problem for each missing required field and each
- * enum field whose present value is outside its declared set. Basic by design:
- * required-present + enum-membership only (no deep type coercion). The page is
- * NOT dropped — a contract violation is surfaced, not fatal.
+ * pushing a `field-violation` problem for each missing required field and, for
+ * each PRESENT field value, every declared-type / enum / min-max mismatch. The
+ * page is NOT dropped — a contract violation is surfaced, not fatal — and this
+ * NEVER throws. Messages are PATH-FREE (the offending path lives only on the
+ * structured `filePath` field).
  */
 function checkFieldContract(
   entityType: string,
@@ -100,49 +112,120 @@ function checkFieldContract(
     }
   }
   for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
-    checkEnumMembership(entityType, name, fieldDef, scan, problems);
+    checkFieldValue(entityType, name, fieldDef, scan, problems);
   }
 }
 
-/** Push a `field-violation` when an enum field's present value is out of set. */
-function checkEnumMembership(
+/**
+ * Validate one present field value against its declared type, enum membership,
+ * and numeric min/max. A missing value is not validated here (required-presence
+ * is handled separately). Each mismatch becomes one PATH-FREE `field-violation`.
+ */
+function checkFieldValue(
   entityType: string,
   name: string,
   fieldDef: FieldDef,
   scan: RawEntityScan,
   problems: EntityProblem[],
 ): void {
-  if (fieldDef.type !== "enum" || !fieldDef.enum) return;
   const value = scan.frontmatter[name];
   if (value === undefined) return;
-  if (typeof value !== "string" || !fieldDef.enum.includes(value)) {
-    problems.push({
-      kind: "field-violation",
-      entityType,
-      filePath: scan.filePath,
-      message:
-        `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not one of ` +
-        `${JSON.stringify(fieldDef.enum)}.`,
-    });
+  const typeError = describeTypeMismatch(name, fieldDef, value);
+  if (typeError) {
+    pushFieldViolation(entityType, scan.filePath, typeError, problems);
+    return;
   }
+  const rangeError = describeRangeViolation(name, fieldDef, value);
+  if (rangeError) pushFieldViolation(entityType, scan.filePath, rangeError, problems);
+}
+
+/** Append a `field-violation` problem carrying a PATH-FREE message. */
+function pushFieldViolation(
+  entityType: string,
+  filePath: string,
+  message: string,
+  problems: EntityProblem[],
+): void {
+  problems.push({ kind: "field-violation", entityType, filePath, message });
 }
 
 /**
- * Validate one scanned page. Returns an `EntityPage` (identity PLUS the scan's
- * `frontmatter`/`body`/`title`) for a valid (slug-safe, slug-matching) page —
- * and, when the page violates the declared field contract, still returns the
- * page but appends `field-violation` problems. Returns `null` (and appends a
- * problem) for a non-slug-safe stem or a slug mismatch.
- *
- * The `title` is the frontmatter title only when the scan flagged one present
- * (`parseStatus.hasTitle`); otherwise it is `undefined`.
+ * Return a PATH-FREE message when `value` does not match `fieldDef.type`
+ * (including enum membership), or `undefined` when the type is satisfied.
  */
-function pageFromScan(
+function describeTypeMismatch(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
+  if (matchesDeclaredType(fieldDef, value)) return undefined;
+  if (fieldDef.type === "enum") {
+    return (
+      `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not one of ` +
+      `${JSON.stringify(fieldDef.enum ?? [])}.`
+    );
+  }
+  return `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not a valid ${fieldDef.type}.`;
+}
+
+/** True when `value` is a string parseable as a date, or a valid `Date`. */
+function isValidDate(value: unknown): boolean {
+  // YAML parses an unquoted ISO date into a JS `Date`; a quoted value stays a
+  // string. Accept either, provided it denotes a valid instant.
+  if (value instanceof Date) return !Number.isNaN(value.getTime());
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+/**
+ * Per-field-type value predicates (enum excluded — it needs the `FieldDef`).
+ * A lookup table keeps {@link matchesDeclaredType} flat instead of a wide
+ * switch that would trip the complexity gate.
+ */
+const TYPE_PREDICATES: Record<Exclude<FieldType, "enum">, (value: unknown) => boolean> = {
+  string: (v) => typeof v === "string",
+  slug: (v) => typeof v === "string",
+  integer: (v) => Number.isInteger(v),
+  number: (v) => typeof v === "number" && Number.isFinite(v),
+  boolean: (v) => typeof v === "boolean",
+  date: isValidDate,
+  "string[]": (v) => Array.isArray(v) && v.every((item) => typeof item === "string"),
+};
+
+/** True when `value` satisfies the declared `FieldDef.type` (enum included). */
+function matchesDeclaredType(fieldDef: FieldDef, value: unknown): boolean {
+  if (fieldDef.type === "enum") {
+    return typeof value === "string" && (fieldDef.enum?.includes(value) ?? false);
+  }
+  return TYPE_PREDICATES[fieldDef.type](value);
+}
+
+/**
+ * Return a PATH-FREE message when a numeric `value` falls outside the declared
+ * `[min, max]`, or `undefined` when in range or when no bound applies. Only
+ * meaningful after the value has passed its numeric type check.
+ */
+function describeRangeViolation(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
+  if (typeof value !== "number") return undefined;
+  if (fieldDef.min !== undefined && value < fieldDef.min) {
+    return `Field ${JSON.stringify(name)} value ${value} is below min ${fieldDef.min}.`;
+  }
+  if (fieldDef.max !== undefined && value > fieldDef.max) {
+    return `Field ${JSON.stringify(name)} value ${value} exceeds max ${fieldDef.max}.`;
+  }
+  return undefined;
+}
+
+/**
+ * Validate one scanned page's IDENTITY and field contract, appending problems.
+ * Returns the validated stem for a slug-safe, slug-matching page (still
+ * returned even when it carries `field-violation` problems), or `null` (with a
+ * `non-slug-safe-filename` or `slug-mismatch` problem) for an invalid identity.
+ *
+ * This is the SINGLE per-scan validation used by both the content collector
+ * ({@link pageFromScan}) and the count-only summary, so the two never drift.
+ */
+function validateScan(
   def: EntityTypeDef,
   entityType: string,
   scan: RawEntityScan,
   problems: EntityProblem[],
-): EntityPage | null {
+): string | null {
   const stem = scan.stem;
   if (!isSlugSafe(stem)) {
     problems.push({
@@ -167,17 +250,52 @@ function pageFromScan(
     return null;
   }
   checkFieldContract(entityType, def, scan, problems);
+  return stem;
+}
+
+/**
+ * Build a content-carrying `EntityPage` (identity PLUS the scan's
+ * `frontmatter`/`body`/`title`) for a valid page, or `null` (with a problem)
+ * for an invalid identity. Field-contract violations are surfaced but the page
+ * is still produced. Shares all validation with {@link validateScan}.
+ *
+ * The `title` is the frontmatter title only when the scan flagged one present
+ * (`parseStatus.hasTitle`); otherwise it is `undefined`.
+ */
+function pageFromScan(
+  def: EntityTypeDef,
+  entityType: string,
+  scan: RawEntityScan,
+  problems: EntityProblem[],
+): EntityPage | null {
+  const stem = validateScan(def, entityType, scan, problems);
+  if (stem === null) return null;
   const title = scan.parseStatus.hasTitle ? (scan.frontmatter.title as string) : undefined;
   return {
     entityType,
     directory: def.directory,
-    slug: stem,
+    slug: assertSlugSafe(stem),
     id: entityId(entityType, stem),
     filePath: scan.filePath,
     frontmatter: scan.frontmatter,
     body: scan.body,
     title,
   };
+}
+
+/** Push the shared `invalid-directory` problem for a symlinked/confined-out dir. */
+function pushInvalidDirectory(
+  entityType: string,
+  def: EntityTypeDef,
+  problems: EntityProblem[],
+): void {
+  problems.push({
+    kind: "invalid-directory",
+    entityType,
+    message:
+      `Entity directory ${JSON.stringify(def.directory)} is invalid ` +
+      `(a symlink or confinement failure) and was not read.`,
+  });
 }
 
 /** Collect one entity type's pages, appending pages and problems in place. */
@@ -190,19 +308,37 @@ async function collectOneEntity(
 ): Promise<void> {
   const { scans, dirStatus } = await scanEntityDir(root, def.directory);
   if (dirStatus === "invalid") {
-    problems.push({
-      kind: "invalid-directory",
-      entityType,
-      message:
-        `Entity directory ${JSON.stringify(def.directory)} is invalid ` +
-        `(a symlink or confinement failure) and was not read.`,
-    });
+    pushInvalidDirectory(entityType, def, problems);
     return;
   }
   for (const scan of scans) {
     const page = pageFromScan(def, entityType, scan, problems);
     if (page) pages.push(page);
   }
+}
+
+/**
+ * Summarize one entity type metadata-only: scan WITHOUT bodies, validate each
+ * scan through the SHARED {@link validateScan} (so problems match the content
+ * path exactly), and return this type's valid-page count plus problems. No
+ * content `EntityPage` is ever built or retained.
+ */
+async function summarizeOneEntity(
+  root: string,
+  entityType: string,
+  def: EntityTypeDef,
+  problems: EntityProblem[],
+): Promise<number> {
+  const { scans, dirStatus } = await scanEntityDir(root, def.directory, { includeBody: false });
+  if (dirStatus === "invalid") {
+    pushInvalidDirectory(entityType, def, problems);
+    return 0;
+  }
+  let count = 0;
+  for (const scan of scans) {
+    if (validateScan(def, entityType, scan, problems) !== null) count += 1;
+  }
+  return count;
 }
 
 /**
@@ -234,4 +370,38 @@ export async function collectEntityPages(
     await collectOneEntity(root, entityType, def, pages, problems);
   }
   return { pages, problems };
+}
+
+/**
+ * Summarize a NON-DEFAULT profile's entity pages metadata-only: per-entity-type
+ * valid-page counts plus the same structured problems {@link collectEntityPages}
+ * would surface — WITHOUT building or retaining any content `EntityPage`. Used
+ * by count-only read surfaces (status, viewer) so they no longer hold every
+ * page's body in memory just to tally and validate.
+ *
+ * Counts seed every declared entity type at zero (a declared-but-empty type
+ * still reports `0`), then add one per valid page. Problems are identical to the
+ * content path because both share {@link validateScan}.
+ *
+ * @param root - Absolute project root directory.
+ * @param profile - A non-default profile pack. Passing the default profile is a
+ *   programming error and throws (the only thrown case).
+ * @returns `{ counts, problems }` — no page objects, no bodies.
+ * @throws {EntityCollectError} ONLY when the default profile is passed.
+ */
+export async function collectEntitySummary(
+  root: string,
+  profile: ProfilePack,
+): Promise<EntitySummaryResult> {
+  if (isDefaultProfile(profile)) {
+    throw new EntityCollectError(
+      "collectEntitySummary is for non-default profiles only; use collectRawWikiPages for the default profile.",
+    );
+  }
+  const counts: Record<string, number> = {};
+  const problems: EntityProblem[] = [];
+  for (const [entityType, def] of Object.entries(profile.entities) as [string, EntityTypeDef][]) {
+    counts[entityType] = await summarizeOneEntity(root, entityType, def, problems);
+  }
+  return { counts, problems };
 }

--- a/src/profile/lint.ts
+++ b/src/profile/lint.ts
@@ -1,0 +1,100 @@
+/**
+ * Profile-aware lint findings over non-default entity pages.
+ *
+ * For a custom (non-default) profile, `lintProfileEntities` runs
+ * `collectEntityPages` and surfaces its two output channels as `LintResult`s,
+ * ADDITIVELY — nothing here touches the default lint path or its frozen golden:
+ *
+ *   1. Every structured `EntityProblem` becomes a `LintResult`. The three
+ *      identity/structure problems (`invalid-directory`,
+ *      `non-slug-safe-filename`, `slug-mismatch`) are `error`s; a
+ *      `field-violation` (a contract breach on an otherwise-readable page) is a
+ *      `warning`. Each maps to a stable `profile/<kind>` rule id.
+ *
+ *   2. A CONSERVATIVE subset of the default content rules then runs over each
+ *      collected `EntityPage`. Only checks that need nothing but a page's
+ *      `{ filePath, body, title }` and assume nothing about concepts/queries
+ *      semantics, the schema, or source ownership are included — see
+ *      {@link lintEntityPageContent}.
+ *
+ * Every finding carries the offending page/dir's `entityType` so callers can
+ * group diagnostics by entity type.
+ */
+
+import { collectEntityPages, type EntityProblem, type EntityProblemKind } from "./collect.js";
+import { checkPageEmpty, checkPageMalformedCitations } from "../linter/rules.js";
+import type { ProfilePack, EntityPage } from "./types.js";
+import type { LintResult } from "../linter/types.js";
+
+/** Severity for each problem kind: identity/structure errors, contract warnings. */
+const PROBLEM_SEVERITY: Record<EntityProblemKind, LintResult["severity"]> = {
+  "invalid-directory": "error",
+  "non-slug-safe-filename": "error",
+  "slug-mismatch": "error",
+  "field-violation": "warning",
+};
+
+/**
+ * Map one structured collector problem to a `LintResult`. The `file` is the
+ * offending page path; an `invalid-directory` problem has no page path, so it
+ * falls back to the entity-type label so the finding is never file-less.
+ */
+function problemToResult(problem: EntityProblem): LintResult {
+  return {
+    rule: `profile/${problem.kind}`,
+    severity: PROBLEM_SEVERITY[problem.kind],
+    file: problem.filePath ?? problem.entityType,
+    message: problem.message,
+    entityType: problem.entityType,
+  };
+}
+
+/**
+ * Run the profile-SAFE, content-generic default rules over one entity page.
+ *
+ * Included (and why each is safe — needs only file + body/title, assumes
+ * nothing about concepts/queries, the schema, or source state):
+ *   - `empty-page` — a titled page with a near-empty body is a universal
+ *     content-quality signal, independent of entity semantics.
+ *   - `malformed-claim-citation` — pure grammar check of any `^[...]` markers
+ *     in the body; flags only structurally malformed entries and never
+ *     consults the schema, other pages, or whether the cited source exists.
+ *
+ * Deliberately EXCLUDED: schema-cross-link (needs the schema), stale/orphaned
+ * (need source/freshness state), duplicate-concept and broken-wikilink (need
+ * the concepts/queries page set), broken-citation (needs the sources/ dir),
+ * and the confidence/contradiction/inferred rules (assume default frontmatter
+ * provenance). Applying any of those to arbitrary entity pages would misreport.
+ *
+ * Each finding is tagged with the page's `entityType`.
+ */
+function lintEntityPageContent(page: EntityPage): LintResult[] {
+  const findings = [
+    ...checkPageEmpty({ title: page.title, body: page.body, filePath: page.filePath }),
+    ...checkPageMalformedCitations(page.body, page.filePath),
+  ];
+  return findings.map((finding) => ({ ...finding, entityType: page.entityType }));
+}
+
+/**
+ * Surface a non-default profile's entity-page issues as `LintResult`s,
+ * additively. Collects the profile's entity pages, maps every structured
+ * problem to a finding (correct severity per {@link PROBLEM_SEVERITY}), then
+ * runs the profile-safe content rules over each collected page.
+ *
+ * @param root - Absolute project root directory.
+ * @param profile - A NON-default profile pack (the default profile has no
+ *   entity-collection path; callers gate on `isDefaultProfile` before calling).
+ * @returns All profile-aware findings, each tagged with its `entityType`.
+ */
+export async function lintProfileEntities(
+  root: string,
+  profile: ProfilePack,
+): Promise<LintResult[]> {
+  const { pages, problems } = await collectEntityPages(root, profile);
+  const results: LintResult[] = problems.map(problemToResult);
+  for (const page of pages) {
+    results.push(...lintEntityPageContent(page));
+  }
+  return results;
+}

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -113,9 +113,62 @@ export interface EntityPageRef {
  * page's parsed `frontmatter`, its markdown `body`, and a convenience `title`
  * (the frontmatter title when present). It is produced by the content-carrying
  * collector so downstream read surfaces can render a page without re-reading it.
+ *
+ * This is the INTERNAL collector output: it carries an ABSOLUTE `filePath`
+ * (inherited from `EntityPageRef`). Never expose it directly on a public read
+ * surface — map it through {@link toEntityPageView} first so the machine-local
+ * path is dropped in favour of a project-relative one.
  */
 export interface EntityPage extends EntityPageRef {
   frontmatter: Record<string, unknown>;
   body: string;
   title?: string;
+}
+
+/**
+ * The PUBLIC surface DTO for a non-default profile entity page.
+ *
+ * Unlike the internal {@link EntityPage}, this NEVER carries an absolute
+ * `filePath` — only a PROJECT-RELATIVE `path` (`${directory}/${slug}.md`) — so
+ * read surfaces (`listPages`, JSON export) cannot leak machine-local paths. The
+ * `body` is OPTIONAL and OMITTED entirely (not blanked to `""`) when the caller
+ * did not request it, so an absent body is distinguishable from a genuinely
+ * empty page.
+ */
+export interface EntityPageView {
+  entityType: string;
+  directory: string;
+  slug: string;
+  id: string;
+  /** Project-relative page path (`${directory}/${slug}.md`); never absolute. */
+  path: string;
+  title?: string;
+  frontmatter: Record<string, unknown>;
+  /** Markdown body; OMITTED (key absent) when bodies were not requested. */
+  body?: string;
+}
+
+/**
+ * Map an internal {@link EntityPage} to its public {@link EntityPageView}.
+ *
+ * Drops the absolute `filePath` in favour of the project-relative `path`, and
+ * OMITS `body` entirely when `includeBody` is false (mirroring how the legacy
+ * `Page` shape omits — rather than blanks — an unrequested body).
+ *
+ * @param page - The internal collector entity page.
+ * @param includeBody - When true, carry the markdown body into the view.
+ * @returns The public, path-safe entity-page view.
+ */
+export function toEntityPageView(page: EntityPage, includeBody: boolean): EntityPageView {
+  const view: EntityPageView = {
+    entityType: page.entityType,
+    directory: page.directory,
+    slug: page.slug,
+    id: page.id,
+    path: `${page.directory}/${page.slug}.md`,
+    frontmatter: page.frontmatter,
+    ...(page.title !== undefined ? { title: page.title } : {}),
+    ...(includeBody ? { body: page.body } : {}),
+  };
+  return view;
 }

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -12,6 +12,9 @@
  * constructors in `./identity.js`.
  */
 
+import path from "path";
+import type { EntityProblem, EntityProblemKind } from "./collect.js";
+
 /** A string proven to match the slug-safe grammar (`^[a-z0-9][a-z0-9-]*$`). */
 export type SlugSafe = string & { readonly __slugSafe: unique symbol };
 
@@ -173,4 +176,45 @@ export function toEntityPageView(page: EntityPage, includeBody: boolean): Entity
     ...(includeBody ? { body: page.body } : {}),
   };
   return view;
+}
+
+/**
+ * The PUBLIC surface DTO for a structured non-default-profile collector problem.
+ *
+ * Unlike the internal {@link EntityProblem}, this NEVER carries an absolute
+ * `filePath` — only a PROJECT-RELATIVE `path` (`path.relative(root, filePath)`),
+ * which is OMITTED entirely (key absent) for directory-level problems that have
+ * no file. Carrying the structured `kind`/`entityType` (rather than a flattened
+ * message string) lets a surface group, count, or filter problems, and keeps
+ * repeated field violations distinguishable.
+ *
+ * @experimental Shape may change in a future release.
+ */
+export interface EntityProblemView {
+  kind: EntityProblemKind;
+  entityType: string;
+  /** Project-relative offending page path; ABSENT for directory-level problems. Never absolute. */
+  path?: string;
+  message: string;
+}
+
+/**
+ * Map an internal {@link EntityProblem} to its public {@link EntityProblemView}.
+ *
+ * Drops the absolute `filePath` in favour of a project-relative `path`
+ * (`path.relative(root, filePath)`), OMITTING the key entirely when the problem
+ * is directory-level (no `filePath`) so an absent path is never a misleading
+ * empty string and an absolute path can never leak.
+ *
+ * @param problem - The internal structured collector problem.
+ * @param root - Absolute project root, used to relativize `filePath`.
+ * @returns The public, path-safe problem view.
+ */
+export function toEntityProblemView(problem: EntityProblem, root: string): EntityProblemView {
+  return {
+    kind: problem.kind,
+    entityType: problem.entityType,
+    ...(problem.filePath !== undefined ? { path: path.relative(root, problem.filePath) } : {}),
+    message: problem.message,
+  };
 }

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -134,6 +134,8 @@ export interface EntityPage extends EntityPageRef {
  * `body` is OPTIONAL and OMITTED entirely (not blanked to `""`) when the caller
  * did not request it, so an absent body is distinguishable from a genuinely
  * empty page.
+ *
+ * @experimental Shape may change in a future release.
  */
 export interface EntityPageView {
   entityType: string;

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -105,3 +105,17 @@ export interface EntityPageRef {
   id: EntityId;
   filePath: string;
 }
+
+/**
+ * A non-default profile entity page: identity (`EntityPageRef`) plus content.
+ *
+ * Where `EntityPageRef` is identity-only, `EntityPage` additionally carries the
+ * page's parsed `frontmatter`, its markdown `body`, and a convenience `title`
+ * (the frontmatter title when present). It is produced by the content-carrying
+ * collector so downstream read surfaces can render a page without re-reading it.
+ */
+export interface EntityPage extends EntityPageRef {
+  frontmatter: Record<string, unknown>;
+  body: string;
+  title?: string;
+}

--- a/src/profile/validate.ts
+++ b/src/profile/validate.ts
@@ -31,7 +31,7 @@ import { isSlugSafe } from "./identity.js";
 import { validateEntityDirectory } from "./paths.js";
 import { assertStructurallyValid } from "./schema-validator.js";
 import { ProfileValidationError } from "./errors.js";
-import { SOURCES_DIR, LLMWIKI_DIR, EXPORT_DIR } from "../utils/constants.js";
+import { SOURCES_DIR, LLMWIKI_DIR, EXPORT_DIR, CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 
 export { ProfileValidationError } from "./errors.js";
 
@@ -42,6 +42,16 @@ export { ProfileValidationError } from "./errors.js";
  * so the built-in default can be proven structurally well-formed.
  */
 const RESERVED_PROFILE_IDS = new Set(["default"]);
+
+/**
+ * Entity directories reserved for the built-in DEFAULT profile. A disk profile
+ * may not declare an entity at either, otherwise one physical file would carry
+ * two identities — a legacy `pages: concepts/<slug>` AND a
+ * `profile.entityPages: <type>/<slug>`. `DEFAULT_PROFILE` legitimately uses
+ * these, so this gate lives in `validateProfile` (disk) only, NOT
+ * `validateProfileShape`.
+ */
+const RESERVED_DEFAULT_DIRS = new Set([CONCEPTS_DIR, QUERIES_DIR]);
 
 /** Repo-relative roots an entity directory may not overlap. */
 const RESERVED_ROOTS = [
@@ -222,5 +232,21 @@ export function validateProfileShape(raw: unknown): ProfileValidationResult {
 export function validateProfile(raw: unknown): ProfileValidationResult {
   const result = validateProfileShape(raw);
   assert(!RESERVED_PROFILE_IDS.has(result.profile.profileId), `profileId '${result.profile.profileId}' is reserved`);
+  rejectReservedDefaultDirs(result.profile);
   return result;
+}
+
+/**
+ * Reject any entity whose canonical directory is one of the default profile's
+ * reserved dirs (`wiki/concepts` / `wiki/queries`). Operates on the canonical
+ * directory written back by {@link validateProfileShape}, so `.`-padded aliases
+ * are caught too.
+ */
+function rejectReservedDefaultDirs(profile: ProfilePack): void {
+  for (const [entityType, def] of Object.entries(profile.entities)) {
+    assert(
+      !RESERVED_DEFAULT_DIRS.has(def.directory),
+      `entity '${entityType}' directory '${def.directory}' is reserved for the default profile`,
+    );
+  }
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -16,7 +16,7 @@ import type { EvalReport } from "../eval/types.js";
 import type { WikiStatus } from "../status/collect.js";
 import type { Page, PageRef, ListPagesOptions, ListPagesResult } from "../pages/list.js";
 import type { PageRecord } from "../pages/read.js";
-import type { JsonExportDocument, BuildJsonExportOptions } from "../export/json-export.js";
+import type { JsonExportDocument, ExportJsonOptions } from "../export/json-export.js";
 import type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "../sources/store.js";
 import type { OkfExportReport } from "../export/okf/run.js";
 import type { OkfImportReport } from "../import/run.js";
@@ -148,7 +148,7 @@ export interface Wiki {
    * O(total source bytes) — with no cross-call caching. Avoid calling this in a
    * hot loop; an mtime-keyed cache is planned for v1.x.
    */
-  exportJson(options?: BuildJsonExportOptions): Promise<JsonExportDocument>;
+  exportJson(options?: ExportJsonOptions): Promise<JsonExportDocument>;
   /**
    * Run the eval harness. "fast" mode is credential-free; "full" mode
    * requires LLM credentials for citation-support judging.

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -22,7 +22,7 @@ import { loadProfile } from "../profile/load.js";
 import { collectEntityPages } from "../profile/collect.js";
 import { DEFAULT_PROFILE } from "../profile/default.js";
 import { profileDigest } from "../profile/digest.js";
-import type { ProfilePack, EntityPageRef } from "../profile/types.js";
+import type { ProfilePack, EntityPage } from "../profile/types.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
 
 /**
@@ -156,16 +156,16 @@ function capPendingChanges(
 }
 
 /**
- * Tally entity-page refs per declared entity type for a non-default profile.
+ * Tally entity pages per declared entity type for a non-default profile.
  *
  * Seeds every declared entity type at zero so a declared-but-empty type still
- * reports `0` (rather than being absent), then tallies the strict
- * `EntityPageRef`s collected from disk.
+ * reports `0` (rather than being absent), then tallies the content-carrying
+ * `EntityPage`s collected from disk.
  */
-function countByEntityType(profile: ProfilePack, refs: EntityPageRef[]): Record<string, number> {
+function countByEntityType(profile: ProfilePack, pages: EntityPage[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const entityType of Object.keys(profile.entities)) counts[entityType] = 0;
-  for (const ref of refs) counts[ref.entityType] = (counts[ref.entityType] ?? 0) + 1;
+  for (const page of pages) counts[page.entityType] = (counts[page.entityType] ?? 0) + 1;
   return counts;
 }
 
@@ -226,12 +226,12 @@ async function collectProfileBlock(
   const isBuiltInDefault =
     loaded.loadedFrom === null && loaded.digest === profileDigest(DEFAULT_PROFILE);
   if (isBuiltInDefault) return undefined;
-  const { refs, problems } = await collectEntityPages(root, loaded.profile);
+  const { pages, problems } = await collectEntityPages(root, loaded.profile);
   const messages = problems.map((p) => p.message);
   return {
     profileId: loaded.profile.profileId,
     digest: loaded.digest,
-    entityCounts: countByEntityType(loaded.profile, refs),
+    entityCounts: countByEntityType(loaded.profile, pages),
     ...(messages.length > 0 ? { problems: messages } : {}),
   };
 }

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -20,6 +20,7 @@ import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js"
 import { CONCEPTS_DIR, QUERIES_DIR, SOURCES_DIR } from "../utils/constants.js";
 import { collectProfileSummary } from "../profile/block.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
+import type { EntityProblemView } from "../profile/types.js";
 
 /**
  * Maximum number of items returned in each agent-facing list (stalePages,
@@ -69,12 +70,16 @@ export interface WikiStatus {
     digest: string;
     entityCounts: Record<string, number>;
     /**
-     * Human-readable problem messages from the non-default read path (invalid
-     * directories, non-slug-safe filenames, slug mismatches, field-contract
-     * violations). Present ONLY when non-empty, so a non-default project with a
-     * bad directory or page is never reported as silently healthy.
+     * Structured problems from the non-default read path (invalid directories,
+     * non-slug-safe filenames, slug mismatches, field-contract violations),
+     * CAPPED at PROFILE_PROBLEM_CAP; each `path` is project-relative (never
+     * absolute) and absent for directory-level problems. Present ONLY when
+     * non-empty, so a non-default project with a bad directory or page is never
+     * reported as silently healthy; see `problemTotal` for the full count.
      */
-    problems?: string[];
+    problems?: EntityProblemView[];
+    /** Full problem count (may exceed `problems.length` when capped). */
+    problemTotal?: number;
   };
 }
 

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -18,11 +18,7 @@ import { countCandidates } from "../compiler/candidates.js";
 import { readStateClassified } from "../utils/state.js";
 import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
 import { CONCEPTS_DIR, QUERIES_DIR, SOURCES_DIR } from "../utils/constants.js";
-import { loadProfile } from "../profile/load.js";
-import { collectEntityPages } from "../profile/collect.js";
-import { DEFAULT_PROFILE } from "../profile/default.js";
-import { profileDigest } from "../profile/digest.js";
-import type { ProfilePack, EntityPage } from "../profile/types.js";
+import { collectProfileSummary } from "../profile/block.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
 
 /**
@@ -155,20 +151,6 @@ function capPendingChanges(
   return changes.slice().sort((a, b) => a.file.localeCompare(b.file)).slice(0, MAX_STATUS_LIST);
 }
 
-/**
- * Tally entity pages per declared entity type for a non-default profile.
- *
- * Seeds every declared entity type at zero so a declared-but-empty type still
- * reports `0` (rather than being absent), then tallies the content-carrying
- * `EntityPage`s collected from disk.
- */
-function countByEntityType(profile: ProfilePack, pages: EntityPage[]): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const entityType of Object.keys(profile.entities)) counts[entityType] = 0;
-  for (const page of pages) counts[page.entityType] = (counts[page.entityType] ?? 0) + 1;
-  return counts;
-}
-
 /** Build a read-only status snapshot used by the `wiki_status` MCP tool. */
 export async function collectStatus(root: string): Promise<WikiStatus> {
   const classified = await readStateClassified(root);
@@ -183,7 +165,7 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
   ]);
 
   const { stalePages, orphanedPages } = classifyConceptPages(scannedConcepts, snapshot);
-  const profileBlock = await collectProfileBlock(root);
+  const profileBlock = await collectProfileSummary(root);
 
   // Suppress pendingChanges only on corrupt state: comparing against an empty snapshot
   // on corrupt state would classify every source file as "new", which is false precision.
@@ -205,33 +187,5 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
     pendingChanges: capPendingChanges(pendingChanges),
     pendingChangesCount: pendingChanges.length,
     ...(profileBlock ? { profile: profileBlock } : {}),
-  };
-}
-
-/**
- * Resolve the active profile and, for a NON-DEFAULT profile only, build the
- * status `profile` block (profileId, digest, per-type entity counts). Returns
- * `undefined` for the built-in default so the default envelope is unchanged —
- * the caller omits the `profile` key entirely in that case.
- *
- * The built-in is identified by `loadedFrom === null` (the loader sets null
- * ONLY for the no-file/default path) — never by `profileId === "default"`,
- * which a disk profile can no longer claim but which must not be the gate.
- * The digest comparison is defense-in-depth against a future loader change.
- */
-async function collectProfileBlock(
-  root: string,
-): Promise<WikiStatus["profile"] | undefined> {
-  const loaded = await loadProfile(root);
-  const isBuiltInDefault =
-    loaded.loadedFrom === null && loaded.digest === profileDigest(DEFAULT_PROFILE);
-  if (isBuiltInDefault) return undefined;
-  const { pages, problems } = await collectEntityPages(root, loaded.profile);
-  const messages = problems.map((p) => p.message);
-  return {
-    profileId: loaded.profile.profileId,
-    digest: loaded.digest,
-    entityCounts: countByEntityType(loaded.profile, pages),
-    ...(messages.length > 0 ? { problems: messages } : {}),
   };
 }

--- a/src/viewer/snapshot.ts
+++ b/src/viewer/snapshot.ts
@@ -28,6 +28,7 @@ import { extractWikilinkSlugs } from "../wiki/collect.js";
 import { isMalformedCitationEntry } from "../utils/markdown.js";
 import { buildGraphData } from "./graph.js";
 import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
+import { collectProfileSummary } from "../profile/block.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
 import type {
   ViewerCounts,
@@ -75,6 +76,7 @@ export async function buildViewerSnapshot(root: string): Promise<ViewerSnapshot>
     .map((page) => attachFreshness(page, freshnessSnapshot));
   const counts = buildCounts(annotatedPages, sourceFilenames, pendingReviews, classified.state);
   const graph = buildGraphData(annotatedPages);
+  const profile = await collectProfileSummary(root);
   return {
     root,
     generatedAt: new Date().toISOString(),
@@ -86,6 +88,7 @@ export async function buildViewerSnapshot(root: string): Promise<ViewerSnapshot>
     pages: annotatedPages,
     sourceFilenames,
     graph,
+    ...(profile ? { profile } : {}),
   };
 }
 

--- a/src/viewer/types.ts
+++ b/src/viewer/types.ts
@@ -15,6 +15,7 @@
 import type { ClaimCitation } from "../utils/types.js";
 import type { PageDirectory } from "../export/types.js";
 import type { PageFreshness } from "../freshness/types.js";
+import type { ProfileSummaryBlock } from "../profile/block.js";
 
 /**
  * Canonical page identifier: `concepts/<slug>` or `queries/<slug>`. Bare
@@ -185,4 +186,13 @@ export interface ViewerSnapshot {
   sourceFilenames: string[];
   /** Adjacency data for the `#/graph` route. Built once at snapshot time. */
   graph: GraphData;
+  /**
+   * Active non-default profile summary (profileId, digest, per-type entity
+   * counts, problems), MIRRORING the `status` profile block. ABSENT (undefined)
+   * for the built-in default so the default snapshot is byte-identical. This is
+   * a counts/problems block only — no entity-page rendering, routes, or
+   * navigation. The legacy `counts.concepts`/`counts.queries` stay scoped to the
+   * literal wiki/concepts + wiki/queries dirs in both cases.
+   */
+  profile?: ProfileSummaryBlock;
 }

--- a/src/wiki/collect.ts
+++ b/src/wiki/collect.ts
@@ -174,16 +174,37 @@ async function readBoundedPrefix(filePath: string): Promise<{ text: string; comp
   }
 }
 
+/** The two byte sequences a frontmatter block can open with (LF and CRLF). */
+const FRONTMATTER_OPENINGS = ["---\n", "---\r\n"] as const;
+
+/**
+ * True when `text` begins with a frontmatter opening fence (`---\n`/`---\r\n`).
+ * A prefix that does NOT begin with one cannot contain a frontmatter block at
+ * all — the opening must be the very first bytes — so this alone is decisive.
+ */
+function startsWithFrontmatterOpening(text: string): boolean {
+  return FRONTMATTER_OPENINGS.some((opening) => text.startsWith(opening));
+}
+
 /**
  * Metadata-only read: parse frontmatter from a bounded prefix WITHOUT reading
- * the whole file. Returns a body-less scan when a COMPLETE frontmatter block
- * (or no block at all) is decided within the prefix; returns `null` when the
- * closing fence is not yet visible AND the file exceeds the cap, signalling the
- * caller to fall back to a full read so behaviour is never wrong.
+ * the whole file. Returns a body-less scan when the file CANNOT have frontmatter
+ * (the prefix does not open with `---\n`/`---\r\n`), when a COMPLETE frontmatter
+ * block is decided within the prefix, or when the prefix is complete; returns
+ * `null` only when the closing fence is not yet visible AND the file exceeds the
+ * cap, signalling the caller to fall back to a full read so behaviour is never wrong.
+ *
+ * The no-frontmatter early return reuses the same `parseFrontmatterStatus`
+ * builder as every other path, so its `meta`/`parseStatus` are BYTE-IDENTICAL to
+ * a full read of a file with no leading frontmatter — and a multi-MB body that
+ * does not open with a fence is summarized from the small prefix, never read whole.
  */
 async function readMetadataOnlyScan(filePath: string, stem: string): Promise<RawEntityScan | null> {
   const { text, complete } = await readBoundedPrefix(filePath);
   const parsed = parseFrontmatterStatus(text);
+  // Not opening with a fence is already decisive: there is no frontmatter, so
+  // the rest of the file is irrelevant and need not be read.
+  if (!startsWithFrontmatterOpening(text)) return scanFromParsed(filePath, stem, parsed, "");
   // A complete prefix is authoritative. A truncated prefix is only trustworthy
   // when a closing fence was already found — otherwise the real block may close
   // past the cap, so we must fall back to the full read.

--- a/src/wiki/collect.ts
+++ b/src/wiki/collect.ts
@@ -136,8 +136,16 @@ export interface RawEntityScan {
  * only when the file cannot be read; every parse-level problem (missing
  * frontmatter, malformed YAML, missing title, orphaned flag) is preserved as
  * a `parseStatus` flag so callers decide. The `stem` is passed through raw.
+ *
+ * The frontmatter is ALWAYS parsed (slug/field-contract checks need it); the
+ * body is retained only when `includeBody` is true. A count-only caller passes
+ * `false` so a large project's bodies are never held in memory just to tally.
  */
-async function readEntityScan(filePath: string, stem: string): Promise<RawEntityScan | null> {
+async function readEntityScan(
+  filePath: string,
+  stem: string,
+  includeBody: boolean,
+): Promise<RawEntityScan | null> {
   let raw: string;
   try {
     raw = await readFile(filePath, "utf-8");
@@ -150,7 +158,7 @@ async function readEntityScan(filePath: string, stem: string): Promise<RawEntity
     stem,
     filePath,
     frontmatter: meta,
-    body,
+    body: includeBody ? body : "",
     parseStatus: { hasFrontmatterBlock, malformedFrontmatter, hasTitle: title, orphaned: meta.orphaned === true },
   };
 }
@@ -174,6 +182,16 @@ export interface EntityDirScan {
   dirStatus: EntityDirStatus;
 }
 
+/** Options for {@link scanEntityDir}. */
+export interface ScanEntityDirOptions {
+  /**
+   * When true (the default), each scan retains its markdown body. When false,
+   * frontmatter is still parsed but the body is dropped (`body: ""`) so a
+   * count-only caller never holds O(total bytes) of page content in memory.
+   */
+  includeBody?: boolean;
+}
+
 /**
  * The SINGLE raw directory scanner shared by the default and profile-aware
  * collectors. Walks one entity directory and returns one `RawEntityScan` per
@@ -191,8 +209,15 @@ export interface EntityDirScan {
  *
  * @param root - Project root (raw; canonicalized internally).
  * @param dir - Repo-relative directory for this entity type (e.g. `wiki/concepts`).
+ * @param opts - When `includeBody` is false, bodies are dropped for a count-only
+ *   scan; defaults to retaining bodies so existing callers are byte-unchanged.
  */
-export async function scanEntityDir(root: string, dir: string): Promise<EntityDirScan> {
+export async function scanEntityDir(
+  root: string,
+  dir: string,
+  opts: ScanEntityDirOptions = {},
+): Promise<EntityDirScan> {
+  const includeBody = opts.includeBody ?? true;
   const canonicalRoot = await safeRealpath(root);
   if (!canonicalRoot) return { scans: [], dirStatus: "invalid" };
   const expectedDir = path.join(canonicalRoot, dir);
@@ -208,7 +233,7 @@ export async function scanEntityDir(root: string, dir: string): Promise<EntityDi
   for (const file of files.filter((f) => f.endsWith(".md"))) {
     const resolved = await safeRealpath(path.join(expectedDir, file));
     if (!resolved || !isInsideDir(resolved, expectedDir)) continue;
-    const scan = await readEntityScan(resolved, file.replace(/\.md$/, ""));
+    const scan = await readEntityScan(resolved, file.replace(/\.md$/, ""), includeBody);
     if (scan) scans.push(scan);
   }
   return { scans, dirStatus: "ok" };

--- a/src/wiki/collect.ts
+++ b/src/wiki/collect.ts
@@ -26,7 +26,7 @@
  *     pages in the UI.
  */
 
-import { readdir, readFile, lstat } from "fs/promises";
+import { readdir, readFile, lstat, open } from "fs/promises";
 import path from "path";
 import { parseFrontmatterStatus, slugify } from "../utils/markdown.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
@@ -132,35 +132,99 @@ export interface RawEntityScan {
 }
 
 /**
+ * The maximum number of leading bytes the metadata-only path reads when probing
+ * for a complete `---\n…\n---` frontmatter block. 64 KiB comfortably holds any
+ * realistic frontmatter; a block whose closing fence falls beyond this cap is
+ * rare enough to justify the full-read fallback rather than a larger buffer.
+ */
+const FRONTMATTER_PREFIX_CAP_BYTES = 64 * 1024;
+
+/** Build a `RawEntityScan` from already-parsed frontmatter status + a body. */
+function scanFromParsed(
+  filePath: string,
+  stem: string,
+  parsed: ReturnType<typeof parseFrontmatterStatus>,
+  body: string,
+): RawEntityScan {
+  const { meta, hasFrontmatterBlock, malformedFrontmatter } = parsed;
+  const title = typeof meta.title === "string" && meta.title.length > 0;
+  return {
+    stem,
+    filePath,
+    frontmatter: meta,
+    body,
+    parseStatus: { hasFrontmatterBlock, malformedFrontmatter, hasTitle: title, orphaned: meta.orphaned === true },
+  };
+}
+
+/**
+ * Read only a bounded leading PREFIX of `filePath` (up to
+ * {@link FRONTMATTER_PREFIX_CAP_BYTES}) via a single `fs.open` + bounded read,
+ * returning its UTF-8 decoding alongside whether the whole file fit in the cap.
+ * The metadata-only path uses this to avoid paying full-body I/O on every poll.
+ */
+async function readBoundedPrefix(filePath: string): Promise<{ text: string; complete: boolean }> {
+  const handle = await open(filePath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(FRONTMATTER_PREFIX_CAP_BYTES);
+    const { bytesRead } = await handle.read(buffer, 0, FRONTMATTER_PREFIX_CAP_BYTES, 0);
+    return { text: buffer.toString("utf-8", 0, bytesRead), complete: bytesRead < FRONTMATTER_PREFIX_CAP_BYTES };
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Metadata-only read: parse frontmatter from a bounded prefix WITHOUT reading
+ * the whole file. Returns a body-less scan when a COMPLETE frontmatter block
+ * (or no block at all) is decided within the prefix; returns `null` when the
+ * closing fence is not yet visible AND the file exceeds the cap, signalling the
+ * caller to fall back to a full read so behaviour is never wrong.
+ */
+async function readMetadataOnlyScan(filePath: string, stem: string): Promise<RawEntityScan | null> {
+  const { text, complete } = await readBoundedPrefix(filePath);
+  const parsed = parseFrontmatterStatus(text);
+  // A complete prefix is authoritative. A truncated prefix is only trustworthy
+  // when a closing fence was already found — otherwise the real block may close
+  // past the cap, so we must fall back to the full read.
+  if (complete || parsed.hasFrontmatterBlock) return scanFromParsed(filePath, stem, parsed, "");
+  return null;
+}
+
+/**
  * Read one confirmed-confined `.md` file into a `RawEntityScan`. Returns null
  * only when the file cannot be read; every parse-level problem (missing
  * frontmatter, malformed YAML, missing title, orphaned flag) is preserved as
  * a `parseStatus` flag so callers decide. The `stem` is passed through raw.
  *
- * The frontmatter is ALWAYS parsed (slug/field-contract checks need it); the
- * body is retained only when `includeBody` is true. A count-only caller passes
- * `false` so a large project's bodies are never held in memory just to tally.
+ * When `includeBody` is true the whole file is read. When false (count-only
+ * callers), a bounded frontmatter-only prefix read is attempted first so a large
+ * project's bodies are never read or held in memory just to tally; the produced
+ * `meta`/`parseStatus` are BYTE-IDENTICAL to the full-read path, and a file
+ * whose frontmatter exceeds the prefix cap transparently falls back to a full
+ * read so behaviour is never wrong.
  */
 async function readEntityScan(
   filePath: string,
   stem: string,
   includeBody: boolean,
 ): Promise<RawEntityScan | null> {
+  if (!includeBody) {
+    try {
+      const metadataScan = await readMetadataOnlyScan(filePath, stem);
+      if (metadataScan) return metadataScan;
+    } catch {
+      return null;
+    }
+  }
   let raw: string;
   try {
     raw = await readFile(filePath, "utf-8");
   } catch {
     return null;
   }
-  const { meta, body, hasFrontmatterBlock, malformedFrontmatter } = parseFrontmatterStatus(raw);
-  const title = typeof meta.title === "string" && meta.title.length > 0;
-  return {
-    stem,
-    filePath,
-    frontmatter: meta,
-    body: includeBody ? body : "",
-    parseStatus: { hasFrontmatterBlock, malformedFrontmatter, hasTitle: title, orphaned: meta.orphaned === true },
-  };
+  const parsed = parseFrontmatterStatus(raw);
+  return scanFromParsed(filePath, stem, parsed, includeBody ? parsed.body : "");
 }
 
 /**

--- a/test/fixtures/profile-fixtures.ts
+++ b/test/fixtures/profile-fixtures.ts
@@ -80,19 +80,47 @@ export function expectFirstNotePage(page: EntityPageView): void {
 }
 
 /**
- * Seed a `SAMPLE_PROFILE` project with `count` valid `notes` pages named
+ * Seed a `SAMPLE_PROFILE` project with `count` `notes` pages whose slug is
+ * `<prefix>-NN` (zero-padded so lexical `id` order is stable), each built from
+ * `content(slug, i)`. The shared loop behind both the valid and broken seeders
+ * so their paging/bounding setup never drifts.
+ */
+async function seedNotesProject(
+  root: string,
+  count: number,
+  prefix: string,
+  content: (slug: string, index: number) => string,
+): Promise<void> {
+  await writeProfileFile(root, SAMPLE_PROFILE);
+  for (let i = 0; i < count; i++) {
+    const slug = `${prefix}-${String(i).padStart(2, "0")}`;
+    await writeMarkdownPage(root, "wiki/notes", slug, content(slug, i));
+  }
+}
+
+/**
+ * Seed a `SAMPLE_PROFILE` project with `count` VALID `notes` pages named
  * `note-00`, `note-01`, … so the additive entity section has more pages than a
- * small `limit`. Zero-padded so lexical `id` order is stable and predictable.
+ * small `limit`.
  *
  * @param root - Absolute project root directory.
  * @param count - How many `notes` pages to seed.
  */
 export async function seedManyNotesProject(root: string, count: number): Promise<void> {
-  await writeProfileFile(root, SAMPLE_PROFILE);
-  for (let i = 0; i < count; i++) {
-    const slug = `note-${String(i).padStart(2, "0")}`;
-    await writeMarkdownPage(root, "wiki/notes", slug, `---\ntitle: Note ${i}\n---\nBody ${i}.`);
-  }
+  await seedNotesProject(root, count, "note", (_slug, i) => `---\ntitle: Note ${i}\n---\nBody ${i}.`);
+}
+
+/**
+ * Seed a `SAMPLE_PROFILE` project with `count` INVALID `notes` pages, each
+ * missing the required `title` field so every page yields exactly one
+ * `field-violation` problem (`broken-00`, …). Used to exercise per-surface
+ * problem bounding (windowing / capping).
+ *
+ * @param root - Absolute project root directory.
+ * @param count - How many broken `notes` pages to seed.
+ */
+export async function seedBrokenNotesProject(root: string, count: number): Promise<void> {
+  await seedNotesProject(root, count, "broken", (slug, i) => `---\nslug: ${slug}\n---\nNo title ${i}.`);
 }
 
 /**

--- a/test/fixtures/profile-fixtures.ts
+++ b/test/fixtures/profile-fixtures.ts
@@ -19,7 +19,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect } from "vitest";
 import { PROFILE_FILE } from "../../src/utils/constants.js";
-import type { ProfilePack, EntityPage } from "../../src/profile/types.js";
+import type { ProfilePack, EntityPageView } from "../../src/profile/types.js";
 
 /**
  * A minimal NON-DEFAULT profile: a single `notes` entity type at `wiki/notes`
@@ -66,14 +66,17 @@ export async function seedSampleNotesProject(root: string): Promise<void> {
 }
 
 /**
- * Assert an entity page is the seeded `first-note` from
- * {@link seedSampleNotesProject}: the `notes` type, `first-note` slug, and the
- * full "Note body." body (so a body-stripping bug would fail this).
+ * Assert an entity-page VIEW is the seeded `first-note` from
+ * {@link seedSampleNotesProject}: the `notes` type, `first-note` slug, the full
+ * "Note body." body (so a body-stripping bug would fail this), a
+ * project-relative `path`, and NO leaked absolute `filePath`.
  */
-export function expectFirstNotePage(page: EntityPage): void {
+export function expectFirstNotePage(page: EntityPageView): void {
   expect(page.entityType).toBe("notes");
   expect(page.slug).toBe("first-note");
   expect(page.body).toBe("Note body.");
+  expect(page.path).toBe("wiki/notes/first-note.md");
+  expect("filePath" in page).toBe(false);
 }
 
 /**

--- a/test/fixtures/profile-fixtures.ts
+++ b/test/fixtures/profile-fixtures.ts
@@ -80,6 +80,22 @@ export function expectFirstNotePage(page: EntityPageView): void {
 }
 
 /**
+ * Seed a `SAMPLE_PROFILE` project with `count` valid `notes` pages named
+ * `note-00`, `note-01`, … so the additive entity section has more pages than a
+ * small `limit`. Zero-padded so lexical `id` order is stable and predictable.
+ *
+ * @param root - Absolute project root directory.
+ * @param count - How many `notes` pages to seed.
+ */
+export async function seedManyNotesProject(root: string, count: number): Promise<void> {
+  await writeProfileFile(root, SAMPLE_PROFILE);
+  for (let i = 0; i < count; i++) {
+    const slug = `note-${String(i).padStart(2, "0")}`;
+    await writeMarkdownPage(root, "wiki/notes", slug, `---\ntitle: Note ${i}\n---\nBody ${i}.`);
+  }
+}
+
+/**
  * The research-lite profile pack written to `.llmwiki/profile.json`. Three
  * entity types under `wiki/`; `ideas` carries a lifecycle FSM whose enum field
  * values exactly equal its state set (required by the validator).

--- a/test/fixtures/profile-fixtures.ts
+++ b/test/fixtures/profile-fixtures.ts
@@ -17,6 +17,64 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { expect } from "vitest";
+import { PROFILE_FILE } from "../../src/utils/constants.js";
+import type { ProfilePack, EntityPage } from "../../src/profile/types.js";
+
+/**
+ * A minimal NON-DEFAULT profile: a single `notes` entity type at `wiki/notes`
+ * requiring a `title` field. Shared by the additive read-surface tests
+ * (listPages / export / viewer) so they assert against one fixed shape.
+ */
+export const SAMPLE_PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "sample",
+  entities: {
+    notes: {
+      directory: "wiki/notes",
+      requiredFields: ["title"],
+      fields: { title: { type: "string" } },
+    },
+  },
+};
+
+/** Write a profile.json into the project's `.llmwiki/` dir. */
+export async function writeProfileFile(root: string, pack: ProfilePack): Promise<void> {
+  await mkdir(path.join(root, path.dirname(PROFILE_FILE)), { recursive: true });
+  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(pack));
+}
+
+/** Write a markdown page at `<root>/<dir>/<slug>.md`, creating the dir. */
+export async function writeMarkdownPage(
+  root: string,
+  dir: string,
+  slug: string,
+  content: string,
+): Promise<void> {
+  await mkdir(path.join(root, dir), { recursive: true });
+  await writeFile(path.join(root, dir, `${slug}.md`), content);
+}
+
+/**
+ * Seed a `SAMPLE_PROFILE` project with one valid `notes` page (`first-note`,
+ * body "Note body.") — the shared baseline the additive read-surface tests use
+ * before adding their own contract-violation cases.
+ */
+export async function seedSampleNotesProject(root: string): Promise<void> {
+  await writeProfileFile(root, SAMPLE_PROFILE);
+  await writeMarkdownPage(root, "wiki/notes", "first-note", "---\ntitle: First\n---\nNote body.");
+}
+
+/**
+ * Assert an entity page is the seeded `first-note` from
+ * {@link seedSampleNotesProject}: the `notes` type, `first-note` slug, and the
+ * full "Note body." body (so a body-stripping bug would fail this).
+ */
+export function expectFirstNotePage(page: EntityPage): void {
+  expect(page.entityType).toBe("notes");
+  expect(page.slug).toBe("first-note");
+  expect(page.body).toBe("Note body.");
+}
 
 /**
  * The research-lite profile pack written to `.llmwiki/profile.json`. Three

--- a/test/profile-collect.test.ts
+++ b/test/profile-collect.test.ts
@@ -5,8 +5,8 @@
  *
  * Covers: (a) the default profile is REJECTED by `collectEntityPages`;
  * (b) `collectRawWikiPages` preserves non-slug-safe stems (`Foo Bar`, `研究`)
- * VERBATIM as slug values; (c) a small non-default profile yields strict
- * branded `EntityPageRef`s; (d) a non-slug-safe stem under a non-default entity
+ * VERBATIM as slug values; (c) a small non-default profile yields content-carrying
+ * branded `EntityPage`s; (d) a non-slug-safe stem under a non-default entity
  * dir fails closed with a rename hint (never silently slugified or skipped).
  */
 
@@ -45,15 +45,15 @@ async function makeSampleDirs(): Promise<void> {
 }
 
 /**
- * Collect SAMPLE_PROFILE and assert it yielded no refs and exactly one problem
+ * Collect SAMPLE_PROFILE and assert it yielded no pages and exactly one problem
  * of `kind` under `entityType`. Returns the lone problem for further checks.
  */
 async function expectSoleProblem(
   kind: string,
   entityType: string,
 ): Promise<{ message: string }> {
-  const { refs, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
-  expect(refs).toEqual([]);
+  const { pages, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
+  expect(pages).toEqual([]);
   expect(problems).toHaveLength(1);
   expect(problems[0]).toMatchObject({ kind, entityType });
   return problems[0];
@@ -88,14 +88,14 @@ describe("collectRawWikiPages — verbatim raw stems", () => {
   });
 });
 
-describe("collectEntityPages — strict EntityPageRefs", () => {
+describe("collectEntityPages — content-carrying EntityPages", () => {
   beforeEach(makeSampleDirs);
 
   it("mints branded ids for slug-safe stems across entity types", async () => {
     await writePage(path.join(root, "wiki/notes"), "first-note", "first-note");
     await writePage(path.join(root, "wiki/tasks"), "do-thing");
-    const { refs, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
-    const byId = Object.fromEntries(refs.map((r) => [r.id, r]));
+    const { pages, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
+    const byId = Object.fromEntries(pages.map((r) => [r.id, r]));
     expect(Object.keys(byId).sort()).toEqual(["notes/first-note", "tasks/do-thing"]);
     expect(byId["notes/first-note"]).toMatchObject({ entityType: "notes", slug: "first-note", directory: "wiki/notes" });
     expect(problems).toEqual([]);
@@ -104,8 +104,8 @@ describe("collectEntityPages — strict EntityPageRefs", () => {
   it("records a slug-mismatch problem (does not throw, drops only the bad ref)", async () => {
     await writePage(path.join(root, "wiki/notes"), "first-note", "other-slug");
     await writePage(path.join(root, "wiki/tasks"), "do-thing");
-    const { refs, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
-    expect(refs.map((r) => r.id)).toEqual(["tasks/do-thing"]);
+    const { pages, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
+    expect(pages.map((r) => r.id)).toEqual(["tasks/do-thing"]);
     expect(problems).toHaveLength(1);
     expect(problems[0]).toMatchObject({ kind: "slug-mismatch", entityType: "notes" });
     expect(problems[0].message).toMatch(/does not match file stem/);
@@ -124,8 +124,8 @@ describe("collectEntityPages — non-slug-safe stems become problems", () => {
   it("collects valid siblings even when one page is non-slug-safe", async () => {
     await writePage(path.join(root, "wiki/notes"), "Foo Bar");
     await writePage(path.join(root, "wiki/notes"), "good-note");
-    const { refs, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
-    expect(refs.map((r) => r.id)).toEqual(["notes/good-note"]);
+    const { pages, problems } = await collectEntityPages(root, SAMPLE_PROFILE);
+    expect(pages.map((r) => r.id)).toEqual(["notes/good-note"]);
     expect(problems).toHaveLength(1);
     expect(problems[0].kind).toBe("non-slug-safe-filename");
   });
@@ -162,8 +162,8 @@ describe("collectEntityPages — field contract enforced as problems", () => {
 
   it("records a field-violation for a missing required field, keeping the ref", async () => {
     await writeFile(path.join(root, "wiki/notes/no-title.md"), "# no-title\n");
-    const { refs, problems } = await collectEntityPages(root, CONTRACT_PROFILE);
-    expect(refs.map((r) => r.id)).toEqual(["notes/no-title"]);
+    const { pages, problems } = await collectEntityPages(root, CONTRACT_PROFILE);
+    expect(pages.map((r) => r.id)).toEqual(["notes/no-title"]);
     expect(problems).toHaveLength(1);
     expect(problems[0]).toMatchObject({ kind: "field-violation", entityType: "notes" });
     expect(problems[0].message).toMatch(/title/);
@@ -171,8 +171,8 @@ describe("collectEntityPages — field contract enforced as problems", () => {
 
   it("records a field-violation for an out-of-set enum value", async () => {
     await writeFile(path.join(root, "wiki/notes/bad-status.md"), "---\ntitle: T\nstatus: nope\n---\n");
-    const { refs, problems } = await collectEntityPages(root, CONTRACT_PROFILE);
-    expect(refs.map((r) => r.id)).toEqual(["notes/bad-status"]);
+    const { pages, problems } = await collectEntityPages(root, CONTRACT_PROFILE);
+    expect(pages.map((r) => r.id)).toEqual(["notes/bad-status"]);
     expect(problems).toHaveLength(1);
     expect(problems[0].kind).toBe("field-violation");
     expect(problems[0].message).toMatch(/status/);
@@ -180,8 +180,8 @@ describe("collectEntityPages — field contract enforced as problems", () => {
 
   it("produces no problems for a contract-satisfying page", async () => {
     await writeFile(path.join(root, "wiki/notes/good.md"), "---\ntitle: T\nstatus: open\n---\n");
-    const { refs, problems } = await collectEntityPages(root, CONTRACT_PROFILE);
-    expect(refs.map((r) => r.id)).toEqual(["notes/good"]);
+    const { pages, problems } = await collectEntityPages(root, CONTRACT_PROFILE);
+    expect(pages.map((r) => r.id)).toEqual(["notes/good"]);
     expect(problems).toEqual([]);
   });
 });

--- a/test/profile-entitypage.test.ts
+++ b/test/profile-entitypage.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @file test/profile-entitypage.test.ts
+ * @description Tests for the content-carrying `EntityPage` model returned by
+ * `collectEntityPages` (CLP Phase 1b, Task 0).
+ *
+ * Where the identity-only assertions live in `profile-collect.test.ts`, this
+ * suite proves the NEW content guarantees: each collected page carries its
+ * branded `id`/`slug` AND the scan's `frontmatter`/`body`, and `title` is the
+ * frontmatter title when present (undefined otherwise). It also re-confirms the
+ * fail-soft contract at the new shape — a non-slug-safe filename yields a
+ * problem (no page, no throw) — and that the default profile still throws the
+ * programming-error guard.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { collectEntityPages, EntityCollectError } from "../src/profile/collect.js";
+import { DEFAULT_PROFILE } from "../src/profile/default.js";
+import type { ProfilePack } from "../src/profile/types.js";
+
+let root = "";
+
+/** A small non-default profile declaring one `notes` entity type. */
+const PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "entitypage-sample",
+  entities: { notes: { directory: "wiki/notes" } },
+};
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "profile-entitypage-"));
+  await mkdir(path.join(root, "wiki/notes"), { recursive: true });
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("collectEntityPages — content-carrying EntityPage", () => {
+  it("carries branded identity plus frontmatter, body, and title", async () => {
+    await writeFile(
+      path.join(root, "wiki/notes/alpha.md"),
+      "---\ntitle: Alpha Note\ntag: x\n---\n\nHello body.\n",
+    );
+    const { pages, problems } = await collectEntityPages(root, PROFILE);
+    expect(problems).toEqual([]);
+    expect(pages).toHaveLength(1);
+    const page = pages[0];
+    expect(page).toMatchObject({ id: "notes/alpha", slug: "alpha", entityType: "notes" });
+    expect(page.frontmatter).toMatchObject({ title: "Alpha Note", tag: "x" });
+    expect(page.body).toContain("Hello body.");
+    expect(page.title).toBe("Alpha Note");
+  });
+
+  it("leaves title undefined when frontmatter has no title", async () => {
+    await writeFile(path.join(root, "wiki/notes/beta.md"), "Just a body, no frontmatter.\n");
+    const { pages } = await collectEntityPages(root, PROFILE);
+    expect(pages).toHaveLength(1);
+    expect(pages[0].title).toBeUndefined();
+    expect(pages[0].frontmatter).toEqual({});
+    expect(pages[0].body).toContain("Just a body");
+  });
+});
+
+describe("collectEntityPages — fail-soft at the content shape", () => {
+  it("yields a problem (no page, no throw) for a non-slug-safe filename", async () => {
+    await writeFile(path.join(root, "wiki/notes/Bad Name.md"), "# Bad Name\n");
+    const { pages, problems } = await collectEntityPages(root, PROFILE);
+    expect(pages).toEqual([]);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatchObject({ kind: "non-slug-safe-filename", entityType: "notes" });
+  });
+
+  it("still throws the programming-error guard for the default profile", async () => {
+    await expect(collectEntityPages(root, DEFAULT_PROFILE)).rejects.toBeInstanceOf(EntityCollectError);
+  });
+});

--- a/test/profile-export.test.ts
+++ b/test/profile-export.test.ts
@@ -14,6 +14,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { exportJson } from "../src/commands/export.js";
+import { createWiki } from "../src/index.js";
 import { CONCEPTS_DIR } from "../src/utils/constants.js";
 import {
   writeMarkdownPage,
@@ -61,5 +62,21 @@ describe("exportJson — non-default profile", () => {
     await writeMarkdownPage(root, "wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title.");
     const doc = await exportJson(root);
     expect(doc.profile?.problems?.some((m) => m.includes("title"))).toBe(true);
+  });
+
+  it("never leaks an absolute filePath in the profile block", async () => {
+    const doc = await exportJson(root);
+    const json = JSON.stringify(doc.profile);
+    expect(json).not.toContain("filePath");
+    expect(json).not.toContain(root);
+  });
+});
+
+describe("exportJson — forge-proof public options", () => {
+  it("ignores a forged profile block on a default project", async () => {
+    await writeMarkdownPage(root, CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody.");
+    const wiki = createWiki({ root });
+    const doc = await wiki.exportJson({ profile: { profileId: "forged" } } as never);
+    expect("profile" in doc).toBe(false);
   });
 });

--- a/test/profile-export.test.ts
+++ b/test/profile-export.test.ts
@@ -10,39 +10,18 @@
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { exportJson } from "../src/commands/export.js";
-import { CONCEPTS_DIR, PROFILE_FILE } from "../src/utils/constants.js";
-import type { ProfilePack } from "../src/profile/types.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import {
+  writeMarkdownPage,
+  seedSampleNotesProject,
+  expectFirstNotePage,
+} from "./fixtures/profile-fixtures.js";
 
 let root = "";
-
-/** A non-default profile: `notes` requires a `title`, lives at wiki/notes. */
-const PROFILE: ProfilePack = {
-  schemaVersion: 1,
-  profileId: "sample",
-  entities: {
-    notes: {
-      directory: "wiki/notes",
-      requiredFields: ["title"],
-      fields: { title: { type: "string" } },
-    },
-  },
-};
-
-/** Write the profile.json into the project's .llmwiki/ dir. */
-async function writeProfile(pack: ProfilePack): Promise<void> {
-  await mkdir(path.join(root, path.dirname(PROFILE_FILE)), { recursive: true });
-  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(pack));
-}
-
-/** Write a markdown page with the given relative dir, slug, and content. */
-async function writePage(dir: string, slug: string, content: string): Promise<void> {
-  await mkdir(path.join(root, dir), { recursive: true });
-  await writeFile(path.join(root, dir, `${slug}.md`), content);
-}
 
 beforeEach(async () => {
   root = await mkdtemp(path.join(os.tmpdir(), "profile-export-"));
@@ -54,7 +33,7 @@ afterEach(async () => {
 
 describe("exportJson — default profile", () => {
   it("has no profile key and exports concepts legacily", async () => {
-    await writePage(CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody.");
+    await writeMarkdownPage(root, CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody.");
     const doc = await exportJson(root);
     expect("profile" in doc).toBe(false);
     expect(doc.pages.map((p) => p.slug)).toEqual(["alpha"]);
@@ -63,18 +42,14 @@ describe("exportJson — default profile", () => {
 
 describe("exportJson — non-default profile", () => {
   beforeEach(async () => {
-    await writeProfile(PROFILE);
-    await writePage("wiki/notes", "first-note", "---\ntitle: First\n---\nNote body.");
+    await seedSampleNotesProject(root);
   });
 
   it("adds a profile block with content-bearing entity pages", async () => {
     const doc = await exportJson(root);
     expect(doc.profile?.profileId).toBe("sample");
     expect(doc.profile?.entityPages).toHaveLength(1);
-    const page = doc.profile!.entityPages[0];
-    expect(page.entityType).toBe("notes");
-    expect(page.slug).toBe("first-note");
-    expect(page.body).toBe("Note body.");
+    expectFirstNotePage(doc.profile!.entityPages[0]);
   });
 
   it("leaves the legacy pages array scoped to concepts/queries", async () => {
@@ -83,7 +58,7 @@ describe("exportJson — non-default profile", () => {
   });
 
   it("surfaces collector problems for a contract violation", async () => {
-    await writePage("wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title.");
+    await writeMarkdownPage(root, "wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title.");
     const doc = await exportJson(root);
     expect(doc.profile?.problems?.some((m) => m.includes("title"))).toBe(true);
   });

--- a/test/profile-export.test.ts
+++ b/test/profile-export.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @file test/profile-export.test.ts
+ * @description Tests for the additive `profile` entity block on JSON export.
+ *
+ * Covers: (a) a DEFAULT project's `exportJson` document has NO `profile` key and
+ * its legacy `pages` reflects only concepts/queries; (b) a NON-default project
+ * surfaces `profile.entityPages` (the content-bearing EntityPage shape) with
+ * `profileId`, leaving the legacy `pages` array scoped to concepts/queries; and
+ * surfaces collector `problems` for a contract violation.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { exportJson } from "../src/commands/export.js";
+import { CONCEPTS_DIR, PROFILE_FILE } from "../src/utils/constants.js";
+import type { ProfilePack } from "../src/profile/types.js";
+
+let root = "";
+
+/** A non-default profile: `notes` requires a `title`, lives at wiki/notes. */
+const PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "sample",
+  entities: {
+    notes: {
+      directory: "wiki/notes",
+      requiredFields: ["title"],
+      fields: { title: { type: "string" } },
+    },
+  },
+};
+
+/** Write the profile.json into the project's .llmwiki/ dir. */
+async function writeProfile(pack: ProfilePack): Promise<void> {
+  await mkdir(path.join(root, path.dirname(PROFILE_FILE)), { recursive: true });
+  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(pack));
+}
+
+/** Write a markdown page with the given relative dir, slug, and content. */
+async function writePage(dir: string, slug: string, content: string): Promise<void> {
+  await mkdir(path.join(root, dir), { recursive: true });
+  await writeFile(path.join(root, dir, `${slug}.md`), content);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "profile-export-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("exportJson — default profile", () => {
+  it("has no profile key and exports concepts legacily", async () => {
+    await writePage(CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody.");
+    const doc = await exportJson(root);
+    expect("profile" in doc).toBe(false);
+    expect(doc.pages.map((p) => p.slug)).toEqual(["alpha"]);
+  });
+});
+
+describe("exportJson — non-default profile", () => {
+  beforeEach(async () => {
+    await writeProfile(PROFILE);
+    await writePage("wiki/notes", "first-note", "---\ntitle: First\n---\nNote body.");
+  });
+
+  it("adds a profile block with content-bearing entity pages", async () => {
+    const doc = await exportJson(root);
+    expect(doc.profile?.profileId).toBe("sample");
+    expect(doc.profile?.entityPages).toHaveLength(1);
+    const page = doc.profile!.entityPages[0];
+    expect(page.entityType).toBe("notes");
+    expect(page.slug).toBe("first-note");
+    expect(page.body).toBe("Note body.");
+  });
+
+  it("leaves the legacy pages array scoped to concepts/queries", async () => {
+    const doc = await exportJson(root);
+    expect(doc.pages).toHaveLength(0);
+  });
+
+  it("surfaces collector problems for a contract violation", async () => {
+    await writePage("wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title.");
+    const doc = await exportJson(root);
+    expect(doc.profile?.problems?.some((m) => m.includes("title"))).toBe(true);
+  });
+});

--- a/test/profile-export.test.ts
+++ b/test/profile-export.test.ts
@@ -67,7 +67,18 @@ describe("exportJson — non-default profile", () => {
   it("surfaces collector problems for a contract violation", async () => {
     await writeMarkdownPage(root, "wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title.");
     const doc = await exportJson(root);
-    expect(doc.profile?.problems?.some((m) => m.includes("title"))).toBe(true);
+    expect(doc.profile?.problems?.some((p) => p.message.includes("title"))).toBe(true);
+  });
+
+  it("keeps ALL problems uncapped with problemTotal equal to the full count", async () => {
+    for (let i = 0; i < 3; i++) {
+      await writeMarkdownPage(root, "wiki/notes", `bad-${i}`, `---\nslug: bad-${i}\n---\nNo title.`);
+    }
+    const doc = await exportJson(root);
+    expect(doc.profile?.problems).toHaveLength(doc.profile!.problemTotal!);
+    expect(doc.profile?.problemTotal).toBeGreaterThanOrEqual(3);
+    const problem = doc.profile!.problems![0];
+    expect(problem.path?.startsWith("/")).toBe(false);
   });
 
   it("never leaks an absolute filePath in the profile block", async () => {

--- a/test/profile-export.test.ts
+++ b/test/profile-export.test.ts
@@ -53,6 +53,12 @@ describe("exportJson — non-default profile", () => {
     expectFirstNotePage(doc.profile!.entityPages[0]);
   });
 
+  it("stamps the experimental block version (distinct from schemaVersion)", async () => {
+    const doc = await exportJson(root);
+    expect(doc.profile?.version).toBe(1);
+    expect(doc.schemaVersion).toBe(1);
+  });
+
   it("leaves the legacy pages array scoped to concepts/queries", async () => {
     const doc = await exportJson(root);
     expect(doc.pages).toHaveLength(0);

--- a/test/profile-field-types.test.ts
+++ b/test/profile-field-types.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @file test/profile-field-types.test.ts
+ * @description Tests for full field-TYPE and min/max contract validation in the
+ * non-default collector (`collectEntityPages`), plus the count-only summary path
+ * (`collectEntitySummary`) that produces counts + problems WITHOUT retaining
+ * page bodies.
+ *
+ * Covers (M3): a present value mismatching its declared `integer`/`string[]`/
+ * `date` type, and a numeric value outside its declared `[min, max]`, each yield
+ * a PATH-FREE `field-violation` problem while the page is STILL produced.
+ * Covers (M2): `collectEntitySummary` returns per-type counts + identical
+ * problems with no body-bearing page objects.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  collectEntityPages,
+  collectEntitySummary,
+  EntityCollectError,
+} from "../src/profile/collect.js";
+import { DEFAULT_PROFILE } from "../src/profile/default.js";
+import type { ProfilePack } from "../src/profile/types.js";
+
+let root = "";
+
+/** A profile whose `notes` type declares typed + bounded fields. */
+const TYPED_PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "typed",
+  entities: {
+    notes: {
+      directory: "wiki/notes",
+      fields: {
+        year: { type: "integer" },
+        importance: { type: "integer", min: 1, max: 5 },
+        tags: { type: "string[]" },
+        due: { type: "date" },
+      },
+    },
+  },
+};
+
+/** Write a `wiki/notes/<stem>.md` page with the given raw frontmatter body. */
+async function writeNote(stem: string, frontmatter: string): Promise<void> {
+  const notesDir = path.join(root, "wiki/notes");
+  await mkdir(notesDir, { recursive: true });
+  await writeFile(path.join(notesDir, `${stem}.md`), `---\n${frontmatter}\n---\n# ${stem}\n`);
+}
+
+/** Collect TYPED_PROFILE and return only the `notes` field-violation messages. */
+async function violationMessages(): Promise<string[]> {
+  const { problems } = await collectEntityPages(root, TYPED_PROFILE);
+  return problems.filter((p) => p.kind === "field-violation").map((p) => p.message);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "profile-field-types-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("checkFieldContract — declared TYPE enforced as field-violation", () => {
+  it("flags a non-integer integer field, still producing the page", async () => {
+    await writeNote("bad-year", 'year: "twenty"');
+    const { pages } = await collectEntityPages(root, TYPED_PROFILE);
+    expect(pages.map((p) => p.id)).toEqual(["notes/bad-year"]);
+    const messages = await violationMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/"year".*not a valid integer/);
+  });
+
+  it("flags a string[] field whose value is a bare string", async () => {
+    await writeNote("bad-tags", 'tags: "x"');
+    const messages = await violationMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/"tags".*not a valid string\[\]/);
+  });
+
+  it("flags a date field whose value does not parse as a date", async () => {
+    await writeNote("bad-date", 'due: "not-a-date"');
+    const messages = await violationMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/"due".*not a valid date/);
+  });
+});
+
+describe("checkFieldContract — min/max enforced as field-violation", () => {
+  it("flags a numeric value above the declared max", async () => {
+    await writeNote("too-big", "importance: 99");
+    const messages = await violationMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/"importance" value 99 exceeds max 5/);
+  });
+
+  it("flags a numeric value below the declared min", async () => {
+    await writeNote("too-small", "importance: 0");
+    const messages = await violationMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/"importance" value 0 is below min 1/);
+  });
+
+  it("accepts an in-range, correctly-typed page with no problems", async () => {
+    await writeNote("good", "year: 2026\nimportance: 3\ntags:\n  - a\ndue: 2026-01-01");
+    const { pages, problems } = await collectEntityPages(root, TYPED_PROFILE);
+    expect(pages.map((p) => p.id)).toEqual(["notes/good"]);
+    expect(problems).toEqual([]);
+  });
+});
+
+describe("field-violation messages are PATH-FREE", () => {
+  it("never embeds the absolute filePath in the message text", async () => {
+    await writeNote("bad-year", 'year: "twenty"');
+    const { problems } = await collectEntityPages(root, TYPED_PROFILE);
+    const violation = problems.find((p) => p.kind === "field-violation");
+    expect(violation?.filePath).toContain(root);
+    expect(violation?.message).not.toContain(root);
+    expect(violation?.message).not.toContain("/");
+  });
+});
+
+describe("collectEntitySummary — count-only, no bodies retained", () => {
+  it("rejects the default profile (programming-error guard)", async () => {
+    await expect(collectEntitySummary(root, DEFAULT_PROFILE)).rejects.toBeInstanceOf(EntityCollectError);
+  });
+
+  it("returns per-type counts + problems and no page/body objects", async () => {
+    await writeNote("a", "year: 2026");
+    await writeNote("b", 'year: "twenty"');
+    const summary = await collectEntitySummary(root, TYPED_PROFILE);
+    expect(summary.counts).toEqual({ notes: 2 });
+    expect(summary.problems.map((p) => p.message)).toEqual([
+      expect.stringMatching(/"year".*not a valid integer/),
+    ]);
+    expect("pages" in summary).toBe(false);
+    expect(Object.values(summary).some((v) => Array.isArray(v) && v.some((x: unknown) => typeof x === "object" && x !== null && "body" in (x as object)))).toBe(false);
+  });
+
+  it("produces counts + problems IDENTICAL to the content collector", async () => {
+    await writeNote("a", "importance: 99");
+    await writeNote("b", "importance: 3");
+    const summary = await collectEntitySummary(root, TYPED_PROFILE);
+    const full = await collectEntityPages(root, TYPED_PROFILE);
+    expect(summary.counts).toEqual({ notes: 2 });
+    expect(summary.problems).toEqual(full.problems);
+  });
+});

--- a/test/profile-field-types.test.ts
+++ b/test/profile-field-types.test.ts
@@ -123,6 +123,77 @@ describe("field-violation messages are PATH-FREE", () => {
   });
 });
 
+/** A profile whose `notes` type marks `title` required via per-field `required`. */
+const PER_FIELD_REQUIRED_PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "per-field-required",
+  entities: {
+    notes: { directory: "wiki/notes", fields: { title: { type: "string", required: true } } },
+  },
+};
+
+/** A profile that declares `title` required BOTH via array AND per-field flag. */
+const DOUBLY_REQUIRED_PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "doubly-required",
+  entities: {
+    notes: {
+      directory: "wiki/notes",
+      requiredFields: ["title"],
+      fields: { title: { type: "string", required: true } },
+    },
+  },
+};
+
+/** Collect `profile` and return only the `field-violation` problem messages. */
+async function violationsFor(profile: ProfilePack): Promise<string[]> {
+  const { problems } = await collectEntityPages(root, profile);
+  return problems.filter((p) => p.kind === "field-violation").map((p) => p.message);
+}
+
+describe("checkFieldContract — per-field required: true enforced", () => {
+  it("flags a missing field declared required via per-field flag exactly once", async () => {
+    await writeNote("no-title", "year: 2026");
+    const messages = await violationsFor(PER_FIELD_REQUIRED_PROFILE);
+    expect(messages).toEqual([expect.stringMatching(/Required field "title" is missing/)]);
+  });
+
+  it("does not flag a present per-field-required field", async () => {
+    await writeNote("has-title", 'title: "Hello"');
+    expect(await violationsFor(PER_FIELD_REQUIRED_PROFILE)).toEqual([]);
+  });
+
+  it("yields ONE problem when a field is required both via array and per-field", async () => {
+    await writeNote("no-title", "year: 2026");
+    const messages = await violationsFor(DOUBLY_REQUIRED_PROFILE);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/Required field "title" is missing/);
+  });
+});
+
+/** A profile whose `notes` type declares an `owner` field of type `slug`. */
+const SLUG_FIELD_PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "slug-field",
+  entities: { notes: { directory: "wiki/notes", fields: { owner: { type: "slug" } } } },
+};
+
+describe("checkFieldContract — slug type validates slug-safety", () => {
+  it("accepts a slug-safe owner value with no problems", async () => {
+    await writeNote("ok", 'owner: "ok-slug"');
+    expect(await violationsFor(SLUG_FIELD_PROFILE)).toEqual([]);
+  });
+
+  it.each([["Bad Slug!"], ["UPPER"], [" leading"]])(
+    "flags a non-slug-safe owner value %j as a field-violation",
+    async (value) => {
+      await writeNote("bad", `owner: ${JSON.stringify(value)}`);
+      const messages = await violationsFor(SLUG_FIELD_PROFILE);
+      expect(messages).toEqual([expect.stringMatching(/"owner".*not a valid slug/)]);
+    },
+  );
+});
+
 describe("collectEntitySummary — count-only, no bodies retained", () => {
   it("rejects the default profile (programming-error guard)", async () => {
     await expect(collectEntitySummary(root, DEFAULT_PROFILE)).rejects.toBeInstanceOf(EntityCollectError);

--- a/test/profile-lint.test.ts
+++ b/test/profile-lint.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @file test/profile-lint.test.ts
+ * @description Tests for profile-aware lint over non-default entity pages.
+ *
+ * Covers: (a) a NON-default project surfaces a `LintResult` (correct severity)
+ * for each EntityProblem kind — invalid-directory, non-slug-safe-filename,
+ * field-violation — plus an `empty-page` warning over an entity page's body;
+ * (b) a DEFAULT project's `lint(root)` is unchanged (no profile findings, no
+ * `entityType` on any result), proving the default path stays byte-identical.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, symlink } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { lint } from "../src/linter/index.js";
+import { CONCEPTS_DIR, PROFILE_FILE } from "../src/utils/constants.js";
+import type { ProfilePack } from "../src/profile/types.js";
+
+let root = "";
+
+/**
+ * A non-default profile: `notes` requires a `title` field and lives at
+ * wiki/notes; `tasks` lives at wiki/tasks (used as the symlinked-dir victim).
+ */
+const PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "sample",
+  entities: {
+    notes: {
+      directory: "wiki/notes",
+      requiredFields: ["title"],
+      fields: { title: { type: "string" } },
+    },
+    tasks: { directory: "wiki/tasks" },
+  },
+};
+
+/** Write the profile.json into the project's .llmwiki/ dir. */
+async function writeProfile(pack: ProfilePack): Promise<void> {
+  await mkdir(path.join(root, path.dirname(PROFILE_FILE)), { recursive: true });
+  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(pack));
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "profile-lint-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+/** Find the lone result for a given rule id; assert exactly one exists. */
+function ruleResult(results: { rule: string }[], rule: string): { severity: string; entityType?: string } {
+  const matches = results.filter((r) => r.rule === rule);
+  expect(matches).toHaveLength(1);
+  return matches[0] as { severity: string; entityType?: string };
+}
+
+describe("lint — non-default profile entity findings", () => {
+  beforeEach(async () => {
+    await mkdir(path.join(root, "wiki/notes"), { recursive: true });
+    // (a) symlinked entity dir for `tasks` → invalid-directory (error).
+    const elsewhere = path.join(root, "elsewhere");
+    await mkdir(elsewhere, { recursive: true });
+    await symlink(elsewhere, path.join(root, "wiki/tasks"));
+    // (b) non-slug-safe filename → non-slug-safe-filename (error).
+    await writeFile(path.join(root, "wiki/notes/Bad Name.md"), "---\ntitle: T\n---\n\nbody body body body body body body body.\n");
+    // (c) field-contract violation: missing required `title` → field-violation (warning).
+    await writeFile(path.join(root, "wiki/notes/no-title.md"), "# no-title\n\nbody body body body body body body body.\n");
+    // (d) empty entity page (titled, near-empty body) → empty-page (warning).
+    await writeFile(path.join(root, "wiki/notes/sparse.md"), "---\ntitle: Sparse\n---\n\nhi\n");
+    await writeProfile(PROFILE);
+  });
+
+  it("surfaces an error for each structural EntityProblem kind", async () => {
+    const { results } = await lint(root);
+    expect(ruleResult(results, "profile/invalid-directory").severity).toBe("error");
+    expect(ruleResult(results, "profile/non-slug-safe-filename").severity).toBe("error");
+  });
+
+  it("surfaces field-violation and empty-page as warnings, tagged by entityType", async () => {
+    const { results } = await lint(root);
+    const fieldViolation = ruleResult(results, "profile/field-violation");
+    expect(fieldViolation.severity).toBe("warning");
+    expect(fieldViolation.entityType).toBe("notes");
+    const empty = ruleResult(results, "empty-page");
+    expect(empty.severity).toBe("warning");
+    expect(empty.entityType).toBe("notes");
+  });
+});
+
+describe("lint — default project unchanged", () => {
+  it("emits no profile findings and no entityType on any result", async () => {
+    const concepts = path.join(root, CONCEPTS_DIR);
+    await mkdir(concepts, { recursive: true });
+    await writeFile(path.join(concepts, "foo.md"), "---\ntitle: Foo\n---\n\nbody body body body body body body body.\n");
+    const { results } = await lint(root);
+    expect(results.some((r) => r.rule.startsWith("profile/"))).toBe(false);
+    expect(results.every((r) => r.entityType === undefined)).toBe(true);
+  });
+});

--- a/test/profile-listpages-pagination.test.ts
+++ b/test/profile-listpages-pagination.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @file test/profile-listpages-pagination.test.ts
+ * @description Tests for the BOUNDED, independently-paginated entity section of
+ * the additive `profile` block on `listPages` (audit fix M1).
+ *
+ * Covers: a non-default project with more entity pages than `limit` returns at
+ * most `limit` `entityPages`, the full `profile.total`, and an opaque
+ * `profile.cursor`; passing that cursor as `profileCursor` returns the next
+ * batch; the final batch carries no `cursor`; the window is sorted by `id`
+ * (stable across calls); `includeBody` is still honored; and a DEFAULT project
+ * still has no `profile` block at all.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { listPages } from "../src/pages/list.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import {
+  writeMarkdownPage,
+  seedManyNotesProject,
+} from "./fixtures/profile-fixtures.js";
+
+let root = "";
+const TOTAL_NOTES = 5;
+const PAGE_LIMIT = 2;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "profile-listpages-pg-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("listPages entity section — default profile", () => {
+  it("has no profile block regardless of limit", async () => {
+    await writeMarkdownPage(root, CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody.");
+    const result = await listPages(root, { limit: PAGE_LIMIT });
+    expect(result.profile).toBeUndefined();
+  });
+});
+
+describe("listPages entity section — bounded + paginated", () => {
+  beforeEach(async () => {
+    await seedManyNotesProject(root, TOTAL_NOTES);
+  });
+
+  it("returns at most `limit` entity pages with total and a cursor", async () => {
+    const result = await listPages(root, { limit: PAGE_LIMIT });
+    expect(result.profile?.entityPages).toHaveLength(PAGE_LIMIT);
+    expect(result.profile?.total).toBe(TOTAL_NOTES);
+    expect(result.profile?.cursor).toBeDefined();
+  });
+
+  it("walks every page via profileCursor, sorted by id, last batch has no cursor", async () => {
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const result = await listPages(root, { limit: PAGE_LIMIT, profileCursor: cursor });
+      expect(result.profile!.entityPages.length).toBeLessThanOrEqual(PAGE_LIMIT);
+      for (const p of result.profile!.entityPages) seen.push(p.id);
+      cursor = result.profile!.cursor;
+    } while (cursor !== undefined);
+    expect(seen).toHaveLength(TOTAL_NOTES);
+    expect(seen).toEqual([...seen].sort());
+  });
+
+  it("honors includeBody on the windowed entity pages", async () => {
+    const withBody = await listPages(root, { limit: PAGE_LIMIT, includeBody: true });
+    const withoutBody = await listPages(root, { limit: PAGE_LIMIT, includeBody: false });
+    expect(typeof withBody.profile!.entityPages[0].body).toBe("string");
+    expect("body" in withoutBody.profile!.entityPages[0]).toBe(false);
+  });
+
+  it("is not re-sliced by the legacy pages cursor", async () => {
+    const first = await listPages(root, { limit: PAGE_LIMIT });
+    const firstIds = first.profile!.entityPages.map((p) => p.id);
+    // A legacy `cursor` paginates `pages` only; the entity window must be stable.
+    const withLegacyCursor = await listPages(root, { limit: PAGE_LIMIT, cursor: "0" });
+    expect(withLegacyCursor.profile!.entityPages.map((p) => p.id)).toEqual(firstIds);
+  });
+});

--- a/test/profile-listpages-pagination.test.ts
+++ b/test/profile-listpages-pagination.test.ts
@@ -20,6 +20,7 @@ import { CONCEPTS_DIR } from "../src/utils/constants.js";
 import {
   writeMarkdownPage,
   seedManyNotesProject,
+  seedBrokenNotesProject,
 } from "./fixtures/profile-fixtures.js";
 
 let root = "";
@@ -80,5 +81,37 @@ describe("listPages entity section — bounded + paginated", () => {
     // A legacy `cursor` paginates `pages` only; the entity window must be stable.
     const withLegacyCursor = await listPages(root, { limit: PAGE_LIMIT, cursor: "0" });
     expect(withLegacyCursor.profile!.entityPages.map((p) => p.id)).toEqual(firstIds);
+  });
+});
+
+describe("listPages problems — bounded by limit with own problemCursor", () => {
+  beforeEach(async () => {
+    await seedBrokenNotesProject(root, TOTAL_NOTES);
+  });
+
+  it("returns at most `limit` problems with the full problemTotal and a problemCursor", async () => {
+    const result = await listPages(root, { limit: PAGE_LIMIT });
+    expect(result.profile!.problems!.length).toBeLessThanOrEqual(PAGE_LIMIT);
+    expect(result.profile!.problemTotal).toBe(TOTAL_NOTES);
+    expect(result.profile!.problemCursor).toBeDefined();
+  });
+
+  it("walks every problem via problemCursor, last batch has no problemCursor", async () => {
+    let seen = 0;
+    let problemCursor: string | undefined;
+    do {
+      const result = await listPages(root, { limit: PAGE_LIMIT, problemCursor });
+      seen += result.profile!.problems!.length;
+      problemCursor = result.profile!.problemCursor;
+    } while (problemCursor !== undefined);
+    expect(seen).toBe(TOTAL_NOTES);
+  });
+
+  it("paginates problems independently of the entity-page window", async () => {
+    const result = await listPages(root, { limit: PAGE_LIMIT, profileCursor: "4" });
+    // entity window is exhausted (offset 4 of 5) but problems restart at offset 0.
+    expect(result.profile!.entityPages).toHaveLength(1);
+    expect(result.profile!.problems!.length).toBe(PAGE_LIMIT);
+    expect(result.profile!.problemTotal).toBe(TOTAL_NOTES);
   });
 });

--- a/test/profile-listpages.test.ts
+++ b/test/profile-listpages.test.ts
@@ -9,39 +9,18 @@
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { listPages } from "../src/pages/list.js";
-import { CONCEPTS_DIR, PROFILE_FILE } from "../src/utils/constants.js";
-import type { ProfilePack } from "../src/profile/types.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import {
+  writeMarkdownPage,
+  seedSampleNotesProject,
+  expectFirstNotePage,
+} from "./fixtures/profile-fixtures.js";
 
 let root = "";
-
-/** A non-default profile: `notes` requires a `title`, lives at wiki/notes. */
-const PROFILE: ProfilePack = {
-  schemaVersion: 1,
-  profileId: "sample",
-  entities: {
-    notes: {
-      directory: "wiki/notes",
-      requiredFields: ["title"],
-      fields: { title: { type: "string" } },
-    },
-  },
-};
-
-/** Write the profile.json into the project's .llmwiki/ dir. */
-async function writeProfile(pack: ProfilePack): Promise<void> {
-  await mkdir(path.join(root, path.dirname(PROFILE_FILE)), { recursive: true });
-  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(pack));
-}
-
-/** Write a markdown page with the given relative dir, slug, and content. */
-async function writePage(dir: string, slug: string, content: string): Promise<void> {
-  await mkdir(path.join(root, dir), { recursive: true });
-  await writeFile(path.join(root, dir, `${slug}.md`), content);
-}
 
 beforeEach(async () => {
   root = await mkdtemp(path.join(os.tmpdir(), "profile-listpages-"));
@@ -53,7 +32,7 @@ afterEach(async () => {
 
 describe("listPages — default profile", () => {
   it("has no profile block and lists concept pages legacily", async () => {
-    await writePage(CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody alpha.");
+    await writeMarkdownPage(root, CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody alpha.");
     const result = await listPages(root, { includeBody: true });
     expect(result.profile).toBeUndefined();
     expect(result.pages.map((p) => p.slug)).toEqual(["alpha"]);
@@ -63,18 +42,14 @@ describe("listPages — default profile", () => {
 
 describe("listPages — non-default profile", () => {
   beforeEach(async () => {
-    await writeProfile(PROFILE);
-    await writePage("wiki/notes", "first-note", "---\ntitle: First\n---\nNote body.");
+    await seedSampleNotesProject(root);
   });
 
   it("surfaces entity pages with body when includeBody is true", async () => {
     const result = await listPages(root, { includeBody: true });
     expect(result.pages).toHaveLength(0);
     expect(result.profile?.entityPages).toHaveLength(1);
-    const page = result.profile!.entityPages[0];
-    expect(page.entityType).toBe("notes");
-    expect(page.slug).toBe("first-note");
-    expect(page.body).toBe("Note body.");
+    expectFirstNotePage(result.profile!.entityPages[0]);
   });
 
   it("strips entity-page body when includeBody is false", async () => {
@@ -83,7 +58,7 @@ describe("listPages — non-default profile", () => {
   });
 
   it("surfaces collector problems for a contract violation", async () => {
-    await writePage("wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title here.");
+    await writeMarkdownPage(root, "wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title here.");
     const result = await listPages(root, {});
     expect(result.profile?.problems?.length).toBeGreaterThan(0);
     expect(result.profile!.problems!.some((m) => m.includes("title"))).toBe(true);

--- a/test/profile-listpages.test.ts
+++ b/test/profile-listpages.test.ts
@@ -71,6 +71,6 @@ describe("listPages — non-default profile", () => {
     await writeMarkdownPage(root, "wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title here.");
     const result = await listPages(root, {});
     expect(result.profile?.problems?.length).toBeGreaterThan(0);
-    expect(result.profile!.problems!.some((m) => m.includes("title"))).toBe(true);
+    expect(result.profile!.problems!.some((p) => p.message.includes("title"))).toBe(true);
   });
 });

--- a/test/profile-listpages.test.ts
+++ b/test/profile-listpages.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @file test/profile-listpages.test.ts
+ * @description Tests for the additive `profile` entity block on `listPages`.
+ *
+ * Covers: (a) a DEFAULT project's result has NO `profile` key and the legacy
+ * `pages` block reflects only concepts/queries; (b) a NON-default project
+ * surfaces `profile.entityPages` with content, honors `includeBody` (body
+ * present when true, empty when false), and surfaces collector `problems`.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { listPages } from "../src/pages/list.js";
+import { CONCEPTS_DIR, PROFILE_FILE } from "../src/utils/constants.js";
+import type { ProfilePack } from "../src/profile/types.js";
+
+let root = "";
+
+/** A non-default profile: `notes` requires a `title`, lives at wiki/notes. */
+const PROFILE: ProfilePack = {
+  schemaVersion: 1,
+  profileId: "sample",
+  entities: {
+    notes: {
+      directory: "wiki/notes",
+      requiredFields: ["title"],
+      fields: { title: { type: "string" } },
+    },
+  },
+};
+
+/** Write the profile.json into the project's .llmwiki/ dir. */
+async function writeProfile(pack: ProfilePack): Promise<void> {
+  await mkdir(path.join(root, path.dirname(PROFILE_FILE)), { recursive: true });
+  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(pack));
+}
+
+/** Write a markdown page with the given relative dir, slug, and content. */
+async function writePage(dir: string, slug: string, content: string): Promise<void> {
+  await mkdir(path.join(root, dir), { recursive: true });
+  await writeFile(path.join(root, dir, `${slug}.md`), content);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "profile-listpages-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("listPages — default profile", () => {
+  it("has no profile block and lists concept pages legacily", async () => {
+    await writePage(CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody alpha.");
+    const result = await listPages(root, { includeBody: true });
+    expect(result.profile).toBeUndefined();
+    expect(result.pages.map((p) => p.slug)).toEqual(["alpha"]);
+    expect(result.pages[0].body).toBe("Body alpha.");
+  });
+});
+
+describe("listPages — non-default profile", () => {
+  beforeEach(async () => {
+    await writeProfile(PROFILE);
+    await writePage("wiki/notes", "first-note", "---\ntitle: First\n---\nNote body.");
+  });
+
+  it("surfaces entity pages with body when includeBody is true", async () => {
+    const result = await listPages(root, { includeBody: true });
+    expect(result.pages).toHaveLength(0);
+    expect(result.profile?.entityPages).toHaveLength(1);
+    const page = result.profile!.entityPages[0];
+    expect(page.entityType).toBe("notes");
+    expect(page.slug).toBe("first-note");
+    expect(page.body).toBe("Note body.");
+  });
+
+  it("strips entity-page body when includeBody is false", async () => {
+    const result = await listPages(root, { includeBody: false });
+    expect(result.profile?.entityPages[0].body).toBe("");
+  });
+
+  it("surfaces collector problems for a contract violation", async () => {
+    await writePage("wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title here.");
+    const result = await listPages(root, {});
+    expect(result.profile?.problems?.length).toBeGreaterThan(0);
+    expect(result.profile!.problems!.some((m) => m.includes("title"))).toBe(true);
+  });
+});

--- a/test/profile-listpages.test.ts
+++ b/test/profile-listpages.test.ts
@@ -4,8 +4,10 @@
  *
  * Covers: (a) a DEFAULT project's result has NO `profile` key and the legacy
  * `pages` block reflects only concepts/queries; (b) a NON-default project
- * surfaces `profile.entityPages` with content, honors `includeBody` (body
- * present when true, empty when false), and surfaces collector `problems`.
+ * surfaces `profile.entityPages` with content as the public `EntityPageView`
+ * (project-relative `path`, never an absolute `filePath`), honors `includeBody`
+ * (body present when true, OMITTED when false), and surfaces collector
+ * `problems`.
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
@@ -52,9 +54,17 @@ describe("listPages — non-default profile", () => {
     expectFirstNotePage(result.profile!.entityPages[0]);
   });
 
-  it("strips entity-page body when includeBody is false", async () => {
+  it("OMITS entity-page body when includeBody is false", async () => {
     const result = await listPages(root, { includeBody: false });
-    expect(result.profile?.entityPages[0].body).toBe("");
+    const page = result.profile!.entityPages[0];
+    expect("body" in page).toBe(false);
+  });
+
+  it("never leaks an absolute filePath in entity pages", async () => {
+    const result = await listPages(root, { includeBody: true });
+    const json = JSON.stringify(result.profile!.entityPages);
+    expect(json).not.toContain("filePath");
+    expect(json).not.toContain(root);
   });
 
   it("surfaces collector problems for a contract violation", async () => {

--- a/test/profile-status.test.ts
+++ b/test/profile-status.test.ts
@@ -18,6 +18,7 @@ import { mkdtemp, rm, mkdir, writeFile, symlink } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { collectStatus } from "../src/status/collect.js";
+import { PROFILE_PROBLEM_CAP } from "../src/profile/block.js";
 import { PROFILE_FILE, CONCEPTS_DIR, QUERIES_DIR } from "../src/utils/constants.js";
 
 let root = "";
@@ -49,6 +50,13 @@ async function writePage(dir: string, stem: string, withTitle = false): Promise<
   await mkdir(dir, { recursive: true });
   const fm = withTitle ? `---\ntitle: ${stem}\n---\n\n` : "";
   await writeFile(path.join(dir, `${stem}.md`), `${fm}# ${stem}\n`);
+}
+
+/** Make `wiki/notes` a symlink to an out-of-tree dir so the collector flags it invalid. */
+async function symlinkNotesDirOutOfTree(): Promise<void> {
+  await mkdir(path.join(root, "elsewhere"), { recursive: true });
+  await mkdir(path.join(root, "wiki"), { recursive: true });
+  await symlink(path.join(root, "elsewhere"), path.join(root, "wiki/notes"));
 }
 
 beforeEach(async () => {
@@ -101,11 +109,9 @@ describe("collectStatus — non-default profile", () => {
 describe("collectStatus — surfaces non-default problems (never silent)", () => {
   it("reports a symlinked entity dir as a problem instead of a silent 0", async () => {
     await writeProfile(SAMPLE_PROFILE);
-    await mkdir(path.join(root, "elsewhere"), { recursive: true });
-    await mkdir(path.join(root, "wiki"), { recursive: true });
-    await symlink(path.join(root, "elsewhere"), path.join(root, "wiki/notes"));
+    await symlinkNotesDirOutOfTree();
     const result = await collectStatus(root);
-    expect(result.profile?.problems?.some((m) => /invalid/i.test(m))).toBe(true);
+    expect(result.profile?.problems?.some((p) => /invalid/i.test(p.message))).toBe(true);
     expect(result.profile?.entityCounts.notes).toBe(0);
   });
 
@@ -116,5 +122,37 @@ describe("collectStatus — surfaces non-default problems (never silent)", () =>
     const result = await collectStatus(root);
     expect(result.profile?.entityCounts.notes).toBe(1);
     expect(result.profile?.problems).toHaveLength(1);
+  });
+
+  it("caps problems at PROFILE_PROBLEM_CAP while problemTotal reports the full count", async () => {
+    const overCap = PROFILE_PROBLEM_CAP + 5;
+    await writeProfile({ ...SAMPLE_PROFILE, entities: { notes: { directory: "wiki/notes", requiredFields: ["title"], fields: { title: { type: "string" } } } } });
+    await mkdir(path.join(root, "wiki/notes"), { recursive: true });
+    for (let i = 0; i < overCap; i++) {
+      const slug = `n-${String(i).padStart(3, "0")}`;
+      await writeFile(path.join(root, "wiki/notes", `${slug}.md`), `---\nslug: ${slug}\n---\nNo title.`);
+    }
+    const result = await collectStatus(root);
+    expect(result.profile?.problems).toHaveLength(PROFILE_PROBLEM_CAP);
+    expect(result.profile?.problemTotal).toBe(overCap);
+  });
+
+  it("gives field-violation problems a project-relative path (never absolute)", async () => {
+    await writeProfile({ ...SAMPLE_PROFILE, entities: { notes: { directory: "wiki/notes", requiredFields: ["title"], fields: { title: { type: "string" } } } } });
+    await mkdir(path.join(root, "wiki/notes"), { recursive: true });
+    await writeFile(path.join(root, "wiki/notes", "untitled.md"), "---\nslug: untitled\n---\nNo title.");
+    const result = await collectStatus(root);
+    const problem = result.profile!.problems![0];
+    expect(problem.path).toBe("wiki/notes/untitled.md");
+    expect(problem.path?.startsWith("/")).toBe(false);
+  });
+
+  it("omits path on a directory-level (invalid-directory) problem", async () => {
+    await writeProfile(SAMPLE_PROFILE);
+    await symlinkNotesDirOutOfTree();
+    const result = await collectStatus(root);
+    const dirProblem = result.profile!.problems!.find((p) => p.kind === "invalid-directory");
+    expect(dirProblem).toBeDefined();
+    expect("path" in dirProblem!).toBe(false);
   });
 });

--- a/test/profile-substrate.test.ts
+++ b/test/profile-substrate.test.ts
@@ -67,9 +67,9 @@ describe("research-lite substrate — read surfaces agree", () => {
 
   it("collectEntityPages finds the seeded pages", async () => {
     const loaded = await loadProfile(root);
-    const { refs, problems } = await collectEntityPages(root, loaded.profile);
+    const { pages, problems } = await collectEntityPages(root, loaded.profile);
     expect(problems).toEqual([]);
-    const ids = refs.map((r) => r.id).sort();
+    const ids = pages.map((r) => r.id).sort();
     expect(ids).toContain("papers/scaling-laws");
     expect(ids).toContain("ideas/sparse-routing");
     expect(ids).toContain("experiments/ablation-batch-size");

--- a/test/profile-validate.test.ts
+++ b/test/profile-validate.test.ts
@@ -12,8 +12,9 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import path from "path";
 import { describe, it, expect } from "vitest";
-import { validateProfile, ProfileValidationError } from "../src/profile/validate.js";
+import { validateProfile, validateProfileShape, ProfileValidationError } from "../src/profile/validate.js";
 import { ProfilePathError } from "../src/profile/paths.js";
+import { DEFAULT_PROFILE } from "../src/profile/default.js";
 import type { ProfilePack } from "../src/profile/types.js";
 
 /** A minimal valid two-entity profile used as a base for negative cases. */
@@ -89,6 +90,24 @@ describe("validateProfile — directories", () => {
     raw.entities.papers.directory = "wiki/papers/.";
     const result = validateProfile(raw);
     expect(result.profile.entities.papers.directory).toBe("wiki/papers");
+  });
+});
+
+describe("validateProfile — legacy default dirs (disk path only)", () => {
+  it("rejects a disk entity directory of wiki/concepts", () => {
+    const raw = baseProfile();
+    raw.entities.papers.directory = "wiki/concepts";
+    expect(() => validateProfile(raw)).toThrow(/reserved for the default profile/);
+  });
+
+  it("rejects a disk entity directory of wiki/queries (even '.'-padded)", () => {
+    const raw = baseProfile();
+    raw.entities.papers.directory = "wiki/queries/.";
+    expect(() => validateProfile(raw)).toThrow(/reserved for the default profile/);
+  });
+
+  it("still accepts DEFAULT_PROFILE through validateProfileShape", () => {
+    expect(() => validateProfileShape(DEFAULT_PROFILE)).not.toThrow();
   });
 });
 

--- a/test/profile-viewer.test.ts
+++ b/test/profile-viewer.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @file test/profile-viewer.test.ts
+ * @description Tests for the additive `profile` counts/problems block on the
+ * viewer snapshot (NO rendering — counts and problems only).
+ *
+ * Covers: (a) a DEFAULT project's snapshot has NO `profile` key and its legacy
+ * `counts.concepts`/`counts.queries` stay scoped to wiki/concepts + wiki/queries;
+ * (b) a NON-default project surfaces `profile` with profileId, digest, per-type
+ * entity counts, and collector problems — while `counts` stays unchanged and no
+ * entity pages leak into the rendered `pages` list.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { buildViewerSnapshot } from "../src/viewer/snapshot.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import { writeMarkdownPage, seedSampleNotesProject } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "profile-viewer-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("viewer snapshot — default profile", () => {
+  it("has no profile block and counts scoped to concepts/queries", async () => {
+    await writeMarkdownPage(root, CONCEPTS_DIR, "alpha", "---\ntitle: Alpha\n---\nBody.");
+    const snapshot = await buildViewerSnapshot(root);
+    expect(snapshot.profile).toBeUndefined();
+    expect(snapshot.counts.concepts).toBe(1);
+    expect(snapshot.counts.queries).toBe(0);
+  });
+});
+
+describe("viewer snapshot — non-default profile", () => {
+  beforeEach(async () => {
+    await seedSampleNotesProject(root);
+  });
+
+  it("adds a profile block with per-type entity counts and digest", async () => {
+    const snapshot = await buildViewerSnapshot(root);
+    expect(snapshot.profile?.profileId).toBe("sample");
+    expect(typeof snapshot.profile?.digest).toBe("string");
+    expect(snapshot.profile?.entityCounts).toEqual({ notes: 1 });
+  });
+
+  it("leaves legacy counts unchanged and renders no entity pages", async () => {
+    const snapshot = await buildViewerSnapshot(root);
+    expect(snapshot.counts.concepts).toBe(0);
+    expect(snapshot.counts.queries).toBe(0);
+    expect(snapshot.pages).toHaveLength(0);
+  });
+
+  it("surfaces collector problems for a contract violation", async () => {
+    await writeMarkdownPage(root, "wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title.");
+    const snapshot = await buildViewerSnapshot(root);
+    expect(snapshot.profile?.problems?.some((m) => m.includes("title"))).toBe(true);
+  });
+});

--- a/test/profile-viewer.test.ts
+++ b/test/profile-viewer.test.ts
@@ -60,6 +60,6 @@ describe("viewer snapshot — non-default profile", () => {
   it("surfaces collector problems for a contract violation", async () => {
     await writeMarkdownPage(root, "wiki/notes", "no-title", "---\nslug: no-title\n---\nNo title.");
     const snapshot = await buildViewerSnapshot(root);
-    expect(snapshot.profile?.problems?.some((m) => m.includes("title"))).toBe(true);
+    expect(snapshot.profile?.problems?.some((p) => p.message.includes("title"))).toBe(true);
   });
 });

--- a/test/wiki-collect-metadata-only.test.ts
+++ b/test/wiki-collect-metadata-only.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @file test/wiki-collect-metadata-only.test.ts
+ * @description Tests for the bounded frontmatter-only read path of
+ * `scanEntityDir({ includeBody: false })`.
+ *
+ * The metadata-only path must (a) produce `frontmatter`/`parseStatus`
+ * BYTE-IDENTICAL to a full body-reading scan across representative files (with
+ * frontmatter, without, malformed YAML, CRLF, body larger than the cap), so
+ * counts/problems are unchanged whether bodies are read or not; and (b) actually
+ * avoid reading the whole file — a multi-MB body is summarized by reading only a
+ * bounded prefix, never its full size.
+ */
+
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { scanEntityDir } from "../src/wiki/collect.js";
+
+/**
+ * Spy that wraps `fs/promises.open` and tallies the bytes returned by each
+ * `FileHandle.read`, so a test can assert the metadata-only path reads only a
+ * bounded prefix rather than a multi-MB file's full size. Installed via
+ * `vi.mock` because ESM named exports cannot be re-spied in place.
+ */
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      const handle = await actual.open(...args);
+      const originalRead = handle.read.bind(handle);
+      handle.read = (async (...readArgs: unknown[]) => {
+        const result = await (originalRead as (...a: unknown[]) => Promise<{ bytesRead: number }>)(...readArgs);
+        bytesReadViaOpen += result.bytesRead;
+        return result;
+      }) as typeof handle.read;
+      return handle;
+    },
+  };
+});
+
+let bytesReadViaOpen = 0;
+
+let root = "";
+const DIR = "wiki/notes";
+
+/** Write a raw `.md` file (no transformation) under the notes directory. */
+async function writeRaw(name: string, content: string): Promise<void> {
+  await writeFile(path.join(root, DIR, name), content);
+}
+
+/** Scan the notes dir with bodies on/off and return scans sorted by stem. */
+async function scanBoth() {
+  const full = await scanEntityDir(root, DIR, { includeBody: true });
+  const meta = await scanEntityDir(root, DIR, { includeBody: false });
+  const sort = (a: { stem: string }, b: { stem: string }) => a.stem.localeCompare(b.stem);
+  return { full: [...full.scans].sort(sort), meta: [...meta.scans].sort(sort) };
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "wiki-meta-only-"));
+  await mkdir(path.join(root, DIR), { recursive: true });
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("scanEntityDir metadata-only — meta/parseStatus identical to full read", () => {
+  beforeEach(async () => {
+    await writeRaw("with-fm.md", "---\ntitle: Hello\nstatus: open\n---\n# Body\n\nProse here.\n");
+    await writeRaw("no-fm.md", "# Just a body\n\nNo frontmatter at all.\n");
+    await writeRaw("malformed.md", "---\ntitle: [unclosed\n---\nbody\n");
+    await writeRaw("crlf.md", "---\r\ntitle: CRLF\r\n---\r\nbody line\r\n");
+    await writeRaw("big-body.md", `---\ntitle: Big\n---\n${"x".repeat(200 * 1024)}\n`);
+  });
+
+  it("produces identical frontmatter and parseStatus for every representative file", async () => {
+    const { full, meta } = await scanBoth();
+    expect(meta.map((s) => s.stem)).toEqual(full.map((s) => s.stem));
+    for (let i = 0; i < full.length; i += 1) {
+      expect(meta[i].frontmatter).toEqual(full[i].frontmatter);
+      expect(meta[i].parseStatus).toEqual(full[i].parseStatus);
+    }
+  });
+
+  it("drops the body on the metadata-only path while the full path keeps it", async () => {
+    const { full, meta } = await scanBoth();
+    expect(meta.every((s) => s.body === "")).toBe(true);
+    expect(full.find((s) => s.stem === "with-fm")?.body).toContain("Prose here.");
+  });
+});
+
+describe("scanEntityDir metadata-only — bounded prefix avoids full-body I/O", () => {
+  it("reads far fewer than a multi-MB file's full size when summarizing", async () => {
+    const bodyBytes = 4 * 1024 * 1024;
+    await writeRaw("huge.md", `---\ntitle: Huge\n---\n${"y".repeat(bodyBytes)}\n`);
+    bytesReadViaOpen = 0;
+    const { scans } = await scanEntityDir(root, DIR, { includeBody: false });
+    expect(scans).toHaveLength(1);
+    expect(scans[0].body).toBe("");
+    expect(scans[0].frontmatter).toEqual({ title: "Huge" });
+    // The bounded prefix (<= 64 KiB) is a tiny fraction of the 4 MiB file.
+    expect(bytesReadViaOpen).toBeLessThanOrEqual(64 * 1024);
+    expect(bytesReadViaOpen).toBeLessThan(bodyBytes);
+  });
+
+  it("falls back to a full read when frontmatter closes beyond the prefix cap", async () => {
+    const padding = "  - item\n".repeat(20 * 1024); // pushes the closing fence past 64 KiB
+    await writeRaw("late-fence.md", `---\ntitle: Late\nitems:\n${padding}---\nbody\n`);
+    const full = await scanEntityDir(root, DIR, { includeBody: true });
+    const meta = await scanEntityDir(root, DIR, { includeBody: false });
+    expect(meta.scans[0].frontmatter).toEqual(full.scans[0].frontmatter);
+    expect(meta.scans[0].parseStatus).toEqual(full.scans[0].parseStatus);
+    expect(meta.scans[0].frontmatter.title).toBe("Late");
+  });
+});

--- a/test/wiki-collect-metadata-only.test.ts
+++ b/test/wiki-collect-metadata-only.test.ts
@@ -116,4 +116,18 @@ describe("scanEntityDir metadata-only — bounded prefix avoids full-body I/O", 
     expect(meta.scans[0].parseStatus).toEqual(full.scans[0].parseStatus);
     expect(meta.scans[0].frontmatter.title).toBe("Late");
   });
+
+  it("summarizes a large NO-leading-frontmatter file reading only the bounded prefix", async () => {
+    const bodyBytes = 2 * 1024 * 1024;
+    await writeRaw("no-leading-fm.md", `# Heading\n\n${"z".repeat(bodyBytes)}\n`);
+    bytesReadViaOpen = 0;
+    const full = await scanEntityDir(root, DIR, { includeBody: true });
+    const meta = await scanEntityDir(root, DIR, { includeBody: false });
+    // Decisive: a file not opening with a fence never triggers the full read.
+    expect(bytesReadViaOpen).toBeLessThanOrEqual(64 * 1024);
+    expect(bytesReadViaOpen).toBeLessThan(bodyBytes);
+    expect(meta.scans[0].frontmatter).toEqual(full.scans[0].frontmatter);
+    expect(meta.scans[0].parseStatus).toEqual(full.scans[0].parseStatus);
+    expect(meta.scans[0].parseStatus.hasFrontmatterBlock).toBe(false);
+  });
 });

--- a/test/wiki-collect.test.ts
+++ b/test/wiki-collect.test.ts
@@ -13,7 +13,7 @@ import path from "path";
 import { makeTempRoot } from "./fixtures/temp-root.js";
 import { writePage } from "./fixtures/write-page.js";
 import { makeOutsideDir } from "./fixtures/outside-dir.js";
-import { collectRawWikiPages, extractWikilinkSlugs, extractWikilinkTargets } from "../src/wiki/collect.js";
+import { collectRawWikiPages, scanEntityDir, extractWikilinkSlugs, extractWikilinkTargets } from "../src/wiki/collect.js";
 
 describe("collectRawWikiPages", () => {
   it("collects pages from concepts and queries directories", async () => {
@@ -159,6 +159,25 @@ async function assertConceptSlugDropped(root: string, droppedSlug: string): Prom
   expect(slugs).toContain("ok");
   expect(slugs).not.toContain(droppedSlug);
 }
+
+describe("scanEntityDir — includeBody option", () => {
+  it("retains the body by default and parses frontmatter", async () => {
+    const root = await makeTempRoot("scan-default-body");
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha" }, "Hello body.");
+    const { scans } = await scanEntityDir(root, "wiki/concepts");
+    expect(scans[0].body).toContain("Hello body.");
+    expect(scans[0].frontmatter.title).toBe("Alpha");
+  });
+
+  it("drops the body but keeps frontmatter when includeBody is false", async () => {
+    const root = await makeTempRoot("scan-no-body");
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha" }, "Hello body.");
+    const { scans } = await scanEntityDir(root, "wiki/concepts", { includeBody: false });
+    expect(scans[0].body).toBe("");
+    expect(scans[0].frontmatter.title).toBe("Alpha");
+    expect(scans[0].parseStatus.hasTitle).toBe(true);
+  });
+});
 
 describe("extractWikilinkSlugs", () => {
   it("returns deduplicated slugified targets", () => {


### PR DESCRIPTION
## What
Makes the programmatic read surfaces aware of non-default profile entity pages, additively, with **default output byte-identical**. No write paths.

Targets the `feature/configurable-profiles` integration branch (not `main`). Builds on the merged Phase 0/1 substrate.

## Delivered
- A content-bearing **`EntityPage`** model (identity + frontmatter/body) and a collector that carries page content (the legacy `PageDirectory`/`ExportPage`/`Page` model is deliberately left narrow — a distinct typed model is used for non-default entities instead of widening anything).
- **`lint`** surfaces non-default entity issues (invalid/symlinked directories, non-slug-safe filenames, slug mismatches, field-contract violations) plus a conservative set of profile-safe content checks over entity pages.
- SDK **`listPages`** and **JSON export** return non-default entity pages with content in an additive `profile` block (honoring `includeBody`).
- The **viewer snapshot** gains a profile counts/problems block mirroring `status` (no page rendering, routes, or navigation yet).

## Guarantees
- Every addition is an **omitted-for-default** block — the default `listPages`/`exportJson`/`viewer.snapshot`/`lint` output is byte-identical (the frozen parity goldens are untouched).
- The legacy two-directory contract is unchanged; entity content flows only through the new typed model.
- 1791 tests pass; type-check, build, and duplication checks clean.

## Not in this slice
Viewer page rendering / routes / navigation, non-JSON export formats (llms.txt, Marp, OKF, GraphML) for custom entity types, and any write path — deferred to later phases.