### PR TITLE
fix(compile): normalize bare-number citations before writing pages

### DIFF
--- a/src/compiler/citation-normalize.ts
+++ b/src/compiler/citation-normalize.ts
@@ -13,11 +13,18 @@
  * and validate that repaired line references are within the source's range.
  */
 
+import { splitCitationMarker } from "../utils/markdown.js";
+
 /** Regex matching `^[...]` citation markers — same pattern as the viewer uses. */
 const MARKER_PATTERN = /\^\[([^\]\n]+)\]/g;
 
-/** Regex matching a line number or line range with no filename component, e.g. `81` or `81-90`. */
-const BARE_LINE_RANGE_PATTERN = /^\d+(?:[,-]\s*\d+)?$/;
+/**
+ * Regex matching a bare line reference with no filename component.
+ * Accepts: single numbers (`81`), hyphen ranges (`81-90`), and comma lists
+ * (`81, 90` or `1-5, 12`). `splitCitationMarker` keeps comma-separated
+ * line lists together, so we must accept them here as a single entry.
+ */
+const BARE_LINE_RANGE_PATTERN = /^\d+(?:-\d+)?(?:\s*,\s*\d+(?:-\d+)?)*$/;
 
 /** Regex matching a numbered line as emitted by buildBudgetedCombinedContent: ` N | text`. */
 const NUMBERED_LINE_PATTERN = /^\s*(\d+)\s*\|/;
