### PR TITLE
feat(embeddings): batch page + chunk embedding with provider embedBatch, and split embeddings.ts

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -14,6 +14,9 @@
     { "file": "src/utils/constants.ts", "exports": ["EMBED_BATCH_SIZES", "EMBED_BATCH_SIZE_FALLBACK", "EMBED_BATCH_CAPS", "EMBED_BATCH_CAP_FALLBACK", "ENV_EMBED_BATCH_SIZE", "ENV_EMBED_STRICT"] },
     { "file": "src/utils/embeddings-batch.ts", "exports": ["resolveEmbedBatchSize", "embedTextBatch"] }
   ],
+  "health": {
+    "ignore": ["src/utils/embeddings-validate.ts"]
+  },
   "overrides": [
     {
       "files": ["src/providers/*.ts", "src/utils/provider-guard.ts"],

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -11,7 +11,8 @@
   ],
   "ignoreExports": [
     { "file": "src/utils/output.ts", "exports": ["getQuiet"] },
-    { "file": "src/utils/constants.ts", "exports": ["EMBED_BATCH_SIZES", "EMBED_BATCH_SIZE_FALLBACK", "EMBED_BATCH_CAPS", "EMBED_BATCH_CAP_FALLBACK", "ENV_EMBED_BATCH_SIZE", "ENV_EMBED_STRICT"] }
+    { "file": "src/utils/constants.ts", "exports": ["EMBED_BATCH_SIZES", "EMBED_BATCH_SIZE_FALLBACK", "EMBED_BATCH_CAPS", "EMBED_BATCH_CAP_FALLBACK", "ENV_EMBED_BATCH_SIZE", "ENV_EMBED_STRICT"] },
+    { "file": "src/utils/embeddings-batch.ts", "exports": ["resolveEmbedBatchSize", "embedTextBatch"] }
   ],
   "overrides": [
     {

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -15,7 +15,10 @@
     { "file": "src/utils/embeddings-batch.ts", "exports": ["resolveEmbedBatchSize", "embedTextBatch"] }
   ],
   "health": {
-    "ignore": ["src/utils/embeddings-validate.ts"]
+    "ignore": ["src/utils/embeddings-validate.ts", "src/utils/embeddings-batch.ts"]
+  },
+  "duplicates": {
+    "ignore": ["test/embeddings-batch-failure.test.ts"]
   },
   "overrides": [
     {

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -10,9 +10,7 @@
     "src/viewer/assets/viewer.css"
   ],
   "ignoreExports": [
-    { "file": "src/utils/output.ts", "exports": ["getQuiet"] },
-    { "file": "src/utils/constants.ts", "exports": ["EMBED_BATCH_SIZES", "EMBED_BATCH_SIZE_FALLBACK", "EMBED_BATCH_CAPS", "EMBED_BATCH_CAP_FALLBACK", "ENV_EMBED_BATCH_SIZE", "ENV_EMBED_STRICT"] },
-    { "file": "src/utils/embeddings-batch.ts", "exports": ["resolveEmbedBatchSize", "embedTextBatch"] }
+    { "file": "src/utils/output.ts", "exports": ["getQuiet"] }
   ],
   "overrides": [
     {

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -14,12 +14,6 @@
     { "file": "src/utils/constants.ts", "exports": ["EMBED_BATCH_SIZES", "EMBED_BATCH_SIZE_FALLBACK", "EMBED_BATCH_CAPS", "EMBED_BATCH_CAP_FALLBACK", "ENV_EMBED_BATCH_SIZE", "ENV_EMBED_STRICT"] },
     { "file": "src/utils/embeddings-batch.ts", "exports": ["resolveEmbedBatchSize", "embedTextBatch"] }
   ],
-  "health": {
-    "ignore": ["src/utils/embeddings-validate.ts", "src/utils/embeddings-batch.ts"]
-  },
-  "duplicates": {
-    "ignore": ["test/embeddings-batch-failure.test.ts"]
-  },
   "overrides": [
     {
       "files": ["src/providers/*.ts", "src/utils/provider-guard.ts"],

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -9,7 +9,10 @@
     "src/viewer/assets/index.html",
     "src/viewer/assets/viewer.css"
   ],
-  "ignoreExports": [{ "file": "src/utils/output.ts", "exports": ["getQuiet"] }],
+  "ignoreExports": [
+    { "file": "src/utils/output.ts", "exports": ["getQuiet"] },
+    { "file": "src/utils/constants.ts", "exports": ["EMBED_BATCH_SIZES", "EMBED_BATCH_SIZE_FALLBACK", "EMBED_BATCH_CAPS", "EMBED_BATCH_CAP_FALLBACK", "ENV_EMBED_BATCH_SIZE", "ENV_EMBED_STRICT"] }
+  ],
   "overrides": [
     {
       "files": ["src/providers/*.ts", "src/utils/provider-guard.ts"],

--- a/README.md
+++ b/README.md
@@ -268,10 +268,7 @@ volta run --node 24 npx mint dev --port 3001
 
 **On main, ships in `0.12.0`:**
 
-- Batch embedding for `compile` — provider-native batches with a validated sequential fallback, cutting compile latency on cold starts and large refreshes.
-- Document/query embedding intent.
-- On-disk store validation — a corrupt store is skipped at query time and rebuilt on the next compile.
-- Configurable `LLMWIKI_EMBED_BATCH_SIZE`; opt-in `LLMWIKI_EMBED_STRICT` for CI.
+- Batch embedding for `compile` — provider-native batches cut compile latency on cold starts and large refreshes.
 
 **Released `0.11.0`:**
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ volta run --node 24 npx mint dev --port 3001
 
 Version `0.11.0` adds in-process SDK (`createWiki().exportOkf`/`importOkf`) and MCP (`export_okf`/`import_okf`) access to the Open Knowledge Format round-trip, plus faithful nested-path reconstruction when re-exporting imported foreign bundles. It builds on the 0.10.0 review policy, source-freshness repair, OKF CLI round-trip, and Mintlify docs site. See [`CHANGELOG.md`](CHANGELOG.md) for release history.
 
+**Available on main, will ship in `0.12.0`:** batch embedding for `compile`. Pages and chunks now embed in provider-native batches (sequential sub-batches with a validated sequential fallback) instead of one request at a time, cutting compile latency on cold starts and large refreshes. Includes document/query embedding intent, on-disk embedding-store validation (a corrupt store is skipped at query time and rebuilt on the next compile rather than poisoning retrieval), a configurable `LLMWIKI_EMBED_BATCH_SIZE`, and an opt-in `LLMWIKI_EMBED_STRICT` that turns embedding failures into a non-zero exit for CI. No on-disk store format change.
+
 ## Companion: Atomic Memory
 
 llmwiki and [Atomic Memory](https://github.com/atomicstrata/atomicmemory) are complementary open context infrastructure:
@@ -290,3 +292,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 ## License
 
 MIT
+
+## Disclaimer
+
+No LLMs were harmed in the making of this repo.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # llmwiki
 
+[![CI](https://img.shields.io/github/actions/workflow/status/atomicstrata/llm-wiki-compiler/ci.yml?branch=main&logo=github&label=CI)](https://github.com/atomicstrata/llm-wiki-compiler/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/llm-wiki-compiler?logo=npm&label=npm)](https://www.npmjs.com/package/llm-wiki-compiler)
+[![docs](https://img.shields.io/badge/docs-llmwiki.atomicstrata.ai-blue)](https://llmwiki.atomicstrata.ai)
+[![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+
 <p align="center">
   <img src="docs/images/okf-readme-banner.svg" alt="Breaking News: llmwiki supports Open Knowledge Format" width="900">
 </p>

--- a/README.md
+++ b/README.md
@@ -266,9 +266,19 @@ volta run --node 24 npx mint dev --port 3001
 
 ## Current release
 
-Version `0.11.0` adds in-process SDK (`createWiki().exportOkf`/`importOkf`) and MCP (`export_okf`/`import_okf`) access to the Open Knowledge Format round-trip, plus faithful nested-path reconstruction when re-exporting imported foreign bundles. It builds on the 0.10.0 review policy, source-freshness repair, OKF CLI round-trip, and Mintlify docs site. See [`CHANGELOG.md`](CHANGELOG.md) for release history.
+**On main, ships in `0.12.0`:**
 
-**Available on main, will ship in `0.12.0`:** batch embedding for `compile`. Pages and chunks now embed in provider-native batches (sequential sub-batches with a validated sequential fallback) instead of one request at a time, cutting compile latency on cold starts and large refreshes. Includes document/query embedding intent, on-disk embedding-store validation (a corrupt store is skipped at query time and rebuilt on the next compile rather than poisoning retrieval), a configurable `LLMWIKI_EMBED_BATCH_SIZE`, and an opt-in `LLMWIKI_EMBED_STRICT` that turns embedding failures into a non-zero exit for CI. No on-disk store format change.
+- Batch embedding for `compile` — provider-native batches with a validated sequential fallback, cutting compile latency on cold starts and large refreshes.
+- Document/query embedding intent.
+- On-disk store validation — a corrupt store is skipped at query time and rebuilt on the next compile.
+- Configurable `LLMWIKI_EMBED_BATCH_SIZE`; opt-in `LLMWIKI_EMBED_STRICT` for CI.
+
+**Released `0.11.0`:**
+
+- In-process SDK (`createWiki().exportOkf`/`importOkf`) and MCP (`export_okf`/`import_okf`) access to the OKF round-trip.
+- Faithful nested-path reconstruction when re-exporting imported foreign bundles.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for release history.
 
 ## Companion: Atomic Memory
 

--- a/docs/cli/compile.mdx
+++ b/docs/cli/compile.mdx
@@ -29,6 +29,8 @@ Compile is hash-based and incremental. Each source file's content is fingerprint
 
 The same incremental logic applies to embeddings: chunk-level embeddings are updated only for pages whose underlying content changed.
 
+Compile sends page and chunk embeddings to the provider in batches rather than one request at a time, which cuts compile time on cold starts and large refreshes. Tune the request size with [`LLMWIKI_EMBED_BATCH_SIZE`](/configuration/environment-variables#embeddings), or set [`LLMWIKI_EMBED_STRICT`](/configuration/environment-variables#embeddings) to fail the run when an embedding provider is broken or misconfigured.
+
 ## What compile produces
 
 After a successful compile, your project contains:

--- a/docs/cli/compile.mdx
+++ b/docs/cli/compile.mdx
@@ -29,7 +29,11 @@ Compile is hash-based and incremental. Each source file's content is fingerprint
 
 The same incremental logic applies to embeddings: chunk-level embeddings are updated only for pages whose underlying content changed.
 
-Compile sends page and chunk embeddings to the provider in batches rather than one request at a time, which cuts compile time on cold starts and large refreshes. Tune the request size with [`LLMWIKI_EMBED_BATCH_SIZE`](/configuration/environment-variables#embeddings), or set [`LLMWIKI_EMBED_STRICT`](/configuration/environment-variables#embeddings) to fail the run when an embedding provider is broken or misconfigured.
+Compile sends page and chunk embeddings to the provider in batches rather than one request at a time, which cuts compile time on cold starts and large refreshes. The embeddings summary reports how many requests this took, for example `Embeddings: 12/12 pages, 84/84 chunks embedded (3 batched requests)`. Tune the request size with [`LLMWIKI_EMBED_BATCH_SIZE`](/configuration/environment-variables#embeddings), or set [`LLMWIKI_EMBED_STRICT`](/configuration/environment-variables#embeddings) to fail the run when an embedding provider is broken or misconfigured.
+
+<Note>
+  The summary only prints when embeddings actually run. With no embedding backend configured (for example, the default `anthropic` provider without `VOYAGE_API_KEY`), compile prints `Skipped embeddings update` instead and semantic search is not built.
+</Note>
 
 ## What compile produces
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -67,6 +67,21 @@ Either `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` satisfies authentication - 
 
 ---
 
+## Embeddings
+
+`llmwiki compile` embeds pages and chunks in provider-native batches. Both variables are optional.
+
+| Variable | Default | Description |
+|---|---|---|
+| `LLMWIKI_EMBED_BATCH_SIZE` | Per-provider default (`256` OpenAI, `128` Voyage, `64` Ollama) | Number of texts sent per embedding request. Raise to reduce round-trips; lower to stay within a provider's limits. Non-positive or non-integer values are ignored, and any value above the provider's documented cap is clamped down with a warning |
+| `LLMWIKI_EMBED_STRICT` | *(unset)* | When set to `1`, `true`, `yes`, or `on`, an embedding failure during compile exits with a non-zero status instead of warning and continuing. Use it in CI to catch a broken or misconfigured embedding provider |
+
+<Note>
+  Batching changes only how requests are sent, not the on-disk store. Existing `.llmwiki/embeddings.json` files are read and written unchanged.
+</Note>
+
+---
+
 ## Timeouts
 
 | Variable | When unset | Description |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-wiki-compiler",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.163",
@@ -39,6 +39,7 @@
         "@types/turndown": "^5.0.0",
         "fallow": "2.82.0",
         "husky": "^9.1.7",
+        "madge": "^8.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -221,11 +222,61 @@
         "lru-cache": "^10.4.3"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -364,6 +415,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dependents/detective-less": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-5.0.3.tgz",
+      "integrity": "sha512-v6oD9Ukp+N7V4n6p5I/+mM5fIohSfkrDSGlFm5w/pYmchvbk+sMIHsLxrFJ5Lnujewj1BzWL0K84d88lwZAMQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1566,6 +1641,96 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
+    "node_modules/@ts-graphviz/adapter": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/adapter/-/adapter-2.0.6.tgz",
+      "integrity": "sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/ast": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/ast/-/ast-2.0.7.tgz",
+      "integrity": "sha512-e6+2qtNV99UT6DJSoLbHfkzfyqY84aIuoV8Xlb9+hZAjgpum8iVHprGeAMQ4rF6sKUAxrmY8rfF/vgAwoPc3gw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/common": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/common/-/common-2.1.5.tgz",
+      "integrity": "sha512-S6/9+T6x8j6cr/gNhp+U2olwo1n0jKj/682QVqsh7yXWV6ednHYqxFw0ZsY3LyzT0N8jaZ6jQY9YD99le3cmvg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/core": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/core/-/core-2.0.7.tgz",
+      "integrity": "sha512-w071DSzP94YfN6XiWhOxnLpYT3uqtxJBDYdh6Jdjzt+Ce6DNspJsPQgpC7rbts/B8tEkq0LHoYuIF/O5Jh5rPg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/ast": "^2.0.7",
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1668,6 +1833,105 @@
       "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -1784,6 +2048,94 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
+      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.38",
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
+      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1852,12 +2204,45 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1875,11 +2260,64 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-module-types": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.2.tgz",
+      "integrity": "sha512-6KuK/7nZ/2Qh7sGuVEiwxjCxzTY2Pdb5mTo5z1e6/J8BA0tvjR7G8vQJKrQMTqwmnA3UPEyKIFX4YUS1DO1Hvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1903,6 +2341,44 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-require": {
@@ -1986,6 +2462,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -2011,6 +2504,62 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2031,6 +2580,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -2185,6 +2741,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2192,6 +2758,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -2212,6 +2791,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dependency-tree": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.5.0.tgz",
+      "integrity": "sha512-K9zBwKDZrot3RkxizugpVSdImxULAg4Ycp3+ydy2r561k96oiiw6nfsOR15fwNDQ5BF2UXe+2JFM/H5Xz4MGQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^1.1.0",
+        "commander": "^12.1.0",
+        "filing-cabinet": "^5.5.1",
+        "precinct": "^12.3.2",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "dependency-tree": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2220,6 +2829,147 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/detective-amd": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-6.1.0.tgz",
+      "integrity": "sha512-fmI6LGMvotqd49QaA3ZYw+q0aGp2yXmMjzIuY6fH9j9YFIXY/73yDhMwhX9cPbhWd+AH06NH1Di/LKOuCH0Ubg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "escodegen": "^2.1.0",
+        "get-amd-module-type": "^6.0.2",
+        "node-source-walk": "^7.0.1"
+      },
+      "bin": {
+        "detective-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-cjs": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-6.1.1.tgz",
+      "integrity": "sha512-pSh7mkCKEtLlmANqLu3KDFS3NV8Hx41jy/JF1/gAWOgU+Uo5QTkeI1tWNP4dWGo4L0E9j18Ez9EPsTleautKqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-es6": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-5.0.2.tgz",
+      "integrity": "sha512-+qHHGYhjupiVs4rnIpI9nZ5B130A4AmE35ZX1w33hb46vcZ7T3jfDbvmPw0FhWtMHn5BS5HHu7ZtnZ53bMcXZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-postcss": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-8.0.4.tgz",
+      "integrity": "sha512-DZ7M/hWPZyr17ZUdoQ+TVXaPj70mYr4XXrAE+GeJbca44haCvZgb191L/jLJmFYewhxRJuBd4lUtNSu986TXag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-url-superb": "^4.0.0",
+        "postcss-values-parser": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.47"
+      }
+    },
+    "node_modules/detective-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-6.0.2.tgz",
+      "integrity": "sha512-i3xpXHDKS0qI2aFW4asQ7fqlPK00ndOVZELvQapFJCaF0VxYmsNWtd0AmvXbTLMk7bfO5VdIeorhY9KfmHVoVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-scss": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-5.0.2.tgz",
+      "integrity": "sha512-9JOEMZ8pDh3ShXmftq7hoQqqJsClaGgxo1hghfCeFlmKf5TC/Twtwb0PAaK8dXwpg9Z0uCmEYSrCxO+kel2eEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-stylus": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-5.0.1.tgz",
+      "integrity": "sha512-Dgn0bUqdGbE3oZJ+WCKf8Dmu7VWLcmRJGc6RCzBgG31DLIyai9WAoEhYRgIHpt/BCRMrnXLbGWGPQuBUrnF0TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-typescript": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-14.1.2.tgz",
+      "integrity": "sha512-bIeEn0eVi/JRsE1YizBR2ilnMlWRAIBJJ6kXCKNFxEEWhUcEY3R6I3KYIAy48ieURbD1hcb3Ebvl8AqeoPMSzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^8.58.2",
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4 || ^6.0.2"
+      }
+    },
+    "node_modules/detective-vue2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.3.0.tgz",
+      "integrity": "sha512-3gwbZPqVTm9sL9XdZsgEJ7x4x99O853VVZHapQAiEkGuMJMpFPjHDrecSgfqnS5JW3FJfYXesLZGvUOibjn49g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dependents/detective-less": "^5.0.1",
+        "@vue/compiler-sfc": "^3.5.32",
+        "detective-es6": "^5.0.1",
+        "detective-sass": "^6.0.1",
+        "detective-scss": "^5.0.1",
+        "detective-stylus": "^5.0.1",
+        "detective-typescript": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4 || ^6.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -2328,6 +3078,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -2454,6 +3218,76 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2462,6 +3296,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2639,6 +3483,42 @@
         }
       }
     },
+    "node_modules/filing-cabinet": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.5.1.tgz",
+      "integrity": "sha512-PzLBTChlVPn6LnNxF0KWs+XqPziVh3Sfmz/3TXOymHxu6a9yhrDcQn7YwgpcRM6mqhR2WHVGPR8RU4fmcF1IVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-module-path": "^2.2.0",
+        "commander": "^12.1.0",
+        "enhanced-resolve": "^5.21.0",
+        "module-definition": "^6.0.2",
+        "module-lookup-amd": "^9.1.3",
+        "resolve": "^1.22.12",
+        "resolve-dependency-path": "^4.0.1",
+        "sass-lookup": "^6.1.2",
+        "stylus-lookup": "^6.1.2",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "filing-cabinet": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2751,6 +3631,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-amd-module-type": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-6.0.2.tgz",
+      "integrity": "sha512-7zShVYAYtMnj9S65CfN+hvpBCByfuB1OY8xID01nZEzXTZbx4YyysAfi+nMl95JSR6odt4q8TCj2W63KAoyVLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2775,6 +3669,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -2788,6 +3689,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "gonzales": "bin/gonzales.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2798,6 +3715,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -2828,9 +3762,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2969,10 +3903,38 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -2991,6 +3953,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -3013,6 +4011,42 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3123,6 +4157,19 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -3162,6 +4209,23 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -3174,6 +4238,55 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/madge": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-8.0.0.tgz",
+      "integrity": "sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^7.2.0",
+        "commondir": "^1.0.1",
+        "debug": "^4.3.4",
+        "dependency-tree": "^11.0.0",
+        "ora": "^5.4.1",
+        "pluralize": "^8.0.0",
+        "pretty-ms": "^7.0.1",
+        "rc": "^1.2.8",
+        "stream-to-array": "^2.3.0",
+        "ts-graphviz": "^2.1.2",
+        "walkdir": "^0.4.1"
+      },
+      "bin": {
+        "madge": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/pahen"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/madge/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3275,6 +4388,42 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -3286,6 +4435,51 @@
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/module-definition": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.2.tgz",
+      "integrity": "sha512-SvAU3lB0+Yjbq55yHY3wkRZBOh+fhU1SnIF3IFbTewv6mtAh7yUT8ACHAJ2mGIJ7tCes2QuCL/cl6m0JSZ/ArA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "bin": {
+        "module-definition": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/module-lookup-amd": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.1.3.tgz",
+      "integrity": "sha512-Jc3XmOaR9FdfMJSK8+vyLgsCkzm8z2L0NS6vrlRWi12DjS7MY7TMNE7E1yj8yXx837xtMDbKSSgcdXnFlJ2YLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "requirejs": "^2.3.8",
+        "requirejs-config-file": "^4.0.0"
+      },
+      "bin": {
+        "lookup-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ms": {
@@ -3307,9 +4501,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -3331,6 +4525,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-source-walk": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.2.tgz",
+      "integrity": "sha512-71kFFjYaSshDTA8/a2HiTYPLdASWjLJxUyJxGE+ffxU+KhxSBtM9kiLUX+R2yooFdSFKMFpi4n3PFtDy6qXv8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/nwsapi": {
@@ -3381,6 +4588,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openai": {
       "version": "6.42.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
@@ -3399,6 +4622,30 @@
         }
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
@@ -3412,6 +4659,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parse-srcset": {
@@ -3449,6 +4706,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
@@ -3559,10 +4823,20 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3579,7 +4853,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3630,6 +4904,80 @@
         }
       }
     },
+    "node_modules/postcss-values-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.9"
+      }
+    },
+    "node_modules/precinct": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-12.3.2.tgz",
+      "integrity": "sha512-JbJevI1K80z8e/WIyDt/4vUN/4qcfBSKKqOjJA4mosPPPb7zODKRJQV7YN7apVWN3k58nZYm/vEsLgEGYmnxwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dependents/detective-less": "^5.0.3",
+        "commander": "^12.1.0",
+        "detective-amd": "^6.1.0",
+        "detective-cjs": "^6.1.1",
+        "detective-es6": "^5.0.2",
+        "detective-postcss": "^8.0.3",
+        "detective-sass": "^6.0.2",
+        "detective-scss": "^5.0.2",
+        "detective-stylus": "^5.0.1",
+        "detective-typescript": "^14.1.2",
+        "detective-vue2": "^2.3.0",
+        "module-definition": "^6.0.2",
+        "node-source-walk": "^7.0.2",
+        "postcss": "^8.5.14",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "precinct": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/precinct/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3676,6 +5024,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -3700,6 +5055,37 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3722,12 +5108,86 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requirejs": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
+      "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/requirejs-config-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
+      "integrity": "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "^4.0.0",
+        "stringify-object": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-dependency-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-4.0.1.tgz",
+      "integrity": "sha512-YQftIIC4vzO9UMhO/sCgXukNyiwVRCVaxiWskCBy7Zpqkplm8kTAISZ8O1MoKW1ca6xzgLUBjZTcDgypXvXxiQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -3799,6 +5259,27 @@
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3819,6 +5300,33 @@
         "postcss": "^8.3.11"
       }
     },
+    "node_modules/sass-lookup": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.1.2.tgz",
+      "integrity": "sha512-GjmndmKQBtlPil79RK72L7yc5kDXZPCQeH97bP8R8DcxtXQJO6vECExb3WP/m6+cxaV9h4ZxrSRvCkPG2v/VSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "enhanced-resolve": "^5.20.0"
+      },
+      "bin": {
+        "sass-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sass-lookup/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -3829,6 +5337,19 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -3982,6 +5503,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -4034,6 +5562,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -4045,6 +5641,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/stylus-lookup": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.1.2.tgz",
+      "integrity": "sha512-O+Q/SJ8s1X2aMLh4213fQ9X/bND9M3dhSsyTRe+O1OXPcewGLiYmAtKCrnP7FDvDBaXB2ZHPkCt3zi4cJXBlCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "stylus-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/stylus-lookup/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/sucrase": {
@@ -4080,11 +5702,51 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -4237,12 +5899,66 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-graphviz": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-2.1.6.tgz",
+      "integrity": "sha512-XyLVuhBVvdJTJr2FJJV2L1pc4MwSjMhcunRVgDE9k4wbb2ee7ORYnPewxMWUav12vxyfUM686MSGsqnVRIInuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/adapter": "^2.0.6",
+        "@ts-graphviz/ast": "^2.0.7",
+        "@ts-graphviz/common": "^2.1.5",
+        "@ts-graphviz/core": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -4366,6 +6082,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4557,6 +6280,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/turndown": "^5.0.0",
     "fallow": "2.82.0",
     "husky": "^9.1.7",
+    "madge": "^8.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -33,6 +33,7 @@ import {
   updateEmbeddings,
   type ChunkEmbeddingEntry,
 } from "../utils/embeddings.js";
+import { handleSafeEmbeddingFailure } from "../utils/embeddings-batch.js";
 import { rerankWithBm25 } from "../utils/retrieval.js";
 import { appendLog, formatWikilinkList } from "../utils/activity-log.js";
 import type { ChunkCitation, QueryResult, RetrievalDebug } from "../utils/types.js";
@@ -405,7 +406,7 @@ async function saveQueryPage(root: string, question: string, answer: string): Pr
     await updateEmbeddings(root, [slug]);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+    handleSafeEmbeddingFailure(err, `Skipped embeddings update: ${message}`);
   }
 
   return slug;

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -23,6 +23,7 @@ import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
+import { handleSafeEmbeddingFailure } from "../utils/embeddings-batch.js";
 import { readState, updateSourceState } from "../utils/state.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import * as output from "../utils/output.js";
@@ -126,6 +127,6 @@ async function safelyUpdateEmbeddings(root: string, slugs: string[]): Promise<vo
     await updateEmbeddings(root, slugs);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+    handleSafeEmbeddingFailure(err, `Skipped embeddings update: ${message}`);
   }
 }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -49,6 +49,7 @@ import { buildBudgetedCombinedContent, type SourceSlice } from "./prompt-budget.
 import { addObsidianMeta, generateMOC } from "./obsidian.js";
 import { addModelProvenanceMeta } from "./provenance.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
+import { handleSafeEmbeddingFailure } from "../utils/embeddings-batch.js";
 import { deleteCandidateBySlug, listCandidates, writeCandidate } from "./candidates.js";
 import { appendLog, formatList, formatWikilinkList } from "../utils/activity-log.js";
 import {
@@ -1034,6 +1035,6 @@ async function safelyUpdateEmbeddings(root: string, changedSlugs: string[]): Pro
     await updateEmbeddings(root, changedSlugs);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+    handleSafeEmbeddingFailure(err, `Skipped embeddings update: ${message}`);
   }
 }

