### PR TITLE
feat(profile): Phase 2 — typed state v2 + write planner + trust-guard staging

### DIFF
--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -27,7 +27,7 @@ import {
   CANDIDATES_ARCHIVE_DIR,
 } from "../utils/constants.js";
 import type { ReviewCandidate, SourceState } from "../utils/types.js";
-import type { HeldReason, HeldReasonCode, ReviewMode } from "../review/policy.js";
+import type { HeldReason, PolicyHeldReasonCode, ReviewMode } from "../review/policy.js";
 import type { LintResult } from "../linter/types.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
@@ -84,8 +84,8 @@ const DEFAULT_HELD_REASONS: HeldReason[] = [{ code: "manual-review-requested" }]
 /** All valid ReviewMode values. */
 const VALID_REVIEW_MODES: ReviewMode[] = ["policy", "forced", "imported"];
 
-/** All valid HeldReasonCode values — mirrors the union in policy.ts. */
-const VALID_HELD_REASON_CODES: HeldReasonCode[] = [
+/** All valid PolicyHeldReasonCode values — mirrors the closed union in policy.ts. */
+const VALID_HELD_REASON_CODES: PolicyHeldReasonCode[] = [
   "low-confidence",
   "contradicted",
   "schema-violating",

--- a/src/compiler/refresh-plan.ts
+++ b/src/compiler/refresh-plan.ts
@@ -16,6 +16,7 @@ import { scanWikiPages } from "./indexgen.js";
 import { CONCEPTS_DIR, SOURCES_DIR } from "../utils/constants.js";
 import type { SourceChange, WikiState } from "../utils/types.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
+import type { StateStatus } from "../utils/state.js";
 
 export interface RefreshPlan {
   /** Stale pages with a changed live owner — recompiled. Disjoint from the other outcome lists. */
@@ -42,8 +43,12 @@ export interface RefreshPlan {
   changeFilter: (change: SourceChange) => boolean;
 }
 
-/** Classified outcome of reading .llmwiki/state.json for a refresh run. */
-export type RefreshStateStatus = "ok" | "missing" | "corrupt";
+/**
+ * Classified outcome of reading .llmwiki/state.json for a refresh run.
+ * A non-"ok" status (missing/corrupt/too-new) yields a null plan: refresh is
+ * skipped, so a too-new project is never silently treated as compilable.
+ */
+export type RefreshStateStatus = StateStatus;
 
 export interface RefreshResolution {
   stateStatus: RefreshStateStatus;

--- a/src/freshness/types.ts
+++ b/src/freshness/types.ts
@@ -6,6 +6,8 @@
  * shared by every consumer (lint, export, MCP, context, viewer).
  */
 
+import type { StateStatus } from "../utils/state.js";
+
 /** A page's computed freshness on the source-derived axis. */
 export type FreshnessStatus = "fresh" | "stale" | "orphaned" | "unverified";
 
@@ -30,7 +32,7 @@ export interface SourceFreshness {
 
 /** Reusable, per-run snapshot of all freshness inputs. */
 export interface FreshnessSnapshot {
-  stateStatus: "ok" | "missing" | "corrupt";
+  stateStatus: StateStatus;
   /** Source filename -> its freshness inputs (empty unless stateStatus === "ok"). */
   sources: Record<string, SourceFreshness>;
 }

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -98,7 +98,21 @@ function registerStateResource(server: McpServer, root: string): void {
       mimeType: "application/json",
     },
     async (uri) => {
-      const { state } = await readStateClassified(root);
+      const { status, state } = await readStateClassified(root);
+      // Fail closed on a too-new state: every sibling surface branches on
+      // `status`, so the resource must too rather than streaming a body written
+      // by a newer llmwiki as if it were healthy. "ok"/"missing"/"corrupt" keep
+      // their current byte-identical output (the carried state body).
+      if (status === "too-new") {
+        return {
+          contents: [
+            jsonContent(uri, {
+              stateStatus: "too-new",
+              error: "written by a newer llmwiki version",
+            }),
+          ],
+        };
+      }
       return { contents: [jsonContent(uri, state)] };
     },
   );

--- a/src/project/state.ts
+++ b/src/project/state.ts
@@ -31,6 +31,7 @@ import { countCandidates } from "../compiler/candidates.js";
 import { LINT_CACHE_TIMESTAMP_PATTERN } from "../linter/cache.js";
 import type { LintCacheEntry } from "../linter/cache.js";
 import { readStateClassified } from "../utils/state.js";
+import type { StateStatus } from "../utils/state.js";
 
 /** Markdown extension treated as a wiki page for counting purposes. */
 const MARKDOWN_EXT = ".md";
@@ -45,6 +46,7 @@ type ProjectStateWarningCode =
   | "pending-candidates"
   | "project-unreadable"
   | "state-unreadable"
+  | "state-too-new"
   | "stale-pages";
 
 /** One structural warning surfaced alongside the primary state. */
@@ -239,7 +241,7 @@ interface AssembleStateInput {
   counts: PageCounts;
   lint: LintCacheStatus;
   mtimes: MtimePair;
-  stateStatus: "ok" | "missing" | "corrupt";
+  stateStatus: StateStatus;
 }
 
 /** Combine the per-section reads into the final ProjectState + warning list. */
@@ -255,7 +257,7 @@ interface WarningInput {
   counts: PageCounts;
   lint: LintCacheStatus;
   mtimes: MtimePair;
-  stateStatus: "ok" | "missing" | "corrupt";
+  stateStatus: StateStatus;
 }
 
 /** Derive every structural warning from the already-collected state slices. */
@@ -326,7 +328,7 @@ function appendStructuralWarnings(
 function appendFreshnessWarnings(
   warnings: ProjectStateWarning[],
   lint: LintCacheStatus,
-  stateStatus: "ok" | "missing" | "corrupt",
+  stateStatus: StateStatus,
   latestSourceMtimeMs: number | null,
 ): void {
   if (stateStatus === "corrupt") {
@@ -334,6 +336,13 @@ function appendFreshnessWarnings(
       code: "state-unreadable",
       message:
         ".llmwiki/state.json is corrupt — run `llmwiki compile` to rebuild it (freshness figures shown are from the last lint and may be stale).",
+    });
+  }
+  if (stateStatus === "too-new") {
+    warnings.push({
+      code: "state-too-new",
+      message:
+        ".llmwiki/state.json was written by a newer llmwiki version — upgrade llmwiki to read this project (freshness figures shown are from the last lint and may be stale).",
     });
   }
   const f = lint.entry?.freshness;

--- a/src/review/policy.ts
+++ b/src/review/policy.ts
@@ -10,8 +10,16 @@
 
 import type { LintResult } from "../linter/types.js";
 
-/** Policy reasons stored on review candidates and surfaced in CLI output. */
-export type HeldReasonCode =
+/**
+ * Closed set of review-policy reasons that fire from the compile pipeline and
+ * are stored on review candidates / surfaced in CLI output.
+ *
+ * The Trust Guard's staged-write surface widens this into an OPEN union
+ * (`HeldReasonCode` in `src/trust/staged-change.ts`) that keeps these literals
+ * as a strict subset and adds trust-routing codes; this stays the narrow,
+ * canonical policy set so the candidate store and CLI keep an exhaustive union.
+ */
+export type PolicyHeldReasonCode =
   | "low-confidence"
   | "contradicted"
   | "schema-violating"
@@ -22,7 +30,7 @@ export type HeldReasonCode =
 
 /** Structured reason a generated page was held for review. */
 export interface HeldReason {
-  code: HeldReasonCode;
+  code: PolicyHeldReasonCode;
   detail?: string;
 }
 
@@ -31,7 +39,7 @@ export type ReviewMode = "policy" | "forced" | "imported";
 
 /** Configurable review policy modes. */
 export type ReviewPolicyMode =
-  | Exclude<HeldReasonCode, "manual-review-requested" | "imported-okf">
+  | Exclude<PolicyHeldReasonCode, "manual-review-requested" | "imported-okf">
   | "off";
 
 /** How low-confidence policy treats a missing confidence signal. */

--- a/src/state/migrate.ts
+++ b/src/state/migrate.ts
@@ -31,7 +31,7 @@ const CONCEPT_ENTITY_TYPE = "concepts";
  */
 function mintConceptEntities(slugs: string[]): EntityId[] {
   const ids = slugs.map((slug) => entityId(CONCEPT_ENTITY_TYPE, assertSlugSafe(slug)));
-  return [...ids].sort();
+  return [...new Set(ids)].sort();
 }
 
 /** Upgrade a single source entry, adding its typed `entities` mirror. */
@@ -53,10 +53,11 @@ function migrateSources(
 /**
  * Migrate a WikiState to v2, adding the typed-ownership mirror to every source
  * and to the frozen-slug set while carrying all v1 fields through unchanged.
- * Returns the state untouched when it is already v2 (idempotent).
+ * Returns the state untouched when it is already v2-or-newer (idempotent): the
+ * `>= 2` gate is defensive against re-typing an already-typed state.
  */
 export function migrateStateToV2(state: WikiState): WikiState {
-  if (state.version === 2) {
+  if (state.version >= 2) {
     return state;
   }
   return {

--- a/src/state/migrate.ts
+++ b/src/state/migrate.ts
@@ -1,0 +1,68 @@
+/**
+ * Lossless v1→v2 migration for the persisted `.llmwiki/state.json` WikiState.
+ *
+ * Phase 2 of the Configurable Lifecycle Knowledge Platform adds a typed
+ * ownership mirror to the incremental state: alongside the v1 string lists
+ * (`SourceState.concepts`, `WikiState.frozenSlugs`) the migrated v2 state
+ * carries branded `concepts/<slug>` {@link EntityId}s in `entities` /
+ * `frozenEntities`. The v1 fields are preserved verbatim, so the upgrade is
+ * lossless and the state remains downgradeable.
+ *
+ * Three invariants are load-bearing for callers:
+ *  - idempotent: a `version: 2` state is returned unchanged, so re-running the
+ *    migration never double-types a slug (no `concepts/concepts/rag`);
+ *  - deterministic: minted id arrays are sorted lexicographically so repeated
+ *    migrations of equal inputs serialise byte-for-byte identically;
+ *  - fail-closed: a bare slug that violates the slug-safe grammar throws
+ *    {@link EntityIdError} via {@link assertSlugSafe} rather than being dropped.
+ */
+
+import { entityId, assertSlugSafe } from "../profile/identity.js";
+import type { EntityId } from "../profile/types.js";
+import type { SourceState, WikiState } from "../utils/types.js";
+
+/** The single entity type owned by the compiler's incremental state. */
+const CONCEPT_ENTITY_TYPE = "concepts";
+
+/**
+ * Mint a sorted, deduplicated list of `concepts/<slug>` EntityIds from bare
+ * concept slugs. Each slug is asserted slug-safe at mint time, so an invalid
+ * slug throws rather than being silently skipped.
+ */
+function mintConceptEntities(slugs: string[]): EntityId[] {
+  const ids = slugs.map((slug) => entityId(CONCEPT_ENTITY_TYPE, assertSlugSafe(slug)));
+  return [...ids].sort();
+}
+
+/** Upgrade a single source entry, adding its typed `entities` mirror. */
+function migrateSource(source: SourceState): SourceState {
+  return { ...source, entities: mintConceptEntities(source.concepts) };
+}
+
+/** Apply {@link migrateSource} across every source, preserving keys. */
+function migrateSources(
+  sources: Record<string, SourceState>,
+): Record<string, SourceState> {
+  const out: Record<string, SourceState> = {};
+  for (const [file, source] of Object.entries(sources)) {
+    out[file] = migrateSource(source);
+  }
+  return out;
+}
+
+/**
+ * Migrate a WikiState to v2, adding the typed-ownership mirror to every source
+ * and to the frozen-slug set while carrying all v1 fields through unchanged.
+ * Returns the state untouched when it is already v2 (idempotent).
+ */
+export function migrateStateToV2(state: WikiState): WikiState {
+  if (state.version === 2) {
+    return state;
+  }
+  return {
+    ...state,
+    version: 2,
+    sources: migrateSources(state.sources),
+    frozenEntities: mintConceptEntities(state.frozenSlugs ?? []),
+  };
+}

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -16,6 +16,7 @@ import { readdir } from "fs/promises";
 import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
 import { countCandidates } from "../compiler/candidates.js";
 import { readStateClassified } from "../utils/state.js";
+import type { StateStatus } from "../utils/state.js";
 import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
 import { CONCEPTS_DIR, QUERIES_DIR, SOURCES_DIR } from "../utils/constants.js";
 import { collectProfileSummary } from "../profile/block.js";
@@ -48,8 +49,11 @@ export interface WikiStatus {
   orphanedPages: string[];
   /** True total of orphaned pages (may exceed orphanedPages.length when capped). */
   orphanedCount: number;
-  /** Readability of .llmwiki/state.json — surfaced so corrupt state is never silent. */
-  stateStatus: "ok" | "missing" | "corrupt";
+  /**
+   * Readability of .llmwiki/state.json — surfaced so corrupt OR too-new state
+   * (written by a newer llmwiki) is never silently reported as healthy.
+   */
+  stateStatus: StateStatus;
   /** Number of compile candidates awaiting human review. */
   pendingCandidates: number;
   /**
@@ -172,10 +176,12 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
   const { stalePages, orphanedPages } = classifyConceptPages(scannedConcepts, snapshot);
   const profileBlock = await collectProfileSummary(root);
 
-  // Suppress pendingChanges only on corrupt state: comparing against an empty snapshot
-  // on corrupt state would classify every source file as "new", which is false precision.
+  // Suppress pendingChanges when state is corrupt OR too-new: comparing against an
+  // empty snapshot would classify every source file as "new", which is false precision
+  // (and would make a too-new project look like an ordinary fresh checkout).
   // On missing state the snapshot is legitimately empty, so every on-disk source is "new" — correct.
-  const pendingChanges = classified.status === "corrupt"
+  const stateUnusable = classified.status === "corrupt" || classified.status === "too-new";
+  const pendingChanges = stateUnusable
     ? []
     : pendingChangesFromSnapshot(snapshot, sourceFilesOnDisk);
 

--- a/src/trust/checks.ts
+++ b/src/trust/checks.ts
@@ -17,8 +17,8 @@
  * - collision/no-overwrite → existence probe under the confined path (creates
  *   block on an existing target);
  * - resource-limit → the per-file content cap {@link MAX_SOURCE_CHARS}, decided
- *   on raw byte length BEFORE any parsing so an oversized body never gets heavy
- *   processing;
+ *   on raw character length BEFORE any parsing so an oversized body never gets
+ *   heavy processing;
  * - frontmatter-parse → {@link parseFrontmatterStatus} (rejects malformed YAML
  *   frontmatter).
  *
@@ -94,18 +94,20 @@ export const checkTargetCollision: MandatoryPageCheck = async (ctx) => {
 };
 
 /**
- * Block a body whose raw byte length exceeds the per-file content cap
- * ({@link MAX_SOURCE_CHARS}), the same bound applied to ingested source bodies.
- * The decision is made on `Buffer.byteLength` alone — no parsing — so an
- * oversized payload is rejected before any heavy processing runs.
+ * Block a body whose character length exceeds the per-file content cap
+ * ({@link MAX_SOURCE_CHARS}). This matches the ingest character bound exactly:
+ * `src/commands/ingest.ts` gates on `content.length <= MAX_SOURCE_CHARS` (the
+ * same UTF-16 code-unit length used here), so the trust floor and ingest agree.
+ * The decision is made on `length` alone — no parsing — so an oversized payload
+ * is rejected before any heavy processing runs.
  */
 export const checkResourceLimit: MandatoryPageCheck = async (ctx) => {
   const code = "resource-limit";
-  const bytes = Buffer.byteLength(ctx.body, "utf-8");
-  if (bytes > MAX_SOURCE_CHARS) {
-    return { code, verdict: "block", message: `body ${bytes} bytes exceeds cap of ${MAX_SOURCE_CHARS}` };
+  const chars = ctx.body.length;
+  if (chars > MAX_SOURCE_CHARS) {
+    return { code, verdict: "block", message: `body ${chars} chars exceeds cap of ${MAX_SOURCE_CHARS}` };
   }
-  return pass(code, `body within the ${MAX_SOURCE_CHARS}-byte cap`);
+  return pass(code, `body within the ${MAX_SOURCE_CHARS}-char cap`);
 };
 
 /**

--- a/src/trust/checks.ts
+++ b/src/trust/checks.ts
@@ -1,0 +1,149 @@
+/**
+ * @file src/trust/checks.ts
+ * @description The MANDATORY CORE CHECKS for a page mutation — the unconditional
+ * trust floor that CLP Invariant 3 forbids any profile from disabling.
+ *
+ * A configurable profile may ADD checks (stricter policy, extra heuristics), but
+ * it can NEVER remove or gate the four checks defined here. That guarantee is
+ * structural, not a runtime flag: {@link runMandatoryPageChecks} takes ONLY a
+ * {@link PageWriteContext}. There is no profile, predicate, or allow/deny-list
+ * parameter through which a check could be skipped, so no caller — however
+ * configured — can reach the write path with one of these checks unevaluated.
+ *
+ * Each check is a pure-ish `async (ctx) => TrustCheckResult` that reuses the
+ * project's existing trust primitives rather than re-deriving them:
+ * - path-confinement → {@link confineUnderRoot} (rejects targets and symlinked
+ *   ancestors that escape the project root);
+ * - collision/no-overwrite → existence probe under the confined path (creates
+ *   block on an existing target);
+ * - resource-limit → the per-file content cap {@link MAX_SOURCE_CHARS}, decided
+ *   on raw byte length BEFORE any parsing so an oversized body never gets heavy
+ *   processing;
+ * - frontmatter-parse → {@link parseFrontmatterStatus} (rejects malformed YAML
+ *   frontmatter).
+ *
+ * All blocks emit a STABLE `code` so downstream routing/telemetry can key on the
+ * specific floor that was hit. None of these blocks request `quarantine` —
+ * quarantine is reserved for untrusted-content isolation, a separate concern.
+ */
+
+import path from "path";
+import { lstat } from "fs/promises";
+import { confineUnderRoot } from "../utils/path-confine.js";
+import { parseFrontmatterStatus } from "../utils/markdown.js";
+import { MAX_SOURCE_CHARS } from "../utils/constants.js";
+import type { TrustCheckResult } from "./decision.js";
+
+/**
+ * The proposed page mutation a mandatory check inspects.
+ *
+ * `targetPath` is the intended `wiki/<dir>/<slug>.md`; it may be relative or
+ * absolute and is normalized through {@link confineUnderRoot} against `root`.
+ */
+export interface PageWriteContext {
+  /** Absolute project root the write must stay confined to. */
+  root: string;
+  /** Intended on-disk target for the page (relative or absolute). */
+  targetPath: string;
+  /** Full markdown content (frontmatter + body) to be written. */
+  body: string;
+}
+
+/** A single mandatory check over a page mutation. */
+export type MandatoryPageCheck = (ctx: PageWriteContext) => Promise<TrustCheckResult>;
+
+/** Helper: build a passing result for a named check. */
+function pass(code: string, message: string): TrustCheckResult {
+  return { code, verdict: "pass", message };
+}
+
+/**
+ * Reject any target that escapes the project root, including via a symlinked
+ * ancestor. Delegates to {@link confineUnderRoot} (with `mustExist:false`, since
+ * the page file itself may not exist yet) and treats a throw as the escape.
+ */
+export const checkPathConfinement: MandatoryPageCheck = async (ctx) => {
+  const code = "path-escape";
+  try {
+    await confineUnderRoot(ctx.targetPath, ctx.root, { mustExist: false });
+    return pass(code, "target path stays within the project root");
+  } catch {
+    return { code, verdict: "block", message: `target path escapes the project root: ${ctx.targetPath}` };
+  }
+};
+
+/**
+ * Block when the confined target already exists: page creation is create-only
+ * and never silently overwrites. A target whose own path escapes root is also
+ * blocked here (a non-confinable target cannot be a safe create destination).
+ */
+export const checkTargetCollision: MandatoryPageCheck = async (ctx) => {
+  const code = "target-exists";
+  let abs: string;
+  try {
+    abs = await confineUnderRoot(ctx.targetPath, ctx.root, { mustExist: false });
+  } catch {
+    return { code, verdict: "block", message: `target path escapes the project root: ${ctx.targetPath}` };
+  }
+  try {
+    await lstat(abs);
+  } catch {
+    return pass(code, "target path is free");
+  }
+  return { code, verdict: "block", message: `target already exists (create-only): ${path.basename(abs)}` };
+};
+
+/**
+ * Block a body whose raw byte length exceeds the per-file content cap
+ * ({@link MAX_SOURCE_CHARS}), the same bound applied to ingested source bodies.
+ * The decision is made on `Buffer.byteLength` alone — no parsing — so an
+ * oversized payload is rejected before any heavy processing runs.
+ */
+export const checkResourceLimit: MandatoryPageCheck = async (ctx) => {
+  const code = "resource-limit";
+  const bytes = Buffer.byteLength(ctx.body, "utf-8");
+  if (bytes > MAX_SOURCE_CHARS) {
+    return { code, verdict: "block", message: `body ${bytes} bytes exceeds cap of ${MAX_SOURCE_CHARS}` };
+  }
+  return pass(code, `body within the ${MAX_SOURCE_CHARS}-byte cap`);
+};
+
+/**
+ * Block a body whose frontmatter block is present but malformed (invalid YAML
+ * or a non-mapping scalar/array), reusing {@link parseFrontmatterStatus}. A body
+ * with no frontmatter block or with clean frontmatter passes.
+ */
+export const checkFrontmatter: MandatoryPageCheck = async (ctx) => {
+  const code = "frontmatter-invalid";
+  const { malformedFrontmatter } = parseFrontmatterStatus(ctx.body);
+  if (malformedFrontmatter) {
+    return { code, verdict: "block", message: "frontmatter block is present but not valid YAML mapping" };
+  }
+  return pass(code, "frontmatter parses cleanly");
+};
+
+/**
+ * The four Invariant-3 mandatory checks, in evaluation order. A profile may
+ * append checks elsewhere, but this array is the floor — it is never filtered.
+ */
+export const mandatoryPageChecks: readonly MandatoryPageCheck[] = [
+  checkPathConfinement,
+  checkTargetCollision,
+  checkResourceLimit,
+  checkFrontmatter,
+];
+
+/**
+ * Run EVERY mandatory check over the proposed page mutation and return one
+ * result per check, in registration order.
+ *
+ * The signature is the enforcement of Invariant 3: it accepts only the
+ * {@link PageWriteContext}. There is deliberately no profile/predicate/skip
+ * parameter, so there is no value a caller could pass to remove a core check.
+ *
+ * @param ctx - The proposed page-write context.
+ * @returns One {@link TrustCheckResult} per mandatory check.
+ */
+export async function runMandatoryPageChecks(ctx: PageWriteContext): Promise<TrustCheckResult[]> {
+  return Promise.all(mandatoryPageChecks.map((check) => check(ctx)));
+}

--- a/src/trust/decision.ts
+++ b/src/trust/decision.ts
@@ -1,0 +1,105 @@
+/**
+ * Trust Guard decision core: composing per-check verdicts into one write
+ * decision.
+ *
+ * The Trust Guard runs a set of independent checks over a proposed write. Each
+ * check yields a {@link TrustCheckResult} carrying a {@link TrustVerdict}
+ * (`pass` | `warn` | `block`). This module reduces a whole result set, together
+ * with a routing flag, into exactly one {@link TrustDecision}.
+ *
+ * The composition is deliberately a pure, self-contained function with two
+ * structural guarantees that downstream tasks (staging, quarantine, denial)
+ * rely on:
+ *
+ * - **Total.** Every possible verdict set — including the empty set — and every
+ *   value of `reviewRouted` maps to exactly one decision. There is no verdict
+ *   combination for which the result is undefined, and no silent fall-through
+ *   to a permissive `allow` default: the `allow` branch is reached only when it
+ *   is positively earned (no warns, no blocks).
+ *
+ * - **Monotone in `block`.** Adding a `block` verdict can only make the decision
+ *   stricter, never more permissive. If ANY check blocks, the decision is one
+ *   of `stage-for-review` | `quarantine` | `deny` — never `allow` or
+ *   `allow-with-warning`. Likewise a `warn` (absent any block) can never yield a
+ *   plain `allow`; it raises the floor to `allow-with-warning`.
+ *
+ * Routing & quarantine on a block:
+ * - If any blocking check requests quarantine (`quarantine: true`), the decision
+ *   is `quarantine`, regardless of routing — untrusted content is isolated.
+ * - Otherwise a **review-routed** surface yields `stage-for-review`, and a
+ *   non-review-routed surface yields `deny`.
+ *
+ * This file has no I/O and no side effects; it is pure decision logic.
+ */
+
+/** A single check's outcome severity, lowest to highest. */
+export type TrustVerdict = "pass" | "warn" | "block";
+
+/** The composed write decision for a proposed write. */
+export type TrustDecision =
+  | "allow"
+  | "allow-with-warning"
+  | "stage-for-review"
+  | "quarantine"
+  | "deny";
+
+/**
+ * One Trust Guard check's result.
+ *
+ * `quarantine` is meaningful only on a `block` result: it marks the block as an
+ * untrusted-content isolation case, which routes the composed decision to
+ * `quarantine` instead of `stage-for-review`/`deny`.
+ */
+export interface TrustCheckResult {
+  /** Stable machine-readable check identifier (e.g. `"untrusted-content"`). */
+  code: string;
+  /** This check's severity. */
+  verdict: TrustVerdict;
+  /** Human-readable explanation of the verdict. */
+  message: string;
+  /** When `true` on a `block`, isolate the write to quarantine. */
+  quarantine?: boolean;
+}
+
+/** Routing context for the surface the write targets. */
+export interface TrustRouting {
+  /** Whether this surface stages risky writes for human review. */
+  reviewRouted: boolean;
+}
+
+/** Decision for a result set containing at least one `block`. */
+function decideBlocked(
+  results: TrustCheckResult[],
+  routing: TrustRouting
+): TrustDecision {
+  const quarantineRequested = results.some(
+    (r) => r.verdict === "block" && r.quarantine === true
+  );
+  if (quarantineRequested) return "quarantine";
+  return routing.reviewRouted ? "stage-for-review" : "deny";
+}
+
+/**
+ * Compose a set of trust check results into one write decision.
+ *
+ * Total and monotone in `block` (see the file-level contract). Evaluates from
+ * the strictest verdict down: any `block` routes through {@link decideBlocked};
+ * otherwise any `warn` raises the floor to `allow-with-warning`; otherwise (all
+ * `pass`, or no checks at all) the write is allowed.
+ *
+ * @param results - The per-check results for the proposed write.
+ * @param routing - Routing context for the target surface.
+ * @returns The single composed {@link TrustDecision}.
+ */
+export function composeTrustDecision(
+  results: TrustCheckResult[],
+  routing: TrustRouting
+): TrustDecision {
+  const hasBlock = results.some((r) => r.verdict === "block");
+  if (hasBlock) return decideBlocked(results, routing);
+
+  const hasWarn = results.some((r) => r.verdict === "warn");
+  if (hasWarn) return "allow-with-warning";
+
+  return "allow";
+}

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -27,7 +27,14 @@ import { lstat } from "fs/promises";
 import { acquireLock, releaseLock } from "../utils/lock.js";
 import { atomicWrite } from "../utils/markdown.js";
 import { confineUnderRoot } from "../utils/path-confine.js";
-import { openBatch, recordPreState, commitBatch, type JournalBatch } from "./journal.js";
+import {
+  openBatch,
+  recordPreState,
+  commitBatch,
+  replayJournal,
+  type JournalBatch,
+} from "./journal.js";
+import { parseEntityId } from "../profile/identity.js";
 import type { PlannedMutation } from "./planner.js";
 
 /** A single page write. Injectable so tests can fault-inject a failure. */
@@ -64,6 +71,19 @@ class CreateCollisionError extends Error {
   }
 }
 
+/**
+ * Thrown when a mutation's target identity is not slug-safe. The planner's
+ * `checkIdentitySafe` guard only protects the planner path; a hand-built
+ * {@link PlannedMutation} bypasses it, so the executor re-asserts the identity
+ * before deriving a path. Callers match on the typed `invalid-identity:` prefix.
+ */
+class InvalidIdentityError extends Error {
+  constructor(message: string) {
+    super(`invalid-identity: ${message}`);
+    this.name = "InvalidIdentityError";
+  }
+}
+
 /** True when something exists at `abs` (regular file, dir, or symlink). */
 async function targetExists(abs: string): Promise<boolean> {
   try {
@@ -74,9 +94,23 @@ async function targetExists(abs: string): Promise<boolean> {
   }
 }
 
-/** The wiki-relative page path for a page mutation's target. */
+/**
+ * The wiki-relative page path for a page mutation's target.
+ *
+ * Defense-in-depth: the entityType/slug are re-validated by re-parsing the
+ * branded `target.id` (which throws on a non-slug-safe slug half), so a
+ * hand-built mutation carrying a `..` slug is rejected with a typed
+ * {@link InvalidIdentityError} BEFORE `path.join` could collapse it into a wrong
+ * in-root location — the planner's `checkIdentitySafe` guard is not on this path.
+ */
 function pageRelPath(mutation: PlannedMutation): string {
-  const { entityType, slug } = mutation.target;
+  let entityType: string;
+  let slug: string;
+  try {
+    ({ entityType, slug } = parseEntityId(mutation.target.id));
+  } catch (err) {
+    throw new InvalidIdentityError((err as Error).message);
+  }
   return path.join("wiki", entityType, `${slug}.md`);
 }
 
@@ -114,6 +148,11 @@ async function applyBatch(
  * `not-implemented`. A mid-batch failure leaves a `pending` journal for
  * {@link replayJournal} to revert to the full pre-state.
  *
+ * Self-recovery: BEFORE opening the new batch (but AFTER the lock is held), it
+ * runs {@link replayJournal}, so a `pending` journal left dangling by a prior
+ * crash is reverted under the same lock before this batch begins — the atomicity
+ * guarantee no longer depends on an external caller invoking replay.
+ *
  * @param root - Absolute project root.
  * @param planned - The approved mutations to apply.
  * @param opts - Optional injectable write primitive (for fault injection).
@@ -127,6 +166,8 @@ export async function applyApprovedMutations(
   const acquired = await acquireLock(root);
   if (!acquired) throw new Error("could not acquire project lock for mutation batch");
   try {
+    // Recover any dangling pending batch from a prior crash under the held lock.
+    await replayJournal(root);
     const batch = await openBatch(root);
     await applyBatch(root, planned, batch, writeOne);
     await commitBatch(batch);

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -1,0 +1,104 @@
+/**
+ * @file src/trust/executor.ts
+ * @description The guarded PAGE EXECUTOR — the only path that turns an approved
+ * {@link PlannedMutation} plan into bytes on disk, under the CLP atomicity
+ * contract ("partial application of an approved batch is a bug").
+ *
+ * {@link applyApprovedMutations} runs the batch behind the project lock and a
+ * single-store intent journal:
+ *  1. acquire the PID-based project lock (same discipline as compile/review);
+ *  2. open a journal batch and record EVERY target's pre-state before any write;
+ *  3. apply each `page` mutation via {@link atomicWrite} (temp-then-rename);
+ *  4. commit the journal once all writes land;
+ *  5. release the lock in `finally`.
+ *
+ * If any write throws mid-batch, the journal stays `pending` (uncommitted), so a
+ * subsequent {@link replayJournal} reverts the whole batch to its pre-state — no
+ * partial post-state ever survives. Every write target is confined under the
+ * project root via {@link confineUnderRoot} before it is touched.
+ *
+ * SCOPE: Task 5 executes `kind:"page"` only. Any other {@link MutationKind} is
+ * rejected with a typed `not-implemented` error, so an unhandled store can never
+ * be silently no-op'd or half-applied.
+ */
+
+import path from "path";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { atomicWrite } from "../utils/markdown.js";
+import { confineUnderRoot } from "../utils/path-confine.js";
+import { openBatch, recordPreState, commitBatch, type JournalBatch } from "./journal.js";
+import type { PlannedMutation } from "./planner.js";
+
+/** A single page write. Injectable so tests can fault-inject a failure. */
+export type WriteOne = (filePath: string, content: string) => Promise<void>;
+
+/** Options for {@link applyApprovedMutations}; `writeOne` defaults to atomicWrite. */
+export interface ApplyOptions {
+  /** Per-target write primitive (defaults to {@link atomicWrite}). */
+  writeOne?: WriteOne;
+}
+
+/**
+ * Error thrown when a mutation targets a store the executor does not handle.
+ * Module-private: callers match on the typed `not-implemented:` message prefix
+ * (the stable contract) rather than the class, so the class need not be exported.
+ */
+class NotImplementedMutationError extends Error {
+  constructor(kind: string) {
+    super(`not-implemented: executor does not handle mutation kind "${kind}"`);
+    this.name = "NotImplementedMutationError";
+  }
+}
+
+/** The wiki-relative page path for a page mutation's target. */
+function pageRelPath(mutation: PlannedMutation): string {
+  const { entityType, slug } = mutation.target;
+  return path.join("wiki", entityType, `${slug}.md`);
+}
+
+/**
+ * Apply every page mutation in the batch under an already-open journal: record
+ * each target's pre-state, then write it. Throws on the first non-page kind or
+ * the first failing write, leaving the journal uncommitted for replay.
+ */
+async function applyBatch(
+  root: string,
+  planned: PlannedMutation[],
+  batch: JournalBatch,
+  writeOne: WriteOne,
+): Promise<void> {
+  for (const mutation of planned) {
+    if (mutation.kind !== "page") throw new NotImplementedMutationError(mutation.kind);
+    const abs = await confineUnderRoot(pageRelPath(mutation), root, { mustExist: false });
+    await recordPreState(batch, abs);
+    await writeOne(abs, mutation.body);
+  }
+}
+
+/**
+ * Apply an approved plan to disk atomically. Acquires the project lock, journals
+ * every target's pre-state before writing, applies each page mutation, then
+ * commits the journal — releasing the lock in `finally`. A non-page kind throws
+ * `not-implemented`. A mid-batch failure leaves a `pending` journal for
+ * {@link replayJournal} to revert to the full pre-state.
+ *
+ * @param root - Absolute project root.
+ * @param planned - The approved mutations to apply.
+ * @param opts - Optional injectable write primitive (for fault injection).
+ */
+export async function applyApprovedMutations(
+  root: string,
+  planned: PlannedMutation[],
+  opts: ApplyOptions = {},
+): Promise<void> {
+  const writeOne = opts.writeOne ?? atomicWrite;
+  const acquired = await acquireLock(root);
+  if (!acquired) throw new Error("could not acquire project lock for mutation batch");
+  try {
+    const batch = await openBatch(root);
+    await applyBatch(root, planned, batch, writeOne);
+    await commitBatch(batch);
+  } finally {
+    await releaseLock(root);
+  }
+}

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -23,6 +23,7 @@
  */
 
 import path from "path";
+import { lstat } from "fs/promises";
 import { acquireLock, releaseLock } from "../utils/lock.js";
 import { atomicWrite } from "../utils/markdown.js";
 import { confineUnderRoot } from "../utils/path-confine.js";
@@ -50,6 +51,29 @@ class NotImplementedMutationError extends Error {
   }
 }
 
+/**
+ * Thrown when a `create` target — free at plan time — has appeared on disk by
+ * the time the batch runs under the lock. Aborting before any write closes the
+ * plan→apply TOCTOU so a create never clobbers a concurrently-created file.
+ * Callers match on the typed `create-collision:` message prefix.
+ */
+class CreateCollisionError extends Error {
+  constructor(targetPath: string) {
+    super(`create-collision: target already exists, refusing to overwrite: ${targetPath}`);
+    this.name = "CreateCollisionError";
+  }
+}
+
+/** True when something exists at `abs` (regular file, dir, or symlink). */
+async function targetExists(abs: string): Promise<boolean> {
+  try {
+    await lstat(abs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** The wiki-relative page path for a page mutation's target. */
 function pageRelPath(mutation: PlannedMutation): string {
   const { entityType, slug } = mutation.target;
@@ -60,6 +84,11 @@ function pageRelPath(mutation: PlannedMutation): string {
  * Apply every page mutation in the batch under an already-open journal: record
  * each target's pre-state, then write it. Throws on the first non-page kind or
  * the first failing write, leaving the journal uncommitted for replay.
+ *
+ * A `create` target is RE-PROBED under the lock (the planner's collision check
+ * runs before the lock): if it now exists, abort with {@link CreateCollisionError}
+ * BEFORE any write lands, so a create never overwrites a file that appeared
+ * after planning. `update` operations may legitimately overwrite.
  */
 async function applyBatch(
   root: string,
@@ -70,6 +99,9 @@ async function applyBatch(
   for (const mutation of planned) {
     if (mutation.kind !== "page") throw new NotImplementedMutationError(mutation.kind);
     const abs = await confineUnderRoot(pageRelPath(mutation), root, { mustExist: false });
+    if (mutation.operation === "create" && (await targetExists(abs))) {
+      throw new CreateCollisionError(abs);
+    }
     await recordPreState(batch, abs);
     await writeOne(abs, mutation.body);
   }

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -1,0 +1,191 @@
+/**
+ * @file src/trust/journal.ts
+ * @description The single-store INTENT JOURNAL for the PAGE store — the
+ * durability record that realizes the CLP atomicity contract: "partial
+ * application of an approved mutation batch is a bug."
+ *
+ * A batch is journalled under `.llmwiki/journal/<batchId>.json` in two phases:
+ *
+ *  1. `pending` — opened and persisted BEFORE any file write lands. For every
+ *     target it records the PRE-STATE: the prior file bytes, or an `absent`
+ *     marker when the target did not exist. This is the information a revert
+ *     needs to restore the exact world that existed before the batch began.
+ *  2. `committed` — written once EVERY file write in the batch has succeeded.
+ *
+ * {@link replayJournal} is the crash-recovery seam, run on startup. For any
+ * `pending`-but-not-`committed` batch it REVERTS every recorded target to its
+ * pre-state — restoring prior bytes, or deleting a file that was absent
+ * pre-batch — then resolves (deletes) the journal. A committed batch is left
+ * untouched. Replay is idempotent: once a pending batch is reverted its journal
+ * is gone, so a second pass finds nothing to do.
+ *
+ * The journal NEVER records a post-state, so a half-applied batch can only ever
+ * resolve toward the FULL pre-state, never toward a partial post-state. All
+ * journal files live under `.llmwiki/`, the project's existing private dir.
+ */
+
+import { readFile, writeFile, mkdir, readdir, unlink, rename } from "fs/promises";
+import path from "path";
+import { LLMWIKI_DIR } from "../utils/constants.js";
+
+/** Sentinel recorded when a target did not exist before the batch. */
+const ABSENT = { absent: true } as const;
+
+/** The pre-state of one target: prior file bytes, or the absent marker. */
+export type PreState = { absent: true } | { absent: false; content: string };
+
+/** One target's recorded pre-state under its absolute on-disk path. */
+export interface JournalEntry {
+  /** Absolute path of the target file this batch will write. */
+  targetPath: string;
+  /** What existed at `targetPath` before the batch began. */
+  preState: PreState;
+}
+
+/** Lifecycle status of a journalled batch. */
+export type BatchStatus = "pending" | "committed";
+
+/** A journalled batch of planned writes plus the project root it lives in. */
+export interface JournalBatch {
+  /** Unique id; also the journal filename stem. */
+  batchId: string;
+  /** Project root the journal directory hangs off. */
+  root: string;
+  /** Lifecycle status. */
+  status: BatchStatus;
+  /** Per-target pre-state records, in declaration order. */
+  entries: JournalEntry[];
+}
+
+/** Absolute path to the journal directory for a project root. */
+function journalDir(root: string): string {
+  return path.join(root, LLMWIKI_DIR, "journal");
+}
+
+/** Absolute path to a batch's journal file. */
+function journalPath(root: string, batchId: string): string {
+  return path.join(journalDir(root), `${batchId}.json`);
+}
+
+/** Read a file's bytes, or `null` when it does not exist. */
+async function readOrNull(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/** Atomically persist a batch's current state to its journal file. */
+async function persist(batch: JournalBatch): Promise<void> {
+  const file = journalPath(batch.root, batch.batchId);
+  await mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  const payload = {
+    batchId: batch.batchId,
+    status: batch.status,
+    entries: batch.entries,
+  };
+  await writeFile(tmp, JSON.stringify(payload, null, 2), "utf-8");
+  await rename(tmp, file);
+}
+
+/**
+ * Open a fresh `pending` batch and persist its (empty) journal file. Targets
+ * are recorded one at a time via {@link recordPreState} before any write lands.
+ *
+ * @param root - Absolute project root the journal hangs off.
+ * @returns The opened, persisted {@link JournalBatch}.
+ */
+export async function openBatch(root: string): Promise<JournalBatch> {
+  const batchId = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const batch: JournalBatch = { batchId, root, status: "pending", entries: [] };
+  await persist(batch);
+  return batch;
+}
+
+/**
+ * Record one target's pre-state into the batch and re-persist the journal. Must
+ * be called for EVERY target before that target is written, so a crash can
+ * always restore the pre-batch world.
+ *
+ * @param batch - The open pending batch.
+ * @param targetPath - Absolute path of the target about to be written.
+ */
+export async function recordPreState(batch: JournalBatch, targetPath: string): Promise<void> {
+  const prior = await readOrNull(targetPath);
+  const preState: PreState = prior === null ? ABSENT : { absent: false, content: prior };
+  batch.entries.push({ targetPath, preState });
+  await persist(batch);
+}
+
+/**
+ * Mark a batch `committed` and persist it: every write has landed, so the
+ * batch's intent is now durable and replay will leave it untouched.
+ *
+ * @param batch - The batch whose writes have all succeeded.
+ */
+export async function commitBatch(batch: JournalBatch): Promise<void> {
+  batch.status = "committed";
+  await persist(batch);
+}
+
+/** Revert one target to its recorded pre-state (restore bytes or delete). */
+async function revertEntry(entry: JournalEntry): Promise<void> {
+  if (entry.preState.absent) {
+    try {
+      await unlink(entry.targetPath);
+    } catch {
+      // Already absent — the pre-state is already satisfied.
+    }
+    return;
+  }
+  await mkdir(path.dirname(entry.targetPath), { recursive: true });
+  await writeFile(entry.targetPath, entry.preState.content, "utf-8");
+}
+
+/** Parse a single journal file, returning null on any malformed/unreadable file. */
+async function loadBatch(root: string, batchId: string): Promise<JournalBatch | null> {
+  const raw = await readOrNull(journalPath(root, batchId));
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as Omit<JournalBatch, "root">;
+    return { ...parsed, root };
+  } catch {
+    return null;
+  }
+}
+
+/** Revert a pending batch to its full pre-state, then delete its journal file. */
+async function resolvePending(batch: JournalBatch): Promise<void> {
+  for (const entry of batch.entries) {
+    await revertEntry(entry);
+  }
+  await unlink(journalPath(batch.root, batch.batchId));
+}
+
+/**
+ * Crash-recovery seam: revert every `pending`-but-not-`committed` batch to its
+ * full pre-state, then resolve it. A `committed` batch is left untouched.
+ *
+ * Idempotent: reverting a pending batch deletes its journal file, so a second
+ * call finds no pending batches and does nothing. A missing journal directory
+ * is treated as "nothing pending".
+ *
+ * @param root - Absolute project root whose journal directory is replayed.
+ */
+export async function replayJournal(root: string): Promise<void> {
+  let files: string[];
+  try {
+    files = await readdir(journalDir(root));
+  } catch {
+    return; // no journal directory → nothing pending
+  }
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const batch = await loadBatch(root, file.replace(/\.json$/, ""));
+    if (batch !== null && batch.status === "pending") {
+      await resolvePending(batch);
+    }
+  }
+}

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -31,6 +31,9 @@ import { LLMWIKI_DIR } from "../utils/constants.js";
 /** Sentinel recorded when a target did not exist before the batch. */
 const ABSENT = { absent: true } as const;
 
+/** How many base-36 random characters to append to a batch id for uniqueness. */
+const BATCH_ID_RANDOM_CHARS = 6;
+
 /** The pre-state of one target: prior file bytes, or the absent marker. */
 export type PreState = { absent: true } | { absent: false; content: string };
 
@@ -98,7 +101,8 @@ async function persist(batch: JournalBatch): Promise<void> {
  * @returns The opened, persisted {@link JournalBatch}.
  */
 export async function openBatch(root: string): Promise<JournalBatch> {
-  const batchId = `${Date.now()}-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const random = Math.random().toString(36).slice(2, 2 + BATCH_ID_RANDOM_CHARS);
+  const batchId = `${Date.now()}-${process.pid}-${random}`;
   const batch: JournalBatch = { batchId, root, status: "pending", entries: [] };
   await persist(batch);
   return batch;
@@ -179,6 +183,12 @@ async function resolvePending(batch: JournalBatch): Promise<void> {
  * Idempotent: reverting a pending batch deletes its journal file, so a second
  * call finds no pending batches and does nothing. A missing journal directory
  * is treated as "nothing pending".
+ *
+ * LOCKING: this function does NOT acquire the project lock — the CALLER must
+ * already hold it so replay runs under the same mutual exclusion as the batch it
+ * recovers (see {@link applyApprovedMutations}, which calls replay under the
+ * held lock). A future standalone startup hook must acquire the lock itself
+ * before calling this.
  *
  * @param root - Absolute project root whose journal directory is replayed.
  */

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -109,10 +109,18 @@ export async function openBatch(root: string): Promise<JournalBatch> {
  * be called for EVERY target before that target is written, so a crash can
  * always restore the pre-batch world.
  *
+ * De-duplicated per DISTINCT target path: the FIRST observation of a path (the
+ * true pre-batch state, captured before any write in this batch) is the one
+ * kept. A second call for the same path is a no-op, so two mutations to one
+ * target cannot record a mid-batch post-state that revert would restore.
+ *
  * @param batch - The open pending batch.
  * @param targetPath - Absolute path of the target about to be written.
  */
 export async function recordPreState(batch: JournalBatch, targetPath: string): Promise<void> {
+  if (batch.entries.some((entry) => entry.targetPath === targetPath)) {
+    return;
+  }
   const prior = await readOrNull(targetPath);
   const preState: PreState = prior === null ? ABSENT : { absent: false, content: prior };
   batch.entries.push({ targetPath, preState });

--- a/src/trust/planner.ts
+++ b/src/trust/planner.ts
@@ -131,8 +131,10 @@ function checkIdentitySafe(entityType: string, slug: string): TrustCheckResult {
 }
 
 /**
- * Build the single live-write mutation for an approved page. Chooses `create`
- * for a free target and `update` when the target already exists on disk.
+ * Build the single live-write mutation for an approved page. Phase 2 page
+ * mutations are CREATE-ONLY: a colliding (already-existing) target is blocked
+ * upstream by `checkTargetCollision`, so an approved page is always a fresh
+ * `create`. In-place `update` of an existing page is a later phase.
  */
 async function buildPageMutation(input: PlanPageInput, decision: TrustDecision): Promise<PlannedMutation> {
   const id = entityId(input.entityType, input.slug);

--- a/src/trust/planner.ts
+++ b/src/trust/planner.ts
@@ -1,0 +1,170 @@
+/**
+ * @file src/trust/planner.ts
+ * @description The WRITE PLANNER — the single seam through which every proposed
+ * mutation passes (CLP Invariant 4). The planner does NOT touch disk: it runs
+ * the mandatory trust checks, composes the {@link TrustDecision}, and emits a
+ * declarative plan of {@link PlannedMutation}s for the executor to apply.
+ *
+ * Vocabulary is declared in full for the whole CLP mutation surface
+ * (page / relation / artifact / lifecycle-transition / workflow-gate /
+ * workflow-state), but Phase 2 Task 5 plans only PAGE mutations; the executor
+ * rejects every other kind as `not-implemented`.
+ *
+ * Decision→plan mapping (per the Trust Guard spec):
+ * - `allow` / `allow-with-warning` ⇒ exactly ONE live-write mutation (a `create`
+ *   for a free target, an `update` for an existing one).
+ * - `deny` / `stage-for-review` / `quarantine` ⇒ NO live-write mutation
+ *   (`planned: []`); the returned decision carries the routing, so nothing is
+ *   ever applied behind a block.
+ *
+ * The target path is derived lexically as `wiki/<entityType>/<slug>.md` so the
+ * mandatory path-confinement check can run BEFORE any slug-safe id is minted —
+ * an escaping slug is rejected by the decision, never by an exception.
+ */
+
+import path from "path";
+import { runMandatoryPageChecks, type PageWriteContext } from "./checks.js";
+import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
+import { entityId, isSlugSafe } from "../profile/identity.js";
+import type { EntityId } from "../profile/types.js";
+
+/** Every CLP store a mutation can target. Task 5 executes `page` only. */
+export type MutationKind =
+  | "page"
+  | "relation"
+  | "artifact"
+  | "lifecycle-transition"
+  | "workflow-gate"
+  | "workflow-state";
+
+/** The shape of a mutation against its store. */
+export type MutationOperation = "create" | "update" | "delete" | "transition";
+
+/** Reference to a profile entity page: type + slug, plus its branded id. */
+export interface EntityRef {
+  entityType: string;
+  slug: string;
+  id: EntityId;
+}
+
+/** The store-specific target a mutation acts on. Page mutations use EntityRef. */
+export type MutationTarget = EntityRef;
+
+/** Where a proposed mutation came from and how it was vetted. */
+export interface MutationProvenance {
+  /** The origin surface/actor that proposed the mutation (e.g. `"agent"`). */
+  origin: string;
+  /** The composed decision the planner reached for this mutation. */
+  decision: TrustDecision;
+  /** Whether the proposing surface routes risky writes for human review. */
+  reviewRouted: boolean;
+}
+
+/**
+ * One planned, approved mutation. `target` is a union over stores; `page` uses
+ * {@link EntityRef}. `proposedHash` / `preconditionHash` are reserved for
+ * optimistic-concurrency enforcement in later tasks.
+ */
+export interface PlannedMutation {
+  kind: MutationKind;
+  operation: MutationOperation;
+  target: MutationTarget;
+  /** The body bytes to write for a page mutation. */
+  body: string;
+  /** Hash of the proposed content (reserved; not enforced in Task 5). */
+  proposedHash?: string;
+  /** Expected hash of the current target (reserved; not enforced in Task 5). */
+  preconditionHash?: string;
+  provenance: MutationProvenance;
+}
+
+/** Inputs to {@link planPageMutation}. */
+export interface PlanPageInput {
+  /** Absolute project root the write must stay confined to. */
+  root: string;
+  /** Profile entity type (the wiki subdirectory). */
+  entityType: string;
+  /** Page slug (the filename stem); may be invalid — checks decide. */
+  slug: string;
+  /** Full markdown body (frontmatter + prose). */
+  body: string;
+  /** Origin surface/actor of the proposal. */
+  origin: string;
+  /** Whether the surface stages risky writes for human review. */
+  reviewRouted: boolean;
+}
+
+/** The planner's output: the plan, the composed decision, and the raw checks. */
+export interface PlanResult {
+  planned: PlannedMutation[];
+  decision: TrustDecision;
+  checks: TrustCheckResult[];
+}
+
+/**
+ * The wiki-relative page path for an entity: `wiki/<type>/<slug>.md`.
+ *
+ * Joined with raw separators (NOT `path.join`) so a traversal-bearing slug like
+ * `../escape` is preserved verbatim for the mandatory path-confinement check to
+ * reject — `path.join` would silently normalize `..` away and hide the escape.
+ */
+function pageTargetPath(entityType: string, slug: string): string {
+  return ["wiki", entityType, `${slug}.md`].join(path.sep);
+}
+
+/** Decisions that earn a live-write mutation. */
+const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
+
+/**
+ * Guard the identity itself: a non-slug-safe `entityType`/`slug` (e.g. one
+ * carrying path traversal like `../escape`) yields a `block`. This runs ahead of
+ * the mandatory file checks so a malformed identity is rejected via the SAME
+ * decision composition — never as a thrown {@link entityId} exception — and the
+ * `create` target's {@link EntityId} can only be minted once it is known valid.
+ */
+function checkIdentitySafe(entityType: string, slug: string): TrustCheckResult {
+  const code = "invalid-identity";
+  if (isSlugSafe(entityType) && isSlugSafe(slug)) {
+    return { code, verdict: "pass", message: "entity type and slug are slug-safe" };
+  }
+  return { code, verdict: "block", message: `entity type/slug is not slug-safe: ${entityType}/${slug}` };
+}
+
+/**
+ * Build the single live-write mutation for an approved page. Chooses `create`
+ * for a free target and `update` when the target already exists on disk.
+ */
+async function buildPageMutation(input: PlanPageInput, decision: TrustDecision): Promise<PlannedMutation> {
+  const id = entityId(input.entityType, input.slug);
+  const target: EntityRef = { entityType: input.entityType, slug: input.slug, id };
+  return {
+    kind: "page",
+    operation: "create",
+    target,
+    body: input.body,
+    provenance: { origin: input.origin, decision, reviewRouted: input.reviewRouted },
+  };
+}
+
+/**
+ * Plan a single page mutation: derive the target, run the mandatory checks,
+ * compose the decision, and emit either one live-write mutation (on
+ * allow/allow-with-warning) or none (on any block-derived decision).
+ *
+ * @param input - The proposed page mutation.
+ * @returns The plan, composed decision, and per-check results.
+ */
+export async function planPageMutation(input: PlanPageInput): Promise<PlanResult> {
+  const targetPath = pageTargetPath(input.entityType, input.slug);
+  const ctx: PageWriteContext = { root: input.root, targetPath, body: input.body };
+  const checks = [
+    checkIdentitySafe(input.entityType, input.slug),
+    ...(await runMandatoryPageChecks(ctx)),
+  ];
+  const decision = composeTrustDecision(checks, { reviewRouted: input.reviewRouted });
+
+  if (!LIVE_WRITE_DECISIONS.has(decision)) {
+    return { planned: [], decision, checks };
+  }
+  return { planned: [await buildPageMutation(input, decision)], decision, checks };
+}

--- a/src/trust/staged-change.ts
+++ b/src/trust/staged-change.ts
@@ -134,14 +134,39 @@ export class StagedWriteOverflowError extends Error {
 }
 
 /**
- * Fail-closed staged-write volume bound. Passes only when the request fits BOTH
- * the per-call cap (`requested <= perCall`) AND the per-session cap
+ * Thrown when a staged-write count is not a non-negative integer. A negative,
+ * NaN, or fractional count would slip past the pure `>` cap comparisons and
+ * defeat the flood guard (fail OPEN), so it is rejected up front by name.
+ */
+export class StagedWriteInputError extends Error {
+  constructor(field: "existingCount" | "requested", value: number) {
+    super(`staged-write ${field} must be a non-negative integer, got ${value}`);
+    this.name = "StagedWriteInputError";
+  }
+}
+
+/** Assert a staged-write count is a non-negative integer, else throw by name. */
+function assertNonNegativeInteger(
+  field: "existingCount" | "requested",
+  value: number,
+): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new StagedWriteInputError(field, value);
+  }
+}
+
+/**
+ * Fail-closed staged-write volume bound. First validates both counts are
+ * non-negative integers (a negative/NaN/fractional input would otherwise slip
+ * past the `>` comparisons and fail OPEN). Then passes only when the request
+ * fits BOTH the per-call cap (`requested <= perCall`) AND the per-session cap
  * (`existingCount + requested <= perSession`); otherwise throws a typed
  * {@link StagedWriteOverflowError} naming the breached cap. Never clamps.
  *
  * @param existingCount - Staged writes already held this session.
  * @param requested - Staged writes this call wants to add.
  * @param caps - The per-call and per-session ceilings to enforce.
+ * @throws {StagedWriteInputError} When either count is not a non-negative integer.
  * @throws {StagedWriteOverflowError} When either ceiling would be exceeded.
  */
 export function assertStagedWriteBudget(
@@ -149,6 +174,8 @@ export function assertStagedWriteBudget(
   requested: number,
   caps: StagedWriteCaps,
 ): void {
+  assertNonNegativeInteger("existingCount", existingCount);
+  assertNonNegativeInteger("requested", requested);
   if (requested > caps.perCall) {
     throw new StagedWriteOverflowError("per-call", requested, caps.perCall);
   }

--- a/src/trust/staged-change.ts
+++ b/src/trust/staged-change.ts
@@ -1,0 +1,159 @@
+/**
+ * @file src/trust/staged-change.ts
+ * @description The typed STAGED-CHANGE model and the fail-closed staged-write
+ * volume bound — the CLP Phase-2 deferred refinement of the candidate cap.
+ *
+ * When the Write Planner reaches a non-live-write {@link TrustDecision}
+ * (`stage-for-review` / `quarantine` / `deny`), the proposed mutation is not
+ * applied; it is captured as a {@link StagedChange} — a declarative,
+ * serializable record of WHAT was proposed, WHY it was held, and the exact
+ * {@link PlannedMutation}s that would run on approval. This module owns only
+ * those types plus the volume guard; it performs NO I/O and holds no relation/
+ * artifact logic.
+ *
+ * Volume bound. Staging is an unbounded-by-default surface: an untrusted actor
+ * can otherwise flood the review queue. {@link assertStagedWriteBudget}
+ * generalizes the existing fail-closed candidate cap — `src/import/run.ts`
+ * throws `QueueFullError` when `pending + valid > maxNewCandidates` for
+ * untrusted imports, and `src/mcp/okf-tools.ts` pins
+ * `MAX_MCP_PENDING_CANDIDATES = 200` — into a two-level (per-call + per-session)
+ * ceiling that throws a typed {@link StagedWriteOverflowError} naming the
+ * breached cap. It NEVER silently clamps: an overflow is an error the caller
+ * must handle, not a truncation it can miss.
+ *
+ * Cap defaults. {@link DEFAULT_STAGED_WRITE_PER_SESSION} is `200`, anchored
+ * directly to the existing pending-candidate ceiling so the two surfaces agree.
+ * {@link DEFAULT_STAGED_WRITE_PER_CALL} is `50`: a single planning call should
+ * not be able to consume the whole session budget in one shot, but the limit is
+ * generous enough for realistic batch proposals. Per-session ≥ per-call always.
+ *
+ * `RelationRef` / `ArtifactRef` are Phase-4 STUBS declared here purely so the
+ * {@link StagedChange.target} union is total across all {@link CandidateKind}s;
+ * relation/artifact staging logic lands later and may replace these shapes.
+ */
+
+import type { TrustDecision } from "./decision.js";
+import type {
+  EntityRef,
+  MutationOperation,
+  PlannedMutation,
+} from "./planner.js";
+import type { PolicyHeldReasonCode } from "../review/policy.js";
+
+/** The store a staged change targets. Phase 2 stages `page` only. */
+export type CandidateKind =
+  | "page"
+  | "relation"
+  | "artifact"
+  | "lifecycle-transition"
+  | "workflow-gate";
+
+/**
+ * Why a change was held for review. OPEN union that imports and extends the
+ * canonical review-policy {@link PolicyHeldReasonCode} (so the policy codes —
+ * `low-confidence`, `contradicted`, `schema-violating`, `provenance-violating`,
+ * `manual-review-requested`, `imported-okf`, `all`) stay a strict subset, plus
+ * the trust-routing codes `trust-blocked` / `human-gate`, and any future code.
+ */
+export type HeldReasonCode =
+  | PolicyHeldReasonCode
+  | "trust-blocked"
+  | "human-gate"
+  | (string & {});
+
+/** Phase-4 STUB: a staged relation target. Replaced when relations land. */
+export interface RelationRef {
+  fromId: string;
+  toId: string;
+  relationType: string;
+}
+
+/** Phase-4 STUB: a staged artifact target. Replaced when artifacts land. */
+export interface ArtifactRef {
+  artifactId: string;
+  artifactType: string;
+}
+
+/** Target of a staged workflow-gate change. */
+export interface WorkflowRunRef {
+  workflowRunId: string;
+}
+
+/**
+ * One held, not-yet-applied mutation captured for review. `planned` is the exact
+ * set of live writes that would run on approval; `trustDecision` is the routing
+ * the planner reached; `preconditionHash` (when present) pins optimistic
+ * concurrency for replay.
+ */
+export interface StagedChange {
+  id: string;
+  kind: CandidateKind;
+  target: EntityRef | RelationRef | ArtifactRef | WorkflowRunRef;
+  operation: MutationOperation;
+  planned: PlannedMutation[];
+  heldReasons: HeldReasonCode[];
+  trustDecision: TrustDecision;
+  preconditionHash?: string;
+  createdAt: string;
+}
+
+/** Per-call / per-session ceilings for staged writes. */
+export interface StagedWriteCaps {
+  perCall: number;
+  perSession: number;
+}
+
+/**
+ * Default max staged writes a single planning call may add. Kept well below the
+ * session ceiling so one call cannot exhaust the whole budget at once.
+ */
+export const DEFAULT_STAGED_WRITE_PER_CALL = 50;
+
+/**
+ * Default max staged writes held across a session. Anchored to the existing
+ * `MAX_MCP_PENDING_CANDIDATES` so the staging and import surfaces share a limit.
+ */
+export const DEFAULT_STAGED_WRITE_PER_SESSION = 200;
+
+/**
+ * Thrown when a staged-write request would exceed a cap. Carries the breached
+ * `cap` name and the numbers so callers can report fail-closed, never clamp.
+ */
+export class StagedWriteOverflowError extends Error {
+  readonly cap: "per-call" | "per-session";
+  readonly attempted: number;
+  readonly limit: number;
+
+  constructor(cap: "per-call" | "per-session", attempted: number, limit: number) {
+    super(`staged-write ${cap} cap exceeded: ${attempted} > ${limit}`);
+    this.name = "StagedWriteOverflowError";
+    this.cap = cap;
+    this.attempted = attempted;
+    this.limit = limit;
+  }
+}
+
+/**
+ * Fail-closed staged-write volume bound. Passes only when the request fits BOTH
+ * the per-call cap (`requested <= perCall`) AND the per-session cap
+ * (`existingCount + requested <= perSession`); otherwise throws a typed
+ * {@link StagedWriteOverflowError} naming the breached cap. Never clamps.
+ *
+ * @param existingCount - Staged writes already held this session.
+ * @param requested - Staged writes this call wants to add.
+ * @param caps - The per-call and per-session ceilings to enforce.
+ * @throws {StagedWriteOverflowError} When either ceiling would be exceeded.
+ */
+export function assertStagedWriteBudget(
+  existingCount: number,
+  requested: number,
+  caps: StagedWriteCaps,
+): void {
+  if (requested > caps.perCall) {
+    throw new StagedWriteOverflowError("per-call", requested, caps.perCall);
+  }
+  const sessionTotal = existingCount + requested;
+  if (sessionTotal > caps.perSession) {
+    throw new StagedWriteOverflowError("per-session", sessionTotal, caps.perSession);
+  }
+}

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -18,9 +18,44 @@ function emptyState(): WikiState {
   return { version: 1, indexHash: "", sources: {} };
 }
 
-/** State file read outcome: ok = parsed, missing = no file, corrupt = unparseable. */
+/**
+ * Highest state.json schema version this build understands. A state file whose
+ * `version` exceeds this was written by a newer llmwiki; we fail closed rather
+ * than risk misinterpreting (or clobbering) a forward-incompatible layout.
+ */
+export const KNOWN_STATE_VERSION = 2;
+
+/**
+ * Thrown by {@link readState} when state.json was written by a newer-than-known
+ * llmwiki version. Carries a distinct `.name` so callers can branch on the type
+ * rather than string-matching the message.
+ */
+export class StateTooNewError extends Error {
+  constructor(version: number) {
+    super(
+      `.llmwiki/state.json (version ${version}) was written by a newer llmwiki version ` +
+        `(this build understands up to version ${KNOWN_STATE_VERSION}). ` +
+        `Upgrade llmwiki to read this project.`,
+    );
+    this.name = "StateTooNewError";
+  }
+}
+
+/**
+ * Readability classification of `.llmwiki/state.json`, shared by every
+ * read-only surface so the fail-closed `too-new` outcome is represented
+ * uniformly:
+ * - ok = parsed and within the known schema range
+ * - missing = no file
+ * - corrupt = unparseable
+ * - too-new = parsed but `version` exceeds {@link KNOWN_STATE_VERSION}; the
+ *   parsed state is carried (never reset) and nothing is written to disk.
+ */
+export type StateStatus = "ok" | "missing" | "corrupt" | "too-new";
+
+/** State file read outcome plus the carried (parsed or empty) state. */
 export interface ClassifiedState {
-  status: "ok" | "missing" | "corrupt";
+  status: StateStatus;
   state: WikiState;
 }
 
@@ -34,15 +69,32 @@ export async function readStateClassified(root: string): Promise<ClassifiedState
   if (!existsSync(filePath)) return { status: "missing", state: emptyState() };
   try {
     const raw = await readFile(filePath, "utf-8");
-    return { status: "ok", state: JSON.parse(raw) as WikiState };
+    return classifyParsedState(JSON.parse(raw) as WikiState);
   } catch {
     return { status: "corrupt", state: emptyState() };
   }
 }
 
+/**
+ * Classify a successfully parsed state. Fails closed on a newer-than-known
+ * `version` by returning `too-new` with the parsed state carried intact — no
+ * reset and no disk write, so read-only callers can surface the condition.
+ */
+function classifyParsedState(state: WikiState): ClassifiedState {
+  if ((state.version as number) > KNOWN_STATE_VERSION) {
+    return { status: "too-new", state };
+  }
+  return { status: "ok", state };
+}
+
 /** Read .llmwiki/state.json, recovering from corruption gracefully (writes a .bak). */
 export async function readState(root: string): Promise<WikiState> {
   const classified = await readStateClassified(root);
+  if (classified.status === "too-new") {
+    // Fail closed: never start fresh (which would clobber a forward-incompatible
+    // file on the next write) and never copy a .bak.
+    throw new StateTooNewError(classified.state.version as number);
+  }
   if (classified.status === "corrupt") {
     const filePath = path.join(root, STATE_FILE);
     const bakPath = filePath + ".bak";

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -5,6 +5,17 @@
  *
  * Uses atomic writes (write to .tmp, then rename) to prevent corruption
  * from interrupted compiles.
+ *
+ * VERSION GUARD (Phase 2, v2-aware reads): {@link KNOWN_STATE_VERSION} is the
+ * highest schema version this build understands. {@link readStateClassified}
+ * classifies a read into a {@link StateStatus} — `ok` / `missing` / `corrupt` /
+ * `too-new` — without side effects, so read-only surfaces (freshness, lint,
+ * view, export) can branch on the outcome. A `too-new` file (one whose `version`
+ * exceeds the known version) is the FAIL-CLOSED case: the parsed state is carried
+ * intact, nothing is written, and the recovering {@link readState} throws
+ * {@link StateTooNewError} rather than starting fresh — which would clobber the
+ * forward-incompatible layout on the next write. A `corrupt` (unparseable) file
+ * is backed up to `.bak` and recovered as empty state instead.
  */
 
 import { readFile, writeFile, rename, mkdir, copyFile } from "fs/promises";

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,6 +6,7 @@
 import type { PageKind } from "../schema/types.js";
 import type { HeldReason, PolicyHeldReasonCode, ReviewMode } from "../review/policy.js";
 import type { EntityId } from "../profile/types.js";
+import type { TrustDecision } from "../trust/decision.js";
 
 /**
  * Lifecycle state of a concept or page's provenance.
@@ -206,6 +207,18 @@ export interface ReviewCandidate {
    * OKF query docs set `queries` to round-trip back into the right subdir.
    */
   targetDirectory?: "concepts" | "queries";
+  /**
+   * Typed entity directory the approved page routes to under a configurable
+   * profile (e.g. `"papers"`). Phase-2 typed-target metadata; OMITTED for
+   * default-profile candidates.
+   */
+  targetEntityType?: string;
+  /**
+   * Trust Guard decision attached to this candidate at generation time, so
+   * reviewers see how the write was routed. Phase-2 typed-target metadata;
+   * OMITTED for default-profile candidates.
+   */
+  trustDecision?: TrustDecision;
   /** Original OKF bundle-relative path, for imported candidates. */
   okfPath?: string;
   /** Confidence parsed from the generated page frontmatter, for review display. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,6 +5,7 @@
 
 import type { PageKind } from "../schema/types.js";
 import type { HeldReason, HeldReasonCode, ReviewMode } from "../review/policy.js";
+import type { EntityId } from "../profile/types.js";
 
 /**
  * Lifecycle state of a concept or page's provenance.
@@ -72,15 +73,29 @@ export interface SourceState {
   hash: string;
   concepts: string[];
   compiledAt: string;
+  /**
+   * v2 typed-ownership mirror of {@link concepts}: each bare concept slug
+   * minted into a branded `concepts/<slug>` {@link EntityId}. Kept ALONGSIDE
+   * the v1 `concepts` list (never replacing it) so a v2 state stays losslessly
+   * downgradeable. Present only after migration to `version: 2`.
+   */
+  entities?: EntityId[];
 }
 
 /** Root shape of .llmwiki/state.json. */
 export interface WikiState {
-  version: 1;
+  version: 1 | 2;
   indexHash: string;
   sources: Record<string, SourceState>;
   /** Concept slugs frozen across batches to preserve content from deleted sources. */
   frozenSlugs?: string[];
+  /**
+   * v2 typed-ownership mirror of {@link frozenSlugs}: each frozen concept slug
+   * minted into a branded `concepts/<slug>` {@link EntityId}. Kept ALONGSIDE
+   * the v1 `frozenSlugs` list (never replacing it). Present only after
+   * migration to `version: 2`.
+   */
+  frozenEntities?: EntityId[];
 }
 
 /** Change detection result for a single source file. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,7 +4,7 @@
  */
 
 import type { PageKind } from "../schema/types.js";
-import type { HeldReason, HeldReasonCode, ReviewMode } from "../review/policy.js";
+import type { HeldReason, PolicyHeldReasonCode, ReviewMode } from "../review/policy.js";
 import type { EntityId } from "../profile/types.js";
 
 /**
@@ -151,7 +151,7 @@ export interface CompileResult {
 export interface ReviewedCandidateRef {
   id: string;
   slug: string;
-  reasons: HeldReasonCode[];
+  reasons: PolicyHeldReasonCode[];
 }
 
 /** Optional behaviour controls for the compile pipeline. */

--- a/src/viewer/assets/viewer.js
+++ b/src/viewer/assets/viewer.js
@@ -282,24 +282,35 @@ function buildHealthDashboard(health) {
   return wrap;
 }
 
-/** Prepend a corrupt-state banner to `container` if one is not already in the document. */
+/** state.json classifications that surface a user-visible warning banner. */
+const BANNER_STATE_STATUSES = new Set(["corrupt", "too-new"]);
+
+/** Banner copy keyed by the state.json classification that triggers it. */
+const STATE_BANNER_MESSAGES = {
+  corrupt:
+    "Warning: state.json is corrupt. Freshness data is unavailable. Re-run `llmwiki compile` to restore.",
+  "too-new":
+    "Warning: this wiki's state was written by a newer version of llmwiki. Update llmwiki to view it safely.",
+};
+
+/** Prepend a state-status banner to `container` if one is not already in the document. */
 function prependBannerIfNeeded(container, stateStatus) {
-  if (stateStatus !== "corrupt") return;
+  if (!BANNER_STATE_STATUSES.has(stateStatus)) return;
   if (document.querySelector(".corrupt-state-banner")) return;
-  container.prepend(buildCorruptStateBanner());
+  container.prepend(buildStateStatusBanner(stateStatus));
 }
 
 /**
- * Build the corrupt-state warning banner. Displayed when `/api/health`
- * reports `stateStatus === "corrupt"`, meaning the project's state.json
- * could not be parsed at viewer startup and freshness data is unreliable.
+ * Build the state-status warning banner. Displayed when `/api/health` or
+ * `/api/pages` reports `stateStatus === "corrupt"` (state.json could not be
+ * parsed at viewer startup, so freshness data is unreliable) or `"too-new"`
+ * (state.json was written by a newer llmwiki than this build understands).
  */
-function buildCorruptStateBanner() {
+function buildStateStatusBanner(stateStatus) {
   const banner = document.createElement("div");
   banner.className = "corrupt-state-banner";
   banner.setAttribute("role", "alert");
-  banner.textContent =
-    "Warning: state.json is corrupt. Freshness data is unavailable. Re-run `llmwiki compile` to restore.";
+  banner.textContent = STATE_BANNER_MESSAGES[stateStatus];
   return banner;
 }
 
@@ -337,16 +348,16 @@ function applyHomeEnvelope(envelope) {
 }
 
 /**
- * Inject the corrupt-state banner into the app-layout container (above `main`)
+ * Inject the state-status banner into the app-layout container (above `main`)
  * so it persists across route changes. Runs once at app bootstrap from the
- * /api/pages envelope. No-ops when not corrupt or already injected.
+ * /api/pages envelope. No-ops when state is ok/missing or already injected.
  */
 function injectGlobalCorruptBanner(stateStatus) {
-  if (stateStatus !== "corrupt") return;
+  if (!BANNER_STATE_STATUSES.has(stateStatus)) return;
   if (document.querySelector(".corrupt-state-banner")) return;
   const layout = document.querySelector(".app-layout");
   if (!layout) return;
-  layout.prepend(buildCorruptStateBanner());
+  layout.prepend(buildStateStatusBanner(stateStatus));
 }
 
 /** Fetch /api/index and render the rendered HTML coming back from the server. */

--- a/src/viewer/health.ts
+++ b/src/viewer/health.ts
@@ -11,6 +11,7 @@
 import { readLintCache } from "../linter/cache.js";
 import type { LintCacheEntry } from "../linter/cache.js";
 import type { ViewerSnapshot } from "./types.js";
+import type { StateStatus } from "../utils/state.js";
 
 /**
  * Cheap health summary surfacing the same count fields MCP `wiki_status`
@@ -26,8 +27,8 @@ interface ViewerHealthResponse {
   queries: number;
   stale: number;
   orphaned: number;
-  /** Classification of state.json at snapshot build time. "corrupt" triggers the client-side banner. */
-  stateStatus: "ok" | "missing" | "corrupt";
+  /** Classification of state.json at snapshot build time. "corrupt"/"too-new" trigger the client-side banner. */
+  stateStatus: StateStatus;
   lint: LintCacheEntry | null;
 }
 

--- a/src/viewer/types.ts
+++ b/src/viewer/types.ts
@@ -16,6 +16,7 @@ import type { ClaimCitation } from "../utils/types.js";
 import type { PageDirectory } from "../export/types.js";
 import type { PageFreshness } from "../freshness/types.js";
 import type { ProfileSummaryBlock } from "../profile/block.js";
+import type { StateStatus } from "../utils/state.js";
 
 /**
  * Canonical page identifier: `concepts/<slug>` or `queries/<slug>`. Bare
@@ -165,8 +166,8 @@ export interface ViewerSnapshot {
   root: string;
   /** ISO-8601 timestamp the snapshot was built at. */
   generatedAt: string;
-  /** Classification of state.json at snapshot build time. Exposed on /api/health for the corrupt-state banner. */
-  stateStatus: "ok" | "missing" | "corrupt";
+  /** Classification of state.json at snapshot build time. Exposed on /api/health for the corrupt/too-new-state banner. */
+  stateStatus: StateStatus;
   /** Project metadata for the dashboard header. */
   project: ViewerProject;
   /** Frozen counts for `/api/pages` and `/api/health`. */

--- a/test/fixtures/state-json.ts
+++ b/test/fixtures/state-json.ts
@@ -53,3 +53,14 @@ export async function writeTestStateJson(root: string, state: WikiState): Promis
 export async function writeCorruptTestStateJson(root: string): Promise<void> {
   await writeRawTestStateJson(root, "{ not valid json");
 }
+
+/**
+ * Canonical valid version:1 state fixture shared by state-read tests so the
+ * "reports ok and carries the parsed source" assertion isn't re-declared per
+ * file. One tracked source with a known hash.
+ */
+export const SAMPLE_OK_STATE_V1: WikiState = {
+  version: 1,
+  indexHash: "",
+  sources: { "a.md": { hash: "h", concepts: ["x"], compiledAt: "t" } },
+};

--- a/test/fixtures/state-read-assertions.ts
+++ b/test/fixtures/state-read-assertions.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared assertion helpers for `readStateClassified` outcomes.
+ *
+ * The version-guard and classified-state suites both assert the canonical
+ * "ok" and "corrupt" read outcomes (status + carried state + no `.bak` side
+ * effect). Centralizing those assertions keeps the suites DRY and gives both
+ * a single place to update if the contract changes.
+ */
+
+import { expect } from "vitest";
+import { existsSync } from "fs";
+import path from "path";
+import { readStateClassified } from "../../src/utils/state.js";
+import { STATE_FILE } from "../../src/utils/constants.js";
+import { SAMPLE_OK_STATE_V1, writeCorruptTestStateJson, writeTestStateJson } from "./state-json.js";
+
+const bakPath = (root: string) => path.join(root, STATE_FILE + ".bak");
+
+/** Write {@link SAMPLE_OK_STATE_V1} then assert it reads back as a parsed "ok" state. */
+export async function expectReadsOkV1(root: string): Promise<void> {
+  await writeTestStateJson(root, SAMPLE_OK_STATE_V1);
+  const result = await readStateClassified(root);
+  expect(result.status).toBe("ok");
+  expect(result.state.sources["a.md"].hash).toBe("h");
+}
+
+/** Write unparseable JSON then assert "corrupt" with an empty state and NO `.bak`. */
+export async function expectReadsCorruptNoBak(root: string): Promise<void> {
+  await writeCorruptTestStateJson(root);
+  const result = await readStateClassified(root);
+  expect(result.status).toBe("corrupt");
+  expect(result.state.sources).toEqual({});
+  expect(existsSync(bakPath(root))).toBe(false);
+}

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -249,6 +249,14 @@ describe("error handling", () => {
 
 type ResourceMap = Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>;
 
+/** Read a static resource and return its first content block's raw text. */
+async function readStaticResourceText(uri: string): Promise<string> {
+  const server = buildServer();
+  const resource = (getRegisteredResources(server) as ResourceMap)[uri];
+  const result = await resource.readCallback(new URL(uri));
+  return result.contents[0].text;
+}
+
 describe("MCP resources", () => {
   it("resolves the wiki-index static resource", async () => {
     await writeFile(path.join(root, "wiki/index.md"), "# Test Index\n");
@@ -259,11 +267,24 @@ describe("MCP resources", () => {
   });
 
   it("resolves the wiki-state static resource", async () => {
-    const server = buildServer();
-    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://state"];
-    const result = await resource.readCallback(new URL("llmwiki://state"));
-    const parsed = JSON.parse(result.contents[0].text);
+    const parsed = JSON.parse(await readStaticResourceText("llmwiki://state"));
     expect(parsed).toMatchObject({ version: 1, sources: expect.any(Object) });
+  });
+
+  it("fails closed on a too-new state — does NOT stream the raw body", async () => {
+    // A version-3 state was written by a newer llmwiki; the resource must not
+    // serialize the body verbatim as if healthy (every sibling surface branches
+    // on status). It surfaces the too-new condition and omits the real state.
+    await writeFile(
+      path.join(root, ".llmwiki/state.json"),
+      JSON.stringify({ version: 3, indexHash: "secret", sources: { "leak.md": {} } }),
+    );
+    const text = await readStaticResourceText("llmwiki://state");
+    const parsed = JSON.parse(text);
+    expect(parsed.stateStatus).toBe("too-new");
+    expect(parsed.error).toMatch(/newer llmwiki version/);
+    expect(parsed).not.toHaveProperty("sources");
+    expect(text).not.toContain("secret");
   });
 
   it("resolves the wiki-sources static resource", async () => {

--- a/test/state-classified.test.ts
+++ b/test/state-classified.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { existsSync } from "fs";
-import path from "path";
 import { readStateClassified } from "../src/utils/state.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
-import { writeCorruptTestStateJson, writeTestStateJson } from "./fixtures/state-json.js";
+import { expectReadsCorruptNoBak, expectReadsOkV1 } from "./fixtures/state-read-assertions.js";
 
 describe("readStateClassified", () => {
   const env = useLintTempRoot("state-classified");
@@ -15,21 +13,10 @@ describe("readStateClassified", () => {
   });
 
   it("reports ok and parses a valid state file", async () => {
-    await writeTestStateJson(env.dir, {
-      version: 1,
-      indexHash: "",
-      sources: { "a.md": { hash: "h", concepts: ["x"], compiledAt: "t" } },
-    });
-    const result = await readStateClassified(env.dir);
-    expect(result.status).toBe("ok");
-    expect(result.state.sources["a.md"].hash).toBe("h");
+    await expectReadsOkV1(env.dir);
   });
 
   it("reports corrupt WITHOUT writing a .bak (read-only)", async () => {
-    await writeCorruptTestStateJson(env.dir);
-    const result = await readStateClassified(env.dir);
-    expect(result.status).toBe("corrupt");
-    expect(result.state.sources).toEqual({});
-    expect(existsSync(path.join(env.dir, ".llmwiki/state.json.bak"))).toBe(false);
+    await expectReadsCorruptNoBak(env.dir);
   });
 });

--- a/test/state-migrate.test.ts
+++ b/test/state-migrate.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the lossless v1→v2 WikiState migration.
+ *
+ * Phase 2 of the Configurable Lifecycle Knowledge Platform introduces a typed
+ * ownership mirror: alongside the v1 `concepts` / `frozenSlugs` string lists,
+ * a v2 state carries `entities` / `frozenEntities` as branded `EntityId`s of
+ * the form `concepts/<slug>`. These tests pin the migration's four contracts:
+ *
+ *  - lossless upgrade (v1 fields retained, typed mirror added),
+ *  - idempotency (re-migrating a v2 state is a no-op, never double-typed),
+ *  - determinism (sorted output, byte-stable across repeated runs), and
+ *  - fail-closed behaviour (a non-slug-safe bare slug throws, never dropped).
+ */
+
+import { describe, it, expect } from "vitest";
+import { migrateStateToV2 } from "../src/state/migrate.js";
+import { EntityIdError } from "../src/profile/identity.js";
+import type { WikiState } from "../src/utils/types.js";
+
+/** A minimal, valid v1 state used as the base fixture for the suite. */
+function v1Fixture(): WikiState {
+  return {
+    version: 1,
+    indexHash: "i",
+    sources: {
+      "a.md": { hash: "h", concepts: ["rag", "x"], compiledAt: "T" },
+    },
+    frozenSlugs: ["rag"],
+  };
+}
+
+describe("migrateStateToV2 — lossless v1→v2 upgrade", () => {
+  it("bumps version and adds the typed mirror while retaining v1 fields", () => {
+    const v2 = migrateStateToV2(v1Fixture());
+    expect(v2.version).toBe(2);
+    const src = v2.sources["a.md"];
+    expect(src.entities).toEqual(["concepts/rag", "concepts/x"]);
+    expect(src.concepts).toEqual(["rag", "x"]);
+    expect(v2.frozenEntities).toEqual(["concepts/rag"]);
+    expect(v2.frozenSlugs).toEqual(["rag"]);
+  });
+
+  it("carries hash, compiledAt, and indexHash through unchanged", () => {
+    const v2 = migrateStateToV2(v1Fixture());
+    expect(v2.indexHash).toBe("i");
+    expect(v2.sources["a.md"].hash).toBe("h");
+    expect(v2.sources["a.md"].compiledAt).toBe("T");
+  });
+});
+
+describe("migrateStateToV2 — idempotency", () => {
+  it("returns a deep-equal v2 state when given an already-v2 state", () => {
+    const once = migrateStateToV2(v1Fixture());
+    const twice = migrateStateToV2(once);
+    expect(twice).toEqual(once);
+  });
+
+  it("never double-types entities on a second migration", () => {
+    const twice = migrateStateToV2(migrateStateToV2(v1Fixture()));
+    expect(twice.sources["a.md"].entities).toEqual(["concepts/rag", "concepts/x"]);
+    expect(twice.frozenEntities).toEqual(["concepts/rag"]);
+  });
+});
+
+describe("migrateStateToV2 — determinism", () => {
+  it("produces deep-equal output across two migrations of the same input", () => {
+    expect(migrateStateToV2(v1Fixture())).toEqual(migrateStateToV2(v1Fixture()));
+  });
+
+  it("sorts entities and frozenEntities lexicographically", () => {
+    const v1 = v1Fixture();
+    v1.sources["a.md"].concepts = ["zebra", "apple", "mango"];
+    v1.frozenSlugs = ["zebra", "apple"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.sources["a.md"].entities).toEqual([
+      "concepts/apple",
+      "concepts/mango",
+      "concepts/zebra",
+    ]);
+    expect(v2.frozenEntities).toEqual(["concepts/apple", "concepts/zebra"]);
+  });
+});
+
+describe("migrateStateToV2 — fail-closed", () => {
+  it("throws on a bare slug with spaces rather than silently dropping it", () => {
+    const v1 = v1Fixture();
+    v1.sources["a.md"].concepts = ["Bad Slug"];
+    expect(() => migrateStateToV2(v1)).toThrow(EntityIdError);
+  });
+
+  it("throws on an uppercase frozen slug rather than silently dropping it", () => {
+    const v1 = v1Fixture();
+    v1.frozenSlugs = ["UPPER"];
+    expect(() => migrateStateToV2(v1)).toThrow(EntityIdError);
+  });
+});

--- a/test/state-migrate.test.ts
+++ b/test/state-migrate.test.ts
@@ -81,6 +81,25 @@ describe("migrateStateToV2 — determinism", () => {
   });
 });
 
+describe("migrateStateToV2 — dedup", () => {
+  it("dedups duplicate concept slugs into a single typed entity", () => {
+    const v1 = v1Fixture();
+    v1.sources["a.md"].concepts = ["rag", "rag", "x"];
+    v1.frozenSlugs = ["rag", "rag"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.sources["a.md"].entities).toEqual(["concepts/rag", "concepts/x"]);
+    expect(v2.frozenEntities).toEqual(["concepts/rag"]);
+  });
+});
+
+describe("migrateStateToV2 — idempotency gate >= 2", () => {
+  it("returns a v2 state unchanged even if its version reads higher than 2", () => {
+    const v2 = migrateStateToV2(v1Fixture());
+    const future = { ...v2, version: 3 as unknown as 2 };
+    expect(migrateStateToV2(future)).toBe(future);
+  });
+});
+
 describe("migrateStateToV2 — fail-closed", () => {
   it("throws on a bare slug with spaces rather than silently dropping it", () => {
     const v1 = v1Fixture();

--- a/test/state-version-guard.test.ts
+++ b/test/state-version-guard.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression tests for the fail-closed newer-than-known state-version guard.
+ *
+ * A `state.json` written by a future llmwiki (version > KNOWN_STATE_VERSION)
+ * must NOT be silently treated as healthy/empty. `readStateClassified` reports
+ * `status: "too-new"` (carrying the parsed state, writing nothing); `readState`
+ * throws a typed `StateTooNewError`. v1/v2/missing/corrupt behavior is unchanged.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+import {
+  readStateClassified,
+  readState,
+  StateTooNewError,
+  KNOWN_STATE_VERSION,
+} from "../src/utils/state.js";
+import { collectStatus } from "../src/status/collect.js";
+import { STATE_FILE } from "../src/utils/constants.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+import {
+  writeRawTestStateJson,
+  writeTestStateJson,
+  writeCorruptTestStateJson,
+} from "./fixtures/state-json.js";
+import { expectReadsCorruptNoBak, expectReadsOkV1 } from "./fixtures/state-read-assertions.js";
+
+const NEWER_STATE = '{"version":3,"indexHash":"h3","sources":{}}';
+const bakPath = (dir: string) => path.join(dir, STATE_FILE + ".bak");
+const stateText = (dir: string) => readFile(path.join(dir, STATE_FILE), "utf-8");
+
+/** Assert the on-disk state file was neither rewritten nor backed up. */
+async function expectFileUntouched(dir: string): Promise<void> {
+  expect(existsSync(bakPath(dir))).toBe(false);
+  expect(await stateText(dir)).toBe(NEWER_STATE);
+}
+
+describe("readStateClassified version guard", () => {
+  const env = useLintTempRoot("state-version-guard-classified");
+
+  it("(a) reports too-new without resetting, writing, or backing up", async () => {
+    await writeRawTestStateJson(env.dir, NEWER_STATE);
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("too-new");
+    // Parsed state is carried, NOT reset to empty.
+    expect(result.state.version).toBe(3);
+    expect(result.state.indexHash).toBe("h3");
+    await expectFileUntouched(env.dir);
+  });
+
+  it("(c) reports ok on a version:1 file (unchanged)", async () => {
+    await expectReadsOkV1(env.dir);
+  });
+
+  it("(d) reports ok on a state at exactly KNOWN_STATE_VERSION (2)", async () => {
+    expect(KNOWN_STATE_VERSION).toBe(2);
+    await writeTestStateJson(env.dir, { version: 2, indexHash: "", sources: {} });
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("ok");
+    expect(result.state.version).toBe(2);
+  });
+
+  it("(e) still reports corrupt on unparseable input (read-only)", async () => {
+    await expectReadsCorruptNoBak(env.dir);
+  });
+});
+
+describe("readState version guard", () => {
+  const env = useLintTempRoot("state-version-guard-read");
+
+  it("(b) throws StateTooNewError, writes no .bak, leaves file byte-unchanged", async () => {
+    await writeRawTestStateJson(env.dir, NEWER_STATE);
+    await expect(readState(env.dir)).rejects.toBeInstanceOf(StateTooNewError);
+    await expect(readState(env.dir)).rejects.toThrow("written by a newer llmwiki version");
+    await expectFileUntouched(env.dir);
+  });
+
+  it("(e) still backs up corrupt state to .bak (unchanged behavior)", async () => {
+    await writeCorruptTestStateJson(env.dir);
+    const state = await readState(env.dir);
+    expect(state.sources).toEqual({});
+    expect(existsSync(bakPath(env.dir))).toBe(true);
+  });
+});
+
+describe("collectStatus version guard", () => {
+  const env = useLintTempRoot("state-version-guard-status");
+
+  it("surfaces too-new instead of reporting a healthy empty project", async () => {
+    await writeRawTestStateJson(env.dir, NEWER_STATE);
+    await env.writeSource("a.md", "# a");
+    const status = await collectStatus(env.dir);
+    expect(status.stateStatus).toBe("too-new");
+    // Fail closed: do not invent "new" pending changes from an empty snapshot,
+    // exactly as the corrupt path does.
+    expect(status.pendingChanges).toEqual([]);
+  });
+});

--- a/test/trust-candidate-typed.test.ts
+++ b/test/trust-candidate-typed.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Phase-2 typed-target metadata on page review candidates.
+ *
+ * A {@link ReviewCandidate} can optionally carry a typed entity target
+ * (`targetEntityType`, e.g. `"papers"`) and an attached Trust Guard decision
+ * (`trustDecision`). These fields exist ONLY for configurable (non-default)
+ * profiles; default-profile candidates must never populate them.
+ *
+ * These tests pin three guarantees:
+ *  (a) a candidate WITH the new fields round-trips through the candidate
+ *      serialization (`JSON.stringify(candidate, null, 2)`) → `readCandidate`
+ *      with both fields intact;
+ *  (b) PARITY GUARD — a candidate created WITHOUT the new fields, serialized via
+ *      the SAME path, produces JSON with neither key present, proving that
+ *      `undefined` optional fields never leak into the persisted bytes;
+ *  (c) `review list` rendering for a default candidate is byte-identical whether
+ *      or not the (absent) typed fields are part of the model.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import path from "path";
+import { writeFile } from "fs/promises";
+import {
+  writeCandidate,
+  readCandidate,
+} from "../src/compiler/candidates.js";
+import reviewListCommand from "../src/commands/review-list.js";
+import { CANDIDATES_DIR } from "../src/utils/constants.js";
+import type { ReviewCandidate } from "../src/utils/types.js";
+import type { TrustDecision } from "../src/trust/decision.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+const BODY = [
+  "---",
+  "title: Typed Target",
+  "summary: A typed candidate.",
+  "sources: []",
+  "---",
+  "",
+  "Body.",
+].join("\n");
+
+/** Persist a full ReviewCandidate via the exact serialization writeCandidate uses. */
+async function persistCandidate(dir: string, candidate: ReviewCandidate): Promise<void> {
+  const file = path.join(dir, CANDIDATES_DIR, `${candidate.id}.json`);
+  await writeFile(file, JSON.stringify(candidate, null, 2));
+}
+
+/** Join all logged args from a console spy into a single string. */
+function collectLog(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((args) => args.join(" ")).join("\n");
+}
+
+describe("typed-target metadata on page candidates", () => {
+  it("(a) round-trips targetEntityType + trustDecision with the fields intact", async () => {
+    const base = await writeCandidate(root.dir, {
+      title: "Typed Target",
+      slug: "typed-target",
+      summary: "A typed candidate.",
+      sources: [],
+      body: BODY,
+    });
+    const decision: TrustDecision = "stage-for-review";
+    const typed: ReviewCandidate = {
+      ...base,
+      targetEntityType: "papers",
+      trustDecision: decision,
+    };
+    await persistCandidate(root.dir, typed);
+
+    const loaded = await readCandidate(root.dir, base.id);
+    expect(loaded?.targetEntityType).toBe("papers");
+    expect(loaded?.trustDecision).toBe("stage-for-review");
+  });
+
+  it("(b) PARITY GUARD: a default candidate serializes with neither key present", async () => {
+    const candidate = await writeCandidate(root.dir, {
+      title: "Default",
+      slug: "default-candidate",
+      summary: "No typed fields.",
+      sources: [],
+      body: BODY,
+    });
+    const parsed = JSON.parse(JSON.stringify(candidate, null, 2));
+    expect("targetEntityType" in parsed).toBe(false);
+    expect("trustDecision" in parsed).toBe(false);
+  });
+
+  it("(c) review list rendering is unchanged for a default candidate", async () => {
+    await writeCandidate(root.dir, {
+      title: "Default",
+      slug: "default-candidate",
+      summary: "No typed fields.",
+      sources: ["a.md"],
+      body: BODY,
+    });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await reviewListCommand();
+    const rendered = collectLog(spy);
+    spy.mockRestore();
+
+    expect(rendered).not.toContain("targetEntityType");
+    expect(rendered).not.toContain("trustDecision");
+    expect(rendered).toContain("default-candidate");
+  });
+});

--- a/test/trust-checks.test.ts
+++ b/test/trust-checks.test.ts
@@ -91,6 +91,15 @@ describe("checkResourceLimit", () => {
     const res = await checkResourceLimit(ctx(`${WIKI}/small.md`, "x".repeat(MAX_SOURCE_CHARS)));
     expect(res.verdict).toBe("pass");
   });
+
+  it("uses the CHARACTER cap (matches ingest), not byte length", async () => {
+    // Exactly MAX_SOURCE_CHARS multi-byte chars: well over the cap in BYTES, but
+    // at the cap in CHARS. Ingest gates on `content.length`, so this must pass.
+    const multibyte = "é".repeat(MAX_SOURCE_CHARS);
+    expect(Buffer.byteLength(multibyte, "utf-8")).toBeGreaterThan(MAX_SOURCE_CHARS);
+    const res = await checkResourceLimit(ctx(`${WIKI}/multibyte.md`, multibyte));
+    expect(res.verdict).toBe("pass");
+  });
 });
 
 describe("checkFrontmatter", () => {

--- a/test/trust-checks.test.ts
+++ b/test/trust-checks.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @file test/trust-checks.test.ts
+ * @description Unit coverage for the MANDATORY CORE CHECKS over a page mutation
+ * (`src/trust/checks.ts`) — the unconditional trust floor of CLP Invariant 3.
+ *
+ * These tests pin the four core checks (path-confinement, collision/no-overwrite,
+ * resource-limit, frontmatter-parse) against a real tmp-dir fixture, then assert
+ * the Invariant-3 floor itself: `runMandatoryPageChecks` runs ALL four checks
+ * with no parameter by which a profile could gate or remove any of them. A
+ * profile that *tries* to disable a check has no effect, because the runner takes
+ * only the page-write context — there is no predicate, allow/deny list, or
+ * profile argument in its signature.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, symlink } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { MAX_SOURCE_CHARS } from "../src/utils/constants.js";
+import {
+  checkPathConfinement,
+  checkTargetCollision,
+  checkResourceLimit,
+  checkFrontmatter,
+  mandatoryPageChecks,
+  runMandatoryPageChecks,
+  type PageWriteContext,
+} from "../src/trust/checks.js";
+
+let root: string;
+const WIKI = "wiki/concepts";
+const GOOD_BODY = "---\ntitle: Ok\n---\n\nbody\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "trust-checks-"));
+  await mkdir(path.join(root, WIKI), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function ctx(targetPath: string, body = GOOD_BODY): PageWriteContext {
+  return { root, targetPath, body };
+}
+
+describe("checkPathConfinement", () => {
+  it("blocks a target that escapes the root", async () => {
+    const res = await checkPathConfinement(ctx("../escape.md"));
+    expect(res.verdict).toBe("block");
+    expect(res.code).toBe("path-escape");
+  });
+
+  it("passes a target confined under the root", async () => {
+    const res = await checkPathConfinement(ctx(`${WIKI}/page.md`));
+    expect(res.verdict).toBe("pass");
+  });
+
+  it("blocks a target whose ancestor symlink escapes the root", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "trust-outside-"));
+    await symlink(outside, path.join(root, "wiki/link"), "dir");
+    const res = await checkPathConfinement(ctx("wiki/link/page.md"));
+    expect(res.verdict).toBe("block");
+    expect(res.code).toBe("path-escape");
+    await rm(outside, { recursive: true, force: true });
+  });
+});
+
+describe("checkTargetCollision", () => {
+  it("blocks when the target file already exists (create-only)", async () => {
+    await writeFile(path.join(root, WIKI, "dup.md"), GOOD_BODY);
+    const res = await checkTargetCollision(ctx(`${WIKI}/dup.md`));
+    expect(res.verdict).toBe("block");
+    expect(res.code).toBe("target-exists");
+  });
+
+  it("passes when the target path is free", async () => {
+    const res = await checkTargetCollision(ctx(`${WIKI}/free.md`));
+    expect(res.verdict).toBe("pass");
+  });
+});
+
+describe("checkResourceLimit", () => {
+  it("blocks a body exceeding the reused byte cap", async () => {
+    const res = await checkResourceLimit(ctx(`${WIKI}/big.md`, "x".repeat(MAX_SOURCE_CHARS + 1)));
+    expect(res.verdict).toBe("block");
+    expect(res.code).toBe("resource-limit");
+  });
+
+  it("passes a body within the cap", async () => {
+    const res = await checkResourceLimit(ctx(`${WIKI}/small.md`, "x".repeat(MAX_SOURCE_CHARS)));
+    expect(res.verdict).toBe("pass");
+  });
+});
+
+describe("checkFrontmatter", () => {
+  it("blocks a malformed-frontmatter body", async () => {
+    const bad = "---\ntitle: : : bad\n  nope\n---\n\nbody\n";
+    const res = await checkFrontmatter(ctx(`${WIKI}/bad.md`, bad));
+    expect(res.verdict).toBe("block");
+    expect(res.code).toBe("frontmatter-invalid");
+  });
+
+  it("passes a well-formed frontmatter body", async () => {
+    const res = await checkFrontmatter(ctx(`${WIKI}/ok.md`));
+    expect(res.verdict).toBe("pass");
+  });
+});
+
+describe("runMandatoryPageChecks (Invariant-3 floor)", () => {
+  it("returns one result per registered check", async () => {
+    const results = await runMandatoryPageChecks(ctx(`${WIKI}/page.md`));
+    expect(results).toHaveLength(mandatoryPageChecks.length);
+    expect(results.every((r) => typeof r.code === "string")).toBe(true);
+  });
+
+  it("runs ALL checks even when a profile tries to disable some", async () => {
+    // A profile-shaped object asking to drop checks is structurally inert: the
+    // runner accepts ONLY PageWriteContext, so there is no parameter through
+    // which the profile could remove a core check. We attach it to the context
+    // and confirm every mandatory check still ran on the failing input.
+    const profileTryingToDisable = { disableChecks: ["path-escape", "resource-limit"] };
+    const failing = { ...ctx("../escape.md", "x".repeat(MAX_SOURCE_CHARS + 1)), profileTryingToDisable };
+    const results = await runMandatoryPageChecks(failing);
+    const blocked = results.filter((r) => r.verdict === "block").map((r) => r.code);
+    expect(blocked).toContain("path-escape");
+    expect(blocked).toContain("resource-limit");
+    expect(results).toHaveLength(mandatoryPageChecks.length);
+  });
+});

--- a/test/trust-checks.test.ts
+++ b/test/trust-checks.test.ts
@@ -123,17 +123,18 @@ describe("runMandatoryPageChecks (Invariant-3 floor)", () => {
     expect(results.every((r) => typeof r.code === "string")).toBe(true);
   });
 
-  it("runs ALL checks even when a profile tries to disable some", async () => {
-    // A profile-shaped object asking to drop checks is structurally inert: the
-    // runner accepts ONLY PageWriteContext, so there is no parameter through
-    // which the profile could remove a core check. We attach it to the context
-    // and confirm every mandatory check still ran on the failing input.
-    const profileTryingToDisable = { disableChecks: ["path-escape", "resource-limit"] };
-    const failing = { ...ctx("../escape.md", "x".repeat(MAX_SOURCE_CHARS + 1)), profileTryingToDisable };
+  it("runs EVERY mandatory check — no profile parameter can remove one", async () => {
+    // The Invariant-3 floor is enforced by TYPE, not convention:
+    // `runMandatoryPageChecks(ctx: PageWriteContext)` takes ONLY the page-write
+    // context — there is no predicate, allow/deny list, or profile argument in
+    // its signature through which a profile could gate or drop a core check.
+    // So the proof is simply that ALL mandatory checks always run, even on an
+    // input that fails several of them at once.
+    const failing = ctx("../escape.md", "x".repeat(MAX_SOURCE_CHARS + 1));
     const results = await runMandatoryPageChecks(failing);
+    expect(results).toHaveLength(mandatoryPageChecks.length);
     const blocked = results.filter((r) => r.verdict === "block").map((r) => r.code);
     expect(blocked).toContain("path-escape");
     expect(blocked).toContain("resource-limit");
-    expect(results).toHaveLength(mandatoryPageChecks.length);
   });
 });

--- a/test/trust-decision.test.ts
+++ b/test/trust-decision.test.ts
@@ -51,21 +51,14 @@ function enumerateVerdictSets(maxSize: number): TrustVerdict[][] {
 const ALL_SETS = enumerateVerdictSets(3);
 
 describe("composeTrustDecision totality", () => {
-  it("returns a defined decision for every verdict set × routing", () => {
+  it("returns a defined decision (never throwing) for every verdict set × routing", () => {
+    // Totality: across the full ALL_SETS × ROUTINGS product the function always
+    // resolves to a DECISIONS member. A returned, defined decision also proves
+    // it did not throw, so the two properties fold into this one enumeration.
     for (const set of ALL_SETS) {
       for (const reviewRouted of ROUTINGS) {
         const decision = composeTrustDecision(set.map(check), { reviewRouted });
         expect(DECISIONS).toContain(decision);
-      }
-    }
-  });
-
-  it("never throws across the full enumeration", () => {
-    for (const set of ALL_SETS) {
-      for (const reviewRouted of ROUTINGS) {
-        expect(() =>
-          composeTrustDecision(set.map(check), { reviewRouted })
-        ).not.toThrow();
       }
     }
   });

--- a/test/trust-decision.test.ts
+++ b/test/trust-decision.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit coverage for the Trust Guard decision core
+ * (`src/trust/decision.ts`). These tests pin the two structural contracts of
+ * `composeTrustDecision` — totality and monotonicity in `block` — plus the
+ * concrete routing/quarantine/warn-floor rules from the CLP Trust Guard spec.
+ *
+ * Totality is proven by EXHAUSTIVE NESTED ENUMERATION (fast-check is not a
+ * project dependency): every verdict multiset of size 0..3 over
+ * {pass,warn,block}, crossed with `reviewRouted` ∈ {true,false}, is fed to the
+ * composer and asserted to return one of the five defined decisions without
+ * throwing or returning undefined. The same enumeration backs the
+ * monotone-in-block and warn-floor properties.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  composeTrustDecision,
+  type TrustVerdict,
+  type TrustDecision,
+  type TrustCheckResult,
+} from "../src/trust/decision.js";
+
+const VERDICTS: TrustVerdict[] = ["pass", "warn", "block"];
+const DECISIONS: TrustDecision[] = [
+  "allow",
+  "allow-with-warning",
+  "stage-for-review",
+  "quarantine",
+  "deny",
+];
+const ROUTINGS = [true, false];
+
+/** A check result carrying only a verdict (no quarantine flag). */
+function check(verdict: TrustVerdict): TrustCheckResult {
+  return { code: verdict, verdict, message: verdict };
+}
+
+/** Every verdict multiset of length 0..maxSize over {pass,warn,block}. */
+function enumerateVerdictSets(maxSize: number): TrustVerdict[][] {
+  let sets: TrustVerdict[][] = [[]];
+  for (let size = 1; size <= maxSize; size++) {
+    const grown: TrustVerdict[][] = [];
+    for (const set of sets.filter((s) => s.length === size - 1)) {
+      for (const v of VERDICTS) grown.push([...set, v]);
+    }
+    sets = sets.concat(grown);
+  }
+  return sets;
+}
+
+const ALL_SETS = enumerateVerdictSets(3);
+
+describe("composeTrustDecision totality", () => {
+  it("returns a defined decision for every verdict set × routing", () => {
+    for (const set of ALL_SETS) {
+      for (const reviewRouted of ROUTINGS) {
+        const decision = composeTrustDecision(set.map(check), { reviewRouted });
+        expect(DECISIONS).toContain(decision);
+      }
+    }
+  });
+
+  it("never throws across the full enumeration", () => {
+    for (const set of ALL_SETS) {
+      for (const reviewRouted of ROUTINGS) {
+        expect(() =>
+          composeTrustDecision(set.map(check), { reviewRouted })
+        ).not.toThrow();
+      }
+    }
+  });
+});
+
+describe("composeTrustDecision monotone-in-block", () => {
+  it("any block ⇒ decision is strict (never allow/allow-with-warning)", () => {
+    const strict = ["stage-for-review", "quarantine", "deny"];
+    for (const set of ALL_SETS.filter((s) => s.includes("block"))) {
+      for (const reviewRouted of ROUTINGS) {
+        const decision = composeTrustDecision(set.map(check), { reviewRouted });
+        expect(strict).toContain(decision);
+      }
+    }
+  });
+});
+
+describe("composeTrustDecision warn floor", () => {
+  it("≥1 warn and 0 block ⇒ allow-with-warning (never allow)", () => {
+    const warnSets = ALL_SETS.filter(
+      (s) => s.includes("warn") && !s.includes("block")
+    );
+    for (const set of warnSets) {
+      for (const reviewRouted of ROUTINGS) {
+        const decision = composeTrustDecision(set.map(check), { reviewRouted });
+        expect(decision).toBe("allow-with-warning");
+      }
+    }
+  });
+});
+
+describe("composeTrustDecision pass/empty", () => {
+  it("empty result set ⇒ allow", () => {
+    expect(composeTrustDecision([], { reviewRouted: false })).toBe("allow");
+    expect(composeTrustDecision([], { reviewRouted: true })).toBe("allow");
+  });
+
+  it("all-pass ⇒ allow regardless of routing", () => {
+    const allPass = ALL_SETS.filter(
+      (s) => s.length > 0 && s.every((v) => v === "pass")
+    );
+    for (const set of allPass) {
+      for (const reviewRouted of ROUTINGS) {
+        expect(composeTrustDecision(set.map(check), { reviewRouted })).toBe(
+          "allow"
+        );
+      }
+    }
+  });
+});
+
+describe("composeTrustDecision block routing", () => {
+  it("block + reviewRouted=true ⇒ stage-for-review", () => {
+    expect(
+      composeTrustDecision([check("block")], { reviewRouted: true })
+    ).toBe("stage-for-review");
+  });
+
+  it("block + reviewRouted=false ⇒ deny", () => {
+    expect(
+      composeTrustDecision([check("block")], { reviewRouted: false })
+    ).toBe("deny");
+  });
+
+  it("block mixed with pass/warn still routes by the block", () => {
+    const mixed = [check("pass"), check("warn"), check("block")];
+    expect(composeTrustDecision(mixed, { reviewRouted: true })).toBe(
+      "stage-for-review"
+    );
+    expect(composeTrustDecision(mixed, { reviewRouted: false })).toBe("deny");
+  });
+});
+
+describe("composeTrustDecision quarantine", () => {
+  it("a block with quarantine:true ⇒ quarantine regardless of routing", () => {
+    const q: TrustCheckResult = {
+      code: "untrusted",
+      verdict: "block",
+      message: "untrusted content",
+      quarantine: true,
+    };
+    expect(composeTrustDecision([q], { reviewRouted: true })).toBe(
+      "quarantine"
+    );
+    expect(composeTrustDecision([q], { reviewRouted: false })).toBe(
+      "quarantine"
+    );
+  });
+
+  it("quarantine wins even when other blocks are present", () => {
+    const q: TrustCheckResult = {
+      code: "untrusted",
+      verdict: "block",
+      message: "untrusted content",
+      quarantine: true,
+    };
+    const mixed = [check("warn"), check("block"), q];
+    expect(composeTrustDecision(mixed, { reviewRouted: true })).toBe(
+      "quarantine"
+    );
+  });
+});

--- a/test/trust-journal.test.ts
+++ b/test/trust-journal.test.ts
@@ -50,6 +50,12 @@ async function openTwoTargetBatch(t1: string, t2: string): Promise<JournalBatch>
   return batch;
 }
 
+/** Open a batch, record one target's pre-state, then write `bytes` to it (no commit). */
+async function recordThenWrite(batch: JournalBatch, rel: string, bytes: string): Promise<void> {
+  await recordPreState(batch, path.join(root, rel));
+  await writeFile(path.join(root, rel), bytes);
+}
+
 describe("replayJournal — committed batch", () => {
   it("leaves files in place and is a no-op", async () => {
     const t1 = `${WIKI}/a.md`;
@@ -85,11 +91,27 @@ describe("replayJournal — pending (crashed) batch", () => {
   it("deletes a file that was absent pre-batch but got written before the crash", async () => {
     const t1 = `${WIKI}/c.md`;
     const batch = await openBatch(root);
-    await recordPreState(batch, path.join(root, t1));
-    await writeFile(path.join(root, t1), "PARTIAL"); // written, never committed
+    await recordThenWrite(batch, t1, "PARTIAL"); // written, never committed
 
     await replayJournal(root);
 
+    expect(await exists(t1)).toBe(false);
+  });
+});
+
+describe("recordPreState — duplicate target in one batch", () => {
+  it("reverts an absent-pre-batch path to ABSENT despite two writes to it", async () => {
+    const t1 = `${WIKI}/dup-target.md`; // absent pre-batch
+    const batch = await openBatch(root);
+    // First mutation records pre-state (absent), then writes.
+    await recordThenWrite(batch, t1, "FIRST");
+    // Second mutation to the SAME path: a naive impl would now snapshot "FIRST"
+    // (a partial post-state). The dedup must keep the first (absent) observation.
+    await recordThenWrite(batch, t1, "SECOND"); // crash before commit
+
+    await replayJournal(root);
+
+    // The true pre-batch state was ABSENT; revert must delete, not re-create.
     expect(await exists(t1)).toBe(false);
   });
 });

--- a/test/trust-journal.test.ts
+++ b/test/trust-journal.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @file test/trust-journal.test.ts
+ * @description Coverage for the single-store INTENT JOURNAL
+ * (`src/trust/journal.ts`) — the durability record that realizes the CLP
+ * atomicity contract for the PAGE store: "partial application is a bug".
+ *
+ * A batch is journalled `pending` (recording every target's pre-state — prior
+ * bytes or an `absent` marker) BEFORE any write lands, then marked `committed`
+ * once all writes succeed. {@link replayJournal} is the crash-recovery seam: on
+ * startup, any `pending`-but-not-`committed` batch is REVERTED to its recorded
+ * pre-state (prior bytes restored, or absent files deleted) and resolved.
+ *
+ * These tests pin the three contracts against a real tmp-dir fixture:
+ *  (a) a committed batch survives replay untouched (no-op);
+ *  (b) a crash-simulated pending batch (journal written + file 1 of 2 applied,
+ *      never committed) replays to the FULL pre-state — never a partial
+ *      post-state;
+ *  (c) replay is idempotent (a second call is a no-op).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, readFile } from "fs/promises";
+import path from "path";
+import {
+  openBatch,
+  recordPreState,
+  commitBatch,
+  replayJournal,
+  type JournalBatch,
+} from "../src/trust/journal.js";
+import { WIKI, makeTrustRoot, cleanupTrustRoot, existsUnder, expectRevertedToPreState } from "./trust/fixture.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await makeTrustRoot("trust-journal-");
+});
+
+afterEach(async () => {
+  await cleanupTrustRoot(root);
+});
+
+const exists = (rel: string) => existsUnder(root, rel);
+
+/** Open a 2-target batch, recording pre-state for each, without committing. */
+async function openTwoTargetBatch(t1: string, t2: string): Promise<JournalBatch> {
+  const batch = await openBatch(root);
+  await recordPreState(batch, path.join(root, t1));
+  await recordPreState(batch, path.join(root, t2));
+  return batch;
+}
+
+describe("replayJournal — committed batch", () => {
+  it("leaves files in place and is a no-op", async () => {
+    const t1 = `${WIKI}/a.md`;
+    const t2 = `${WIKI}/b.md`;
+    const batch = await openTwoTargetBatch(t1, t2);
+    await writeFile(path.join(root, t1), "A-new");
+    await writeFile(path.join(root, t2), "B-new");
+    await commitBatch(batch);
+
+    await replayJournal(root);
+
+    expect(await readFile(path.join(root, t1), "utf-8")).toBe("A-new");
+    expect(await readFile(path.join(root, t2), "utf-8")).toBe("B-new");
+  });
+});
+
+describe("replayJournal — pending (crashed) batch", () => {
+  it("reverts to FULL pre-state, never a partial post-state", async () => {
+    const t1 = `${WIKI}/exists.md`; // pre-existing → revert to prior bytes
+    const t2 = `${WIKI}/fresh.md`; //  absent pre-batch → delete on revert
+    await writeFile(path.join(root, t1), "OLD-1");
+
+    const batch = await openTwoTargetBatch(t1, t2);
+    // Crash simulation: apply ONLY file 1, never commit.
+    await writeFile(path.join(root, t1), "NEW-1");
+
+    await replayJournal(root);
+
+    // file 1 reverted to its prior bytes; file 2 (absent pre-batch) stays absent.
+    await expectRevertedToPreState(root, t1, "OLD-1", t2);
+  });
+
+  it("deletes a file that was absent pre-batch but got written before the crash", async () => {
+    const t1 = `${WIKI}/c.md`;
+    const batch = await openBatch(root);
+    await recordPreState(batch, path.join(root, t1));
+    await writeFile(path.join(root, t1), "PARTIAL"); // written, never committed
+
+    await replayJournal(root);
+
+    expect(await exists(t1)).toBe(false);
+  });
+});
+
+describe("replayJournal — idempotence", () => {
+  it("a second replay is a no-op", async () => {
+    const t1 = `${WIKI}/d.md`;
+    await writeFile(path.join(root, t1), "OLD-D");
+    const batch = await openBatch(root);
+    await recordPreState(batch, path.join(root, t1));
+    await writeFile(path.join(root, t1), "NEW-D");
+
+    await replayJournal(root);
+    expect(await readFile(path.join(root, t1), "utf-8")).toBe("OLD-D");
+
+    // Second call: nothing pending remains, on-disk state is unchanged.
+    await replayJournal(root);
+    expect(await readFile(path.join(root, t1), "utf-8")).toBe("OLD-D");
+  });
+});

--- a/test/trust-planner.test.ts
+++ b/test/trust-planner.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @file test/trust-planner.test.ts
+ * @description Coverage for the WRITE PLANNER (`src/trust/planner.ts`) and the
+ * guarded page EXECUTOR (`src/trust/executor.ts`) — the seam that realizes CLP
+ * Invariant 4 (every mutation passes through ONE planner) and the PAGE-store
+ * atomicity contract ("partial application is a bug").
+ *
+ * Planner tests pin the decision→plan mapping: an allowed, confined, well-formed
+ * page yields exactly one `create` PlannedMutation; any block-derived decision
+ * yields NO live-write mutation (the decision carries the routing instead).
+ *
+ * Executor tests prove ATOMICITY by fault injection: a clean 2-mutation batch
+ * applies BOTH and commits; a 2-mutation batch whose SECOND write is forced to
+ * throw (via the injectable `writeOne` seam) leaves, after the failure plus
+ * `replayJournal`, the FULL PRE-STATE — file 1 reverted, file 2 absent — never a
+ * partial post-state where file 1 persisted and file 2 is missing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, readFile } from "fs/promises";
+import path from "path";
+import { planPageMutation, type PlannedMutation } from "../src/trust/planner.js";
+import { applyApprovedMutations } from "../src/trust/executor.js";
+import { replayJournal } from "../src/trust/journal.js";
+import { WIKI, makeTrustRoot, cleanupTrustRoot, expectRevertedToPreState } from "./trust/fixture.js";
+
+let root: string;
+const GOOD_BODY = "---\ntitle: Ok\n---\n\nbody\n";
+
+beforeEach(async () => {
+  root = await makeTrustRoot("trust-planner-");
+});
+
+afterEach(async () => {
+  await cleanupTrustRoot(root);
+});
+
+function planArgs(slug: string, overrides: Record<string, unknown> = {}) {
+  return { root, entityType: "concepts", slug, body: GOOD_BODY, origin: "agent", reviewRouted: false, ...overrides };
+}
+
+describe("planPageMutation — decision→plan mapping", () => {
+  it("plans exactly one create for a confined, well-formed, non-colliding page", async () => {
+    const out = await planPageMutation(planArgs("alpha"));
+    expect(out.decision).toBe("allow");
+    expect(out.planned).toHaveLength(1);
+    expect(out.planned[0].kind).toBe("page");
+    expect(out.planned[0].operation).toBe("create");
+  });
+
+  it("denies an escaping slug with no planned mutation", async () => {
+    const out = await planPageMutation(planArgs("../escape"));
+    expect(out.decision).toBe("deny");
+    expect(out.planned).toEqual([]);
+  });
+
+  it("yields a block-derived decision and no plan for an existing target", async () => {
+    await writeFile(path.join(root, WIKI, "dup.md"), GOOD_BODY);
+    const out = await planPageMutation(planArgs("dup"));
+    expect(out.decision).toBe("deny"); // block + non-review-routed ⇒ deny
+    expect(out.planned).toEqual([]);
+  });
+
+  it("stages a block for review when reviewRouted is true", async () => {
+    await writeFile(path.join(root, WIKI, "dup.md"), GOOD_BODY);
+    const out = await planPageMutation(planArgs("dup", { reviewRouted: true }));
+    expect(out.decision).toBe("stage-for-review");
+    expect(out.planned).toEqual([]);
+  });
+});
+
+/** Build a page-create PlannedMutation targeting `<WIKI>/<slug>.md`. */
+async function plannedFor(slug: string): Promise<PlannedMutation> {
+  const out = await planPageMutation(planArgs(slug));
+  return out.planned[0];
+}
+
+describe("applyApprovedMutations — clean batch", () => {
+  it("applies BOTH mutations and commits", async () => {
+    const planned = [await plannedFor("one"), await plannedFor("two")];
+    await applyApprovedMutations(root, planned);
+    expect(await readFile(path.join(root, WIKI, "one.md"), "utf-8")).toBe(GOOD_BODY);
+    expect(await readFile(path.join(root, WIKI, "two.md"), "utf-8")).toBe(GOOD_BODY);
+  });
+
+  it("throws not-implemented for a non-page mutation kind", async () => {
+    const page = await plannedFor("p");
+    const relation = { ...page, kind: "relation" as const };
+    await expect(applyApprovedMutations(root, [relation])).rejects.toThrow(/not-implemented/);
+  });
+});
+
+describe("applyApprovedMutations — atomicity under fault injection", () => {
+  it("reverts to FULL pre-state when the second write throws", async () => {
+    const t1 = `${WIKI}/exists.md`; // pre-existing → must revert to prior bytes
+    const t2 = `${WIKI}/fresh.md`; //  absent pre-batch → must stay absent
+    await writeFile(path.join(root, t1), "OLD-1");
+
+    // Plan an UPDATE of t1 and a CREATE of t2 by hand-building mutations so the
+    // pre-existing t1 does not trip the create-only collision check.
+    const create2 = await plannedFor("fresh");
+    const update1: PlannedMutation = {
+      ...create2,
+      operation: "update",
+      target: { entityType: "concepts", slug: "exists", id: create2.target.id },
+    };
+
+    // Fault seam: a writeOne hook that throws on the SECOND target only.
+    let calls = 0;
+    const faultyWriteOne = async (filePath: string, content: string) => {
+      calls += 1;
+      if (calls === 2) throw new Error("injected write failure");
+      await writeFile(filePath, content, "utf-8");
+    };
+
+    await expect(
+      applyApprovedMutations(root, [update1, create2], { writeOne: faultyWriteOne }),
+    ).rejects.toThrow(/injected write failure/);
+
+    await replayJournal(root);
+
+    await expectRevertedToPreState(root, t1, "OLD-1", t2);
+  });
+});

--- a/test/trust-planner.test.ts
+++ b/test/trust-planner.test.ts
@@ -90,6 +90,22 @@ describe("applyApprovedMutations — clean batch", () => {
   });
 });
 
+describe("applyApprovedMutations — create-collision re-probe under lock", () => {
+  it("aborts and does NOT clobber a target created after planning", async () => {
+    // Plan a create while the target is free (collision check passes here).
+    const create = await plannedFor("late");
+    // A concurrent actor creates the target AFTER planning, BEFORE apply.
+    const target = path.join(root, WIKI, "late.md");
+    await writeFile(target, "CONCURRENT");
+
+    // Apply must re-probe under the lock and abort before any write lands.
+    await expect(applyApprovedMutations(root, [create])).rejects.toThrow(/create-collision/);
+
+    // The pre-existing file is untouched — never overwritten by the create.
+    expect(await readFile(target, "utf-8")).toBe("CONCURRENT");
+  });
+});
+
 describe("applyApprovedMutations — atomicity under fault injection", () => {
   it("reverts to FULL pre-state when the second write throws", async () => {
     const t1 = `${WIKI}/exists.md`; // pre-existing → must revert to prior bytes

--- a/test/trust-planner.test.ts
+++ b/test/trust-planner.test.ts
@@ -21,8 +21,15 @@ import { writeFile, readFile } from "fs/promises";
 import path from "path";
 import { planPageMutation, type PlannedMutation } from "../src/trust/planner.js";
 import { applyApprovedMutations } from "../src/trust/executor.js";
-import { replayJournal } from "../src/trust/journal.js";
-import { WIKI, makeTrustRoot, cleanupTrustRoot, expectRevertedToPreState } from "./trust/fixture.js";
+import { replayJournal, openBatch, recordPreState } from "../src/trust/journal.js";
+import { entityId } from "../src/profile/identity.js";
+import {
+  WIKI,
+  makeTrustRoot,
+  cleanupTrustRoot,
+  expectRevertedToPreState,
+  existsUnder,
+} from "./trust/fixture.js";
 
 let root: string;
 const GOOD_BODY = "---\ntitle: Ok\n---\n\nbody\n";
@@ -118,7 +125,7 @@ describe("applyApprovedMutations — atomicity under fault injection", () => {
     const update1: PlannedMutation = {
       ...create2,
       operation: "update",
-      target: { entityType: "concepts", slug: "exists", id: create2.target.id },
+      target: { entityType: "concepts", slug: "exists", id: entityId("concepts", "exists") },
     };
 
     // Fault seam: a writeOne hook that throws on the SECOND target only.
@@ -136,5 +143,43 @@ describe("applyApprovedMutations — atomicity under fault injection", () => {
     await replayJournal(root);
 
     await expectRevertedToPreState(root, t1, "OLD-1", t2);
+  });
+});
+
+describe("applyApprovedMutations — self-enforcing replay on startup", () => {
+  it("reverts a dangling pending batch from a prior crash before the new batch", async () => {
+    // Simulate a prior crash: open a pending batch, record a target's pre-state,
+    // then "write" a post-state without committing — exactly a dangling journal.
+    const danglingRel = `${WIKI}/crashed.md`;
+    const danglingAbs = path.join(root, danglingRel);
+    await writeFile(danglingAbs, "PRE-CRASH");
+    const stale = await openBatch(root);
+    await recordPreState(stale, danglingAbs);
+    await writeFile(danglingAbs, "MID-CRASH-POST-STATE"); // uncommitted post-state
+
+    // A fresh, UNRELATED clean batch must trigger replay under the lock first.
+    const clean = await plannedFor("unrelated");
+    await applyApprovedMutations(root, [clean]);
+
+    // Replay ran: the dangling target was reverted to its pre-crash bytes...
+    expect(await readFile(danglingAbs, "utf-8")).toBe("PRE-CRASH");
+    // ...and the new batch applied and committed normally.
+    expect(await readFile(path.join(root, WIKI, "unrelated.md"), "utf-8")).toBe(GOOD_BODY);
+  });
+});
+
+describe("applyApprovedMutations — executor re-asserts slug safety", () => {
+  it("throws invalid-identity and writes nothing for a hand-built `..` slug", async () => {
+    const base = await plannedFor("safe");
+    // Hand-built mutation whose id carries a traversal slug — bypasses the
+    // planner's checkIdentitySafe guard, so the executor must re-validate.
+    const evil: PlannedMutation = {
+      ...base,
+      target: { entityType: "concepts", slug: "../escape", id: "concepts/../escape" as never },
+    };
+    await expect(applyApprovedMutations(root, [evil])).rejects.toThrow(/invalid-identity/);
+    // Nothing escaped the root: no file was created outside wiki/concepts.
+    expect(await existsUnder(root, "escape.md")).toBe(false);
+    expect(await existsUnder(root, "wiki/escape.md")).toBe(false);
   });
 });

--- a/test/trust-staged-change.test.ts
+++ b/test/trust-staged-change.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @file test/trust-staged-change.test.ts
+ * @description Unit coverage for the typed {@link StagedChange} model and the
+ * fail-closed staged-write volume bound (`assertStagedWriteBudget`) — the CLP
+ * Phase-2 deferred refinement of the candidate cap.
+ *
+ * These tests pin three things: (a) a `kind:"page"` StagedChange constructs and
+ * round-trips with the spec fields; (b) the two-level volume bound passes only
+ * within BOTH the per-call and per-session caps and otherwise throws a typed
+ * {@link StagedWriteOverflowError} that names the breached cap and the numbers
+ * (fail closed — never silently clamp); (c) the default cap constants are
+ * exported and sane (per-session ≥ per-call), mirroring the existing
+ * 200-pending-candidate ceiling.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  type StagedChange,
+  type CandidateKind,
+  type HeldReasonCode,
+  assertStagedWriteBudget,
+  StagedWriteOverflowError,
+  DEFAULT_STAGED_WRITE_PER_CALL,
+  DEFAULT_STAGED_WRITE_PER_SESSION,
+} from "../src/trust/staged-change.js";
+import type { TrustDecision } from "../src/trust/decision.js";
+
+/** A representative `kind:"page"` StagedChange built from the spec fields. */
+function pageStagedChange(): StagedChange {
+  const trustDecision: TrustDecision = "stage-for-review";
+  return {
+    id: "stg_0001",
+    kind: "page",
+    target: { entityType: "person", slug: "ada-lovelace", id: "person/ada-lovelace" as never },
+    operation: "create",
+    planned: [],
+    heldReasons: ["manual-review-requested"],
+    trustDecision,
+    createdAt: "2026-06-18T00:00:00.000Z",
+  };
+}
+
+describe("StagedChange model", () => {
+  it("constructs and round-trips a kind:page change with the spec fields", () => {
+    const change = pageStagedChange();
+    expect(change.kind satisfies CandidateKind).toBe("page");
+    expect(change.target).toMatchObject({ entityType: "person", slug: "ada-lovelace" });
+    expect(change.planned).toEqual([]);
+    expect(change.trustDecision).toBe("stage-for-review");
+  });
+
+  it("accepts every defined CandidateKind and an open-union HeldReasonCode", () => {
+    const kinds: CandidateKind[] = [
+      "page", "relation", "artifact", "lifecycle-transition", "workflow-gate",
+    ];
+    expect(kinds).toHaveLength(5);
+    const reasons: HeldReasonCode[] = ["trust-blocked", "human-gate", "custom-code"];
+    expect(reasons).toContain("trust-blocked");
+  });
+});
+
+describe("default staged-write caps", () => {
+  it("exports sane per-call and per-session caps (per-session >= per-call)", () => {
+    expect(DEFAULT_STAGED_WRITE_PER_CALL).toBeGreaterThan(0);
+    expect(DEFAULT_STAGED_WRITE_PER_SESSION).toBeGreaterThanOrEqual(DEFAULT_STAGED_WRITE_PER_CALL);
+  });
+
+  it("anchors the per-session cap to the existing 200 pending-candidate ceiling", () => {
+    expect(DEFAULT_STAGED_WRITE_PER_SESSION).toBe(200);
+    expect(DEFAULT_STAGED_WRITE_PER_CALL).toBe(50);
+  });
+});
+
+describe("assertStagedWriteBudget", () => {
+  const caps = { perCall: 50, perSession: 200 };
+
+  it("passes when within both the per-call and per-session caps", () => {
+    expect(() => assertStagedWriteBudget(100, 50, caps)).not.toThrow();
+    expect(() => assertStagedWriteBudget(0, 1, caps)).not.toThrow();
+  });
+
+  it("throws StagedWriteOverflowError naming the per-call cap when requested > perCall", () => {
+    try {
+      assertStagedWriteBudget(0, 51, caps);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StagedWriteOverflowError);
+      expect((err as StagedWriteOverflowError).message).toContain("per-call");
+      expect((err as StagedWriteOverflowError).message).toMatch(/51.*50/);
+    }
+  });
+
+  it("throws StagedWriteOverflowError naming the per-session cap when existing + requested > perSession", () => {
+    try {
+      assertStagedWriteBudget(180, 30, caps);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(StagedWriteOverflowError);
+      expect((err as StagedWriteOverflowError).message).toContain("per-session");
+      expect((err as StagedWriteOverflowError).message).toMatch(/210.*200/);
+    }
+  });
+
+  it("fails closed exactly at the per-session boundary + 1 (never clamps)", () => {
+    expect(() => assertStagedWriteBudget(150, 50, caps)).not.toThrow();
+    expect(() => assertStagedWriteBudget(151, 50, caps)).toThrow(StagedWriteOverflowError);
+  });
+});

--- a/test/trust-staged-change.test.ts
+++ b/test/trust-staged-change.test.ts
@@ -20,6 +20,7 @@ import {
   type HeldReasonCode,
   assertStagedWriteBudget,
   StagedWriteOverflowError,
+  StagedWriteInputError,
   DEFAULT_STAGED_WRITE_PER_CALL,
   DEFAULT_STAGED_WRITE_PER_SESSION,
 } from "../src/trust/staged-change.js";
@@ -104,5 +105,23 @@ describe("assertStagedWriteBudget", () => {
   it("fails closed exactly at the per-session boundary + 1 (never clamps)", () => {
     expect(() => assertStagedWriteBudget(150, 50, caps)).not.toThrow();
     expect(() => assertStagedWriteBudget(151, 50, caps)).toThrow(StagedWriteOverflowError);
+  });
+
+  it("rejects a negative requested rather than failing open", () => {
+    expect(() => assertStagedWriteBudget(0, -50, caps)).toThrow(StagedWriteInputError);
+  });
+
+  it("rejects a NaN requested rather than failing open", () => {
+    expect(() => assertStagedWriteBudget(0, Number.NaN, caps)).toThrow(StagedWriteInputError);
+  });
+
+  it("rejects a non-integer requested rather than failing open", () => {
+    expect(() => assertStagedWriteBudget(0, 49.9, caps)).toThrow(StagedWriteInputError);
+  });
+
+  it("rejects a negative or non-integer existingCount", () => {
+    expect(() => assertStagedWriteBudget(-1, 1, caps)).toThrow(StagedWriteInputError);
+    expect(() => assertStagedWriteBudget(10.5, 1, caps)).toThrow(StagedWriteInputError);
+    expect(() => assertStagedWriteBudget(Number.NaN, 1, caps)).toThrow(StagedWriteInputError);
   });
 });

--- a/test/trust/fixture.ts
+++ b/test/trust/fixture.ts
@@ -1,0 +1,54 @@
+/**
+ * @file test/trust/fixture.ts
+ * @description Shared tmp-dir fixture for the Trust Guard write-path tests
+ * (journal + planner/executor). Both suites stand up an isolated project root
+ * with a `wiki/concepts` directory, then probe/clean it the same way; this
+ * module is the single definition of that fixture so the setup is not duplicated
+ * across test files.
+ */
+
+import { mkdtemp, rm, mkdir, access, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { expect } from "vitest";
+
+/** The wiki subdirectory page targets live under in these tests. */
+export const WIKI = "wiki/concepts";
+
+/** Create an isolated project root with `wiki/concepts/` ready. */
+export async function makeTrustRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  await mkdir(path.join(root, WIKI), { recursive: true });
+  return root;
+}
+
+/** Recursively remove a fixture root (best-effort). */
+export async function cleanupTrustRoot(root: string): Promise<void> {
+  await rm(root, { recursive: true, force: true });
+}
+
+/** True when `rel` exists under `root`. */
+export async function existsUnder(root: string, rel: string): Promise<boolean> {
+  try {
+    await access(path.join(root, rel));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Assert the two-target FULL pre-state contract shared by the journal-replay and
+ * executor-atomicity tests: the pre-existing target was reverted to its prior
+ * bytes and the absent-pre-batch target stays absent — never a partial
+ * post-state. `restored` is the bytes the pre-existing file must hold again.
+ */
+export async function expectRevertedToPreState(
+  root: string,
+  priorRel: string,
+  restored: string,
+  absentRel: string,
+): Promise<void> {
+  expect(await readFile(path.join(root, priorRel), "utf-8")).toBe(restored);
+  expect(await existsUnder(root, absentRel)).toBe(false);
+}

--- a/test/viewer-health-dashboard.test.ts
+++ b/test/viewer-health-dashboard.test.ts
@@ -40,6 +40,51 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/** Build a /api/pages responder carrying a given stateStatus, plus /api/health. */
+function pagesResponder(stateStatus: string): FetchResponder {
+  return (url) => {
+    if (url.endsWith("/api/pages")) {
+      return jsonResponse({
+        project: { title: "demo" },
+        counts: {},
+        pages: [],
+        recentPages: [],
+        index: { available: false },
+        stateStatus,
+      });
+    }
+    if (url.endsWith("/api/health")) return jsonResponse({ stateStatus });
+    return null;
+  };
+}
+
+/** Mount the viewer with a given bootstrap stateStatus and return its document. */
+async function mountWithStateStatus(stateStatus: string): Promise<Document> {
+  const { dom } = await mountViewerDom(EMPTY_PAGES, pagesResponder(stateStatus));
+  return dom.window.document;
+}
+
+describe("state-status banner — corrupt and too-new", () => {
+  it("renders the corrupt banner when stateStatus is corrupt", async () => {
+    const doc = await mountWithStateStatus("corrupt");
+    const banner = doc.querySelector(".corrupt-state-banner");
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain("corrupt");
+  });
+
+  it("renders the too-new banner when stateStatus is too-new", async () => {
+    const doc = await mountWithStateStatus("too-new");
+    const banner = doc.querySelector(".corrupt-state-banner");
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain("newer version of llmwiki");
+  });
+
+  it("renders no banner when stateStatus is ok", async () => {
+    const doc = await mountWithStateStatus("ok");
+    expect(doc.querySelector(".corrupt-state-banner")).toBeNull();
+  });
+});
+
 describe("health dashboard — stale and orphaned counts", () => {
   it("renders the 'Stale pages' row with the count from /api/health", async () => {
     const main = await renderHealthPane({ stale: 3, orphaned: 0 });


### PR DESCRIPTION
## What

Lands the typed-identity/state and single-planner/trust-guard-staging foundation for the configurable-profiles platform. Everything is additive and the default profile stays byte-identical — all 15 frozen parity goldens are unchanged.

**Source state v2 (typed ownership)**
- Forward-compatible `WikiState` (`version: 1 | 2`) with optional typed-ownership fields (`entities`/`frozenEntities`) kept alongside the v1 `concepts`/`frozenSlugs` compatibility mirror.
- Lossless, deterministic, idempotent v1→v2 migration (bare slug → `concepts/<slug>`), fail-closed on a non-slug-safe slug.
- Reader fails **closed** on a state written by a newer-than-known version ("written by a newer llmwiki version") — never resets, never down-converts. The fail-closed posture is propagated across status, freshness, viewer, refresh-plan, project orientation, and the MCP state resource.

**Trust Guard + Write Planner**
- A total, monotone-in-block composition from check verdicts to a write decision (allow / allow-with-warning / stage-for-review / quarantine / deny), proven by exhaustive enumeration.
- Unconditional mandatory core checks for page mutations (path-confinement, collision/no-overwrite, resource-limit, frontmatter-parse) that a profile can never disable.
- A write planner + single-store intent journal + guarded executor: a page mutation set applies fully or not at all (self-enforcing replay-on-startup reverts a crashed batch under the project lock), with atomicity proven by fault injection.

**Staged-write model**
- A typed `StagedChange` model and a fail-closed staged-write volume bound (per-call + per-session caps).
- Page review candidates gain optional typed-target + trust-decision metadata, omitted entirely for default-profile candidates.

## Why

This is the substrate that turns on typed identity before any non-default write path exists, and establishes the single seam every future mutation routes through. Doing it as a tested capability + seam (rather than rewiring existing writes in one step) keeps the default profile provably unchanged while the platform grows.

## Scope / boundaries

This branch ships the capability and the seam; it deliberately does **not** wire the planner or state-v2 migration into existing default write paths yet — that parity-pinned reroute, the multi-store atomic-recovery harness, and relation/event stores are follow-on work. Wiring the migration into the default read path would itself change default output bytes, so it stays unwired until a non-default write path (next phase) is the first real consumer.

## Validation

- Full suite green (1907 passing); the 15 frozen default goldens byte-identical (no regeneration).
- Four independent review passes (spec-compliance, code-quality, a junior-developer adversarial audit, and a parity/fail-closed security pass) plus two follow-up fix rounds closing every finding.