@@ -39,12 +46,25 @@ function maxLineNumber(combinedContent: string): number {
 }
 
 /**
- * Return true when the line range expressed in `entry` (e.g. "81" or "81-90")
- * is fully within [1, maxLine].
+ * Return true when every part of a bare line entry is valid within [1, maxLine].
+ *
+ * An entry may be a single number ("81"), a hyphen range ("81-90"), or a
+ * comma list kept together by `splitCitationMarker` ("81, 90" or "1-5, 12").
+ * Each comma-separated segment is validated individually:
+ * - Hyphen range `A-B`: requires A >= 1, A <= B, B <= maxLine (rejects backward).
+ * - Single number `N`: requires 1 <= N <= maxLine.
  */
 function rangeIsValid(entry: string, maxLine: number): boolean {
-  const parts = entry.split(/[,-]/).map((p) => Number(p.trim()));
-  return parts.every((n) => n >= 1 && n <= maxLine);
+  const segments = entry.split(/\s*,\s*/);
+  return segments.every((seg) => {
+    const dashParts = seg.split("-").map((p) => Number(p.trim()));
+    if (dashParts.length === 2) {
+      const [start, end] = dashParts;
+      return start >= 1 && start <= end && end <= maxLine;
+    }
+    const n = Number(seg.trim());
+    return n >= 1 && n <= maxLine;
+  });
 }
 
 /**
@@ -129,7 +149,7 @@ export function normalizeCitations(
   MARKER_PATTERN.lastIndex = 0;
 
   return body.replace(MARKER_PATTERN, (fullMatch, inner: string) => {
-    const entries = inner.split(",").map((e) => normalizeEntry(e, sourceFiles, maxLine));
+    const entries = splitCitationMarker(inner).map((e) => normalizeEntry(e, sourceFiles, maxLine));
     const rebuilt = rebuildMarker(entries as string[]);
     if (rebuilt === null) {
       // Signal for post-replace space cleanup: return empty string; the

--- a/src/compiler/citation-normalize.ts
+++ b/src/compiler/citation-normalize.ts
@@ -1,0 +1,157 @@
+/**
+ * Compile-time citation normalizer for the llmwiki compile pipeline.
+ *
+ * The LLM occasionally emits a bare line number as a citation marker,
+ * e.g. `^[81]` instead of the required `^[filename.md:81]`. This module
+ * repairs or removes such markers BEFORE the page body is written to disk,
+ * so bad markers never reach the viewer (which would render a
+ * "Source not found: 81" error callout for them).
+ *
+ * Design: pure function, no I/O. The caller owns the source-file list and
+ * the numbered combined-content string that the LLM was given during the
+ * compile prompt, so we can both repair unambiguous single-source markers
+ * and validate that repaired line references are within the source's range.
+ */
+
+/** Regex matching `^[...]` citation markers — same pattern as the viewer uses. */
+const MARKER_PATTERN = /\^\[([^\]\n]+)\]/g;
+
+/** Regex matching a line number or line range with no filename component, e.g. `81` or `81-90`. */
+const BARE_LINE_RANGE_PATTERN = /^\d+(?:[,-]\s*\d+)?$/;
+
+/** Regex matching a numbered line as emitted by buildBudgetedCombinedContent: ` N | text`. */
+const NUMBERED_LINE_PATTERN = /^\s*(\d+)\s*\|/;
+
+/**
+ * Return the highest line number present in `combinedContent` (the numbered
+ * source text the LLM received). Returns 0 when no numbered lines are found.
+ */
+function maxLineNumber(combinedContent: string): number {
+  let max = 0;
+  for (const line of combinedContent.split("\n")) {
+    const m = NUMBERED_LINE_PATTERN.exec(line);
+    if (m) {
+      const n = Number(m[1]);
+      if (n > max) max = n;
+    }
+  }
+  return max;
+}
+
+/**
+ * Return true when the line range expressed in `entry` (e.g. "81" or "81-90")
+ * is fully within [1, maxLine].
+ */
+function rangeIsValid(entry: string, maxLine: number): boolean {
+  const parts = entry.split(/[,-]/).map((p) => Number(p.trim()));
+  return parts.every((n) => n >= 1 && n <= maxLine);
+}
+
+/**
+ * Normalise a single comma-separated entry from inside a `^[...]` marker.
+ *
+ * Returns the (possibly repaired) entry string, or null to signal the entry
+ * should be dropped entirely.
+ *
+ * Only bare line numbers / ranges (no filename component at all) are
+ * normalised here. Entries that contain a filename — even an unresolvable
+ * or malformed one — are left as-is so the downstream provenance linter
+ * (`broken-citation`, `malformed-claim-citation`) can classify them.
+ */
+function normalizeEntry(
+  entry: string,
+  sourceFiles: string[],
+  maxLine: number,
+): string | null {
+  const trimmed = entry.trim();
+  if (trimmed.length === 0) return null;
+
+  // Split off the file token: everything before the first `:` or `#`.
+  const fileToken = trimmed.split(/[:#]/)[0].trim();
+
+  // Case 1: valid filename — keep as-is.
+  if (sourceFiles.includes(fileToken)) return trimmed;
+
+  // Case 2: bare line reference — purely digits/range, no filename component.
+  if (BARE_LINE_RANGE_PATTERN.test(trimmed)) {
+    // Single source: repair if the line is in range, drop if hallucinated.
+    if (sourceFiles.length === 1) {
+      if (!rangeIsValid(trimmed, maxLine)) return null;
+      return `${sourceFiles[0]}:${trimmed}`;
+    }
+    // Multi-source: ambiguous — drop (can't know which source the LLM meant).
+    return null;
+  }
+
+  // Case 3: has a filename component (even if unresolvable or malformed) — leave
+  // as-is for the downstream provenance linter to handle.
+  return trimmed;
+}
+
+/**
+ * Rebuild a full `^[...]` marker from its surviving entries.
+ * Returns null when no entries survive (signals the whole marker should be removed).
+ */
+function rebuildMarker(entries: string[]): string | null {
+  const survivors = entries.filter((e) => e !== null) as string[];
+  if (survivors.length === 0) return null;
+  return `^[${survivors.join(", ")}]`;
+}
+
+/**
+ * Clean every `^[...]` citation marker in `body` before the page is written.
+ *
+ * For each comma-separated entry inside a marker:
+ * - Valid filename entries are kept unchanged.
+ * - Bare line numbers/ranges (`81`, `81-90`) on a single-source page are
+ *   repaired to `<sourceFile>:N` when the line is within the source's range,
+ *   or dropped when the line exceeds the source's actual line count.
+ * - Bare numbers on multi-source pages are dropped (ambiguous — can't determine
+ *   which source the LLM intended).
+ * - Entries with a filename component (even unresolvable or malformed) are left
+ *   as-is for the downstream provenance linter to classify.
+ *
+ * When all entries in a marker are dropped the entire `^[...]` marker is
+ * removed. A trailing space before the removed marker is also collapsed so
+ * `word ^[81]` becomes `word` rather than `word `.
+ *
+ * @param body - Raw LLM output page body to normalise.
+ * @param sourceFiles - Valid source filenames for this page (basenames only).
+ * @param combinedContent - The numbered combined-source text the LLM received.
+ * @returns The normalised body string.
+ */
+export function normalizeCitations(
+  body: string,
+  sourceFiles: string[],
+  combinedContent: string,
+): string {
+  const maxLine = maxLineNumber(combinedContent);
+  MARKER_PATTERN.lastIndex = 0;
+
+  return body.replace(MARKER_PATTERN, (fullMatch, inner: string) => {
+    const entries = inner.split(",").map((e) => normalizeEntry(e, sourceFiles, maxLine));
+    const rebuilt = rebuildMarker(entries as string[]);
+    if (rebuilt === null) {
+      // Signal for post-replace space cleanup: return empty string; the
+      // space cleanup pass below handles the dangling space.
+      return "\x00REMOVED\x00";
+    }
+    return rebuilt;
+  });
+}
+
+/**
+ * Run `normalizeCitations` and also clean up dangling spaces left where a
+ * marker was removed. A space immediately before a removed marker is collapsed.
+ *
+ * This is the public entry point used by the page renderer.
+ */
+export function normalizeCitationsInBody(
+  body: string,
+  sourceFiles: string[],
+  combinedContent: string,
+): string {
+  const withSentinels = normalizeCitations(body, sourceFiles, combinedContent);
+  // Remove sentinels and the optional preceding space.
+  return withSentinels.replace(/ ?\x00REMOVED\x00/g, "");
+}

--- a/src/compiler/page-renderer.ts
+++ b/src/compiler/page-renderer.ts
@@ -19,6 +19,7 @@ import { callClaude } from "../utils/llm.js";
 import { buildPagePrompt } from "./prompts.js";
 import { addObsidianMeta } from "./obsidian.js";
 import { addModelProvenanceMeta, addProvenanceMeta, reportContradictionWarnings } from "./provenance.js";
+import { normalizeCitationsInBody } from "./citation-normalize.js";
 import { CONCEPTS_DIR } from "../utils/constants.js";
 import type { SchemaConfig } from "../schema/index.js";
 import type { ExtractedConcept } from "../utils/types.js";
@@ -58,12 +59,14 @@ export async function renderMergedPageContent(
     relatedPages,
   );
 
-  const pageBody = await callClaude({
+  const rawPageBody = await callClaude({
     system,
     messages: [
       { role: "user", content: `Write the wiki page for "${entry.concept.concept}".` },
     ],
   });
+
+  const pageBody = normalizeCitationsInBody(rawPageBody, entry.sourceFiles, entry.combinedContent);
 
   const frontmatter = buildMergedFrontmatter(entry, existingPage, schema);
   reportContradictionWarnings(entry.concept.concept, entry.concept);

--- a/test/citation-normalize.test.ts
+++ b/test/citation-normalize.test.ts
@@ -116,21 +116,41 @@ describe("normalizeCitationsInBody — valid citations pass through", () => {
 // ---------------------------------------------------------------------------
 
 describe("normalizeCitationsInBody — mixed marker", () => {
-  it("keeps valid andrej-karpathy.md:1-5 and drops bare 99 (two sources, ambiguous)", () => {
+  it("keeps ^[andrej-karpathy.md:1-5, 99] as-is (comma-continuation stays together after splitCitationMarker)", () => {
     const sources = ["andrej-karpathy.md", "other.md"];
     const content =
       makeContent("andrej-karpathy.md", 20) + "\n\n" + makeContent("other.md", 20);
+    // splitCitationMarker keeps ", 99" attached to the file entry (99 is a line continuation),
+    // so the whole entry has a valid file prefix and is preserved unchanged.
     const body = "Claim.^[andrej-karpathy.md:1-5, 99]";
     const result = normalizeCitationsInBody(body, sources, content);
-    expect(result).toBe("Claim.^[andrej-karpathy.md:1-5]");
+    expect(result).toBe("Claim.^[andrej-karpathy.md:1-5, 99]");
   });
 
-  it("keeps valid entry and repairs bare number in single-source mixed marker", () => {
+  it("keeps ^[src.md:1-5, 81] as-is in single-source marker (comma-continuation, not a separate bare entry)", () => {
     const source = "src.md";
     const content = makeContent(source, 100);
+    // splitCitationMarker keeps ", 81" attached to src.md:1-5 (digit after comma = line continuation),
+    // so normalizeEntry sees a valid file prefix and returns the full entry unchanged.
     const body = "Claim.^[src.md:1-5, 81]";
     const result = normalizeCitationsInBody(body, [source], content);
-    expect(result).toBe(`Claim.^[src.md:1-5, ${source}:81]`);
+    expect(result).toBe("Claim.^[src.md:1-5, 81]");
+  });
+
+  it("drops truly bare number from a multi-source marker when separated by a non-digit file entry", () => {
+    const sources = ["a.md", "b.md"];
+    const content = makeContent("a.md", 20) + "\n\n" + makeContent("b.md", 20);
+    // splitCitationMarker DOES split before "b.md" (starts with letter), so "99" in
+    // "a.md:1-5, b.md" is not the issue; a standalone bare number AFTER a file stays bare.
+    // Use a marker where the bare number is clearly separated: ^[a.md:1-5, b.md, 99]
+    // The last ",99" — 99 is a digit at end → stays attached to "b.md"? No: "b.md, 99"
+    // splits at the comma before "b.md" (b is not a digit), leaving "b.md, 99" as one token.
+    // Instead test a plain bare number alongside a valid file without comma-continuation:
+    // ^[99, a.md:1-5] — "99" followed by ", a.md:1-5"; the comma before "a.md" splits
+    // (a is not a digit), so entries are ["99", " a.md:1-5"]. 99 is multi-source → dropped.
+    const body = "Claim.^[99, a.md:1-5]";
+    const result = normalizeCitationsInBody(body, sources, content);
+    expect(result).toBe("Claim.^[a.md:1-5]");
   });
 });
 
@@ -189,5 +209,57 @@ describe("normalizeCitations — sentinel for dropped markers", () => {
     const content = makeContent(source, 5);
     const raw = normalizeCitations("word^[99]", [source], content);
     expect(raw).toContain("\x00REMOVED\x00");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 1 regression: comma-continuation citations must not be split
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — comma-continuation citation preserved", () => {
+  it("keeps ^[source.md:1, 12] unchanged on a single-source page", () => {
+    const source = "source.md";
+    const content = makeContent(source, 20);
+    const body = `Claim.^[${source}:1, 12]`;
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(body);
+  });
+
+  it("keeps ^[source.md:1, 12] unchanged on a multi-source page", () => {
+    const sources = ["source.md", "other.md"];
+    const content = makeContent("source.md", 20) + "\n\n" + makeContent("other.md", 20);
+    const body = "Claim.^[source.md:1, 12]";
+    const result = normalizeCitationsInBody(body, sources, content);
+    expect(result).toBe(body);
+  });
+
+  it("keeps ^[a.md:1-5, 12] unchanged (file with line list)", () => {
+    const source = "a.md";
+    const content = makeContent(source, 20);
+    const body = `Claim.^[${source}:1-5, 12]`;
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2 regression: backward bare ranges must be dropped, not repaired
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — backward range handling", () => {
+  it("drops ^[90-81] on a single-source page (backward range is invalid)", () => {
+    const source = "source.md";
+    const content = makeContent(source, 100);
+    const body = "Claim. ^[90-81]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe("Claim.");
+  });
+
+  it("repairs ^[81, 90] to ^[source.md:81, 90] when both lines exist", () => {
+    const source = "source.md";
+    const content = makeContent(source, 100);
+    const body = "Claim.^[81, 90]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(`Claim.^[${source}:81, 90]`);
   });
 });

--- a/test/citation-normalize.test.ts
+++ b/test/citation-normalize.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for `normalizeCitationsInBody` and `normalizeCitations`.
+ *
+ * Verifies that the compile-time normalizer repairs, drops, or passes through
+ * citation markers so the resulting page body produces ZERO viewer warnings
+ * when processed by `appendCitationWarningsForMarker` / `isMalformedCitationEntry`.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  normalizeCitationsInBody,
+  normalizeCitations,
+} from "../src/compiler/citation-normalize.js";
+import { makeNumberedContent } from "./fixtures/citation-content.js";
+
+// Alias for brevity in this test file.
+const makeContent = makeNumberedContent;
+
+// ---------------------------------------------------------------------------
+// Single-source bare line repair
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — single source, bare line", () => {
+  it("repairs ^[81] to ^[source.md:81] when line 81 exists in combinedContent", () => {
+    const source = "andrej-karpathy.md";
+    const content = makeContent(source, 100);
+    const body = "Some claim.^[81]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(`Some claim.^[${source}:81]`);
+  });
+
+  it("drops ^[81] when source only has 40 lines (hallucinated line)", () => {
+    const source = "short.md";
+    const content = makeContent(source, 40);
+    const body = "Some claim.^[81]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe("Some claim.");
+  });
+
+  it("repairs a range ^[81-90] to ^[source.md:81-90] when max line >= 90", () => {
+    const source = "doc.md";
+    const content = makeContent(source, 100);
+    const body = "Paragraph.^[81-90]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(`Paragraph.^[${source}:81-90]`);
+  });
+
+  it("drops a range when the end exceeds max line", () => {
+    const source = "doc.md";
+    const content = makeContent(source, 50);
+    const body = "Paragraph.^[81-90]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe("Paragraph.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The exact user case: repeated occurrence in one body
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — repeated marker occurrence", () => {
+  it("normalises both occurrences of ^[81] in a body with two paragraphs", () => {
+    const source = "neural-nets.md";
+    const content = makeContent(source, 120);
+    const body = [
+      "First fact.^[81]",
+      "",
+      "Second fact, also capable.^[81]",
+    ].join("\n");
+    const result = normalizeCitationsInBody(body, [source], content);
+    const repaired = `^[${source}:81]`;
+    expect(result).toContain(`First fact.${repaired}`);
+    expect(result).toContain(`Second fact, also capable.${repaired}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-source: bare number must be dropped (ambiguous)
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — multi-source bare number", () => {
+  it("drops ^[81] when there are two sources (ambiguous)", () => {
+    const sources = ["a.md", "b.md"];
+    const content =
+      makeContent("a.md", 100) + "\n\n" + makeContent("b.md", 100);
+    const body = "Claim.^[81]";
+    const result = normalizeCitationsInBody(body, sources, content);
+    expect(result).toBe("Claim.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Valid citation — untouched
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — valid citations pass through", () => {
+  it("leaves ^[andrej-karpathy.md:1-5] unchanged", () => {
+    const source = "andrej-karpathy.md";
+    const content = makeContent(source, 50);
+    const body = `Neural scaling.^[${source}:1-5]`;
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(body);
+  });
+
+  it("leaves ^[file.md] (paragraph-form, no range) unchanged", () => {
+    const source = "notes.md";
+    const content = makeContent(source, 10);
+    const body = "A claim.^[notes.md]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(body);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed marker: one valid entry + one bare entry
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — mixed marker", () => {
+  it("keeps valid andrej-karpathy.md:1-5 and drops bare 99 (two sources, ambiguous)", () => {
+    const sources = ["andrej-karpathy.md", "other.md"];
+    const content =
+      makeContent("andrej-karpathy.md", 20) + "\n\n" + makeContent("other.md", 20);
+    const body = "Claim.^[andrej-karpathy.md:1-5, 99]";
+    const result = normalizeCitationsInBody(body, sources, content);
+    expect(result).toBe("Claim.^[andrej-karpathy.md:1-5]");
+  });
+
+  it("keeps valid entry and repairs bare number in single-source mixed marker", () => {
+    const source = "src.md";
+    const content = makeContent(source, 100);
+    const body = "Claim.^[src.md:1-5, 81]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe(`Claim.^[src.md:1-5, ${source}:81]`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown filename entries — kept for provenance linter
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — unknown filename entries", () => {
+  it("keeps ^[ghost.md:1-5] unchanged so the provenance linter can flag broken-citation", () => {
+    const source = "real.md";
+    const content = makeContent(source, 10);
+    const body = "Claim.^[ghost.md:1-5]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    // The marker is preserved as-is — the downstream linter owns broken-citation.
+    expect(result).toBe("Claim.^[ghost.md:1-5]");
+  });
+
+  it("keeps ^[does-not-exist.md] unchanged (unresolvable file, linter's job)", () => {
+    const source = "real.md";
+    const content = makeContent(source, 10);
+    const body = "Claim.^[does-not-exist.md]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe("Claim.^[does-not-exist.md]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-survivor marker: entire marker removed, no dangling space
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitationsInBody — no-survivor marker removal", () => {
+  it("removes the marker and collapses the preceding space when no entries survive", () => {
+    const source = "src.md";
+    const content = makeContent(source, 10);
+    const body = "word ^[999]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe("word");
+  });
+
+  it("removes adjacent marker with no space before it", () => {
+    const source = "src.md";
+    const content = makeContent(source, 10);
+    const body = "word^[999]";
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(result).toBe("word");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sentinel isolation: normalizeCitations (internal) returns sentinel for removal
+// ---------------------------------------------------------------------------
+
+describe("normalizeCitations — sentinel for dropped markers", () => {
+  it("replaces dropped marker with sentinel (internal check)", () => {
+    const source = "x.md";
+    const content = makeContent(source, 5);
+    const raw = normalizeCitations("word^[99]", [source], content);
+    expect(raw).toContain("\x00REMOVED\x00");
+  });
+});

--- a/test/fixtures/citation-content.ts
+++ b/test/fixtures/citation-content.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared test fixture for building numbered source content strings.
+ *
+ * Produces content in the same format that `buildBudgetedCombinedContent`
+ * emits (right-aligned 1-indexed line numbers, e.g. ` 1 | line 1`).
+ * Used by citation-normalize and page-renderer-citation-normalize tests.
+ */
+
+/**
+ * Build a minimal `combinedContent` string resembling what
+ * `buildBudgetedCombinedContent` produces for a given source file and N lines.
+ * @param file - Source filename (e.g. "karpathy.md").
+ * @param lineCount - Number of lines to include.
+ * @returns Combined content string with numbered lines.
+ */
+export function makeNumberedContent(file: string, lineCount: number): string {
+  const width = String(lineCount).length;
+  const numbered = Array.from(
+    { length: lineCount },
+    (_, i) => `${String(i + 1).padStart(width)} | line ${i + 1}`,
+  ).join("\n");
+  return `--- SOURCE: ${file} ---\n\n${numbered}`;
+}

--- a/test/page-renderer-citation-normalize.test.ts
+++ b/test/page-renderer-citation-normalize.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Integration test: `renderMergedPageContent` runs citation normalization.
+ *
+ * Verifies that when the LLM returns a bare line-number citation like `^[81]`,
+ * `renderMergedPageContent` repairs or drops it before the page body is
+ * assembled — so the returned markdown is free of viewer citation warnings.
+ */
+
+import { vi, describe, it, expect } from "vitest";
+import { callClaude } from "../src/utils/llm.js";
+import { renderMergedPageContent } from "../src/compiler/page-renderer.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { makeNumberedContent } from "./fixtures/citation-content.js";
+
+vi.mock("../src/utils/llm.js", () => ({
+  callClaude: vi.fn(),
+}));
+
+/** Minimal SchemaConfig stub matching the shape page-renderer needs. */
+const STUB_SCHEMA = { defaultKind: "concept" } as Parameters<typeof renderMergedPageContent>[2];
+
+describe("renderMergedPageContent — citation normalization wired in", () => {
+  it("repairs a bare ^[81] emitted by the LLM when the source has >= 81 lines", async () => {
+    const source = "karpathy.md";
+    const root = await makeTempRoot("page-renderer-normalize");
+    const combinedContent = makeNumberedContent(source, 100);
+
+    vi.mocked(callClaude).mockResolvedValue("Neural scaling laws.^[81]");
+
+    const result = await renderMergedPageContent(
+      root,
+      {
+        slug: "neural-scaling",
+        concept: {
+          concept: "Neural Scaling",
+          summary: "How scale affects model quality.",
+          is_new: false,
+          tags: [],
+        },
+        sourceFiles: [source],
+        combinedContent,
+      },
+      STUB_SCHEMA,
+    );
+
+    expect(result).toContain(`^[${source}:81]`);
+    expect(result).not.toContain("^[81]");
+  });
+
+  it("drops a bare ^[99] when the source only has 40 lines", async () => {
+    const source = "short.md";
+    const root = await makeTempRoot("page-renderer-drop");
+    const combinedContent = makeNumberedContent(source, 40);
+
+    vi.mocked(callClaude).mockResolvedValue("Claim.^[99]");
+
+    const result = await renderMergedPageContent(
+      root,
+      {
+        slug: "short-concept",
+        concept: {
+          concept: "Short Concept",
+          summary: "Short source only.",
+          is_new: false,
+          tags: [],
+        },
+        sourceFiles: [source],
+        combinedContent,
+      },
+      STUB_SCHEMA,
+    );
+
+    expect(result).not.toContain("^[99]");
+    expect(result).not.toContain("^[");
+  });
+});


### PR DESCRIPTION
## Summary

The compile LLM sometimes emits a citation marker as a bare line number, e.g. `^[81]` instead of the required `^[filename.md:81]`. The citation parser reads the text before `:`/`#` as the source filename, so `^[81]` resolves to source "81", which doesn't exist — and the viewer renders a "Source not found: 81" error callout on the page. Nothing validated these before the page was written.

This normalizes citations at compile time, in `renderMergedPageContent`, before the page body is persisted.

## What changed

- New `src/compiler/citation-normalize.ts`: for each `^[...]` marker, repair or drop bare line-number entries.
  - Single source: a bare `^[81]` is repaired to `^[<source>.md:81]` when line 81 is within the source's actual range, or dropped when it's a hallucinated line.
  - Multiple sources: a bare number is ambiguous, so it's dropped.
  - When a marker has no surviving entries it's removed, and the dangling space before it is collapsed.
- Wired into `src/compiler/page-renderer.ts` immediately after the LLM response.

## Scope

Only bare-number citations are touched. Entries that carry a filename (even an unresolvable or malformed one, like `^[madeup.md:5]`) are left unchanged so the existing provenance linter (`broken-citation` / `malformed-claim-citation`) keeps responsibility for them.

## Test plan

- `npm test` — green, including 17 new tests covering repair, drop-on-out-of-range, multi-source ambiguity, mixed markers, malformed entries, marker removal + space cleanup, and an end-to-end render test.
- `npx tsc --noEmit`, `npm run build`, and `fallow` all clean.