--- a/src/eval/stats.ts
+++ b/src/eval/stats.ts
@@ -26,6 +26,19 @@ async function countFiles(dir: string): Promise<number> {
 }
 
 /**
+ * Read the embedding store for a stats snapshot, treating a missing OR invalid
+ * store as "no embeddings". `readEmbeddingStore` now validates the store and
+ * throws on corruption; a corpus-size snapshot must degrade, not crash.
+ */
+async function safeReadEmbeddingStore(root: string) {
+  try {
+    return await readEmbeddingStore(root);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Collect a corpus size snapshot for the current project state.
  * @param root - Absolute path to the project root.
  */
@@ -33,7 +46,7 @@ export async function collectStats(root: string): Promise<StatsResult> {
   const [sourceCount, pages, embeddingStore] = await Promise.all([
     countFiles(path.join(root, SOURCES_DIR)),
     collectAllPages(root),
-    readEmbeddingStore(root),
+    safeReadEmbeddingStore(root),
   ]);
 
   let totalWikiChars = 0;

--- a/src/import/okf-refresh.ts
+++ b/src/import/okf-refresh.ts
@@ -3,14 +3,14 @@ import { resolveLinks } from "../compiler/resolver.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
-import * as output from "../utils/output.js";
+import { handleSafeEmbeddingFailure } from "../utils/embeddings-batch.js";
 
 /** Update embeddings without letting an embeddings failure abort the import (mirrors the approve-path wrapper). */
 async function safelyUpdateEmbeddings(root: string, slugs: string[]): Promise<void> {
   try {
     await updateEmbeddings(root, slugs);
   } catch (err) {
-    output.status("!", output.warn(`Embeddings update skipped: ${err instanceof Error ? err.message : err}`));
+    handleSafeEmbeddingFailure(err, `Embeddings update skipped: ${err instanceof Error ? err.message : err}`);
   }
 }
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -7,7 +7,7 @@
 
 import Anthropic, { type ClientOptions } from "@anthropic-ai/sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { voyageEmbed, voyageEmbedBatch } from "./voyage-embed.js";
+import { VoyageEmbeddingProvider } from "./voyage-embed.js";
 
 /**
  * Builds the client options for the Anthropic SDK.
@@ -52,11 +52,12 @@ export function buildAnthropicClientOptions(
 
 
 /** Anthropic-backed LLM provider using the official SDK. */
-export class AnthropicProvider implements LLMProvider {
+export class AnthropicProvider extends VoyageEmbeddingProvider implements LLMProvider {
   private readonly client: Anthropic;
   private readonly model: string;
 
   constructor(model: string, options: AnthropicProviderOptions = {}) {
+    super();
     this.model = model;
     this.client = new Anthropic(buildAnthropicClientOptions(options));
   }
@@ -128,20 +129,5 @@ export class AnthropicProvider implements LLMProvider {
 
     const textBlock = response.content.find((block) => block.type === "text");
     return textBlock?.type === "text" ? textBlock.text : "";
-  }
-
-  /**
-   * Produce a single embedding vector via the Voyage API.
-   *
-   * Anthropic does not ship a first-party embeddings endpoint, so we delegate
-   * to Voyage (their recommended partner). Requires VOYAGE_API_KEY.
-   */
-  async embed(text: string): Promise<number[]> {
-    return voyageEmbed(text);
-  }
-
-  /** Embed many texts via Voyage in one request. */
-  async embedBatch(texts: string[]): Promise<number[][]> {
-    return voyageEmbedBatch(texts);
   }
 }

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -7,7 +7,7 @@
 
 import Anthropic, { type ClientOptions } from "@anthropic-ai/sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { voyageEmbed } from "./voyage-embed.js";
+import { voyageEmbed, voyageEmbedBatch } from "./voyage-embed.js";
 
 /**
  * Builds the client options for the Anthropic SDK.
@@ -138,5 +138,10 @@ export class AnthropicProvider implements LLMProvider {
    */
   async embed(text: string): Promise<number[]> {
     return voyageEmbed(text);
+  }
+
+  /** Embed many texts via Voyage in one request. */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return voyageEmbedBatch(texts);
   }
 }

--- a/src/providers/claude-agent.ts
+++ b/src/providers/claude-agent.ts
@@ -16,7 +16,7 @@
 
 import { query, createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { voyageEmbed } from "./voyage-embed.js";
+import { voyageEmbed, voyageEmbedBatch } from "./voyage-embed.js";
 import { jsonSchemaToZodShape } from "./json-schema-to-zod.js";
 
 /** Name for the throwaway in-process MCP server used to host a tool. */
@@ -211,6 +211,11 @@ export class ClaudeAgentProvider implements LLMProvider {
   /** Produce a single embedding vector via Voyage (Anthropic has no endpoint). */
   async embed(text: string): Promise<number[]> {
     return voyageEmbed(text);
+  }
+
+  /** Embed many texts via Voyage in one request. */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return voyageEmbedBatch(texts);
   }
 }
 

--- a/src/providers/claude-agent.ts
+++ b/src/providers/claude-agent.ts
@@ -16,7 +16,7 @@
 
 import { query, createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { voyageEmbed, voyageEmbedBatch } from "./voyage-embed.js";
+import { VoyageEmbeddingProvider } from "./voyage-embed.js";
 import { jsonSchemaToZodShape } from "./json-schema-to-zod.js";
 
 /** Name for the throwaway in-process MCP server used to host a tool. */
@@ -117,10 +117,11 @@ function findToolInput(
 }
 
 /** Claude Agent SDK-backed LLM provider using the local Claude Code login. */
-export class ClaudeAgentProvider implements LLMProvider {
+export class ClaudeAgentProvider extends VoyageEmbeddingProvider implements LLMProvider {
   private readonly model: string;
 
   constructor(model: string) {
+    super();
     this.model = model;
   }
 
@@ -206,16 +207,6 @@ export class ClaudeAgentProvider implements LLMProvider {
       },
     });
     return collectToolInput(response, requested.name, qualifiedName);
-  }
-
-  /** Produce a single embedding vector via Voyage (Anthropic has no endpoint). */
-  async embed(text: string): Promise<number[]> {
-    return voyageEmbed(text);
-  }
-
-  /** Embed many texts via Voyage in one request. */
-  async embedBatch(texts: string[]): Promise<number[][]> {
-    return voyageEmbedBatch(texts);
   }
 }
 

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -32,4 +32,10 @@ export class CopilotProvider extends OpenAIProvider {
       "    export OPENAI_API_KEY=sk-...",
     );
   }
+
+  /** Copilot has no embeddings API — batch is unsupported too. */
+  override async embedBatch(_texts: string[]): Promise<number[][]> {
+    await this.embed(""); // throws the single-embed not-supported error (one source of truth)
+    return []; // unreachable; satisfies the number[][] return type
+  }
 }

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -15,4 +15,18 @@ export class MiniMaxProvider extends OpenAIProvider {
   constructor(model: string, apiKey: string) {
     super(model, { baseURL: MINIMAX_BASE_URL, apiKey });
   }
+
+  /** MiniMax embedding support is unverified; fail closed instead of inheriting OpenAI semantics. */
+  override async embed(_text: string): Promise<number[]> {
+    throw new Error(
+      "MiniMax provider does not support embeddings in llmwiki yet.\n" +
+      "  For semantic search, use LLMWIKI_PROVIDER=openai, anthropic, claude-agent, or ollama.",
+    );
+  }
+
+  /** MiniMax batch embeddings are unsupported for the same reason as single embeddings. */
+  override async embedBatch(_texts: string[]): Promise<number[][]> {
+    await this.embed("");
+    return [];
+  }
 }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -8,6 +8,7 @@
 import OpenAI from "openai";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
 import { EMBEDDING_MODELS, OPENAI_DEFAULT_TIMEOUT_MS } from "../utils/constants.js";
+import { assertVectorValid, normalizeEmbeddingData } from "../utils/embeddings-validate.js";
 
 /** Construction options for an OpenAI-compatible provider. */
 interface OpenAIProviderOptions {
@@ -154,21 +155,25 @@ export class OpenAIProvider implements LLMProvider {
     return response.choices[0]?.message?.content ?? "";
   }
 
-  /**
-   * Produce a single embedding vector via the OpenAI embeddings API.
-   * Subclasses (e.g. Ollama) override embeddingModel() to pick a different model.
-   */
+  /** Produce a single embedding vector via the OpenAI embeddings API. */
   async embed(text: string): Promise<number[]> {
     const response = await this.embeddingsClient.embeddings.create({
       model: this.embeddingModel(),
       input: text,
     });
-
     const vector = response.data[0]?.embedding;
-    if (!Array.isArray(vector)) {
-      throw new Error("OpenAI embeddings response did not include a vector.");
-    }
+    assertVectorValid(vector); // non-empty + finite (replaces the Array.isArray-only check)
     return vector;
+  }
+
+  /** Embed many texts in one request; vectors returned in input order. */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    const response = await this.embeddingsClient.embeddings.create({
+      model: this.embeddingModel(),
+      input: texts,
+    });
+    return normalizeEmbeddingData(response.data, texts.length);
   }
 
   /** Default embedding model for this provider. Subclasses may override. */

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -160,6 +160,7 @@ export class OpenAIProvider implements LLMProvider {
     const response = await this.embeddingsClient.embeddings.create({
       model: this.embeddingModel(),
       input: text,
+      encoding_format: "float",
     });
     const vector = response.data[0]?.embedding;
     assertVectorValid(vector); // non-empty + finite (replaces the Array.isArray-only check)
@@ -172,6 +173,7 @@ export class OpenAIProvider implements LLMProvider {
     const response = await this.embeddingsClient.embeddings.create({
       model: this.embeddingModel(),
       input: texts,
+      encoding_format: "float",
     });
     return normalizeEmbeddingData(response.data, texts.length);
   }

--- a/src/providers/voyage-embed.ts
+++ b/src/providers/voyage-embed.ts
@@ -8,7 +8,7 @@
  */
 
 import { EMBEDDING_MODELS } from "../utils/constants.js";
-import { normalizeEmbeddingData } from "../utils/embeddings-validate.js";
+import { assertVectorValid, normalizeEmbeddingData } from "../utils/embeddings-validate.js";
 
 const VOYAGE_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
 
@@ -56,9 +56,7 @@ export async function voyageEmbed(
   }
   const json = (await response.json()) as { data?: Array<{ embedding?: number[] }> };
   const vector = json.data?.[0]?.embedding;
-  if (!Array.isArray(vector)) {
-    throw new Error("Voyage embeddings response did not include a vector.");
-  }
+  assertVectorValid(vector); // reject [], NaN, ±Infinity (spec C1) — protects the query path too
   return vector;
 }
 

--- a/src/providers/voyage-embed.ts
+++ b/src/providers/voyage-embed.ts
@@ -12,6 +12,9 @@ import { assertVectorValid, normalizeEmbeddingData } from "../utils/embeddings-v
 
 const VOYAGE_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
 
+/** Voyage embedding mode: stored content is a document; live prompts are queries. */
+export type VoyageInputType = "document" | "query";
+
 /** Build a status-tagged error so the batch taxonomy can classify HTTP failures. */
 function voyageError(status: number, detail: string): Error {
   return Object.assign(new Error(`Voyage embeddings request failed (${status}): ${detail}`), { status });
@@ -29,12 +32,12 @@ function resolveVoyageApiKey(): string {
 }
 
 /** Execute a POST request to the Voyage embeddings endpoint. */
-async function voyagePost(input: string | string[], model: string): Promise<Response> {
+async function voyagePost(input: string | string[], model: string, inputType: VoyageInputType): Promise<Response> {
   const apiKey = resolveVoyageApiKey();
   return fetch(VOYAGE_EMBEDDINGS_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify({ input, model }),
+    body: JSON.stringify({ input, model, input_type: inputType }),
   });
 }
 
@@ -49,8 +52,9 @@ async function voyagePost(input: string | string[], model: string): Promise<Resp
 export async function voyageEmbed(
   text: string,
   model: string = EMBEDDING_MODELS.anthropic,
+  inputType: VoyageInputType = "document",
 ): Promise<number[]> {
-  const response = await voyagePost(text, model);
+  const response = await voyagePost(text, model, inputType);
   if (!response.ok) {
     throw voyageError(response.status, await response.text());
   }
@@ -58,6 +62,11 @@ export async function voyageEmbed(
   const vector = json.data?.[0]?.embedding;
   assertVectorValid(vector); // reject [], NaN, ±Infinity (spec C1) — protects the query path too
   return vector;
+}
+
+/** Embed text with the default Voyage model and an explicit input type. */
+async function voyageEmbedDefault(text: string, inputType: VoyageInputType = "document"): Promise<number[]> {
+  return voyageEmbed(text, undefined, inputType);
 }
 
 /**
@@ -71,12 +80,34 @@ export async function voyageEmbed(
 export async function voyageEmbedBatch(
   texts: string[],
   model: string = EMBEDDING_MODELS.anthropic,
+  inputType: VoyageInputType = "document",
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
-  const response = await voyagePost(texts, model);
+  const response = await voyagePost(texts, model, inputType);
   if (!response.ok) {
     throw voyageError(response.status, await response.text());
   }
   const json = (await response.json()) as { data?: Array<{ index?: number; embedding?: number[] }> };
   return normalizeEmbeddingData(json.data ?? [], texts.length);
+}
+
+/** Batch-embed texts with the default Voyage model and an explicit input type. */
+async function voyageEmbedBatchDefault(
+  texts: string[],
+  inputType: VoyageInputType = "document",
+): Promise<number[][]> {
+  return voyageEmbedBatch(texts, undefined, inputType);
+}
+
+/** Shared embedding implementation for providers that delegate to Voyage. */
+export abstract class VoyageEmbeddingProvider {
+  /** Produce a single embedding vector via Voyage. */
+  async embed(text: string, inputType: VoyageInputType = "document"): Promise<number[]> {
+    return voyageEmbedDefault(text, inputType);
+  }
+
+  /** Embed many texts via Voyage in one request. */
+  async embedBatch(texts: string[], inputType: VoyageInputType = "document"): Promise<number[][]> {
+    return voyageEmbedBatchDefault(texts, inputType);
+  }
 }

--- a/src/providers/voyage-embed.ts
+++ b/src/providers/voyage-embed.ts
@@ -8,8 +8,14 @@
  */
 
 import { EMBEDDING_MODELS } from "../utils/constants.js";
+import { normalizeEmbeddingData } from "../utils/embeddings-validate.js";
 
 const VOYAGE_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
+
+/** Build a status-tagged error so the batch taxonomy can classify HTTP failures. */
+function voyageError(status: number, detail: string): Error {
+  return Object.assign(new Error(`Voyage embeddings request failed (${status}): ${detail}`), { status });
+}
 
 /**
  * Produce a single embedding vector for the given text via the Voyage API.
@@ -40,8 +46,7 @@ export async function voyageEmbed(
   });
 
   if (!response.ok) {
-    const detail = await response.text();
-    throw new Error(`Voyage embeddings request failed (${response.status}): ${detail}`);
+    throw voyageError(response.status, await response.text());
   }
 
   const json = (await response.json()) as { data?: Array<{ embedding?: number[] }> };
@@ -50,4 +55,35 @@ export async function voyageEmbed(
     throw new Error("Voyage embeddings response did not include a vector.");
   }
   return vector;
+}
+
+/**
+ * Embed many texts via Voyage in one request; vectors returned in input order.
+ *
+ * @param texts - Texts to embed.
+ * @param model - Voyage model name; defaults to the Anthropic embedding model.
+ * @returns Array of embedding vectors in input order.
+ * @throws Status-tagged error if the request fails (enables batch taxonomy classification).
+ */
+export async function voyageEmbedBatch(
+  texts: string[],
+  model: string = EMBEDDING_MODELS.anthropic,
+): Promise<number[][]> {
+  if (texts.length === 0) return [];
+  const apiKey = process.env.VOYAGE_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error(
+      "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
+    );
+  }
+  const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ input: texts, model }),
+  });
+  if (!response.ok) {
+    throw voyageError(response.status, await response.text());
+  }
+  const json = (await response.json()) as { data?: Array<{ index?: number; embedding?: number[] }> };
+  return normalizeEmbeddingData(json.data ?? [], texts.length);
 }

--- a/src/providers/voyage-embed.ts
+++ b/src/providers/voyage-embed.ts
@@ -17,6 +17,27 @@ function voyageError(status: number, detail: string): Error {
   return Object.assign(new Error(`Voyage embeddings request failed (${status}): ${detail}`), { status });
 }
 
+/** Resolve and validate the Voyage API key from the environment. */
+function resolveVoyageApiKey(): string {
+  const apiKey = process.env.VOYAGE_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error(
+      "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
+    );
+  }
+  return apiKey;
+}
+
+/** Execute a POST request to the Voyage embeddings endpoint. */
+async function voyagePost(input: string | string[], model: string): Promise<Response> {
+  const apiKey = resolveVoyageApiKey();
+  return fetch(VOYAGE_EMBEDDINGS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ input, model }),
+  });
+}
+
 /**
  * Produce a single embedding vector for the given text via the Voyage API.
  *
@@ -29,26 +50,10 @@ export async function voyageEmbed(
   text: string,
   model: string = EMBEDDING_MODELS.anthropic,
 ): Promise<number[]> {
-  const apiKey = process.env.VOYAGE_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error(
-      "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
-    );
-  }
-
-  const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({ input: text, model }),
-  });
-
+  const response = await voyagePost(text, model);
   if (!response.ok) {
     throw voyageError(response.status, await response.text());
   }
-
   const json = (await response.json()) as { data?: Array<{ embedding?: number[] }> };
   const vector = json.data?.[0]?.embedding;
   if (!Array.isArray(vector)) {
@@ -70,17 +75,7 @@ export async function voyageEmbedBatch(
   model: string = EMBEDDING_MODELS.anthropic,
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
-  const apiKey = process.env.VOYAGE_API_KEY?.trim();
-  if (!apiKey) {
-    throw new Error(
-      "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
-    );
-  }
-  const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-    body: JSON.stringify({ input: texts, model }),
-  });
+  const response = await voyagePost(texts, model);
   if (!response.ok) {
     throw voyageError(response.status, await response.text());
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -162,3 +162,31 @@ export const EMBEDDING_MODELS: Record<string, string> = {
   openai: "text-embedding-3-small",
   ollama: "nomic-embed-text",
 };
+
+/** Per-provider default batch size for embedding requests (count-based). */
+export const EMBED_BATCH_SIZES: Record<string, number> = {
+  openai: 256,
+  ollama: 64,
+  anthropic: 128,
+  "claude-agent": 128,
+};
+
+/** Batch size for providers not in EMBED_BATCH_SIZES. */
+export const EMBED_BATCH_SIZE_FALLBACK = 64;
+
+/** Upper clamp for LLMWIKI_EMBED_BATCH_SIZE, per provider (documented max inputs). */
+export const EMBED_BATCH_CAPS: Record<string, number> = {
+  openai: 2048,
+  ollama: 512, // no documented cap; internal ceiling to bound request size/memory
+  anthropic: 1000,
+  "claude-agent": 1000,
+};
+
+/** Clamp ceiling for providers not in EMBED_BATCH_CAPS. */
+export const EMBED_BATCH_CAP_FALLBACK = 512;
+
+/** Env var: override the embedding batch size (positive integer, clamped to cap). */
+export const ENV_EMBED_BATCH_SIZE = "LLMWIKI_EMBED_BATCH_SIZE";
+
+/** Env var: when set, a failed embedding refresh exits non-zero (for CI). */
+export const ENV_EMBED_STRICT = "LLMWIKI_EMBED_STRICT";

--- a/src/utils/embeddings-batch.ts
+++ b/src/utils/embeddings-batch.ts
@@ -1,0 +1,97 @@
+/**
+ * Batch embedding primitive and its failure taxonomy.
+ *
+ * embedTextBatch is the single entry point both the page and chunk passes use.
+ * It sub-batches a flat text list, calls the provider's native embedBatch when
+ * available, validates every response (cardinality, index order, per-vector
+ * integrity), and degrades to sequential embed() for the cases where that is
+ * safe (no embedBatch, request-too-large, retried-transient). Integrity and
+ * auth failures throw — never silently fall back.
+ *
+ * Imports only a TYPE from provider.ts (erased at compile) and never a value,
+ * so it introduces no runtime dependency on provider.ts. The provider name for
+ * batch sizing is passed in explicitly by the orchestrator.
+ */
+
+import type { LLMProvider } from "./provider.js";
+import {
+  EMBED_BATCH_SIZES,
+  EMBED_BATCH_SIZE_FALLBACK,
+  EMBED_BATCH_CAPS,
+  EMBED_BATCH_CAP_FALLBACK,
+  ENV_EMBED_BATCH_SIZE,
+} from "./constants.js";
+import * as output from "./output.js";
+import { EmbeddingIntegrityError } from "./embeddings-validate.js";
+
+// Re-export so existing test imports `{ EmbeddingIntegrityError } from embeddings-batch.js` keep working.
+export { EmbeddingIntegrityError } from "./embeddings-validate.js";
+
+/** Read a numeric HTTP status off an error if present. */
+function statusOf(err: unknown): number | undefined {
+  const s = (err as { status?: unknown })?.status;
+  return typeof s === "number" ? s : undefined;
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function isIntegrityError(err: unknown): boolean {
+  return err instanceof EmbeddingIntegrityError;
+}
+
+export function isAuthError(err: unknown): boolean {
+  const s = statusOf(err);
+  if (s === 401 || s === 403) return true;
+  return /api[_ ]?key|unauthor|forbidden|not set/i.test(messageOf(err));
+}
+
+export function isRequestTooLarge(err: unknown): boolean {
+  const s = statusOf(err);
+  if (s === 413) return true;
+  if (s === 400 && /too large|maximum context|max .*token|token.*limit|payload|size/i.test(messageOf(err))) {
+    return true;
+  }
+  return false;
+}
+
+export function isTransient(err: unknown): boolean {
+  const s = statusOf(err);
+  if (s === 429 || (s !== undefined && s >= 500)) return true;
+  return /etimedout|econnreset|socket hang up|network|fetch failed|timeout/i.test(messageOf(err));
+}
+
+/**
+ * Resolve the embedding batch size for the active provider. Per-provider default,
+ * overridable by LLMWIKI_EMBED_BATCH_SIZE (positive integer), clamped to the
+ * provider's documented input cap. Invalid overrides warn and fall back.
+ */
+export function resolveEmbedBatchSize(providerName: string): number {
+  const def = EMBED_BATCH_SIZES[providerName] ?? EMBED_BATCH_SIZE_FALLBACK;
+  const cap = EMBED_BATCH_CAPS[providerName] ?? EMBED_BATCH_CAP_FALLBACK;
+  const raw = process.env[ENV_EMBED_BATCH_SIZE]?.trim();
+  if (!raw) return def;
+
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    output.status("!", output.warn(`${ENV_EMBED_BATCH_SIZE}="${raw}" is not a positive integer; using ${def}.`));
+    return def;
+  }
+  if (n > cap) {
+    output.status("!", output.warn(`${ENV_EMBED_BATCH_SIZE}=${n} exceeds the ${providerName} cap; clamping to ${cap}.`));
+    return cap;
+  }
+  return n;
+}
+
+// Placeholder — will be filled in Task 10.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function embedTextBatch(
+  _provider: LLMProvider,
+  _texts: string[],
+  _batchSize: number,
+  _expectedDim?: number,
+): Promise<number[][]> {
+  throw new Error("not implemented");
+}

--- a/src/utils/embeddings-batch.ts
+++ b/src/utils/embeddings-batch.ts
@@ -13,7 +13,7 @@
  * batch sizing is passed in explicitly by the orchestrator.
  */
 
-import type { LLMProvider } from "./provider.js";
+import type { EmbeddingInputType, LLMProvider } from "./provider.js";
 import {
   EMBED_BATCH_SIZES,
   EMBED_BATCH_SIZE_FALLBACK,
@@ -98,8 +98,9 @@ async function validatedBatch(
   provider: LLMProvider,
   sub: string[],
   expectedDim?: number,
+  inputType: EmbeddingInputType = "document",
 ): Promise<number[][]> {
-  const vecs = await provider.embedBatch!(sub); // already index-normalized by the provider
+  const vecs = await provider.embedBatch!(sub, inputType); // already index-normalized by the provider
   if (vecs.length !== sub.length) {
     throw new EmbeddingIntegrityError(`cardinality: got ${vecs.length} for ${sub.length} inputs`);
   }
@@ -112,14 +113,32 @@ async function sequentialEmbed(
   provider: LLMProvider,
   sub: string[],
   expectedDim?: number,
+  inputType: EmbeddingInputType = "document",
 ): Promise<number[][]> {
   const out: number[][] = [];
   for (const text of sub) {
-    const v = await provider.embed(text);
-    assertVectorValid(v, expectedDim);
-    out.push(v);
+    out.push(await embedOneSequential(provider, text, expectedDim, inputType));
   }
   return out;
+}
+
+/** Embed one item, retrying one transient single-item failure. */
+async function embedOneSequential(
+  provider: LLMProvider,
+  text: string,
+  expectedDim?: number,
+  inputType: EmbeddingInputType = "document",
+): Promise<number[]> {
+  try {
+    const v = await provider.embed(text, inputType);
+    assertVectorValid(v, expectedDim);
+    return v;
+  } catch (err) {
+    if (!isTransient(err)) throw err;
+    const retried = await provider.embed(text, inputType);
+    assertVectorValid(retried, expectedDim);
+    return retried;
+  }
 }
 
 /**
@@ -130,12 +149,13 @@ async function retryThenFallback(
   provider: LLMProvider,
   sub: string[],
   expectedDim?: number,
+  inputType: EmbeddingInputType = "document",
 ): Promise<number[][]> {
   try {
-    return await validatedBatch(provider, sub, expectedDim);
+    return await validatedBatch(provider, sub, expectedDim, inputType);
   } catch (retryErr) {
     if (isTransient(retryErr) || isRequestTooLarge(retryErr)) {
-      return sequentialEmbed(provider, sub, expectedDim);
+      return sequentialEmbed(provider, sub, expectedDim, inputType);
     }
     throw retryErr; // integrity / auth / unknown — surface it
   }
@@ -155,14 +175,15 @@ async function embedSubBatch(
   provider: LLMProvider,
   sub: string[],
   expectedDim?: number,
+  inputType: EmbeddingInputType = "document",
 ): Promise<number[][]> {
-  if (!provider.embedBatch) return sequentialEmbed(provider, sub, expectedDim);
+  if (!provider.embedBatch) return sequentialEmbed(provider, sub, expectedDim, inputType);
   try {
-    return await validatedBatch(provider, sub, expectedDim);
+    return await validatedBatch(provider, sub, expectedDim, inputType);
   } catch (err) {
     if (isIntegrityError(err) || isAuthError(err)) throw err;
-    if (isRequestTooLarge(err)) return sequentialEmbed(provider, sub, expectedDim);
-    if (isTransient(err)) return retryThenFallback(provider, sub, expectedDim);
+    if (isRequestTooLarge(err)) return sequentialEmbed(provider, sub, expectedDim, inputType);
+    if (isTransient(err)) return retryThenFallback(provider, sub, expectedDim, inputType);
     throw err; // unknown — surface it
   }
 }
@@ -179,13 +200,14 @@ export async function embedTextBatch(
   texts: string[],
   batchSize: number,
   expectedDim?: number,
+  inputType: EmbeddingInputType = "document",
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
   const out: number[][] = [];
   for (const sub of chunked(texts, batchSize)) {
     const startIndex = out.length;
     try {
-      out.push(...(await embedSubBatch(provider, sub, expectedDim)));
+      out.push(...(await embedSubBatch(provider, sub, expectedDim, inputType)));
     } catch (err) {
       if (err && typeof err === "object" && (err as { failedIndex?: number }).failedIndex === undefined) {
         (err as { failedIndex?: number }).failedIndex = startIndex;
@@ -227,7 +249,8 @@ export function enrichEmbedError(
 
 /** True when LLMWIKI_EMBED_STRICT is set — any embedding failure should exit non-zero. */
 export function shouldRethrowEmbeddingFailure(): boolean {
-  return Boolean(process.env[ENV_EMBED_STRICT]?.trim());
+  const value = process.env[ENV_EMBED_STRICT]?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
 }
 
 /**

--- a/src/utils/embeddings-batch.ts
+++ b/src/utils/embeddings-batch.ts
@@ -20,6 +20,7 @@ import {
   EMBED_BATCH_CAPS,
   EMBED_BATCH_CAP_FALLBACK,
   ENV_EMBED_BATCH_SIZE,
+  ENV_EMBED_STRICT,
 } from "./constants.js";
 import * as output from "./output.js";
 import { EmbeddingIntegrityError, assertVectorValid, assertEveryVectorValid } from "./embeddings-validate.js";
@@ -193,4 +194,47 @@ export async function embedTextBatch(
     }
   }
   return out;
+}
+
+export type EmbeddingErrorClass = "integrity" | "auth" | "request-too-large" | "transient" | "unknown";
+
+/** Map any embedding error onto a stable, user-facing class label. */
+export function classifyEmbeddingError(err: unknown): EmbeddingErrorClass {
+  if (isIntegrityError(err)) return "integrity";
+  if (isAuthError(err)) return "auth";
+  if (isRequestTooLarge(err)) return "request-too-large";
+  if (isTransient(err)) return "transient";
+  return "unknown";
+}
+
+/**
+ * Wrap a failed-batch error into a reportable one naming the pass, the failure
+ * class, and the slug at the failing index (from embedTextBatch's `failedIndex`
+ * annotation). Preserves the original error as `cause` so downstream code can
+ * still classify it.
+ */
+export function enrichEmbedError(
+  err: unknown,
+  pass: "page" | "chunk",
+  slugAt: (index: number) => string | undefined,
+): Error {
+  const index = (err as { failedIndex?: number })?.failedIndex ?? 0;
+  const slug = slugAt(index) ?? "?";
+  const cls = classifyEmbeddingError(err);
+  const detail = err instanceof Error ? err.message : String(err);
+  return Object.assign(new Error(`${pass} embedding failed [${cls}] at "${slug}": ${detail}`), { cause: err });
+}
+
+/** True when LLMWIKI_EMBED_STRICT is set — any embedding failure should exit non-zero. */
+export function shouldRethrowEmbeddingFailure(): boolean {
+  return Boolean(process.env[ENV_EMBED_STRICT]?.trim());
+}
+
+/**
+ * Shared catch handler for the safelyUpdateEmbeddings wrappers. Logs the
+ * warning and re-throws when strict mode is active.
+ */
+export function handleSafeEmbeddingFailure(err: unknown, warningLine: string): void {
+  output.status("!", output.warn(warningLine));
+  if (shouldRethrowEmbeddingFailure()) throw err;
 }

--- a/src/utils/embeddings-batch.ts
+++ b/src/utils/embeddings-batch.ts
@@ -28,6 +28,30 @@ import { EmbeddingIntegrityError, assertVectorValid, assertEveryVectorValid } fr
 // Re-export so existing test imports `{ EmbeddingIntegrityError } from embeddings-batch.js` keep working.
 export { EmbeddingIntegrityError } from "./embeddings-validate.js";
 
+/**
+ * Wrap a provider so every embed / embedBatch call is counted. Lets a pass
+ * report the exact number of provider requests it made — native batch calls
+ * plus any sequential-fallback singles — without changing embedTextBatch's
+ * signature.
+ */
+export function makeCountingProvider(
+  provider: LLMProvider,
+): { provider: LLMProvider; requestCount: () => number } {
+  let requests = 0;
+  const counting: LLMProvider = Object.create(provider);
+  counting.embed = (text: string, inputType?: EmbeddingInputType) => {
+    requests += 1;
+    return provider.embed(text, inputType);
+  };
+  if (provider.embedBatch) {
+    counting.embedBatch = (texts: string[], inputType?: EmbeddingInputType) => {
+      requests += 1;
+      return provider.embedBatch!(texts, inputType);
+    };
+  }
+  return { provider: counting, requestCount: () => requests };
+}
+
 /** Read a numeric HTTP status off an error if present. */
 function statusOf(err: unknown): number | undefined {
   const s = (err as { status?: unknown })?.status;

--- a/src/utils/embeddings-batch.ts
+++ b/src/utils/embeddings-batch.ts
@@ -122,6 +122,25 @@ async function sequentialEmbed(
 }
 
 /**
+ * One retry of the native batch call; falls back to sequential on another
+ * transient or oversized error, re-throws on anything else (integrity, auth, unknown).
+ */
+async function retryThenFallback(
+  provider: LLMProvider,
+  sub: string[],
+  expectedDim?: number,
+): Promise<number[][]> {
+  try {
+    return await validatedBatch(provider, sub, expectedDim);
+  } catch (retryErr) {
+    if (isTransient(retryErr) || isRequestTooLarge(retryErr)) {
+      return sequentialEmbed(provider, sub, expectedDim);
+    }
+    throw retryErr; // integrity / auth / unknown — surface it
+  }
+}
+
+/**
  * Embed one sub-batch with the fallback policy:
  *   - no embedBatch         → sequential
  *   - integrity / auth      → throw (never fall back)
@@ -142,16 +161,7 @@ async function embedSubBatch(
   } catch (err) {
     if (isIntegrityError(err) || isAuthError(err)) throw err;
     if (isRequestTooLarge(err)) return sequentialEmbed(provider, sub, expectedDim);
-    if (isTransient(err)) {
-      try {
-        return await validatedBatch(provider, sub, expectedDim);
-      } catch (retryErr) {
-        if (isTransient(retryErr) || isRequestTooLarge(retryErr)) {
-          return sequentialEmbed(provider, sub, expectedDim);
-        }
-        throw retryErr; // integrity / auth / unknown — surface it
-      }
-    }
+    if (isTransient(err)) return retryThenFallback(provider, sub, expectedDim);
     throw err; // unknown — surface it
   }
 }

--- a/src/utils/embeddings-batch.ts
+++ b/src/utils/embeddings-batch.ts
@@ -22,7 +22,7 @@ import {
   ENV_EMBED_BATCH_SIZE,
 } from "./constants.js";
 import * as output from "./output.js";
-import { EmbeddingIntegrityError } from "./embeddings-validate.js";
+import { EmbeddingIntegrityError, assertVectorValid, assertEveryVectorValid } from "./embeddings-validate.js";
 
 // Re-export so existing test imports `{ EmbeddingIntegrityError } from embeddings-batch.js` keep working.
 export { EmbeddingIntegrityError } from "./embeddings-validate.js";
@@ -85,13 +85,102 @@ export function resolveEmbedBatchSize(providerName: string): number {
   return n;
 }
 
-// Placeholder — will be filled in Task 10.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function embedTextBatch(
-  _provider: LLMProvider,
-  _texts: string[],
-  _batchSize: number,
-  _expectedDim?: number,
+/** Split an array into fixed-size chunks. */
+function chunked<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/** Native batch call with full response validation. Throws EmbeddingIntegrityError. */
+async function validatedBatch(
+  provider: LLMProvider,
+  sub: string[],
+  expectedDim?: number,
 ): Promise<number[][]> {
-  throw new Error("not implemented");
+  const vecs = await provider.embedBatch!(sub); // already index-normalized by the provider
+  if (vecs.length !== sub.length) {
+    throw new EmbeddingIntegrityError(`cardinality: got ${vecs.length} for ${sub.length} inputs`);
+  }
+  assertEveryVectorValid(vecs, expectedDim);
+  return vecs;
+}
+
+/** Validated single-item fallback path. */
+async function sequentialEmbed(
+  provider: LLMProvider,
+  sub: string[],
+  expectedDim?: number,
+): Promise<number[][]> {
+  const out: number[][] = [];
+  for (const text of sub) {
+    const v = await provider.embed(text);
+    assertVectorValid(v, expectedDim);
+    out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Embed one sub-batch with the fallback policy:
+ *   - no embedBatch         → sequential
+ *   - integrity / auth      → throw (never fall back)
+ *   - request-too-large     → sequential immediately (no retry)
+ *   - transient             → ONE retry; if the retry fails with another
+ *                             transient/oversized error → sequential; any other
+ *                             retry error (integrity, auth, unknown) → throw
+ *   - unknown               → throw
+ */
+async function embedSubBatch(
+  provider: LLMProvider,
+  sub: string[],
+  expectedDim?: number,
+): Promise<number[][]> {
+  if (!provider.embedBatch) return sequentialEmbed(provider, sub, expectedDim);
+  try {
+    return await validatedBatch(provider, sub, expectedDim);
+  } catch (err) {
+    if (isIntegrityError(err) || isAuthError(err)) throw err;
+    if (isRequestTooLarge(err)) return sequentialEmbed(provider, sub, expectedDim);
+    if (isTransient(err)) {
+      try {
+        return await validatedBatch(provider, sub, expectedDim);
+      } catch (retryErr) {
+        if (isTransient(retryErr) || isRequestTooLarge(retryErr)) {
+          return sequentialEmbed(provider, sub, expectedDim);
+        }
+        throw retryErr; // integrity / auth / unknown — surface it
+      }
+    }
+    throw err; // unknown — surface it
+  }
+}
+
+/**
+ * Embed `texts` in sequential sub-batches via embedSubBatch. On a terminal
+ * failure, annotate the thrown error with `failedIndex` (the global index of the
+ * first item in the failing sub-batch) so the page/chunk pass can name the
+ * offending slug in its report. The error type is preserved (no wrapper), so
+ * the taxonomy classifiers still apply to it directly.
+ */
+export async function embedTextBatch(
+  provider: LLMProvider,
+  texts: string[],
+  batchSize: number,
+  expectedDim?: number,
+): Promise<number[][]> {
+  if (texts.length === 0) return [];
+  const out: number[][] = [];
+  for (const sub of chunked(texts, batchSize)) {
+    const startIndex = out.length;
+    try {
+      out.push(...(await embedSubBatch(provider, sub, expectedDim)));
+    } catch (err) {
+      if (err && typeof err === "object" && (err as { failedIndex?: number }).failedIndex === undefined) {
+        (err as { failedIndex?: number }).failedIndex = startIndex;
+      }
+      throw err;
+    }
+  }
+  return out;
 }

--- a/src/utils/embeddings-chunks.ts
+++ b/src/utils/embeddings-chunks.ts
@@ -9,7 +9,7 @@ import { getProvider } from "./provider.js";
 import { hashChunkText, splitIntoChunks } from "./retrieval.js";
 import { type ChunkEmbeddingEntry } from "./embeddings-store.js";
 import { type PageRecord } from "./embeddings-pages.js";
-import { embedTextBatch } from "./embeddings-batch.js";
+import { embedTextBatch, enrichEmbedError } from "./embeddings-batch.js";
 
 /** One output position: a reused entry, or a pending one awaiting a fresh vector. */
 type ChunkSlot =
@@ -59,7 +59,12 @@ export async function refreshChunkEmbeddings(
   }
 
   const provider = getProvider();
-  const vectors = await embedTextBatch(provider, work.map((w) => w.text), batchSize, expectedDim);
+  let vectors: number[][];
+  try {
+    vectors = await embedTextBatch(provider, work.map((w) => w.text), batchSize, expectedDim);
+  } catch (err) {
+    throw enrichEmbedError(err, "chunk", (i) => work[i]?.slug);
+  }
 
   const chunks = slots.map((slot) => {
     if (slot.kind === "reused") return slot.entry;

--- a/src/utils/embeddings-chunks.ts
+++ b/src/utils/embeddings-chunks.ts
@@ -1,0 +1,89 @@
+/**
+ * Chunk-level embedding with content-hash reuse. Phase 2 replaces the per-page
+ * sequential loop with a global flat work-list + slot reconstruction so missing
+ * chunks across all pages embed in shared batches while order stays
+ * deterministic (page order, then chunkIndex).
+ */
+
+import { getProvider } from "./provider.js";
+import { hashChunkText, splitIntoChunks } from "./retrieval.js";
+import { type ChunkEmbeddingEntry } from "./embeddings-store.js";
+import { type PageRecord } from "./embeddings-pages.js";
+
+/**
+ * Refresh chunk embeddings for the given pages, reusing existing chunk vectors
+ * whose contentHash still matches. Pages absent from `records` are pruned.
+ */
+export async function refreshChunkEmbeddings(
+  records: PageRecord[],
+  existing: ChunkEmbeddingEntry[],
+  forceAll: boolean,
+): Promise<ChunkEmbeddingEntry[]> {
+  const liveSlugs = new Set(records.map((r) => r.slug));
+  const existingByKey = indexChunksByKey(existing.filter((c) => liveSlugs.has(c.slug)));
+  const now = new Date().toISOString();
+  const fresh: ChunkEmbeddingEntry[] = [];
+
+  for (const record of records) {
+    const pageChunks = await embedRecordChunks(record, existingByKey, forceAll, now);
+    fresh.push(...pageChunks);
+  }
+  return fresh;
+}
+
+/**
+ * Embed (or reuse) every chunk for a single page, in order. Reused chunks have
+ * their `title` refreshed so a renamed page propagates to the chunk metadata.
+ */
+async function embedRecordChunks(
+  record: PageRecord,
+  existingByKey: Map<string, ChunkEmbeddingEntry>,
+  forceAll: boolean,
+  now: string,
+): Promise<ChunkEmbeddingEntry[]> {
+  const provider = getProvider();
+  const chunkTexts = splitIntoChunks(record.body);
+  const out: ChunkEmbeddingEntry[] = [];
+
+  for (let i = 0; i < chunkTexts.length; i++) {
+    const text = chunkTexts[i];
+    const contentHash = hashChunkText(text);
+    const reused = pickReusableChunk(existingByKey, record.slug, i, contentHash, forceAll);
+    if (reused) {
+      out.push({ ...reused, title: record.title });
+      continue;
+    }
+    const vector = await provider.embed(text);
+    out.push({
+      slug: record.slug, title: record.title, chunkIndex: i,
+      contentHash, text, vector, updatedAt: now,
+    });
+  }
+  return out;
+}
+
+/** Index existing chunks by `${slug}#${chunkIndex}` for O(1) reuse lookup. */
+function indexChunksByKey(chunks: ChunkEmbeddingEntry[]): Map<string, ChunkEmbeddingEntry> {
+  const byKey = new Map<string, ChunkEmbeddingEntry>();
+  for (const chunk of chunks) byKey.set(chunkKey(chunk.slug, chunk.chunkIndex), chunk);
+  return byKey;
+}
+
+/** Compose the index key for a chunk lookup. */
+function chunkKey(slug: string, chunkIndex: number): string {
+  return `${slug}#${chunkIndex}`;
+}
+
+/** Return the existing chunk vector when its hash still matches and reuse is allowed. */
+function pickReusableChunk(
+  byKey: Map<string, ChunkEmbeddingEntry>,
+  slug: string,
+  chunkIndex: number,
+  contentHash: string,
+  forceAll: boolean,
+): ChunkEmbeddingEntry | null {
+  if (forceAll) return null;
+  const existing = byKey.get(chunkKey(slug, chunkIndex));
+  if (!existing) return null;
+  return existing.contentHash === contentHash ? existing : null;
+}

--- a/src/utils/embeddings-chunks.ts
+++ b/src/utils/embeddings-chunks.ts
@@ -9,57 +9,67 @@ import { getProvider } from "./provider.js";
 import { hashChunkText, splitIntoChunks } from "./retrieval.js";
 import { type ChunkEmbeddingEntry } from "./embeddings-store.js";
 import { type PageRecord } from "./embeddings-pages.js";
+import { embedTextBatch } from "./embeddings-batch.js";
+
+/** One output position: a reused entry, or a pending one awaiting a fresh vector. */
+type ChunkSlot =
+  | { kind: "reused"; entry: ChunkEmbeddingEntry }
+  | { kind: "pending"; workIndex: number };
+
+interface ChunkWorkItem {
+  text: string;
+  slug: string;
+  title: string;
+  chunkIndex: number;
+  contentHash: string;
+}
 
 /**
- * Refresh chunk embeddings for the given pages, reusing existing chunk vectors
- * whose contentHash still matches. Pages absent from `records` are pruned.
+ * Refresh chunk embeddings for all live pages. Build ordered slots (page order,
+ * then chunkIndex), reuse unchanged chunks by hash, batch only the missing ones
+ * across all pages, then reconstruct from slots so order never depends on the
+ * provider response order.
  */
 export async function refreshChunkEmbeddings(
   records: PageRecord[],
   existing: ChunkEmbeddingEntry[],
   forceAll: boolean,
-): Promise<ChunkEmbeddingEntry[]> {
+  batchSize: number,
+  expectedDim?: number,
+): Promise<{ chunks: ChunkEmbeddingEntry[]; embedded: number }> {
   const liveSlugs = new Set(records.map((r) => r.slug));
   const existingByKey = indexChunksByKey(existing.filter((c) => liveSlugs.has(c.slug)));
   const now = new Date().toISOString();
-  const fresh: ChunkEmbeddingEntry[] = [];
+
+  const slots: ChunkSlot[] = [];
+  const work: ChunkWorkItem[] = [];
 
   for (const record of records) {
-    const pageChunks = await embedRecordChunks(record, existingByKey, forceAll, now);
-    fresh.push(...pageChunks);
-  }
-  return fresh;
-}
-
-/**
- * Embed (or reuse) every chunk for a single page, in order. Reused chunks have
- * their `title` refreshed so a renamed page propagates to the chunk metadata.
- */
-async function embedRecordChunks(
-  record: PageRecord,
-  existingByKey: Map<string, ChunkEmbeddingEntry>,
-  forceAll: boolean,
-  now: string,
-): Promise<ChunkEmbeddingEntry[]> {
-  const provider = getProvider();
-  const chunkTexts = splitIntoChunks(record.body);
-  const out: ChunkEmbeddingEntry[] = [];
-
-  for (let i = 0; i < chunkTexts.length; i++) {
-    const text = chunkTexts[i];
-    const contentHash = hashChunkText(text);
-    const reused = pickReusableChunk(existingByKey, record.slug, i, contentHash, forceAll);
-    if (reused) {
-      out.push({ ...reused, title: record.title });
-      continue;
+    const texts = splitIntoChunks(record.body);
+    for (let i = 0; i < texts.length; i++) {
+      const contentHash = hashChunkText(texts[i]);
+      const reused = pickReusableChunk(existingByKey, record.slug, i, contentHash, forceAll);
+      if (reused) {
+        slots.push({ kind: "reused", entry: { ...reused, title: record.title } });
+      } else {
+        slots.push({ kind: "pending", workIndex: work.length });
+        work.push({ text: texts[i], slug: record.slug, title: record.title, chunkIndex: i, contentHash });
+      }
     }
-    const vector = await provider.embed(text);
-    out.push({
-      slug: record.slug, title: record.title, chunkIndex: i,
-      contentHash, text, vector, updatedAt: now,
-    });
   }
-  return out;
+
+  const provider = getProvider();
+  const vectors = await embedTextBatch(provider, work.map((w) => w.text), batchSize, expectedDim);
+
+  const chunks = slots.map((slot) => {
+    if (slot.kind === "reused") return slot.entry;
+    const w = work[slot.workIndex];
+    return {
+      slug: w.slug, title: w.title, chunkIndex: w.chunkIndex,
+      contentHash: w.contentHash, text: w.text, vector: vectors[slot.workIndex], updatedAt: now,
+    };
+  });
+  return { chunks, embedded: work.length };
 }
 
 /** Index existing chunks by `${slug}#${chunkIndex}` for O(1) reuse lookup. */

--- a/src/utils/embeddings-chunks.ts
+++ b/src/utils/embeddings-chunks.ts
@@ -9,7 +9,7 @@ import { getProvider } from "./provider.js";
 import { hashChunkText, splitIntoChunks } from "./retrieval.js";
 import { type ChunkEmbeddingEntry } from "./embeddings-store.js";
 import { type PageRecord } from "./embeddings-pages.js";
-import { embedTextBatch, enrichEmbedError } from "./embeddings-batch.js";
+import { embedTextBatch, enrichEmbedError, makeCountingProvider } from "./embeddings-batch.js";
 
 /** One output position: a reused entry, or a pending one awaiting a fresh vector. */
 type ChunkSlot =
@@ -36,7 +36,7 @@ export async function refreshChunkEmbeddings(
   forceAll: boolean,
   batchSize: number,
   expectedDim?: number,
-): Promise<{ chunks: ChunkEmbeddingEntry[]; embedded: number }> {
+): Promise<{ chunks: ChunkEmbeddingEntry[]; embedded: number; requests: number }> {
   const liveSlugs = new Set(records.map((r) => r.slug));
   const existingByKey = indexChunksByKey(existing.filter((c) => liveSlugs.has(c.slug)));
   const now = new Date().toISOString();
@@ -58,7 +58,7 @@ export async function refreshChunkEmbeddings(
     }
   }
 
-  const provider = getProvider();
+  const { provider, requestCount } = makeCountingProvider(getProvider());
   let vectors: number[][];
   try {
     vectors = await embedTextBatch(provider, work.map((w) => w.text), batchSize, expectedDim);
@@ -74,7 +74,7 @@ export async function refreshChunkEmbeddings(
       contentHash: w.contentHash, text: w.text, vector: vectors[slot.workIndex], updatedAt: now,
     };
   });
-  return { chunks, embedded: work.length };
+  return { chunks, embedded: work.length, requests: requestCount() };
 }
 
 /** Index existing chunks by `${slug}#${chunkIndex}` for O(1) reuse lookup. */

--- a/src/utils/embeddings-pages.ts
+++ b/src/utils/embeddings-pages.ts
@@ -10,7 +10,7 @@ import { getProvider } from "./provider.js";
 import { safeReadFile, parseFrontmatter } from "./markdown.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "./constants.js";
 import { type EmbeddingEntry } from "./embeddings-store.js";
-import { embedTextBatch, enrichEmbedError } from "./embeddings-batch.js";
+import { embedTextBatch, enrichEmbedError, makeCountingProvider } from "./embeddings-batch.js";
 
 /** A retrievable page record on disk (concepts/ or queries/). */
 export interface PageRecord {
@@ -68,11 +68,11 @@ export async function embedPages(
   slugsToEmbed: Set<string>,
   batchSize: number,
   expectedDim?: number,
-): Promise<EmbeddingEntry[]> {
-  const provider = getProvider();
+): Promise<{ entries: EmbeddingEntry[]; requests: number }> {
+  const { provider, requestCount } = makeCountingProvider(getProvider());
   const now = new Date().toISOString();
   const selected = records.filter((r) => slugsToEmbed.has(r.slug));
-  if (selected.length === 0) return [];
+  if (selected.length === 0) return { entries: [], requests: 0 };
 
   let vectors: number[][];
   try {
@@ -80,13 +80,14 @@ export async function embedPages(
   } catch (err) {
     throw enrichEmbedError(err, "page", (i) => selected[i]?.slug);
   }
-  return selected.map((record, i) => ({
+  const entries = selected.map((record, i) => ({
     slug: record.slug,
     title: record.title,
     summary: record.summary,
     vector: vectors[i],
     updatedAt: now,
   }));
+  return { entries, requests: requestCount() };
 }
 
 /** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */

--- a/src/utils/embeddings-pages.ts
+++ b/src/utils/embeddings-pages.ts
@@ -1,0 +1,101 @@
+/**
+ * Page-level embedding: discover retrievable pages on disk, build their
+ * embedding text, embed the changed/cold ones, and merge results into the
+ * existing entry set. Phase 2 swaps the per-page loop for batched embedding.
+ */
+
+import { readdir } from "fs/promises";
+import path from "path";
+import { getProvider } from "./provider.js";
+import { safeReadFile, parseFrontmatter } from "./markdown.js";
+import { CONCEPTS_DIR, QUERIES_DIR } from "./constants.js";
+import { type EmbeddingEntry } from "./embeddings-store.js";
+
+/** A retrievable page record on disk (concepts/ or queries/). */
+export interface PageRecord {
+  slug: string;
+  title: string;
+  summary: string;
+  body: string;
+}
+
+/** Scan concepts/ and queries/ directories, returning retrievable pages. */
+export async function collectPageRecords(root: string): Promise<PageRecord[]> {
+  const records: PageRecord[] = [];
+  for (const dir of [CONCEPTS_DIR, QUERIES_DIR]) {
+    const absDir = path.join(root, dir);
+    let files: string[];
+    try {
+      files = await readdir(absDir);
+    } catch {
+      continue;
+    }
+    for (const file of files.filter((f) => f.endsWith(".md"))) {
+      const record = await readPageRecord(absDir, file);
+      if (record) records.push(record);
+    }
+  }
+  return records;
+}
+
+/** Parse a single page file into a PageRecord, skipping orphans/untitled pages. */
+async function readPageRecord(absDir: string, file: string): Promise<PageRecord | null> {
+  const content = await safeReadFile(path.join(absDir, file));
+  const { meta, body } = parseFrontmatter(content);
+  if (meta.orphaned || typeof meta.title !== "string") return null;
+  return {
+    slug: file.replace(/\.md$/, ""),
+    title: meta.title,
+    summary: typeof meta.summary === "string" ? meta.summary : "",
+    body,
+  };
+}
+
+/** Build the text that represents a page in the embedding space. */
+function buildEmbeddingText(record: PageRecord): string {
+  return record.summary
+    ? `${record.title}\n\n${record.summary}`
+    : record.title;
+}
+
+/**
+ * Embed every page in `records` whose slug appears in `slugsToEmbed`,
+ * returning the new entries. Failures bubble up to the caller.
+ */
+export async function embedPages(
+  records: PageRecord[],
+  slugsToEmbed: Set<string>,
+): Promise<EmbeddingEntry[]> {
+  const provider = getProvider();
+  const now = new Date().toISOString();
+  const fresh: EmbeddingEntry[] = [];
+
+  for (const record of records) {
+    if (!slugsToEmbed.has(record.slug)) continue;
+    const vector = await provider.embed(buildEmbeddingText(record));
+    fresh.push({
+      slug: record.slug,
+      title: record.title,
+      summary: record.summary,
+      vector,
+      updatedAt: now,
+    });
+  }
+  return fresh;
+}
+
+/** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */
+export function mergeEntries(
+  existing: EmbeddingEntry[],
+  fresh: EmbeddingEntry[],
+  liveSlugs: Set<string>,
+): EmbeddingEntry[] {
+  const bySlug = new Map<string, EmbeddingEntry>();
+  for (const entry of existing) {
+    if (liveSlugs.has(entry.slug)) bySlug.set(entry.slug, entry);
+  }
+  for (const entry of fresh) {
+    bySlug.set(entry.slug, entry);
+  }
+  return Array.from(bySlug.values());
+}

--- a/src/utils/embeddings-pages.ts
+++ b/src/utils/embeddings-pages.ts
@@ -10,6 +10,7 @@ import { getProvider } from "./provider.js";
 import { safeReadFile, parseFrontmatter } from "./markdown.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "./constants.js";
 import { type EmbeddingEntry } from "./embeddings-store.js";
+import { embedTextBatch } from "./embeddings-batch.js";
 
 /** A retrievable page record on disk (concepts/ or queries/). */
 export interface PageRecord {
@@ -59,29 +60,28 @@ function buildEmbeddingText(record: PageRecord): string {
 }
 
 /**
- * Embed every page in `records` whose slug appears in `slugsToEmbed`,
- * returning the new entries. Failures bubble up to the caller.
+ * Embed every page in `records` whose slug is in `slugsToEmbed`, batched.
+ * Vectors come back in input order, so zip them onto the selected records.
  */
 export async function embedPages(
   records: PageRecord[],
   slugsToEmbed: Set<string>,
+  batchSize: number,
+  expectedDim?: number,
 ): Promise<EmbeddingEntry[]> {
   const provider = getProvider();
   const now = new Date().toISOString();
-  const fresh: EmbeddingEntry[] = [];
+  const selected = records.filter((r) => slugsToEmbed.has(r.slug));
+  if (selected.length === 0) return [];
 
-  for (const record of records) {
-    if (!slugsToEmbed.has(record.slug)) continue;
-    const vector = await provider.embed(buildEmbeddingText(record));
-    fresh.push({
-      slug: record.slug,
-      title: record.title,
-      summary: record.summary,
-      vector,
-      updatedAt: now,
-    });
-  }
-  return fresh;
+  const vectors = await embedTextBatch(provider, selected.map(buildEmbeddingText), batchSize, expectedDim);
+  return selected.map((record, i) => ({
+    slug: record.slug,
+    title: record.title,
+    summary: record.summary,
+    vector: vectors[i],
+    updatedAt: now,
+  }));
 }
 
 /** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */

--- a/src/utils/embeddings-pages.ts
+++ b/src/utils/embeddings-pages.ts
@@ -10,7 +10,7 @@ import { getProvider } from "./provider.js";
 import { safeReadFile, parseFrontmatter } from "./markdown.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "./constants.js";
 import { type EmbeddingEntry } from "./embeddings-store.js";
-import { embedTextBatch } from "./embeddings-batch.js";
+import { embedTextBatch, enrichEmbedError } from "./embeddings-batch.js";
 
 /** A retrievable page record on disk (concepts/ or queries/). */
 export interface PageRecord {
@@ -74,7 +74,12 @@ export async function embedPages(
   const selected = records.filter((r) => slugsToEmbed.has(r.slug));
   if (selected.length === 0) return [];
 
-  const vectors = await embedTextBatch(provider, selected.map(buildEmbeddingText), batchSize, expectedDim);
+  let vectors: number[][];
+  try {
+    vectors = await embedTextBatch(provider, selected.map(buildEmbeddingText), batchSize, expectedDim);
+  } catch (err) {
+    throw enrichEmbedError(err, "page", (i) => selected[i]?.slug);
+  }
   return selected.map((record, i) => ({
     slug: record.slug,
     title: record.title,

--- a/src/utils/embeddings-search.ts
+++ b/src/utils/embeddings-search.ts
@@ -1,0 +1,139 @@
+/**
+ * Embedding-based retrieval: cosine similarity ranking and top-K lookup over a
+ * loaded store. Read-side only — never writes the store or calls the embedding
+ * pipeline beyond embedding the live query string.
+ */
+
+import { getProvider } from "./provider.js";
+import { EMBEDDING_TOP_K } from "./constants.js";
+import * as output from "./output.js";
+import {
+  type EmbeddingEntry,
+  type ChunkEmbeddingEntry,
+  type EmbeddingStore,
+  readEmbeddingStore,
+  resolveEmbeddingModel,
+} from "./embeddings-store.js";
+
+/**
+ * Cosine similarity between two equal-length vectors.
+ * Returns 0 when either vector has zero magnitude (safer than NaN for ranking).
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+
+  if (magA === 0 || magB === 0) return 0;
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}
+
+/** Return the top-K entries most similar to the query vector, sorted descending. */
+export function findTopK(
+  queryVec: number[],
+  store: EmbeddingStore,
+  k: number,
+): EmbeddingEntry[] {
+  const scored = store.entries.map((entry) => ({
+    entry,
+    score: cosineSimilarity(queryVec, entry.vector),
+  }));
+  scored.sort((left, right) => right.score - left.score);
+  return scored.slice(0, k).map((item) => item.entry);
+}
+
+/** Score and sort chunk entries by cosine similarity, returning the top-K. */
+export function findTopKChunks(
+  queryVec: number[],
+  chunks: ChunkEmbeddingEntry[],
+  k: number,
+): Array<{ chunk: ChunkEmbeddingEntry; score: number }> {
+  const scored = chunks.map((chunk) => ({
+    chunk,
+    score: cosineSimilarity(queryVec, chunk.vector),
+  }));
+  scored.sort((left, right) => right.score - left.score);
+  return scored.slice(0, k);
+}
+
+/**
+ * Embed the question, look up top-K matches, and return lightweight page records.
+ * Returns [] when no store exists so callers can transparently fall back.
+ */
+export async function findRelevantPages(
+  root: string,
+  question: string,
+): Promise<Array<{ slug: string; title: string; summary: string }>> {
+  const store = await loadActiveStore(root, (s) => s.entries.length > 0);
+  if (!store) return [];
+
+  const queryVec = await getProvider().embed(question);
+  return findTopK(queryVec, store, EMBEDDING_TOP_K).map((entry) => ({
+    slug: entry.slug,
+    title: entry.title,
+    summary: entry.summary,
+  }));
+}
+
+/**
+ * Look up top-K chunks similar to the question. Returns [] when no chunk-level
+ * store exists so callers can fall back to page-level retrieval.
+ */
+export async function findRelevantChunks(
+  root: string,
+  question: string,
+  k: number,
+): Promise<Array<{ chunk: ChunkEmbeddingEntry; score: number }>> {
+  const store = await loadActiveStore(root, (s) => Boolean(s.chunks && s.chunks.length > 0));
+  if (!store) return [];
+  const queryVec = await getProvider().embed(question);
+  return findTopKChunks(queryVec, store.chunks ?? [], k);
+}
+
+/**
+ * Read the embedding store, returning null when it is missing, empty (per the
+ * caller's predicate), or built with a stale model. Centralises the "is this
+ * store usable for semantic lookup right now?" check.
+ */
+async function loadActiveStore(
+  root: string,
+  hasContent: (store: EmbeddingStore) => boolean,
+): Promise<EmbeddingStore | null> {
+  const store = await readEmbeddingStore(root);
+  if (!store || !hasContent(store)) return null;
+  const activeModel = resolveEmbeddingModel();
+  if (store.model !== activeModel) {
+    warnStaleEmbeddingStore(store.model, activeModel);
+    return null;
+  }
+  return store;
+}
+
+/** Tracks which (stored, active) model pairs have already been warned about. */
+const warnedStaleModels = new Set<string>();
+
+/** Warn once per (stored, active) model pair so queries stay quiet on repeat runs. */
+function warnStaleEmbeddingStore(storedModel: string, activeModel: string): void {
+  const key = `${storedModel}→${activeModel}`;
+  if (warnedStaleModels.has(key)) return;
+  warnedStaleModels.add(key);
+  output.status(
+    "!",
+    output.warn(
+      `Embedding store was built with "${storedModel}" but active embedding model is "${activeModel}". ` +
+      `Falling back to full-index selection. Run 'llmwiki compile' to rebuild embeddings.`,
+    ),
+  );
+}
+
+/** Test-only hook: clear the warned-pair cache so each test sees a fresh warning. */
+export function resetStaleEmbeddingWarnings(): void {
+  warnedStaleModels.clear();
+}

--- a/src/utils/embeddings-search.ts
+++ b/src/utils/embeddings-search.ts
@@ -14,6 +14,7 @@ import {
   readEmbeddingStore,
   resolveEmbeddingModel,
 } from "./embeddings-store.js";
+import { EmbeddingIntegrityError, assertVectorValid } from "./embeddings-validate.js";
 
 /**
  * Cosine similarity between two equal-length vectors.
@@ -74,7 +75,8 @@ export async function findRelevantPages(
   const store = await loadActiveStore(root, (s) => s.entries.length > 0);
   if (!store) return [];
 
-  const queryVec = await getProvider().embed(question);
+  const queryVec = await getProvider().embed(question, "query");
+  assertVectorValid(queryVec, store.dimensions);
   return findTopK(queryVec, store, EMBEDDING_TOP_K).map((entry) => ({
     slug: entry.slug,
     title: entry.title,
@@ -93,7 +95,8 @@ export async function findRelevantChunks(
 ): Promise<Array<{ chunk: ChunkEmbeddingEntry; score: number }>> {
   const store = await loadActiveStore(root, (s) => Boolean(s.chunks && s.chunks.length > 0));
   if (!store) return [];
-  const queryVec = await getProvider().embed(question);
+  const queryVec = await getProvider().embed(question, "query");
+  assertVectorValid(queryVec, store.dimensions);
   return findTopKChunks(queryVec, store.chunks ?? [], k);
 }
 
@@ -106,7 +109,7 @@ async function loadActiveStore(
   root: string,
   hasContent: (store: EmbeddingStore) => boolean,
 ): Promise<EmbeddingStore | null> {
-  const store = await readEmbeddingStore(root);
+  const store = await readActiveStore(root);
   if (!store || !hasContent(store)) return null;
   const activeModel = resolveEmbeddingModel();
   if (store.model !== activeModel) {
@@ -114,6 +117,25 @@ async function loadActiveStore(
     return null;
   }
   return store;
+}
+
+/** Read a store for retrieval; invalid local state behaves like no store. */
+async function readActiveStore(root: string): Promise<EmbeddingStore | null> {
+  try {
+    return await readEmbeddingStore(root);
+  } catch (err) {
+    if (!(err instanceof EmbeddingIntegrityError)) throw err;
+    warnInvalidEmbeddingStore(err);
+    return null;
+  }
+}
+
+/** Warn once for invalid embedding state so repeated queries stay readable. */
+function warnInvalidEmbeddingStore(err: Error): void {
+  const key = `invalid:${err.message}`;
+  if (warnedStaleModels.has(key)) return;
+  warnedStaleModels.add(key);
+  output.status("!", output.warn(`Embedding store is invalid; semantic lookup skipped (${err.message}).`));
 }
 
 /** Tracks which (stored, active) model pairs have already been warned about. */

--- a/src/utils/embeddings-store.ts
+++ b/src/utils/embeddings-store.ts
@@ -1,0 +1,78 @@
+/**
+ * Embedding store shape and persistence.
+ *
+ * Owns the on-disk JSON contract for .llmwiki/embeddings.json (types, version,
+ * atomic read/write) and the active-model resolution used to tag and validate
+ * a store. No retrieval or embedding logic lives here — this is the base module
+ * every other embeddings-* module depends on, and it depends on none of them.
+ */
+
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { getActiveProviderName } from "./provider.js";
+import { atomicWrite } from "./markdown.js";
+import { EMBEDDINGS_FILE, EMBEDDING_MODELS } from "./constants.js";
+
+/** Current store version; bumped from 1 → 2 when chunk entries were added. */
+export const STORE_VERSION = 2 as const;
+
+/** A single embedded page record. */
+export interface EmbeddingEntry {
+  slug: string;
+  title: string;
+  summary: string;
+  vector: number[];
+  updatedAt: string;
+}
+
+/** A single embedded chunk drawn from a page body. */
+export interface ChunkEmbeddingEntry {
+  slug: string;
+  title: string;
+  chunkIndex: number;
+  contentHash: string;
+  text: string;
+  vector: number[];
+  updatedAt: string;
+}
+
+/** Root shape of .llmwiki/embeddings.json. */
+export interface EmbeddingStore {
+  version: 1 | 2;
+  model: string;
+  dimensions: number;
+  entries: EmbeddingEntry[];
+  /** Optional in v2 stores; absent in v1 stores. */
+  chunks?: ChunkEmbeddingEntry[];
+}
+
+/** Read .llmwiki/embeddings.json, returning null if it does not exist. */
+export async function readEmbeddingStore(root: string): Promise<EmbeddingStore | null> {
+  const filePath = path.join(root, EMBEDDINGS_FILE);
+  if (!existsSync(filePath)) return null;
+  const raw = await readFile(filePath, "utf-8");
+  return JSON.parse(raw) as EmbeddingStore;
+}
+
+/** Atomically persist the embedding store. */
+export async function writeEmbeddingStore(root: string, store: EmbeddingStore): Promise<void> {
+  const filePath = path.join(root, EMBEDDINGS_FILE);
+  await atomicWrite(filePath, JSON.stringify(store, null, 2));
+}
+
+/** Return true when a store exists on disk but has neither page nor chunk entries. */
+export function isStoreEmpty(store: EmbeddingStore | null): boolean {
+  if (!store) return false;
+  return store.entries.length === 0 && (!store.chunks || store.chunks.length === 0);
+}
+
+/** Choose the active embedding model name, defaulting to anthropic's voyage model. */
+export function resolveEmbeddingModel(): string {
+  const providerName = getActiveProviderName();
+  const configuredModel = process.env.LLMWIKI_EMBEDDING_MODEL?.trim();
+  if (configuredModel && (providerName === "openai" || providerName === "ollama")) {
+    return configuredModel;
+  }
+  return EMBEDDING_MODELS[providerName] ?? EMBEDDING_MODELS.anthropic;
+}

--- a/src/utils/embeddings-store.ts
+++ b/src/utils/embeddings-store.ts
@@ -13,6 +13,7 @@ import path from "path";
 import { getActiveProviderName } from "./provider.js";
 import { atomicWrite } from "./markdown.js";
 import { EMBEDDINGS_FILE, EMBEDDING_MODELS } from "./constants.js";
+import { assertEmbeddingStoreValid } from "./embeddings-validate.js";
 
 /** Current store version; bumped from 1 → 2 when chunk entries were added. */
 export const STORE_VERSION = 2 as const;
@@ -52,12 +53,15 @@ export async function readEmbeddingStore(root: string): Promise<EmbeddingStore |
   const filePath = path.join(root, EMBEDDINGS_FILE);
   if (!existsSync(filePath)) return null;
   const raw = await readFile(filePath, "utf-8");
-  return JSON.parse(raw) as EmbeddingStore;
+  const parsed = JSON.parse(raw) as unknown;
+  assertEmbeddingStoreValid(parsed);
+  return parsed as EmbeddingStore;
 }
 
 /** Atomically persist the embedding store. */
 export async function writeEmbeddingStore(root: string, store: EmbeddingStore): Promise<void> {
   const filePath = path.join(root, EMBEDDINGS_FILE);
+  assertEmbeddingStoreValid(store);
   await atomicWrite(filePath, JSON.stringify(store, null, 2));
 }
 

--- a/src/utils/embeddings-validate.ts
+++ b/src/utils/embeddings-validate.ts
@@ -39,6 +39,44 @@ export function assertEveryVectorValid(vectors: unknown[], expectedDim?: number)
   for (const v of vectors) assertVectorValid(v, dim);
 }
 
+/** Fill output slots by explicit index field; throws on out-of-range or duplicate index. */
+function fillIndexedSlots(
+  data: Array<{ index?: number; embedding?: unknown }>,
+  out: (number[] | undefined)[],
+  n: number,
+): void {
+  for (const d of data) {
+    const i = d.index as number;
+    if (!Number.isInteger(i) || i < 0 || i >= n) {
+      throw new EmbeddingIntegrityError(`response index out of range: ${i}`);
+    }
+    if (out[i] !== undefined) {
+      throw new EmbeddingIntegrityError(`duplicate response index: ${i}`);
+    }
+    assertVectorValid(d.embedding);
+    out[i] = d.embedding as number[];
+  }
+}
+
+/** Fill output slots in positional order (no index field present). */
+function fillPositionalSlots(
+  data: Array<{ index?: number; embedding?: unknown }>,
+  out: (number[] | undefined)[],
+  n: number,
+): void {
+  for (let i = 0; i < n; i++) {
+    assertVectorValid(data[i].embedding);
+    out[i] = data[i].embedding as number[];
+  }
+}
+
+/** Throw if any slot is still unfilled (explicit loop avoids sparse-hole blindspot). */
+function assertAllSlotsFilled(out: (number[] | undefined)[], n: number): void {
+  for (let i = 0; i < n; i++) {
+    if (out[i] === undefined) throw new EmbeddingIntegrityError(`response did not fill slot ${i}`);
+  }
+}
+
 /**
  * Reorder provider response items into input order and validate each embedding.
  * OpenAI/Voyage return `{ index, embedding }`. Rules:
@@ -62,28 +100,8 @@ export function normalizeEmbeddingData(
   }
 
   const out: (number[] | undefined)[] = new Array(n);
-
-  if (indexed === n) {
-    for (const d of data) {
-      const i = d.index as number;
-      if (!Number.isInteger(i) || i < 0 || i >= n) {
-        throw new EmbeddingIntegrityError(`response index out of range: ${i}`);
-      }
-      if (out[i] !== undefined) {
-        throw new EmbeddingIntegrityError(`duplicate response index: ${i}`);
-      }
-      assertVectorValid(d.embedding);
-      out[i] = d.embedding as number[];
-    }
-  } else {
-    for (let i = 0; i < n; i++) {
-      assertVectorValid(data[i].embedding);
-      out[i] = data[i].embedding as number[];
-    }
-  }
-
-  for (let i = 0; i < n; i++) {
-    if (out[i] === undefined) throw new EmbeddingIntegrityError(`response did not fill slot ${i}`);
-  }
+  if (indexed === n) fillIndexedSlots(data, out, n);
+  else fillPositionalSlots(data, out, n);
+  assertAllSlotsFilled(out, n);
   return out as number[][];
 }

--- a/src/utils/embeddings-validate.ts
+++ b/src/utils/embeddings-validate.ts
@@ -1,0 +1,14 @@
+/**
+ * Provider-neutral embedding response validation. Imports NOTHING from
+ * provider.ts — this leaf module is depended on by both the providers and the
+ * batch helper, so the provider → openai → batch → provider cycle can't form.
+ * Validation functions are added in Task 8.
+ */
+
+/** Provider returned structurally invalid data (count, shape, dimension, index). */
+export class EmbeddingIntegrityError extends Error {
+  constructor(message: string) {
+    super(`Embedding integrity error: ${message}`);
+    this.name = "EmbeddingIntegrityError";
+  }
+}

--- a/src/utils/embeddings-validate.ts
+++ b/src/utils/embeddings-validate.ts
@@ -12,3 +12,78 @@ export class EmbeddingIntegrityError extends Error {
     this.name = "EmbeddingIntegrityError";
   }
 }
+
+/** Throw an integrity error unless `v` is a non-empty finite vector of expectedDim. */
+export function assertVectorValid(v: unknown, expectedDim?: number): asserts v is number[] {
+  if (!Array.isArray(v) || v.length === 0) {
+    throw new EmbeddingIntegrityError("empty or non-array vector");
+  }
+  for (const n of v) {
+    if (typeof n !== "number" || !Number.isFinite(n)) {
+      throw new EmbeddingIntegrityError("vector contains a non-finite value");
+    }
+  }
+  if (expectedDim !== undefined && v.length !== expectedDim) {
+    throw new EmbeddingIntegrityError(`vector dimension ${v.length} !== expected ${expectedDim}`);
+  }
+}
+
+/**
+ * Validate every vector: each non-empty + finite, all sharing one dimension, and
+ * (when expectedDim is given) equal to it.
+ */
+export function assertEveryVectorValid(vectors: unknown[], expectedDim?: number): asserts vectors is number[][] {
+  if (vectors.length === 0) return;
+  assertVectorValid(vectors[0], expectedDim);
+  const dim = (vectors[0] as number[]).length;
+  for (const v of vectors) assertVectorValid(v, dim);
+}
+
+/**
+ * Reorder provider response items into input order and validate each embedding.
+ * OpenAI/Voyage return `{ index, embedding }`. Rules:
+ *   - cardinality must equal n;
+ *   - either ALL items carry a numeric index or NONE do (mixed → corruption);
+ *   - indexed: every index is an integer in [0, n), unique, and fills every slot;
+ *   - each embedding is a non-empty finite vector.
+ * Uses an explicit 0..n-1 fill check (NOT Array.prototype.some, which skips
+ * sparse holes) so a missing slot is always caught.
+ */
+export function normalizeEmbeddingData(
+  data: Array<{ index?: number; embedding?: unknown }>,
+  n: number,
+): number[][] {
+  if (!Array.isArray(data) || data.length !== n) {
+    throw new EmbeddingIntegrityError(`cardinality: got ${data?.length} vectors for ${n} inputs`);
+  }
+  const indexed = data.filter((d) => d.index !== undefined).length;
+  if (indexed !== 0 && indexed !== n) {
+    throw new EmbeddingIntegrityError("mixed indexed/unindexed response items");
+  }
+
+  const out: (number[] | undefined)[] = new Array(n);
+
+  if (indexed === n) {
+    for (const d of data) {
+      const i = d.index as number;
+      if (!Number.isInteger(i) || i < 0 || i >= n) {
+        throw new EmbeddingIntegrityError(`response index out of range: ${i}`);
+      }
+      if (out[i] !== undefined) {
+        throw new EmbeddingIntegrityError(`duplicate response index: ${i}`);
+      }
+      assertVectorValid(d.embedding);
+      out[i] = d.embedding as number[];
+    }
+  } else {
+    for (let i = 0; i < n; i++) {
+      assertVectorValid(data[i].embedding);
+      out[i] = data[i].embedding as number[];
+    }
+  }
+
+  for (let i = 0; i < n; i++) {
+    if (out[i] === undefined) throw new EmbeddingIntegrityError(`response did not fill slot ${i}`);
+  }
+  return out as number[][];
+}

--- a/src/utils/embeddings-validate.ts
+++ b/src/utils/embeddings-validate.ts
@@ -78,6 +78,22 @@ function assertAllSlotsFilled(out: (number[] | undefined)[], n: number): void {
 }
 
 /**
+ * Validate that every response item is a non-null object and return how many
+ * carry an `index`. Done before any field access so a malformed item (e.g.
+ * `null`) is classified as an integrity error, not a raw TypeError (unknown).
+ */
+function countIndexedItems(data: Array<{ index?: number; embedding?: unknown }>): number {
+  let indexed = 0;
+  for (const d of data) {
+    if (d === null || typeof d !== "object") {
+      throw new EmbeddingIntegrityError("response item is not an object");
+    }
+    if (d.index !== undefined) indexed++;
+  }
+  return indexed;
+}
+
+/**
  * Reorder provider response items into input order and validate each embedding.
  * OpenAI/Voyage return `{ index, embedding }`. Rules:
  *   - cardinality must equal n;
@@ -94,7 +110,7 @@ export function normalizeEmbeddingData(
   if (!Array.isArray(data) || data.length !== n) {
     throw new EmbeddingIntegrityError(`cardinality: got ${data?.length} vectors for ${n} inputs`);
   }
-  const indexed = data.filter((d) => d.index !== undefined).length;
+  const indexed = countIndexedItems(data);
   if (indexed !== 0 && indexed !== n) {
     throw new EmbeddingIntegrityError("mixed indexed/unindexed response items");
   }

--- a/src/utils/embeddings-validate.ts
+++ b/src/utils/embeddings-validate.ts
@@ -39,6 +39,37 @@ export function assertEveryVectorValid(vectors: unknown[], expectedDim?: number)
   for (const v of vectors) assertVectorValid(v, dim);
 }
 
+/** Return true for plain non-null objects whose fields can be inspected. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+/**
+ * Validate an on-disk embeddings store before search or reuse. The store is
+ * local mutable state, so old or hand-edited poisoned vectors must not survive
+ * just because the current provider write path is stricter.
+ */
+export function assertEmbeddingStoreValid(store: unknown): void {
+  if (!isRecord(store)) throw new EmbeddingIntegrityError("store is not an object");
+  const dimensions = store.dimensions;
+  if (!Number.isInteger(dimensions) || (dimensions as number) < 0) {
+    throw new EmbeddingIntegrityError("store dimensions must be a non-negative integer");
+  }
+  if (!Array.isArray(store.entries)) throw new EmbeddingIntegrityError("store entries must be an array");
+  const chunks = store.chunks;
+  if (chunks !== undefined && !Array.isArray(chunks)) {
+    throw new EmbeddingIntegrityError("store chunks must be an array when present");
+  }
+  const vectors = [...store.entries, ...((chunks as unknown[] | undefined) ?? [])];
+  if (vectors.length > 0 && dimensions === 0) {
+    throw new EmbeddingIntegrityError("store dimensions is 0 but vectors are present");
+  }
+  for (const item of vectors) {
+    if (!isRecord(item)) throw new EmbeddingIntegrityError("store entry is not an object");
+    assertVectorValid(item.vector, dimensions as number);
+  }
+}
+
 /** Fill output slots by explicit index field; throws on out-of-range or duplicate index. */
 function fillIndexedSlots(
   data: Array<{ index?: number; embedding?: unknown }>,

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -34,6 +34,8 @@ import {
   mergeEntries,
 } from "./embeddings-pages.js";
 import { refreshChunkEmbeddings } from "./embeddings-chunks.js";
+import { resolveEmbedBatchSize } from "./embeddings-batch.js";
+import { getActiveProviderName } from "./provider.js";
 
 /**
  * Re-embed the given changed slugs and prune any entries whose pages no longer
@@ -62,7 +64,13 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
     return;
   }
 
-  const freshEntries = await embedPages(records, toEmbed);
+  const batchSize = resolveEmbedBatchSize(getActiveProviderName()); // explicit name — no cycle
+  const expectedDim =
+    !modelChanged && existingStore && existingStore.dimensions > 0
+      ? existingStore.dimensions
+      : undefined;
+
+  const freshEntries = await embedPages(records, toEmbed, batchSize, expectedDim);
   const mergedEntries = mergeEntries(previousEntries, freshEntries, liveSlugs);
   const mergedChunks = await refreshChunkEmbeddings(records, previousChunks, modelChanged);
 

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -16,8 +16,6 @@
  *     and reranking before final page selection.
  */
 
-import { getProvider } from "./provider.js";
-import { hashChunkText, splitIntoChunks } from "./retrieval.js";
 import * as output from "./output.js";
 import {
   STORE_VERSION,
@@ -35,84 +33,7 @@ import {
   embedPages,
   mergeEntries,
 } from "./embeddings-pages.js";
-
-/**
- * Refresh chunk embeddings for the given pages, reusing existing chunk vectors
- * whose contentHash still matches. Pages absent from `records` are pruned.
- */
-async function refreshChunkEmbeddings(
-  records: PageRecord[],
-  existing: ChunkEmbeddingEntry[],
-  forceAll: boolean,
-): Promise<ChunkEmbeddingEntry[]> {
-  const liveSlugs = new Set(records.map((r) => r.slug));
-  const existingByKey = indexChunksByKey(existing.filter((c) => liveSlugs.has(c.slug)));
-  const now = new Date().toISOString();
-  const fresh: ChunkEmbeddingEntry[] = [];
-
-  for (const record of records) {
-    const pageChunks = await embedRecordChunks(record, existingByKey, forceAll, now);
-    fresh.push(...pageChunks);
-  }
-  return fresh;
-}
-
-/**
- * Embed (or reuse) every chunk for a single page, in order. Reused chunks have
- * their `title` refreshed so a renamed page propagates to the chunk metadata.
- */
-async function embedRecordChunks(
-  record: PageRecord,
-  existingByKey: Map<string, ChunkEmbeddingEntry>,
-  forceAll: boolean,
-  now: string,
-): Promise<ChunkEmbeddingEntry[]> {
-  const provider = getProvider();
-  const chunkTexts = splitIntoChunks(record.body);
-  const out: ChunkEmbeddingEntry[] = [];
-
-  for (let i = 0; i < chunkTexts.length; i++) {
-    const text = chunkTexts[i];
-    const contentHash = hashChunkText(text);
-    const reused = pickReusableChunk(existingByKey, record.slug, i, contentHash, forceAll);
-    if (reused) {
-      out.push({ ...reused, title: record.title });
-      continue;
-    }
-    const vector = await provider.embed(text);
-    out.push({
-      slug: record.slug, title: record.title, chunkIndex: i,
-      contentHash, text, vector, updatedAt: now,
-    });
-  }
-  return out;
-}
-
-/** Index existing chunks by `${slug}#${chunkIndex}` for O(1) reuse lookup. */
-function indexChunksByKey(chunks: ChunkEmbeddingEntry[]): Map<string, ChunkEmbeddingEntry> {
-  const byKey = new Map<string, ChunkEmbeddingEntry>();
-  for (const chunk of chunks) byKey.set(chunkKey(chunk.slug, chunk.chunkIndex), chunk);
-  return byKey;
-}
-
-/** Compose the index key for a chunk lookup. */
-function chunkKey(slug: string, chunkIndex: number): string {
-  return `${slug}#${chunkIndex}`;
-}
-
-/** Return the existing chunk vector when its hash still matches and reuse is allowed. */
-function pickReusableChunk(
-  byKey: Map<string, ChunkEmbeddingEntry>,
-  slug: string,
-  chunkIndex: number,
-  contentHash: string,
-  forceAll: boolean,
-): ChunkEmbeddingEntry | null {
-  if (forceAll) return null;
-  const existing = byKey.get(chunkKey(slug, chunkIndex));
-  if (!existing) return null;
-  return existing.contentHash === contentHash ? existing : null;
-}
+import { refreshChunkEmbeddings } from "./embeddings-chunks.js";
 
 /**
  * Re-embed the given changed slugs and prune any entries whose pages no longer

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -72,9 +72,10 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
 
   const freshEntries = await embedPages(records, toEmbed, batchSize, expectedDim);
   const mergedEntries = mergeEntries(previousEntries, freshEntries, liveSlugs);
-  const mergedChunks = await refreshChunkEmbeddings(records, previousChunks, modelChanged);
+  const { chunks: mergedChunks, embedded: chunksEmbedded } =
+    await refreshChunkEmbeddings(records, previousChunks, modelChanged, batchSize, expectedDim);
 
-  await persistRefreshedStore(root, embeddingModel, mergedEntries, mergedChunks);
+  await persistRefreshedStore(root, embeddingModel, mergedEntries, mergedChunks, chunksEmbedded);
 }
 
 /** Persist a freshly merged store and emit a friendly status line. */
@@ -83,6 +84,7 @@ async function persistRefreshedStore(
   embeddingModel: string,
   entries: EmbeddingEntry[],
   chunks: ChunkEmbeddingEntry[],
+  _chunksEmbedded: number,
 ): Promise<void> {
   const dimensions = entries[0]?.vector.length ?? chunks[0]?.vector.length ?? 0;
   const store: EmbeddingStore = {

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -23,7 +23,6 @@ import { safeReadFile, parseFrontmatter } from "./markdown.js";
 import {
   CONCEPTS_DIR,
   QUERIES_DIR,
-  EMBEDDING_TOP_K,
 } from "./constants.js";
 import { hashChunkText, splitIntoChunks } from "./retrieval.js";
 import * as output from "./output.js";
@@ -44,107 +43,6 @@ interface PageRecord {
   title: string;
   summary: string;
   body: string;
-}
-
-/**
- * Cosine similarity between two equal-length vectors.
- * Returns 0 when either vector has zero magnitude (safer than NaN for ranking).
- */
-export function cosineSimilarity(a: number[], b: number[]): number {
-  if (a.length !== b.length || a.length === 0) return 0;
-
-  let dot = 0;
-  let magA = 0;
-  let magB = 0;
-  for (let i = 0; i < a.length; i++) {
-    dot += a[i] * b[i];
-    magA += a[i] * a[i];
-    magB += b[i] * b[i];
-  }
-
-  if (magA === 0 || magB === 0) return 0;
-  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
-}
-
-/** Return the top-K entries most similar to the query vector, sorted descending. */
-export function findTopK(
-  queryVec: number[],
-  store: EmbeddingStore,
-  k: number,
-): EmbeddingEntry[] {
-  const scored = store.entries.map((entry) => ({
-    entry,
-    score: cosineSimilarity(queryVec, entry.vector),
-  }));
-  scored.sort((left, right) => right.score - left.score);
-  return scored.slice(0, k).map((item) => item.entry);
-}
-
-/** Score and sort chunk entries by cosine similarity, returning the top-K. */
-export function findTopKChunks(
-  queryVec: number[],
-  chunks: ChunkEmbeddingEntry[],
-  k: number,
-): Array<{ chunk: ChunkEmbeddingEntry; score: number }> {
-  const scored = chunks.map((chunk) => ({
-    chunk,
-    score: cosineSimilarity(queryVec, chunk.vector),
-  }));
-  scored.sort((left, right) => right.score - left.score);
-  return scored.slice(0, k);
-}
-
-/**
- * Embed the question, look up top-K matches, and return lightweight page records.
- * Returns [] when no store exists so callers can transparently fall back.
- */
-export async function findRelevantPages(
-  root: string,
-  question: string,
-): Promise<Array<{ slug: string; title: string; summary: string }>> {
-  const store = await loadActiveStore(root, (s) => s.entries.length > 0);
-  if (!store) return [];
-
-  const queryVec = await getProvider().embed(question);
-  return findTopK(queryVec, store, EMBEDDING_TOP_K).map((entry) => ({
-    slug: entry.slug,
-    title: entry.title,
-    summary: entry.summary,
-  }));
-}
-
-/**
- * Look up top-K chunks similar to the question. Returns [] when no chunk-level
- * store exists so callers can fall back to page-level retrieval.
- */
-export async function findRelevantChunks(
-  root: string,
-  question: string,
-  k: number,
-): Promise<Array<{ chunk: ChunkEmbeddingEntry; score: number }>> {
-  const store = await loadActiveStore(root, (s) => Boolean(s.chunks && s.chunks.length > 0));
-  if (!store) return [];
-  const queryVec = await getProvider().embed(question);
-  return findTopKChunks(queryVec, store.chunks ?? [], k);
-}
-
-/**
- * Read the embedding store, returning null when it is missing, empty (per the
- * caller's predicate), or built with a stale model. Centralises the "is this
- * store usable for semantic lookup right now?" check.
- */
-async function loadActiveStore(
-  root: string,
-  hasContent: (store: EmbeddingStore) => boolean,
-): Promise<EmbeddingStore | null> {
-  const store = await readEmbeddingStore(root);
-  if (!store || !hasContent(store)) return null;
-  const activeModel = resolveEmbeddingModel();
-  if (store.model !== activeModel) {
-    warnStaleEmbeddingStore(store.model, activeModel);
-    return null;
-  }
-  return store;
 }
 
 /** Scan concepts/ and queries/ directories, returning retrievable pages. */
@@ -210,28 +108,6 @@ async function embedPages(
     });
   }
   return fresh;
-}
-
-/** Tracks which (stored, active) model pairs have already been warned about. */
-const warnedStaleModels = new Set<string>();
-
-/** Warn once per (stored, active) model pair so queries stay quiet on repeat runs. */
-function warnStaleEmbeddingStore(storedModel: string, activeModel: string): void {
-  const key = `${storedModel}→${activeModel}`;
-  if (warnedStaleModels.has(key)) return;
-  warnedStaleModels.add(key);
-  output.status(
-    "!",
-    output.warn(
-      `Embedding store was built with "${storedModel}" but active embedding model is "${activeModel}". ` +
-      `Falling back to full-index selection. Run 'llmwiki compile' to rebuild embeddings.`,
-    ),
-  );
-}
-
-/** Test-only hook: clear the warned-pair cache so each test sees a fresh warning. */
-export function resetStaleEmbeddingWarnings(): void {
-  warnedStaleModels.clear();
 }
 
 /** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */
@@ -409,3 +285,11 @@ export {
   type ChunkEmbeddingEntry,
   type EmbeddingStore,
 } from "./embeddings-store.js";
+export {
+  cosineSimilarity,
+  findTopK,
+  findTopKChunks,
+  findRelevantPages,
+  findRelevantChunks,
+  resetStaleEmbeddingWarnings,
+} from "./embeddings-search.js";

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -36,6 +36,7 @@ import {
 import { refreshChunkEmbeddings } from "./embeddings-chunks.js";
 import { resolveEmbedBatchSize } from "./embeddings-batch.js";
 import { getActiveProviderName } from "./provider.js";
+import { EmbeddingIntegrityError } from "./embeddings-validate.js";
 
 /**
  * Re-embed the given changed slugs and prune any entries whose pages no longer
@@ -45,7 +46,7 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
   const records = await collectPageRecords(root);
   const liveSlugs = new Set(records.map((r) => r.slug));
   const embeddingModel = resolveEmbeddingModel();
-  const existingStore = await readEmbeddingStore(root);
+  const existingStore = await readExistingStoreForUpdate(root);
   const modelChanged = Boolean(existingStore && existingStore.model !== embeddingModel);
   const toEmbed = new Set(changedSlugs.filter((slug) => liveSlugs.has(slug)));
   const previousEntries = modelChanged ? [] : existingStore?.entries ?? [];
@@ -81,6 +82,23 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
     chunksEmbedded,
     chunksTotal: mergedChunks.length,
   });
+}
+
+/** Read the existing store, treating local corruption as a cold rebuild. */
+async function readExistingStoreForUpdate(root: string): Promise<EmbeddingStore | null> {
+  try {
+    return await readEmbeddingStore(root);
+  } catch (err) {
+    if (!isStoreCorruptionError(err)) throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    output.status("!", output.warn(`Embedding store is invalid; rebuilding from live pages (${message}).`));
+    return null;
+  }
+}
+
+/** Store JSON/vector corruption is repairable by rebuilding embeddings. */
+function isStoreCorruptionError(err: unknown): boolean {
+  return err instanceof EmbeddingIntegrityError || err instanceof SyntaxError;
 }
 
 /** Persist a freshly merged store and emit a structured embeddings report. */

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -75,29 +75,31 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
   const { chunks: mergedChunks, embedded: chunksEmbedded } =
     await refreshChunkEmbeddings(records, previousChunks, modelChanged, batchSize, expectedDim);
 
-  await persistRefreshedStore(root, embeddingModel, mergedEntries, mergedChunks, chunksEmbedded);
+  await persistRefreshedStore(root, embeddingModel, mergedEntries, mergedChunks, {
+    pagesEmbedded: freshEntries.length,
+    pagesTotal: records.length,
+    chunksEmbedded,
+    chunksTotal: mergedChunks.length,
+  });
 }
 
-/** Persist a freshly merged store and emit a friendly status line. */
+/** Persist a freshly merged store and emit a structured embeddings report. */
 async function persistRefreshedStore(
   root: string,
   embeddingModel: string,
   entries: EmbeddingEntry[],
   chunks: ChunkEmbeddingEntry[],
-  _chunksEmbedded: number,
+  report: { pagesEmbedded: number; pagesTotal: number; chunksEmbedded: number; chunksTotal: number },
 ): Promise<void> {
   const dimensions = entries[0]?.vector.length ?? chunks[0]?.vector.length ?? 0;
-  const store: EmbeddingStore = {
-    version: STORE_VERSION,
-    model: embeddingModel,
-    dimensions,
-    entries,
-    chunks,
-  };
+  const store: EmbeddingStore = { version: STORE_VERSION, model: embeddingModel, dimensions, entries, chunks };
   await writeEmbeddingStore(root, store);
   output.status(
     "*",
-    output.dim(`Embeddings updated (${entries.length} pages, ${chunks.length} chunks).`),
+    output.dim(
+      `Embeddings: ${report.pagesEmbedded}/${report.pagesTotal} pages, ` +
+      `${report.chunksEmbedded}/${report.chunksTotal} chunks embedded.`,
+    ),
   );
 }
 

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -16,14 +16,7 @@
  *     and reranking before final page selection.
  */
 
-import { readdir } from "fs/promises";
-import path from "path";
 import { getProvider } from "./provider.js";
-import { safeReadFile, parseFrontmatter } from "./markdown.js";
-import {
-  CONCEPTS_DIR,
-  QUERIES_DIR,
-} from "./constants.js";
 import { hashChunkText, splitIntoChunks } from "./retrieval.js";
 import * as output from "./output.js";
 import {
@@ -36,95 +29,12 @@ import {
   isStoreEmpty,
   resolveEmbeddingModel,
 } from "./embeddings-store.js";
-
-/** A retrievable page record on disk (concepts/ or queries/). */
-interface PageRecord {
-  slug: string;
-  title: string;
-  summary: string;
-  body: string;
-}
-
-/** Scan concepts/ and queries/ directories, returning retrievable pages. */
-async function collectPageRecords(root: string): Promise<PageRecord[]> {
-  const records: PageRecord[] = [];
-  for (const dir of [CONCEPTS_DIR, QUERIES_DIR]) {
-    const absDir = path.join(root, dir);
-    let files: string[];
-    try {
-      files = await readdir(absDir);
-    } catch {
-      continue;
-    }
-    for (const file of files.filter((f) => f.endsWith(".md"))) {
-      const record = await readPageRecord(absDir, file);
-      if (record) records.push(record);
-    }
-  }
-  return records;
-}
-
-/** Parse a single page file into a PageRecord, skipping orphans/untitled pages. */
-async function readPageRecord(absDir: string, file: string): Promise<PageRecord | null> {
-  const content = await safeReadFile(path.join(absDir, file));
-  const { meta, body } = parseFrontmatter(content);
-  if (meta.orphaned || typeof meta.title !== "string") return null;
-  return {
-    slug: file.replace(/\.md$/, ""),
-    title: meta.title,
-    summary: typeof meta.summary === "string" ? meta.summary : "",
-    body,
-  };
-}
-
-/** Build the text that represents a page in the embedding space. */
-function buildEmbeddingText(record: PageRecord): string {
-  return record.summary
-    ? `${record.title}\n\n${record.summary}`
-    : record.title;
-}
-
-/**
- * Embed every page in `records` whose slug appears in `slugsToEmbed`,
- * returning the new entries. Failures bubble up to the caller.
- */
-async function embedPages(
-  records: PageRecord[],
-  slugsToEmbed: Set<string>,
-): Promise<EmbeddingEntry[]> {
-  const provider = getProvider();
-  const now = new Date().toISOString();
-  const fresh: EmbeddingEntry[] = [];
-
-  for (const record of records) {
-    if (!slugsToEmbed.has(record.slug)) continue;
-    const vector = await provider.embed(buildEmbeddingText(record));
-    fresh.push({
-      slug: record.slug,
-      title: record.title,
-      summary: record.summary,
-      vector,
-      updatedAt: now,
-    });
-  }
-  return fresh;
-}
-
-/** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */
-function mergeEntries(
-  existing: EmbeddingEntry[],
-  fresh: EmbeddingEntry[],
-  liveSlugs: Set<string>,
-): EmbeddingEntry[] {
-  const bySlug = new Map<string, EmbeddingEntry>();
-  for (const entry of existing) {
-    if (liveSlugs.has(entry.slug)) bySlug.set(entry.slug, entry);
-  }
-  for (const entry of fresh) {
-    bySlug.set(entry.slug, entry);
-  }
-  return Array.from(bySlug.values());
-}
+import {
+  type PageRecord,
+  collectPageRecords,
+  embedPages,
+  mergeEntries,
+} from "./embeddings-pages.js";
 
 /**
  * Refresh chunk embeddings for the given pages, reusing existing chunk vectors

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -71,9 +71,10 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
       ? existingStore.dimensions
       : undefined;
 
-  const freshEntries = await embedPages(records, toEmbed, batchSize, expectedDim);
+  const { entries: freshEntries, requests: pageRequests } =
+    await embedPages(records, toEmbed, batchSize, expectedDim);
   const mergedEntries = mergeEntries(previousEntries, freshEntries, liveSlugs);
-  const { chunks: mergedChunks, embedded: chunksEmbedded } =
+  const { chunks: mergedChunks, embedded: chunksEmbedded, requests: chunkRequests } =
     await refreshChunkEmbeddings(records, previousChunks, modelChanged, batchSize, expectedDim);
 
   await persistRefreshedStore(root, embeddingModel, mergedEntries, mergedChunks, {
@@ -81,6 +82,7 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
     pagesTotal: records.length,
     chunksEmbedded,
     chunksTotal: mergedChunks.length,
+    requests: pageRequests + chunkRequests,
   });
 }
 
@@ -107,7 +109,7 @@ async function persistRefreshedStore(
   embeddingModel: string,
   entries: EmbeddingEntry[],
   chunks: ChunkEmbeddingEntry[],
-  report: { pagesEmbedded: number; pagesTotal: number; chunksEmbedded: number; chunksTotal: number },
+  report: { pagesEmbedded: number; pagesTotal: number; chunksEmbedded: number; chunksTotal: number; requests: number },
 ): Promise<void> {
   const dimensions = entries[0]?.vector.length ?? chunks[0]?.vector.length ?? 0;
   const store: EmbeddingStore = { version: STORE_VERSION, model: embeddingModel, dimensions, entries, chunks };
@@ -116,7 +118,8 @@ async function persistRefreshedStore(
     "*",
     output.dim(
       `Embeddings: ${report.pagesEmbedded}/${report.pagesTotal} pages, ` +
-      `${report.chunksEmbedded}/${report.chunksTotal} chunks embedded.`,
+      `${report.chunksEmbedded}/${report.chunksTotal} chunks embedded ` +
+      `(${report.requests} batched requests).`,
     ),
   );
 }

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -16,53 +16,27 @@
  *     and reranking before final page selection.
  */
 
-import { readFile, readdir } from "fs/promises";
-import { existsSync } from "fs";
+import { readdir } from "fs/promises";
 import path from "path";
-import { getProvider, getActiveProviderName } from "./provider.js";
-import { atomicWrite, safeReadFile, parseFrontmatter } from "./markdown.js";
+import { getProvider } from "./provider.js";
+import { safeReadFile, parseFrontmatter } from "./markdown.js";
 import {
   CONCEPTS_DIR,
   QUERIES_DIR,
-  EMBEDDINGS_FILE,
   EMBEDDING_TOP_K,
-  EMBEDDING_MODELS,
 } from "./constants.js";
 import { hashChunkText, splitIntoChunks } from "./retrieval.js";
 import * as output from "./output.js";
-
-/** Current store version; bumped from 1 → 2 when chunk entries were added. */
-const STORE_VERSION = 2 as const;
-
-/** A single embedded page record. */
-export interface EmbeddingEntry {
-  slug: string;
-  title: string;
-  summary: string;
-  vector: number[];
-  updatedAt: string;
-}
-
-/** A single embedded chunk drawn from a page body. */
-export interface ChunkEmbeddingEntry {
-  slug: string;
-  title: string;
-  chunkIndex: number;
-  contentHash: string;
-  text: string;
-  vector: number[];
-  updatedAt: string;
-}
-
-/** Root shape of .llmwiki/embeddings.json. */
-export interface EmbeddingStore {
-  version: 1 | 2;
-  model: string;
-  dimensions: number;
-  entries: EmbeddingEntry[];
-  /** Optional in v2 stores; absent in v1 stores. */
-  chunks?: ChunkEmbeddingEntry[];
-}
+import {
+  STORE_VERSION,
+  type EmbeddingEntry,
+  type ChunkEmbeddingEntry,
+  type EmbeddingStore,
+  readEmbeddingStore,
+  writeEmbeddingStore,
+  isStoreEmpty,
+  resolveEmbeddingModel,
+} from "./embeddings-store.js";
 
 /** A retrievable page record on disk (concepts/ or queries/). */
 interface PageRecord {
@@ -118,20 +92,6 @@ export function findTopKChunks(
   }));
   scored.sort((left, right) => right.score - left.score);
   return scored.slice(0, k);
-}
-
-/** Read .llmwiki/embeddings.json, returning null if it does not exist. */
-export async function readEmbeddingStore(root: string): Promise<EmbeddingStore | null> {
-  const filePath = path.join(root, EMBEDDINGS_FILE);
-  if (!existsSync(filePath)) return null;
-  const raw = await readFile(filePath, "utf-8");
-  return JSON.parse(raw) as EmbeddingStore;
-}
-
-/** Atomically persist the embedding store. */
-export async function writeEmbeddingStore(root: string, store: EmbeddingStore): Promise<void> {
-  const filePath = path.join(root, EMBEDDINGS_FILE);
-  await atomicWrite(filePath, JSON.stringify(store, null, 2));
 }
 
 /**
@@ -272,16 +232,6 @@ function warnStaleEmbeddingStore(storedModel: string, activeModel: string): void
 /** Test-only hook: clear the warned-pair cache so each test sees a fresh warning. */
 export function resetStaleEmbeddingWarnings(): void {
   warnedStaleModels.clear();
-}
-
-/** Choose the active embedding model name, defaulting to anthropic's voyage model. */
-export function resolveEmbeddingModel(): string {
-  const providerName = getActiveProviderName();
-  const configuredModel = process.env.LLMWIKI_EMBEDDING_MODEL?.trim();
-  if (configuredModel && (providerName === "openai" || providerName === "ollama")) {
-    return configuredModel;
-  }
-  return EMBEDDING_MODELS[providerName] ?? EMBEDDING_MODELS.anthropic;
 }
 
 /** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */
@@ -434,12 +384,6 @@ async function persistRefreshedStore(
   );
 }
 
-/** Return true when a store exists on disk but has neither page nor chunk entries. */
-function isStoreEmpty(store: EmbeddingStore | null): boolean {
-  if (!store) return false;
-  return store.entries.length === 0 && (!store.chunks || store.chunks.length === 0);
-}
-
 /** Decide whether updateEmbeddings has work to do beyond a no-op. */
 function shouldRunEmbedding(
   modelChanged: boolean,
@@ -456,3 +400,12 @@ function shouldRunEmbedding(
   if (previousEntries.length > 0 && previousChunks.length === 0 && liveSlugs.size > 0) return true;
   return false;
 }
+
+export {
+  readEmbeddingStore,
+  writeEmbeddingStore,
+  resolveEmbeddingModel,
+  type EmbeddingEntry,
+  type ChunkEmbeddingEntry,
+  type EmbeddingStore,
+} from "./embeddings-store.js";

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -108,6 +108,8 @@ function shouldRunEmbedding(
   return false;
 }
 
+// Public surface preserved across the module split. Consumers import these from
+// "./embeddings.js" today; keep that contract.
 export {
   readEmbeddingStore,
   writeEmbeddingStore,
@@ -124,3 +126,4 @@ export {
   findRelevantChunks,
   resetStaleEmbeddingWarnings,
 } from "./embeddings-search.js";
+// updateEmbeddings is declared locally and exported inline.

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -32,6 +32,9 @@ export interface LLMTool {
   input_schema: Record<string, unknown>;
 }
 
+/** Embedding input purpose for providers that tune document/query vectors. */
+export type EmbeddingInputType = "document" | "query";
+
 /** Provider-agnostic interface for LLM backends. */
 export interface LLMProvider {
   complete(system: string, messages: LLMMessage[], maxTokens: number): Promise<string>;
@@ -48,9 +51,9 @@ export interface LLMProvider {
     maxTokens: number,
   ): Promise<string>;
   /** Return a single embedding vector for the given text. */
-  embed(text: string): Promise<number[]>;
+  embed(text: string, inputType?: EmbeddingInputType): Promise<number[]>;
   /** Embed multiple texts in a single provider-native request (optional). */
-  embedBatch?(texts: string[]): Promise<number[][]>;
+  embedBatch?(texts: string[], inputType?: EmbeddingInputType): Promise<number[][]>;
 }
 
 const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "claude-agent", "openai", "ollama", "minimax", "copilot"]);

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -49,6 +49,8 @@ export interface LLMProvider {
   ): Promise<string>;
   /** Return a single embedding vector for the given text. */
   embed(text: string): Promise<number[]>;
+  /** Embed multiple texts in a single provider-native request (optional). */
+  embedBatch?(texts: string[]): Promise<number[][]>;
 }
 
 const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "claude-agent", "openai", "ollama", "minimax", "copilot"]);

--- a/test/chunked-retrieval-integration.test.ts
+++ b/test/chunked-retrieval-integration.test.ts
@@ -100,6 +100,17 @@ function makeV1Store(): EmbeddingStore {
   };
 }
 
+/** Stub OpenAI env + provider embed methods for programmatic embedding tests. */
+function stubOpenAIProvider(vector = [0.5, 0.5]): void {
+  process.env.LLMWIKI_PROVIDER = "openai";
+  process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
+  process.env.OPENAI_API_KEY = "test-key";
+  vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue(vector);
+  vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
+    async (texts: string[]) => texts.map(() => vector),
+  );
+}
+
 /**
  * Stub the OpenAI provider and write a v2 store to disk.
  * Returns the root and its cleanup function.
@@ -234,13 +245,7 @@ describe("chunk ranking over v2 fixture (programmatic)", () => {
 describe("v1 → v2 store upgrade (programmatic)", () => {
   it("upgrades a v1 store to version 2 and adds chunks", async () => {
     const root = await makeTempRoot("v1-upgrade");
-    process.env.LLMWIKI_PROVIDER = "openai";
-    process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
-    process.env.OPENAI_API_KEY = "test-key";
-    vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue([0.5, 0.5]);
-    vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
-      async (texts: string[]) => texts.map(() => [0.5, 0.5]),
-    );
+    stubOpenAIProvider();
 
     // Write a v1 store + matching concept page so updateEmbeddings has content.
     await writeEmbeddingStore(root, makeV1Store());
@@ -291,14 +296,7 @@ describe("v1 → v2 store upgrade (programmatic)", () => {
 /** Shared setup: stub OpenAI and write an empty store of the given version. */
 async function setupEmptyStore(label: string, version: 1 | 2): Promise<string> {
   const root = await makeTempRoot(label);
-  process.env.LLMWIKI_PROVIDER = "openai";
-  process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
-  process.env.OPENAI_API_KEY = "test-key";
-  vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue([0.5, 0.5]);
-  // Mock embedBatch so the page-embedding pass (which now uses batch) returns valid vectors.
-  vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
-    async (texts: string[]) => texts.map(() => [0.5, 0.5]),
-  );
+  stubOpenAIProvider();
   const emptyStore: EmbeddingStore = {
     version,
     model: "test-embed",

--- a/test/chunked-retrieval-integration.test.ts
+++ b/test/chunked-retrieval-integration.test.ts
@@ -238,6 +238,9 @@ describe("v1 → v2 store upgrade (programmatic)", () => {
     process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
     process.env.OPENAI_API_KEY = "test-key";
     vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue([0.5, 0.5]);
+    vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
+      async (texts: string[]) => texts.map(() => [0.5, 0.5]),
+    );
 
     // Write a v1 store + matching concept page so updateEmbeddings has content.
     await writeEmbeddingStore(root, makeV1Store());
@@ -292,6 +295,10 @@ async function setupEmptyStore(label: string, version: 1 | 2): Promise<string> {
   process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
   process.env.OPENAI_API_KEY = "test-key";
   vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue([0.5, 0.5]);
+  // Mock embedBatch so the page-embedding pass (which now uses batch) returns valid vectors.
+  vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
+    async (texts: string[]) => texts.map(() => [0.5, 0.5]),
+  );
   const emptyStore: EmbeddingStore = {
     version,
     model: "test-embed",

--- a/test/compile-batch-embeddings.test.ts
+++ b/test/compile-batch-embeddings.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Subprocess acceptance test: `compile` sends batched embeddings requests
+ * and persists a correct v2 store.
+ *
+ * Uses aimock to intercept both chat and embedding calls so no real network
+ * traffic is needed. Three concepts are emitted so the page-embedding pass
+ * must carry input.length > 1, exercising the actual batch path end-to-end.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { runCLI, expectCLIExit, formatCLIFailure } from "./fixtures/run-cli.js";
+import { useAimockLifecycle, mockOpenAIEnv } from "./fixtures/aimock-helper.js";
+
+const aimock = useAimockLifecycle("batch-embed");
+const EMBEDDING_VECTOR = Array.from({ length: 8 }, (_, i) => i / 10);
+
+describe("compile batches embeddings (subprocess)", () => {
+  it("sends batched array-input requests AND persists a correct store", async () => {
+    const handle = await aimock.start();
+    // Three concepts -> three pages -> page-embedding batch carries 3 inputs.
+    handle.mock.onToolCall("extract_concepts", {
+      toolCalls: [{
+        name: "extract_concepts",
+        arguments: { concepts: [
+          { concept: "Alpha", summary: "First concept.", is_new: true, tags: ["t"], confidence: 0.9 },
+          { concept: "Beta", summary: "Second concept.", is_new: true, tags: ["t"], confidence: 0.9 },
+          { concept: "Gamma", summary: "Third concept.", is_new: true, tags: ["t"], confidence: 0.9 },
+        ] },
+      }],
+    });
+    handle.mock.onMessage(/.*/, { content: "Body paragraph one.\n\nBody paragraph two." });
+    handle.mock.onEmbedding(/.*/, { embedding: EMBEDDING_VECTOR });
+
+    const cwd = await aimock.makeWorkspace("# Source\n\nAlpha, Beta, and Gamma are concepts. ".repeat(20));
+    const result = await runCLI(["compile"], cwd, mockOpenAIEnv(handle));
+    expectCLIExit(result, 0);
+
+    // (a) Batching proof: three pages were embedded in fewer HTTP requests than
+    // the number of pages, which can only happen if the page pass batched them.
+    // aimock journals embedding requests with _endpointType === "embedding" in
+    // body.syntheticReq; count them to verify fewer calls than pages.
+    const requests = handle.mock.getRequests() as Array<{ body?: { _endpointType?: string } }>;
+    const embeddingRequests = requests.filter((r) => r.body?._endpointType === "embedding");
+    // 3 pages + 3 page-sized chunks = at least 6 with sequential; with batching
+    // the page pass emits 1 request and the chunk pass emits 1 request = 2 total.
+    expect(embeddingRequests.length, formatCLIFailure(result)).toBeLessThan(3);
+
+    // (b) Store correctness — REQUIRED by spec. A v2 store with entries + chunks
+    // must actually be persisted; this only passes when the batched responses
+    // validate (one vector per input), so it is a genuine end-to-end check.
+    const storePath = path.join(cwd, ".llmwiki", "embeddings.json");
+    expect(existsSync(storePath), formatCLIFailure(result)).toBe(true);
+    const store = JSON.parse(await readFile(storePath, "utf-8")) as {
+      version: number; entries: unknown[]; chunks?: unknown[];
+    };
+    expect(store.version).toBe(2);
+    expect(store.entries.length).toBeGreaterThan(0);
+    expect((store.chunks ?? []).length).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/test/embed-batch-providers.test.ts
+++ b/test/embed-batch-providers.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { OpenAIProvider } from "../src/providers/openai.js";
 import { voyageEmbedBatch } from "../src/providers/voyage-embed.js";
+import { CopilotProvider } from "../src/providers/copilot.js";
 
 // Build a provider and stub its embeddingsClient.embeddings.create.
 function providerWithEmbeddings(create: (args: unknown) => unknown): OpenAIProvider {
@@ -61,5 +62,12 @@ describe("voyageEmbedBatch", () => {
     process.env.VOYAGE_API_KEY = "vk";
     globalThis.fetch = (async () => ({ ok: false, status: 429, text: async () => "slow down" })) as any;
     await expect(voyageEmbedBatch(["a"])).rejects.toMatchObject({ status: 429 });
+  });
+});
+
+describe("CopilotProvider.embedBatch", () => {
+  it("throws the not-supported error", async () => {
+    const p = new CopilotProvider("gpt-4o", "ghp_test");
+    await expect(p.embedBatch!(["a"])).rejects.toThrow(/does not support embeddings/i);
   });
 });

--- a/test/embed-batch-providers.test.ts
+++ b/test/embed-batch-providers.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { OpenAIProvider } from "../src/providers/openai.js";
-import { voyageEmbedBatch } from "../src/providers/voyage-embed.js";
+import { voyageEmbed, voyageEmbedBatch } from "../src/providers/voyage-embed.js";
 import { CopilotProvider } from "../src/providers/copilot.js";
 
 // Build a provider and stub its embeddingsClient.embeddings.create.
@@ -62,6 +62,14 @@ describe("voyageEmbedBatch", () => {
     process.env.VOYAGE_API_KEY = "vk";
     globalThis.fetch = (async () => ({ ok: false, status: 429, text: async () => "slow down" })) as any;
     await expect(voyageEmbedBatch(["a"])).rejects.toMatchObject({ status: 429 });
+  });
+
+  it("single voyageEmbed rejects an empty/non-finite vector (C1, protects the query path)", async () => {
+    process.env.VOYAGE_API_KEY = "vk";
+    globalThis.fetch = (async () => ({ ok: true, json: async () => ({ data: [{ embedding: [] }] }) })) as any;
+    await expect(voyageEmbed("q")).rejects.toThrow();
+    globalThis.fetch = (async () => ({ ok: true, json: async () => ({ data: [{ embedding: [NaN] }] }) })) as any;
+    await expect(voyageEmbed("q")).rejects.toThrow();
   });
 });
 

--- a/test/embed-batch-providers.test.ts
+++ b/test/embed-batch-providers.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { OpenAIProvider } from "../src/providers/openai.js";
 import { voyageEmbed, voyageEmbedBatch } from "../src/providers/voyage-embed.js";
 import { CopilotProvider } from "../src/providers/copilot.js";
+import { MiniMaxProvider } from "../src/providers/minimax.js";
 
 // Build a provider and stub its embeddingsClient.embeddings.create.
 function providerWithEmbeddings(create: (args: unknown) => unknown): OpenAIProvider {
@@ -19,15 +20,27 @@ function providerWithEmbeddings(create: (args: unknown) => unknown): OpenAIProvi
   return p;
 }
 
+function mockVoyageSuccess(json: unknown): () => any {
+  let body: any;
+  globalThis.fetch = (async (_url: string, init: any) => {
+    body = JSON.parse(init.body);
+    return { ok: true, json: async () => json };
+  }) as any;
+  return () => body;
+}
+
 describe("OpenAIProvider.embedBatch", () => {
   it("sends array input and returns vectors in index order", async () => {
     let sentInput: unknown;
+    let sentEncoding: unknown;
     const p = providerWithEmbeddings(async (args: any) => {
       sentInput = args.input;
+      sentEncoding = args.encoding_format;
       return { data: [{ index: 1, embedding: [2, 2] }, { index: 0, embedding: [1, 1] }] };
     });
     const out = await p.embedBatch!(["a", "b"]);
     expect(sentInput).toEqual(["a", "b"]);
+    expect(sentEncoding).toBe("float");
     expect(out).toEqual([[1, 1], [2, 2]]);
   });
 
@@ -48,14 +61,21 @@ describe("voyageEmbedBatch", () => {
 
   it("posts array input and returns index-ordered vectors", async () => {
     process.env.VOYAGE_API_KEY = "vk";
-    let body: any;
-    globalThis.fetch = (async (_url: string, init: any) => {
-      body = JSON.parse(init.body);
-      return { ok: true, json: async () => ({ data: [{ index: 1, embedding: [2] }, { index: 0, embedding: [1] }] }) };
-    }) as any;
+    const readBody = mockVoyageSuccess({ data: [{ index: 1, embedding: [2] }, { index: 0, embedding: [1] }] });
     const out = await voyageEmbedBatch(["a", "b"]);
+    const body = readBody();
     expect(body.input).toEqual(["a", "b"]);
+    expect(body.input_type).toBe("document");
     expect(out).toEqual([[1], [2]]);
+  });
+
+  it("posts query input_type for query embeddings", async () => {
+    process.env.VOYAGE_API_KEY = "vk";
+    const readBody = mockVoyageSuccess({ data: [{ embedding: [1] }] });
+    const out = await (voyageEmbed as any)("question", undefined, "query");
+    const body = readBody();
+    expect(body.input_type).toBe("query");
+    expect(out).toEqual([1]);
   });
 
   it("tags HTTP failures with status for the taxonomy", async () => {
@@ -77,5 +97,17 @@ describe("CopilotProvider.embedBatch", () => {
   it("throws the not-supported error", async () => {
     const p = new CopilotProvider("gpt-4o", "ghp_test");
     await expect(p.embedBatch!(["a"])).rejects.toThrow(/does not support embeddings/i);
+  });
+});
+
+describe("MiniMaxProvider embeddings", () => {
+  it("throws explicit unsupported errors instead of inheriting OpenAI embeddings", async () => {
+    const p = new MiniMaxProvider("MiniMax-M2.7", "test-key");
+    Reflect.set(p, "embeddingsClient", {
+      embeddings: { create: async () => ({ data: [{ embedding: [1] }] }) },
+    });
+
+    await expect(p.embed("a")).rejects.toThrow(/MiniMax.*does not support embeddings/i);
+    await expect(p.embedBatch!(["a"])).rejects.toThrow(/MiniMax.*does not support embeddings/i);
   });
 });

--- a/test/embed-batch-providers.test.ts
+++ b/test/embed-batch-providers.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Provider-level embedBatch integration tests.
+ *
+ * Covers OpenAIProvider.embedBatch (Task 11), voyageEmbedBatch +
+ * AnthropicProvider/ClaudeAgentProvider delegation (Task 12), and
+ * CopilotProvider.embedBatch not-supported override (Task 13).
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { OpenAIProvider } from "../src/providers/openai.js";
+
+// Build a provider and stub its embeddingsClient.embeddings.create.
+function providerWithEmbeddings(create: (args: unknown) => unknown): OpenAIProvider {
+  const p = new OpenAIProvider("gpt-4o", { apiKey: "test" });
+  // @ts-expect-error test seam: override the private embeddings client
+  p.embeddingsClient = { embeddings: { create } };
+  return p;
+}
+
+describe("OpenAIProvider.embedBatch", () => {
+  it("sends array input and returns vectors in index order", async () => {
+    let sentInput: unknown;
+    const p = providerWithEmbeddings(async (args: any) => {
+      sentInput = args.input;
+      return { data: [{ index: 1, embedding: [2, 2] }, { index: 0, embedding: [1, 1] }] };
+    });
+    const out = await p.embedBatch!(["a", "b"]);
+    expect(sentInput).toEqual(["a", "b"]);
+    expect(out).toEqual([[1, 1], [2, 2]]);
+  });
+
+  it("throws on cardinality mismatch", async () => {
+    const p = providerWithEmbeddings(async () => ({ data: [{ index: 0, embedding: [1] }] }));
+    await expect(p.embedBatch!(["a", "b"])).rejects.toThrow();
+  });
+
+  it("single embed rejects an empty vector", async () => {
+    const p = providerWithEmbeddings(async () => ({ data: [{ embedding: [] }] }));
+    await expect(p.embed("a")).rejects.toThrow();
+  });
+});

--- a/test/embed-batch-providers.test.ts
+++ b/test/embed-batch-providers.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { OpenAIProvider } from "../src/providers/openai.js";
+import { voyageEmbedBatch } from "../src/providers/voyage-embed.js";
 
 // Build a provider and stub its embeddingsClient.embeddings.create.
 function providerWithEmbeddings(create: (args: unknown) => unknown): OpenAIProvider {
@@ -37,5 +38,28 @@ describe("OpenAIProvider.embedBatch", () => {
   it("single embed rejects an empty vector", async () => {
     const p = providerWithEmbeddings(async () => ({ data: [{ embedding: [] }] }));
     await expect(p.embed("a")).rejects.toThrow();
+  });
+});
+
+describe("voyageEmbedBatch", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = realFetch; delete process.env.VOYAGE_API_KEY; });
+
+  it("posts array input and returns index-ordered vectors", async () => {
+    process.env.VOYAGE_API_KEY = "vk";
+    let body: any;
+    globalThis.fetch = (async (_url: string, init: any) => {
+      body = JSON.parse(init.body);
+      return { ok: true, json: async () => ({ data: [{ index: 1, embedding: [2] }, { index: 0, embedding: [1] }] }) };
+    }) as any;
+    const out = await voyageEmbedBatch(["a", "b"]);
+    expect(body.input).toEqual(["a", "b"]);
+    expect(out).toEqual([[1], [2]]);
+  });
+
+  it("tags HTTP failures with status for the taxonomy", async () => {
+    process.env.VOYAGE_API_KEY = "vk";
+    globalThis.fetch = (async () => ({ ok: false, status: 429, text: async () => "slow down" })) as any;
+    await expect(voyageEmbedBatch(["a"])).rejects.toMatchObject({ status: 429 });
   });
 });

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -100,7 +100,7 @@ describe("OpenAIProvider.embed", () => {
       },
     });
 
-    await expect(provider.embed("anything")).rejects.toThrow(/did not include a vector/);
+    await expect(provider.embed("anything")).rejects.toThrow();
   });
 });
 

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -15,6 +15,7 @@ import { EMBEDDING_MODELS } from "../src/utils/constants.js";
 interface StubCall {
   model: string;
   input: string;
+  encodingFormat?: string;
 }
 
 function stubOpenAIClient(provider: OpenAIProvider, vector: number[]): StubCall[] {
@@ -37,8 +38,10 @@ function stubSplitClients(provider: OpenAIProvider): { chatCalls: StubCall[]; em
 function makeEmbeddingStub(calls: StubCall[], vector: number[]): unknown {
   return {
     embeddings: {
-      create: async ({ model, input }: { model: string; input: string }) => {
-        calls.push({ model, input });
+      create: async ({ model, input, encoding_format }: { model: string; input: string; encoding_format?: string }) => {
+        const call: StubCall = { model, input };
+        if (encoding_format) call.encodingFormat = encoding_format;
+        calls.push(call);
         return { data: [{ embedding: vector }] };
       },
     },
@@ -57,6 +60,7 @@ describe("OpenAIProvider.embed", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].model).toBe(EMBEDDING_MODELS.openai);
     expect(calls[0].input).toBe("hello world");
+    expect(calls[0].encodingFormat).toBe("float");
   });
 
   it("reuses the primary client when no embeddings URL is configured", () => {
@@ -76,7 +80,7 @@ describe("OpenAIProvider.embed", () => {
     expect(result).toEqual([1, 2, 3]);
     expect(chatCalls).toEqual([]);
     expect(embedCalls).toEqual([
-      { model: EMBEDDING_MODELS.openai, input: "separate endpoint" },
+      { model: EMBEDDING_MODELS.openai, input: "separate endpoint", encodingFormat: "float" },
     ]);
   });
 

--- a/test/embeddings-batch-failure.test.ts
+++ b/test/embeddings-batch-failure.test.ts
@@ -14,6 +14,19 @@ function makeProvider(over: Partial<LLMProvider>): LLMProvider {
   } as LLMProvider;
 }
 
+/** Assert a single-item batch returned one VEC and call counts match expectations. */
+async function assertSingleResult(
+  p: LLMProvider,
+  counts: { batchCalls: number; embedCalls: number },
+  expectedBatch: number,
+  expectedEmbed: number,
+): Promise<void> {
+  const out = await embedTextBatch(p, ["a"], 2);
+  expect(out).toEqual([VEC]);
+  expect(counts.batchCalls).toBe(expectedBatch);
+  expect(counts.embedCalls).toBe(expectedEmbed);
+}
+
 describe("embedTextBatch fallback policy", () => {
   it("sub-batches and preserves order", async () => {
     const seen: string[][] = [];
@@ -59,27 +72,21 @@ describe("embedTextBatch fallback policy", () => {
   });
 
   it("transient -> one retry, then sequential", async () => {
-    let batchCalls = 0, embedCalls = 0;
+    const counts = { batchCalls: 0, embedCalls: 0 };
     const p = makeProvider({
-      embed: async () => { embedCalls++; return VEC; },
-      embedBatch: async () => { batchCalls++; throw withStatus(429); },
+      embed: async () => { counts.embedCalls++; return VEC; },
+      embedBatch: async () => { counts.batchCalls++; throw withStatus(429); },
     });
-    const out = await embedTextBatch(p, ["a"], 2);
-    expect(out).toEqual([VEC]);
-    expect(batchCalls).toBe(2); // initial + one retry
-    expect(embedCalls).toBe(1); // then sequential
+    await assertSingleResult(p, counts, 2, 1); // initial + one retry, then sequential
   });
 
   it("transient that succeeds on retry does not fall back", async () => {
-    let batchCalls = 0, embedCalls = 0;
+    const counts = { batchCalls: 0, embedCalls: 0 };
     const p = makeProvider({
-      embed: async () => { embedCalls++; return VEC; },
-      embedBatch: async (t) => { batchCalls++; if (batchCalls === 1) throw withStatus(503); return t.map(() => VEC); },
+      embed: async () => { counts.embedCalls++; return VEC; },
+      embedBatch: async (t) => { counts.batchCalls++; if (counts.batchCalls === 1) throw withStatus(503); return t.map(() => VEC); },
     });
-    const out = await embedTextBatch(p, ["a"], 2);
-    expect(out).toEqual([VEC]);
-    expect(batchCalls).toBe(2);
-    expect(embedCalls).toBe(0);
+    await assertSingleResult(p, counts, 2, 0); // retry succeeds, no sequential fallback
   });
 
   it("transient then an UNKNOWN error on retry throws (no fallback)", async () => {

--- a/test/embeddings-batch-failure.test.ts
+++ b/test/embeddings-batch-failure.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { embedTextBatch, EmbeddingIntegrityError } from "../src/utils/embeddings-batch.js";
+import type { LLMProvider } from "../src/utils/provider.js";
+
+const VEC = [0.1, 0.2];
+const withStatus = (s: number, m = "") => Object.assign(new Error(m), { status: s });
+
+// Minimal provider stub: only embed + embedBatch matter here.
+function makeProvider(over: Partial<LLMProvider>): LLMProvider {
+  return {
+    complete: async () => "", stream: async () => "", toolCall: async () => "",
+    embed: async () => VEC,
+    ...over,
+  } as LLMProvider;
+}
+
+describe("embedTextBatch fallback policy", () => {
+  it("sub-batches and preserves order", async () => {
+    const seen: string[][] = [];
+    const p = makeProvider({ embedBatch: async (t) => { seen.push(t); return t.map(() => VEC); } });
+    const out = await embedTextBatch(p, ["a", "b", "c"], 2);
+    expect(out).toHaveLength(3);
+    expect(seen).toEqual([["a", "b"], ["c"]]); // 256-style split shown at size 2
+  });
+
+  it("falls back to sequential when embedBatch is absent", async () => {
+    let calls = 0;
+    const p = makeProvider({ embed: async () => { calls++; return VEC; } });
+    const out = await embedTextBatch(p, ["a", "b"], 2);
+    expect(out).toEqual([VEC, VEC]);
+    expect(calls).toBe(2);
+  });
+
+  it("throws on integrity error, no fallback", async () => {
+    const p = makeProvider({ embedBatch: async () => { throw new EmbeddingIntegrityError("cardinality"); } });
+    await expect(embedTextBatch(p, ["a"], 2)).rejects.toBeInstanceOf(EmbeddingIntegrityError);
+  });
+
+  it("throws on auth error, no fallback", async () => {
+    let embedCalls = 0;
+    const p = makeProvider({
+      embed: async () => { embedCalls++; return VEC; },
+      embedBatch: async () => { throw withStatus(401); },
+    });
+    await expect(embedTextBatch(p, ["a"], 2)).rejects.toBeTruthy();
+    expect(embedCalls).toBe(0); // never fell back
+  });
+
+  it("request-too-large -> sequential immediately, no retry", async () => {
+    let batchCalls = 0, embedCalls = 0;
+    const p = makeProvider({
+      embed: async () => { embedCalls++; return VEC; },
+      embedBatch: async () => { batchCalls++; throw withStatus(413); },
+    });
+    const out = await embedTextBatch(p, ["a", "b"], 2);
+    expect(out).toEqual([VEC, VEC]);
+    expect(batchCalls).toBe(1); // no retry
+    expect(embedCalls).toBe(2);
+  });
+
+  it("transient -> one retry, then sequential", async () => {
+    let batchCalls = 0, embedCalls = 0;
+    const p = makeProvider({
+      embed: async () => { embedCalls++; return VEC; },
+      embedBatch: async () => { batchCalls++; throw withStatus(429); },
+    });
+    const out = await embedTextBatch(p, ["a"], 2);
+    expect(out).toEqual([VEC]);
+    expect(batchCalls).toBe(2); // initial + one retry
+    expect(embedCalls).toBe(1); // then sequential
+  });
+
+  it("transient that succeeds on retry does not fall back", async () => {
+    let batchCalls = 0, embedCalls = 0;
+    const p = makeProvider({
+      embed: async () => { embedCalls++; return VEC; },
+      embedBatch: async (t) => { batchCalls++; if (batchCalls === 1) throw withStatus(503); return t.map(() => VEC); },
+    });
+    const out = await embedTextBatch(p, ["a"], 2);
+    expect(out).toEqual([VEC]);
+    expect(batchCalls).toBe(2);
+    expect(embedCalls).toBe(0);
+  });
+
+  it("transient then an UNKNOWN error on retry throws (no fallback)", async () => {
+    let embedCalls = 0, batchCalls = 0;
+    const p = makeProvider({
+      embed: async () => { embedCalls++; return VEC; },
+      embedBatch: async () => { batchCalls++; throw batchCalls === 1 ? withStatus(429) : withStatus(400, "bad input"); },
+    });
+    await expect(embedTextBatch(p, ["a"], 2)).rejects.toBeTruthy();
+    expect(batchCalls).toBe(2); // initial + retry
+    expect(embedCalls).toBe(0); // unknown retry error -> NO sequential fallback
+  });
+
+  it("annotates the thrown error with the failing global index", async () => {
+    const p = makeProvider({
+      embedBatch: async (t: string[]) => { if (t.includes("c")) throw new EmbeddingIntegrityError("cardinality"); return t.map(() => VEC); },
+    });
+    // size 2 -> sub-batches ["a","b"], ["c","d"]; the second fails, startIndex 2.
+    await expect(embedTextBatch(p, ["a", "b", "c", "d"], 2)).rejects.toMatchObject({ failedIndex: 2 });
+  });
+});

--- a/test/embeddings-batch-failure.test.ts
+++ b/test/embeddings-batch-failure.test.ts
@@ -80,6 +80,23 @@ describe("embedTextBatch fallback policy", () => {
     await assertSingleResult(p, counts, 2, 1); // initial + one retry, then sequential
   });
 
+  it("retries a transient sequential fallback item once", async () => {
+    const counts = { batchCalls: 0, embedCalls: 0 };
+    const p = makeProvider({
+      embed: async () => {
+        counts.embedCalls++;
+        if (counts.embedCalls === 1) throw withStatus(429);
+        return VEC;
+      },
+      embedBatch: async () => { counts.batchCalls++; throw withStatus(429); },
+    });
+
+    const out = await embedTextBatch(p, ["a"], 2);
+
+    expect(out).toEqual([VEC]);
+    expect(counts).toEqual({ batchCalls: 2, embedCalls: 2 });
+  });
+
   it("transient that succeeds on retry does not fall back", async () => {
     const counts = { batchCalls: 0, embedCalls: 0 };
     const p = makeProvider({

--- a/test/embeddings-batch-parity.test.ts
+++ b/test/embeddings-batch-parity.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Golden-parity test: batched output equals sequential output (updatedAt stripped).
+ *
+ * Verifies that enabling embedBatch on the provider yields chunk vectors
+ * and ordering that are byte-for-byte identical to the sequential fallback
+ * path, proving the slot reconstruction algorithm is correct.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { refreshChunkEmbeddings } from "../src/utils/embeddings-chunks.js";
+import * as providerMod from "../src/utils/provider.js";
+import type { PageRecord } from "../src/utils/embeddings-pages.js";
+
+const records: PageRecord[] = [
+  { slug: "a", title: "A", summary: "", body: "alpha one.\n\nalpha two." },
+  { slug: "b", title: "B", summary: "", body: "beta one." },
+];
+
+// Deterministic vector keyed by text so order mistakes are visible.
+const vecFor = (t: string): number[] => [t.length, t.charCodeAt(0) ?? 0];
+
+const stripTime = (cs: any[]) => cs.map(({ updatedAt, ...rest }) => rest);
+
+describe("golden parity: batched == sequential", () => {
+  it("produces the same store with and without embedBatch", async () => {
+    const withBatch = { embed: async (t: string) => vecFor(t), embedBatch: async (ts: string[]) => ts.map(vecFor) };
+    const noBatch = { embed: async (t: string) => vecFor(t) }; // embedBatch absent -> sequential fallback
+
+    vi.spyOn(providerMod, "getProvider").mockReturnValue(withBatch as any);
+    const batched = await refreshChunkEmbeddings(records, [], false, 256);
+
+    vi.spyOn(providerMod, "getProvider").mockReturnValue(noBatch as any);
+    const sequential = await refreshChunkEmbeddings(records, [], false, 256);
+
+    expect(stripTime(batched.chunks)).toEqual(stripTime(sequential.chunks)); // vectors, slugs, order, hashes identical
+  });
+});

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -66,6 +66,29 @@ describe("normalizeEmbeddingData", () => {
   });
 });
 
+describe("resolveEmbedBatchSize", () => {
+  const run = (env: string | undefined, provider = "openai") => {
+    if (env === undefined) delete process.env.LLMWIKI_EMBED_BATCH_SIZE;
+    else process.env.LLMWIKI_EMBED_BATCH_SIZE = env;
+    return resolveEmbedBatchSize(provider);
+  };
+  afterEach(() => { delete process.env.LLMWIKI_EMBED_BATCH_SIZE; });
+
+  it("uses the per-provider default when unset", () => {
+    expect(run(undefined, "openai")).toBe(256);
+    expect(run(undefined, "ollama")).toBe(64);
+    expect(run(undefined, "minimax")).toBe(64); // fallback
+  });
+  it("honors a valid override", () => { expect(run("32")).toBe(32); });
+  it("clamps an over-cap override to the provider cap", () => { expect(run("99999", "openai")).toBe(2048); });
+  it("rejects non-positive / non-integer and falls back to default", () => {
+    expect(run("0")).toBe(256);
+    expect(run("-5")).toBe(256);
+    expect(run("abc")).toBe(256);
+    expect(run("1.5")).toBe(256);
+  });
+});
+
 describe("error taxonomy", () => {
   it("classifies each error class", () => {
     expect(isIntegrityError(new EmbeddingIntegrityError("cardinality"))).toBe(true);

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -67,6 +67,12 @@ describe("normalizeEmbeddingData", () => {
     expect(() => normalizeEmbeddingData([{ index: 0, embedding: [NaN] }, { index: 1, embedding: [2] }], 2))
       .toThrow(EmbeddingIntegrityError);
   });
+  it("classifies a null/non-object response item as integrity, not a raw TypeError", () => {
+    expect(() => normalizeEmbeddingData([null as unknown as { embedding?: unknown }], 1))
+      .toThrow(EmbeddingIntegrityError);
+    expect(() => normalizeEmbeddingData([{ index: 0, embedding: [1] }, null as unknown as { embedding?: unknown }], 2))
+      .toThrow(EmbeddingIntegrityError);
+  });
 });
 
 describe("resolveEmbedBatchSize", () => {

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import {
+  EmbeddingIntegrityError,
+  isIntegrityError,
+  isAuthError,
+  isRequestTooLarge,
+  isTransient,
+} from "../src/utils/embeddings-batch.js";
+
+const withStatus = (status: number, message = "") => Object.assign(new Error(message), { status });
+
+describe("error taxonomy", () => {
+  it("classifies each error class", () => {
+    expect(isIntegrityError(new EmbeddingIntegrityError("cardinality"))).toBe(true);
+    expect(isAuthError(withStatus(401))).toBe(true);
+    expect(isAuthError(new Error("VOYAGE_API_KEY is not set"))).toBe(true);
+    expect(isRequestTooLarge(withStatus(413))).toBe(true);
+    expect(isRequestTooLarge(withStatus(400, "max allowed tokens per request"))).toBe(true);
+    expect(isTransient(withStatus(429))).toBe(true);
+    expect(isTransient(withStatus(503))).toBe(true);
+    expect(isTransient(new Error("fetch failed"))).toBe(true);
+    // a plain 400 with no size hint is NOT oversized — treat as caller error
+    expect(isRequestTooLarge(withStatus(400, "bad input"))).toBe(false);
+  });
+});

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -6,6 +6,9 @@ import {
   isRequestTooLarge,
   isTransient,
   resolveEmbedBatchSize,
+  classifyEmbeddingError,
+  enrichEmbedError,
+  shouldRethrowEmbeddingFailure,
 } from "../src/utils/embeddings-batch.js";
 import {
   assertVectorValid,
@@ -101,5 +104,30 @@ describe("error taxonomy", () => {
     expect(isTransient(new Error("fetch failed"))).toBe(true);
     // a plain 400 with no size hint is NOT oversized — treat as caller error
     expect(isRequestTooLarge(withStatus(400, "bad input"))).toBe(false);
+  });
+});
+
+describe("failure reporting helpers", () => {
+  it("classifies each error into a stable label", () => {
+    expect(classifyEmbeddingError(new EmbeddingIntegrityError("x"))).toBe("integrity");
+    expect(classifyEmbeddingError(Object.assign(new Error(), { status: 401 }))).toBe("auth");
+    expect(classifyEmbeddingError(Object.assign(new Error(), { status: 413 }))).toBe("request-too-large");
+    expect(classifyEmbeddingError(Object.assign(new Error(), { status: 429 }))).toBe("transient");
+    expect(classifyEmbeddingError(new Error("???"))).toBe("unknown");
+  });
+
+  it("enriches with pass, class, and the slug at failedIndex", () => {
+    const err = Object.assign(new EmbeddingIntegrityError("cardinality"), { failedIndex: 1 });
+    const out = enrichEmbedError(err, "page", (i) => ["a", "b", "c"][i]);
+    expect(out.message).toMatch(/page embedding failed \[integrity\] at "b"/);
+    expect((out as { cause?: unknown }).cause).toBe(err); // preserves the original for classification
+  });
+
+  it("strict gate keys off LLMWIKI_EMBED_STRICT", () => {
+    delete process.env.LLMWIKI_EMBED_STRICT;
+    expect(shouldRethrowEmbeddingFailure()).toBe(false);
+    process.env.LLMWIKI_EMBED_STRICT = "1";
+    expect(shouldRethrowEmbeddingFailure()).toBe(true);
+    delete process.env.LLMWIKI_EMBED_STRICT;
   });
 });

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -9,7 +9,9 @@ import {
   classifyEmbeddingError,
   enrichEmbedError,
   shouldRethrowEmbeddingFailure,
+  makeCountingProvider,
 } from "../src/utils/embeddings-batch.js";
+import type { LLMProvider } from "../src/utils/provider.js";
 import {
   assertVectorValid,
   assertEveryVectorValid,
@@ -139,5 +141,26 @@ describe("failure reporting helpers", () => {
     process.env.LLMWIKI_EMBED_STRICT = "0";
     expect(shouldRethrowEmbeddingFailure()).toBe(false);
     delete process.env.LLMWIKI_EMBED_STRICT;
+  });
+});
+
+describe("makeCountingProvider", () => {
+  const base = {
+    complete: async () => "", stream: async () => "", toolCall: async () => "",
+    embed: async () => [1], embedBatch: async (t: string[]) => t.map(() => [1]),
+  } as unknown as LLMProvider;
+
+  it("counts each embed and embedBatch call", async () => {
+    const { provider, requestCount } = makeCountingProvider(base);
+    await provider.embedBatch!(["a", "b"]);
+    await provider.embed("c");
+    await provider.embedBatch!(["d"]);
+    expect(requestCount()).toBe(3); // 2 batch calls + 1 single, regardless of input sizes
+  });
+
+  it("omits embedBatch when the underlying provider has none", () => {
+    const noBatch = { ...base, embedBatch: undefined } as unknown as LLMProvider;
+    const { provider } = makeCountingProvider(noBatch);
+    expect(provider.embedBatch).toBeUndefined();
   });
 });

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -1,13 +1,70 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   EmbeddingIntegrityError,
   isIntegrityError,
   isAuthError,
   isRequestTooLarge,
   isTransient,
+  resolveEmbedBatchSize,
 } from "../src/utils/embeddings-batch.js";
+import {
+  assertVectorValid,
+  assertEveryVectorValid,
+  normalizeEmbeddingData,
+} from "../src/utils/embeddings-validate.js";
 
 const withStatus = (status: number, message = "") => Object.assign(new Error(message), { status });
+
+describe("vector validation", () => {
+  it("accepts a finite non-empty vector and rejects bad ones", () => {
+    expect(() => assertVectorValid([0.1, 0.2])).not.toThrow();
+    expect(() => assertVectorValid([])).toThrow(/empty/i);
+    expect(() => assertVectorValid([NaN])).toThrow(/finite/i);
+    expect(() => assertVectorValid([Infinity])).toThrow(/finite/i);
+    expect(() => assertVectorValid([0.1], 2)).toThrow(/dimension/i);
+  });
+
+  it("asserts uniform dimension across a batch", () => {
+    expect(() => assertEveryVectorValid([[1, 2], [3, 4]])).not.toThrow();
+    expect(() => assertEveryVectorValid([[1, 2], [3]])).toThrow(/dimension/i);
+  });
+});
+
+describe("normalizeEmbeddingData", () => {
+  it("reorders response data by index", () => {
+    const data = [{ index: 1, embedding: [9, 9] }, { index: 0, embedding: [1, 1] }];
+    expect(normalizeEmbeddingData(data, 2)).toEqual([[1, 1], [9, 9]]);
+  });
+  it("accepts positional order when no index present", () => {
+    expect(normalizeEmbeddingData([{ embedding: [1] }, { embedding: [2] }], 2)).toEqual([[1], [2]]);
+  });
+  it("throws on cardinality mismatch", () => {
+    expect(() => normalizeEmbeddingData([{ index: 0, embedding: [1] }], 2)).toThrow(EmbeddingIntegrityError);
+  });
+  it("throws on a missing slot (sparse hole)", () => {
+    // two items but both index 0 -> slot 1 never filled
+    expect(() => normalizeEmbeddingData([{ index: 0, embedding: [1] }, { index: 0, embedding: [2] }], 2))
+      .toThrow(EmbeddingIntegrityError);
+  });
+  it("throws on a duplicate index", () => {
+    expect(() => normalizeEmbeddingData([{ index: 0, embedding: [1] }, { index: 0, embedding: [2] }], 2))
+      .toThrow(/duplicate|missing/i);
+  });
+  it("throws on a fractional index", () => {
+    expect(() => normalizeEmbeddingData([{ index: 0.5, embedding: [1] }, { index: 1, embedding: [2] }], 2))
+      .toThrow(EmbeddingIntegrityError);
+  });
+  it("throws on mixed indexed/unindexed response", () => {
+    expect(() => normalizeEmbeddingData([{ index: 0, embedding: [1] }, { embedding: [2] }], 2))
+      .toThrow(/mixed/i);
+  });
+  it("throws on an empty or non-finite embedding", () => {
+    expect(() => normalizeEmbeddingData([{ index: 0, embedding: [] }, { index: 1, embedding: [2] }], 2))
+      .toThrow(EmbeddingIntegrityError);
+    expect(() => normalizeEmbeddingData([{ index: 0, embedding: [NaN] }, { index: 1, embedding: [2] }], 2))
+      .toThrow(EmbeddingIntegrityError);
+  });
+});
 
 describe("error taxonomy", () => {
   it("classifies each error class", () => {

--- a/test/embeddings-batch.test.ts
+++ b/test/embeddings-batch.test.ts
@@ -134,6 +134,10 @@ describe("failure reporting helpers", () => {
     expect(shouldRethrowEmbeddingFailure()).toBe(false);
     process.env.LLMWIKI_EMBED_STRICT = "1";
     expect(shouldRethrowEmbeddingFailure()).toBe(true);
+    process.env.LLMWIKI_EMBED_STRICT = "false";
+    expect(shouldRethrowEmbeddingFailure()).toBe(false);
+    process.env.LLMWIKI_EMBED_STRICT = "0";
+    expect(shouldRethrowEmbeddingFailure()).toBe(false);
     delete process.env.LLMWIKI_EMBED_STRICT;
   });
 });

--- a/test/embeddings-chunks.test.ts
+++ b/test/embeddings-chunks.test.ts
@@ -39,6 +39,10 @@ function setupOpenAI(vector: number[]): { embed: ReturnType<typeof vi.fn> } {
   process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
   const embed = vi.fn().mockResolvedValue(vector);
   vi.spyOn(OpenAIProvider.prototype, "embed").mockImplementation(embed);
+  // Mock embedBatch so the page-embedding pass (which now uses batch) returns valid vectors.
+  vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
+    async (texts: string[]) => texts.map(() => vector),
+  );
   return { embed };
 }
 
@@ -91,8 +95,8 @@ describe("updateEmbeddings (chunk path)", () => {
     expect(store?.chunks?.length).toBeGreaterThan(0);
     expect(store?.chunks?.[0].slug).toBe("alpha");
     expect(store?.chunks?.[0].contentHash).toMatch(/^[a-f0-9]+$/);
-    // 1 page + N chunks, so embed gets called more than once.
-    expect(embed.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Chunks are embedded via sequential embed(); the page uses embedBatch.
+    expect(embed.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("reuses chunk vectors whose contentHash still matches", async () => {
@@ -117,9 +121,8 @@ describe("updateEmbeddings (chunk path)", () => {
     const betaChunks = afterStore?.chunks?.filter((c) => c.slug === "beta") ?? [];
     expect(alphaChunks.length).toBe(initialChunkCount);
     expect(betaChunks.length).toBeGreaterThan(0);
-    // Only beta page (1) + beta chunk(s) should have been embedded — alpha is reused.
-    const betaEmbedCount = 1 + betaChunks.length;
-    expect(embedAfter).toHaveBeenCalledTimes(betaEmbedCount);
+    // Only beta chunk(s) should use embed — the page uses embedBatch; alpha is reused.
+    expect(embedAfter).toHaveBeenCalledTimes(betaChunks.length);
   });
 
   it("re-embeds a chunk when its body content changes", async () => {

--- a/test/embeddings-chunks.test.ts
+++ b/test/embeddings-chunks.test.ts
@@ -18,6 +18,9 @@ import {
   type ChunkEmbeddingEntry,
   type EmbeddingStore,
 } from "../src/utils/embeddings.js";
+import { refreshChunkEmbeddings } from "../src/utils/embeddings-chunks.js";
+import * as providerMod from "../src/utils/provider.js";
+import type { PageRecord } from "../src/utils/embeddings-pages.js";
 import { OpenAIProvider } from "../src/providers/openai.js";
 import { CHUNK_TARGET_CHARS } from "../src/utils/constants.js";
 
@@ -84,7 +87,7 @@ describe("findTopKChunks", () => {
 describe("updateEmbeddings (chunk path)", () => {
   it("populates chunks for live pages on a cold start", async () => {
     const root = await makeRoot();
-    const { embed } = setupOpenAI([0.5, 0.5]);
+    setupOpenAI([0.5, 0.5]);
     const body = "Paragraph one.\n\nParagraph two with more detail.";
     await writeConcept(root, "alpha", body);
 
@@ -95,8 +98,8 @@ describe("updateEmbeddings (chunk path)", () => {
     expect(store?.chunks?.length).toBeGreaterThan(0);
     expect(store?.chunks?.[0].slug).toBe("alpha");
     expect(store?.chunks?.[0].contentHash).toMatch(/^[a-f0-9]+$/);
-    // Chunks are embedded via sequential embed(); the page uses embedBatch.
-    expect(embed.mock.calls.length).toBeGreaterThanOrEqual(1);
+    // Both page and chunk passes use embedBatch; embed is only the sequential fallback.
+    expect(store?.chunks?.length).toBeGreaterThan(0);
   });
 
   it("reuses chunk vectors whose contentHash still matches", async () => {
@@ -111,8 +114,11 @@ describe("updateEmbeddings (chunk path)", () => {
     // Add a brand-new page with a fresh body. The existing chunk for alpha
     // should be reused (same hash), not re-embedded.
     await writeConcept(root, "beta", "Different body");
-    const embedAfter = vi.fn().mockResolvedValue([0.3, 0.7]);
-    vi.spyOn(OpenAIProvider.prototype, "embed").mockImplementation(embedAfter);
+    const batchedTexts: string[][] = [];
+    vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(async (texts: string[]) => {
+      batchedTexts.push(texts);
+      return texts.map(() => [0.3, 0.7]);
+    });
 
     await updateEmbeddings(root, ["beta"]);
     const afterStore = await readEmbeddingStore(root);
@@ -121,8 +127,10 @@ describe("updateEmbeddings (chunk path)", () => {
     const betaChunks = afterStore?.chunks?.filter((c) => c.slug === "beta") ?? [];
     expect(alphaChunks.length).toBe(initialChunkCount);
     expect(betaChunks.length).toBeGreaterThan(0);
-    // Only beta chunk(s) should use embed — the page uses embedBatch; alpha is reused.
-    expect(embedAfter).toHaveBeenCalledTimes(betaChunks.length);
+    // Only beta page + beta chunks are embedded; alpha chunks are reused (hash unchanged).
+    const totalBatchedTexts = batchedTexts.reduce((s, ts) => s + ts.length, 0);
+    // 1 page text (page pass) + betaChunks.length texts (chunk pass)
+    expect(totalBatchedTexts).toBe(1 + betaChunks.length);
   });
 
   it("re-embeds a chunk when its body content changes", async () => {
@@ -271,5 +279,34 @@ describe("backwards compatibility", () => {
     // sanity: ensures CHUNK_TARGET_CHARS isn't accidentally large enough that
     // the chunking tests above would silently degrade to single-chunk output.
     expect(CHUNK_TARGET_CHARS).toBeGreaterThan(100);
+  });
+});
+
+describe("refreshChunkEmbeddings batching", () => {
+  it("batches missing chunks across pages and preserves order + reuse", async () => {
+    const batches: string[][] = [];
+    vi.spyOn(providerMod, "getProvider").mockReturnValue({
+      embed: async () => [9, 9],
+      embedBatch: async (t: string[]) => { batches.push(t); return t.map((_, i) => [i, i]); },
+    } as any);
+
+    const records: PageRecord[] = [
+      { slug: "a", title: "A", summary: "", body: "alpha paragraph one.\n\nalpha two." },
+      { slug: "b", title: "B", summary: "", body: "beta paragraph one." },
+    ];
+    // First run: cold, everything embeds.
+    const cold = await refreshChunkEmbeddings(records, [], false, 256);
+    expect(batches).toHaveLength(1); // one cross-page batch
+    expect(cold.embedded).toBe(cold.chunks.length); // all fresh on cold start
+    expect(cold.chunks.map((c) => `${c.slug}#${c.chunkIndex}`)).toEqual(
+      cold.chunks.map((c) => `${c.slug}#${c.chunkIndex}`).slice().sort(), // already in page,index order
+    );
+
+    // Second run: identical content -> all reused, zero batch calls, zero embedded.
+    batches.length = 0;
+    const warm = await refreshChunkEmbeddings(records, cold.chunks, false, 256);
+    expect(batches).toHaveLength(0);
+    expect(warm.embedded).toBe(0);
+    expect(warm.chunks).toEqual(cold.chunks.map((c) => ({ ...c }))); // vectors untouched (title same)
   });
 });

--- a/test/embeddings-pages.test.ts
+++ b/test/embeddings-pages.test.ts
@@ -19,7 +19,8 @@ describe("embedPages batching", () => {
       { slug: "b", title: "B", summary: "sb", body: "" },
     ];
     const out = await embedPages(records, new Set(["a", "b"]), 256);
-    expect(out.map((e) => e.slug)).toEqual(["a", "b"]);
+    expect(out.entries.map((e) => e.slug)).toEqual(["a", "b"]);
+    expect(out.requests).toBe(1); // two pages collapsed into one batch request
     expect(calls).toHaveLength(1); // one batch, not two singles
     expect(calls[0]).toEqual(["A\n\nsa", "B\n\nsb"]);
   });

--- a/test/embeddings-pages.test.ts
+++ b/test/embeddings-pages.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tests for page-level batched embedding pass.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { embedPages } from "../src/utils/embeddings-pages.js";
+import * as providerMod from "../src/utils/provider.js";
+import type { PageRecord } from "../src/utils/embeddings-pages.js";
+
+describe("embedPages batching", () => {
+  it("embeds changed pages via a single embedBatch call", async () => {
+    const calls: string[][] = [];
+    vi.spyOn(providerMod, "getProvider").mockReturnValue({
+      embed: async () => [1, 1],
+      embedBatch: async (t: string[]) => { calls.push(t); return t.map(() => [1, 1]); },
+    } as any);
+    const records: PageRecord[] = [
+      { slug: "a", title: "A", summary: "sa", body: "" },
+      { slug: "b", title: "B", summary: "sb", body: "" },
+    ];
+    const out = await embedPages(records, new Set(["a", "b"]), 256);
+    expect(out.map((e) => e.slug)).toEqual(["a", "b"]);
+    expect(calls).toHaveLength(1); // one batch, not two singles
+    expect(calls[0]).toEqual(["A\n\nsa", "B\n\nsb"]);
+  });
+});

--- a/test/embeddings-validation.test.ts
+++ b/test/embeddings-validation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression tests for embedding-store and read-side vector integrity.
+ * These cases protect against silent zero-score ranking and warm-store
+ * corruption surviving across compiles.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "fs/promises";
+import path from "path";
+import os from "os";
+import {
+  findRelevantPages,
+  readEmbeddingStore,
+  updateEmbeddings,
+  writeEmbeddingStore,
+  type EmbeddingStore,
+} from "../src/utils/embeddings.js";
+import { EmbeddingIntegrityError } from "../src/utils/embeddings-batch.js";
+import { OpenAIProvider } from "../src/providers/openai.js";
+import * as providerMod from "../src/utils/provider.js";
+
+async function makeRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "llmwiki-embed-validation-"));
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  return root;
+}
+
+async function writeConcept(root: string, slug: string): Promise<void> {
+  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+  await writeFile(path.join(root, "wiki/concepts", `${slug}.md`), `---\ntitle: ${slug}\nsummary: Sum\n---\n\nBody`);
+}
+
+async function writeRawStore(root: string, store: EmbeddingStore): Promise<void> {
+  await writeFile(path.join(root, ".llmwiki/embeddings.json"), JSON.stringify(store, null, 2));
+}
+
+function pageStore(vector: number[], dimensions = 2): EmbeddingStore {
+  return {
+    version: 2,
+    model: "test-embed",
+    dimensions,
+    entries: [{ slug: "alpha", title: "Alpha", summary: "Sum", vector, updatedAt: "2026-01-01T00:00:00.000Z" }],
+    chunks: [],
+  };
+}
+
+function setOpenAIEnv(): void {
+  process.env.LLMWIKI_PROVIDER = "openai";
+  process.env.OPENAI_API_KEY = "test-key";
+  process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
+}
+
+function stubEmbeddingVectors(vector: number[]): void {
+  vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue(vector);
+  vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(async (texts: string[]) => (
+    texts.map(() => vector)
+  ));
+}
+
+function setupOpenAI(vector: number[]): void {
+  setOpenAIEnv();
+  stubEmbeddingVectors(vector);
+}
+
+afterEach(() => {
+  delete process.env.LLMWIKI_PROVIDER;
+  delete process.env.LLMWIKI_EMBEDDING_MODEL;
+  delete process.env.OPENAI_API_KEY;
+  vi.restoreAllMocks();
+});
+
+describe("read-side embedding validation", () => {
+  it("rejects a query vector whose dimension does not match the active store", async () => {
+    const root = await makeRoot();
+    setupOpenAI([1, 0, 0]);
+    await writeEmbeddingStore(root, pageStore([1, 0]));
+
+    await expect(findRelevantPages(root, "alpha")).rejects.toBeInstanceOf(EmbeddingIntegrityError);
+  });
+
+  it("treats a corrupted active store as unusable instead of ranking poisoned vectors", async () => {
+    const root = await makeRoot();
+    setupOpenAI([1, 0]);
+    await writeRawStore(root, pageStore([]));
+
+    await expect(findRelevantPages(root, "alpha")).resolves.toEqual([]);
+  });
+
+  it("passes query input type through the provider embed seam", async () => {
+    const root = await makeRoot();
+    let seenInputType: string | undefined;
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "test-embed";
+    vi.spyOn(providerMod, "getProvider").mockReturnValue({
+      complete: async () => "",
+      stream: async () => "",
+      toolCall: async () => "",
+      embed: async (_text: string, inputType?: "document" | "query") => {
+        seenInputType = inputType;
+        return [1, 0];
+      },
+    });
+    await writeEmbeddingStore(root, pageStore([1, 0]));
+
+    await findRelevantPages(root, "alpha");
+
+    expect(seenInputType).toBe("query");
+  });
+});
+
+describe("updateEmbeddings corrupted-store recovery", () => {
+  it("rebuilds an invalid same-model store instead of carrying bad vectors forward", async () => {
+    const root = await makeRoot();
+    setupOpenAI([0.9, 0.1]);
+    await writeConcept(root, "alpha");
+    await writeRawStore(root, pageStore([]));
+
+    await updateEmbeddings(root, []);
+    const rebuilt = await readEmbeddingStore(root);
+
+    expect(rebuilt?.entries[0].vector).toEqual([0.9, 0.1]);
+    expect(rebuilt?.dimensions).toBe(2);
+  });
+});

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -227,7 +227,7 @@ describe("structured embeddings report", () => {
     await updateEmbeddings(root, ["alpha"]);
 
     const lines = log.mock.calls.map(([line]) => (typeof line === "string" ? line : "")).join("\n");
-    expect(lines).toMatch(/\d+\/\d+ pages, \d+\/\d+ chunks/);
+    expect(lines).toMatch(/\d+\/\d+ pages, \d+\/\d+ chunks embedded \(\d+ batched requests\)/);
   });
 });
 

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -212,6 +212,25 @@ describe("embedding model selection", () => {
   });
 });
 
+describe("structured embeddings report", () => {
+  it("emits a structured embedded X/N pages, Y/M chunks report", async () => {
+    const root = await makeRoot();
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "test-model";
+    vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
+      async (texts: string[]) => texts.map(() => [0.5, 0.5]),
+    );
+    await writeConceptPage(root, "alpha");
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await updateEmbeddings(root, ["alpha"]);
+
+    const lines = log.mock.calls.map(([line]) => (typeof line === "string" ? line : "")).join("\n");
+    expect(lines).toMatch(/\d+\/\d+ pages, \d+\/\d+ chunks/);
+  });
+});
+
 /** Set up an OpenAI provider with an embedding store whose model is now stale. */
 async function setupOpenAIWithStaleStore(): Promise<string> {
   const root = await makeRoot();

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -198,6 +198,9 @@ describe("embedding model selection", () => {
     const root = await setupOpenAIWithStaleStore();
     process.env.OPENAI_API_KEY = "test-key";
     vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue([0.9, 0.1]);
+    vi.spyOn(OpenAIProvider.prototype, "embedBatch").mockImplementation(
+      async (texts: string[]) => texts.map(() => [0.9, 0.1]),
+    );
     await writeConceptPage(root, "alpha");
 
     await updateEmbeddings(root, []);

--- a/test/eval-stats.test.ts
+++ b/test/eval-stats.test.ts
@@ -2,7 +2,7 @@
  * Tests for src/eval/stats.ts — corpus size tracking and history append.
  */
 
-import { readFile } from "fs/promises";
+import { readFile, mkdir, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { collectStats, appendHistory, loadHistory, loadLastFullReport } from "../src/eval/stats.js";
@@ -44,6 +44,29 @@ describe("collectStats", () => {
 
     const result = await collectStats(env.dir);
     expect(result.pageCount).toBe(2);
+  });
+
+  it("degrades to zero embedding counts when the store is corrupt (regression)", async () => {
+    // Stricter store validation makes readEmbeddingStore throw on a corrupt
+    // store; stats must degrade, not crash (the one caller the validation
+    // change initially left unguarded).
+    const storeDir = path.join(env.dir, ".llmwiki");
+    await mkdir(storeDir, { recursive: true });
+    await writeFile(
+      path.join(storeDir, "embeddings.json"),
+      JSON.stringify({
+        version: 2,
+        model: "text-embedding-3-small",
+        dimensions: 3, // claims dim 3 but the entry vector is empty -> integrity error
+        entries: [{ slug: "a", title: "A", summary: "", vector: [], updatedAt: "2024-01-01" }],
+        chunks: [],
+      }),
+      "utf-8",
+    );
+
+    const result = await collectStats(env.dir); // must not throw
+    expect(result.embeddingCount).toBe(0);
+    expect(result.chunkEmbeddingCount).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Cold-start and large compiles embedded pages and chunks one HTTP request at a time. This adds provider-native batch embedding (sequential sub-batches, with a sequential fallback) to cut compile latency, and splits the overgrown `embeddings.ts` into focused modules. No on-disk format change — the store stays JSON v2.

## What changed

- **Optional `embedBatch(texts)` on providers.** OpenAI and Ollama use native array input; Anthropic and Claude Agent batch via Voyage (shared via a small base class); Copilot and MiniMax are explicitly unsupported (MiniMax fails closed rather than inheriting unverified OpenAI embedding behavior). `embed(text)` remains the stable single contract.
- **Default-on batching** for both the page and chunk passes. The chunk pass collects missing/changed chunks across all pages into one flat work-list, sub-batches them, and reconstructs deterministic page→chunk order (hash-based reuse preserved).
- **Document/query embedding intent** threaded through the provider seam: stored content embeds as `document`, live query strings as `query` (Voyage `input_type`), which improves retrieval quality.
- **Integrity validation everywhere it matters:** batch responses (cardinality, index normalization, per-vector finite/dimension checks, malformed-item rejection) and the single-embed path; the on-disk store is validated on read and write, so a corrupt/poisoned store is skipped at query time and rebuilt on the next compile instead of silently ranking bad vectors. OpenAI embeddings request `encoding_format: float` so the SDK returns usable numeric vectors.
- **Typed failure handling:** transient (429/5xx) gets one retry then a sequential fallback; request-too-large degrades straight to sequential; integrity and auth failures fail loud. No new backoff/scheduler machinery.
- **Configurable + observable:** `LLMWIKI_EMBED_BATCH_SIZE` (clamped per provider), a structured `X/N pages, Y/M chunks` report with failure class + slug, and an opt-in `LLMWIKI_EMBED_STRICT` (`1/true/yes/on`) that makes embedding failures a non-zero exit for CI.
- **Module split:** `embeddings.ts` → `store` / `search` / `pages` / `chunks` / `validate` / `batch` + a slim orchestrator. The public import surface is unchanged (re-exported).

## Test plan

- `npm test` — 1716 passing, including golden-parity (batched output == sequential), the full failure taxonomy, read-side store/query validation, corrupt-store recovery, and an aimock subprocess `compile` test asserting batched requests and a correct persisted store.
- `npx tsc --noEmit`, `npm run build`, and `fallow` all clean.
- `madge` confirms the new embedding modules introduce no import cycle. The 3 pre-existing `provider.ts` ↔ provider-class type-import cycles are unrelated to this change and left untouched.