### PR TITLE
feat(cli): add --verbose mode for compile and other commands

### DIFF
--- a/docs/cli/compile.mdx
+++ b/docs/cli/compile.mdx
@@ -22,6 +22,7 @@ Run from your project root. If `sources/` is empty or doesn't exist yet, compile
 |------|-------------|
 | `--review` | Write generated pages to `.llmwiki/candidates/` instead of `wiki/`. Pages are held for human review and don't appear in the live wiki until you approve them with `llmwiki review approve <id>`. |
 | `--lang <code>` | Override the output language for this compile run (e.g. `zh-CN`, `Chinese`, `ja`, `Japanese`). Wins over the `LLMWIKI_OUTPUT_LANG` environment variable. Unset preserves the model's default behaviour. |
+| `--verbose` | Print detailed per-step progress: source sizes, concept merge details, page char counts, embedding batch summary, and total compile time. Equivalent to setting `LLMWIKI_VERBOSE=1`. Quiet mode (`--json`) always wins over verbose. |
 
 ## Incremental behaviour
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -109,6 +109,7 @@ Non-numeric, zero, or negative values are silently ignored and the next source i
 | Variable | Values | Description |
 |---|---|---|
 | `LLMWIKI_DEBUG` | `1` or `verbose` | Debug tracing for the `claude-agent` provider only. `1` prints a concise one-line trace per SDK message plus subprocess errors. `verbose` additionally enables the Agent SDK's full verbose logging |
+| `LLMWIKI_VERBOSE` | any non-empty value | Enable verbose progress output for all commands. Equivalent to passing `--verbose` on the command line. Prints dimmed `  · ` detail lines for each source parsed, concept merged, page written, embedding batch, and total compile time |
 
 ---
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -109,7 +109,7 @@ Non-numeric, zero, or negative values are silently ignored and the next source i
 | Variable | Values | Description |
 |---|---|---|
 | `LLMWIKI_DEBUG` | `1` or `verbose` | Debug tracing for the `claude-agent` provider only. `1` prints a concise one-line trace per SDK message plus subprocess errors. `verbose` additionally enables the Agent SDK's full verbose logging |
-| `LLMWIKI_VERBOSE` | any non-empty value | Enable verbose progress output for all commands. Equivalent to passing `--verbose` on the command line. Prints dimmed `  · ` detail lines for each source parsed, concept merged, page written, embedding batch, and total compile time |
+| `LLMWIKI_VERBOSE` | any non-empty value | Enable verbose progress output on commands that accept `--verbose` (`compile`, `refresh`, `quickstart`, `ingest`, `ingest-session`, `query`, `context`, `export`, `import`). Equivalent to passing `--verbose` on the command line. Detail is richest for `compile`, `refresh`, and `quickstart`, which print per-step lines for source parsing, concept merging, page writes, embedding batches, and total compile time |
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,9 +38,20 @@ import contextCommand, { type ContextCommandOptions } from "./commands/context.j
 import { startMCPServer } from "./mcp/server.js";
 import { applyLanguageOption } from "./utils/output-language.js";
 import { ensureProviderAvailable } from "./utils/provider-guard.js";
+import { setVerbose } from "./utils/output.js";
+import { ENV_VERBOSE } from "./utils/constants.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
+
+/**
+ * Returns true when the --verbose flag was passed or LLMWIKI_VERBOSE is set
+ * to a non-empty value in the environment. Both paths call setVerbose(true)
+ * at the start of the action so verbose() emits output for that run only.
+ */
+function verboseEnabled(flag?: boolean): boolean {
+  return Boolean(flag) || Boolean(process.env[ENV_VERBOSE]?.trim());
+}
 
 const program = new Command();
 
@@ -52,8 +63,10 @@ program
 program
   .command("ingest <source>")
   .description("Ingest a URL or local file into sources/")
-  .action(async (source: string) => {
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (source: string, options: { verbose?: boolean }) => {
     try {
+      setVerbose(verboseEnabled(options.verbose));
       await ingestCommand(source);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
@@ -64,8 +77,10 @@ program
 program
   .command("ingest-session <path>")
   .description("Ingest a coding-agent session export (Claude, Codex, Cursor) into sources/")
-  .action(async (targetPath: string) => {
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (targetPath: string, options: { verbose?: boolean }) => {
     try {
+      setVerbose(verboseEnabled(options.verbose));
       await ingestSessionCommand(targetPath);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
@@ -100,8 +115,10 @@ program
     "--lang <code>",
     "Target language for generated wiki content (e.g. \"Chinese\", \"ja\", \"zh-CN\"). Equivalent to setting LLMWIKI_OUTPUT_LANG.",
   )
-  .action(async (options: { review?: boolean; lang?: string }) => {
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (options: { review?: boolean; lang?: string; verbose?: boolean }) => {
     try {
+      setVerbose(verboseEnabled(options.verbose));
       applyLanguageOption(options.lang);
       requireProvider();
       await compileCommand({ review: options.review });
@@ -116,8 +133,10 @@ program
   .description("Recompile only stale/changed pages without touching unrelated new sources")
   .option("--stale", "Resolve stale/orphaned pages and recompile them")
   .option("--dry-run", "Print the refresh plan without calling the LLM or writing files")
-  .action(async (options: { stale?: boolean; dryRun?: boolean }) => {
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (options: { stale?: boolean; dryRun?: boolean; verbose?: boolean }) => {
     try {
+      setVerbose(verboseEnabled(options.verbose));
       const code = await refreshCommand(options, requireProvider);
       process.exit(code);
     } catch (err) {
@@ -189,12 +208,14 @@ program
     "--lang <code>",
     "Target language for the answer (e.g. \"Chinese\", \"ja\", \"zh-CN\"). Equivalent to setting LLMWIKI_OUTPUT_LANG.",
   )
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
   .action(
     async (
       question: string,
-      options: { save?: boolean; debug?: boolean; lang?: string },
+      options: { save?: boolean; debug?: boolean; lang?: string; verbose?: boolean },
     ) => {
       try {
+        setVerbose(verboseEnabled(options.verbose));
         applyLanguageOption(options.lang);
         requireProvider();
         await queryCommand(process.cwd(), question, options);
@@ -337,8 +358,10 @@ program
     "Bridge identifier embedded in the JSON export envelope. Must match /^[a-z0-9][a-z0-9-]{0,62}$/.",
   )
   .option("--out <dir>", "Output directory for directory-style targets (e.g. okf)")
-  .action(async (options: { target?: string; source?: string; projectId?: string; out?: string }) => {
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (options: { target?: string; source?: string; projectId?: string; out?: string; verbose?: boolean }) => {
     try {
+      setVerbose(verboseEnabled(options.verbose));
       await exportCommand(process.cwd(), options);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
@@ -355,8 +378,10 @@ program
     "Write mapped pages directly into wiki/ instead of staging for review (you vouch for the bundle's contents and its self-declared provenance)",
   )
   .option("--dry-run", "Report what would be imported (and skipped) without writing anything")
-  .action(async (options: { okf: string; trusted?: boolean; dryRun?: boolean }) => {
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (options: { okf: string; trusted?: boolean; dryRun?: boolean; verbose?: boolean }) => {
     try {
+      setVerbose(verboseEnabled(options.verbose));
       await importCommand(process.cwd(), options);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
@@ -391,9 +416,11 @@ program
     "--include-sources",
     "Populate primary[].sourceWindows from claim-level citation spans (max 20 windows, 30 lines each)",
   )
-  .action(async (prompt: string, options: ContextCommandOptions) =>
-    runExitCodeCommand(() => contextCommand(prompt, options)),
-  );
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (prompt: string, options: ContextCommandOptions & { verbose?: boolean }) => {
+    setVerbose(verboseEnabled(options.verbose));
+    return runExitCodeCommand(() => contextCommand(prompt, options));
+  });
 
 program
   .command("quickstart <source>")
@@ -411,9 +438,11 @@ program
     "Target language for generated wiki content (e.g. \"Chinese\", \"ja\", \"zh-CN\"). Equivalent to setting LLMWIKI_OUTPUT_LANG.",
   )
   .option("--json", "Emit the quickstart JSON envelope instead of human output (implies --no-open)")
-  .action(async (source: string, options: QuickstartOptions) =>
-    runExitCodeCommand(() => quickstartCommand(source, options)),
-  );
+  .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
+  .action(async (source: string, options: QuickstartOptions & { verbose?: boolean }) => {
+    setVerbose(verboseEnabled(options.verbose));
+    return runExitCodeCommand(() => quickstartCommand(source, options));
+  });
 
 program
   .command("serve")

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -27,7 +27,7 @@ import {
   DEFAULT_TOP_PAGES,
 } from "../context/types.js";
 import type { RecommendedAction } from "../project/recommendations.js";
-import { verbose } from "../utils/output.js";
+import { verbose, setQuiet } from "../utils/output.js";
 
 /** CLI-supplied options for `llmwiki context`. */
 export interface ContextCommandOptions {
@@ -70,6 +70,25 @@ export default async function contextCommand(
   prompt: string,
   options: ContextCommandOptions = {},
 ): Promise<number> {
+  const format = resolveFormat(options);
+  // Suppress verbose/status output when emitting machine-readable JSON to
+  // stdout — the same pattern quickstart uses for its --json path. The JSON
+  // itself is written via process.stdout.write which quiet mode does not
+  // intercept, so the envelope always reaches the caller cleanly.
+  if (format === "json") setQuiet(true);
+  try {
+    return await runContext(prompt, options, format);
+  } finally {
+    if (format === "json") setQuiet(false);
+  }
+}
+
+/** Inner implementation wrapped by the quiet-mode lifecycle for JSON paths. */
+async function runContext(
+  prompt: string,
+  options: ContextCommandOptions,
+  format: "json" | "markdown",
+): Promise<number> {
   const pack = await buildContextPack({
     root: process.cwd(),
     prompt,
@@ -87,7 +106,7 @@ export default async function contextCommand(
   verbose(`citations gathered: ${totalCitations}`);
   const serialized = JSON.stringify(pack);
   verbose(`pack size: ${serialized.length} chars`);
-  emit(pack, resolveFormat(options));
+  emit(pack, format);
   return 0;
 }
 

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_TOP_PAGES,
 } from "../context/types.js";
 import type { RecommendedAction } from "../project/recommendations.js";
+import { verbose } from "../utils/output.js";
 
 /** CLI-supplied options for `llmwiki context`. */
 export interface ContextCommandOptions {
@@ -80,6 +81,12 @@ export default async function contextCommand(
     neighbors: options.neighbors,
     includeSources: options.includeSources === true,
   });
+  verbose(`primary pages: ${pack.primary.length}`);
+  verbose(`graph neighbors: ${pack.neighbors.length}`);
+  const totalCitations = pack.primary.reduce((sum, p) => sum + p.citations.length, 0);
+  verbose(`citations gathered: ${totalCitations}`);
+  const serialized = JSON.stringify(pack);
+  verbose(`pack size: ${serialized.length} chars`);
   emit(pack, resolveFormat(options));
   return 0;
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -24,6 +24,7 @@ import path from "path";
 import { createRequire } from "module";
 import { atomicWrite } from "../utils/markdown.js";
 import * as output from "../utils/output.js";
+import { verbose } from "../utils/output.js";
 import { collectExportPages } from "../export/collect.js";
 import { buildLlmsTxt, buildLlmsFullTxt } from "../export/llms-txt.js";
 import {
@@ -179,6 +180,7 @@ export async function runExport(root: string, options: ExportOptions = {}): Prom
     options.projectId !== undefined ? validateProjectId(options.projectId) : undefined;
   const pages = await collectExportPages(root);
   const projectTitle = resolveProjectTitle(root);
+  verbose(`export: ${pages.length} pages collected`);
 
   const targets = resolveTargets(options.target);
   const marpSource = resolveMarpSource(options.source);
@@ -196,6 +198,7 @@ export async function runExport(root: string, options: ExportOptions = {}): Prom
     const outPath = path.join(root, EXPORT_DIR, TARGET_FILENAMES[target]);
     await atomicWrite(outPath, content);
     written.push(outPath);
+    verbose(`target ${target}: ${content.length} chars → ${outPath}`);
     output.status("+", output.success(`Exported ${target} → ${output.source(outPath)}`));
   }
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -10,6 +10,7 @@
 import { runOkfImport } from "../import/run.js";
 import { LockUnavailableError } from "../import/run-errors.js";
 import * as output from "../utils/output.js";
+import { verbose } from "../utils/output.js";
 import type { OkfImportReport } from "../import/run.js";
 export { isWritable } from "./import-core.js"; // preserve existing importers
 
@@ -30,6 +31,7 @@ export default async function importCommand(root: string, options: ImportOptions
   if (!options.okf) throw new Error("import: --okf <dir> is required");
   try {
     const report = await runOkfImport(root, options.okf, { trusted: options.trusted, dryRun: options.dryRun });
+    verbose(`import: ${report.pages.length} page(s) processed, ${report.skipped.length} skipped`);
     printReport(report);
   } catch (err) {
     if (err instanceof LockUnavailableError) {

--- a/src/commands/ingest-session.ts
+++ b/src/commands/ingest-session.ts
@@ -66,6 +66,12 @@ export async function ingestSessionFile(root: string, filePath: string): Promise
   output.status("*", output.info(`Ingesting session: ${filePath}`));
 
   const session = await parseSessionFile(filePath);
+  output.verbose(`adapter: ${session.adapter}`);
+  output.verbose(`turns parsed: ${session.turns.length}`);
+
+  const body = formatSessionAsMarkdown(session);
+  output.verbose(`content extracted: ${body.length} chars`);
+
   const savedPath = await saveSessionSource(root, session, filePath);
 
   output.status(
@@ -74,6 +80,7 @@ export async function ingestSessionFile(root: string, filePath: string): Promise
       `Saved ${output.bold(path.basename(savedPath))} [${session.adapter}] → ${output.source(savedPath)}`
     )
   );
+  output.verbose(`output file: ${savedPath}`);
 
   return {
     filename: path.basename(savedPath),

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -17,6 +17,7 @@ import { saveSource } from "../utils/source-writer.js";
 import { appendLog } from "../utils/activity-log.js";
 import { MAX_SOURCE_CHARS, MIN_SOURCE_CHARS, SOURCES_DIR, IMAGE_EXTENSIONS, TRANSCRIPT_EXTENSIONS } from "../utils/constants.js";
 import * as output from "../utils/output.js";
+import { verbose } from "../utils/output.js";
 import ingestWeb from "../ingest/web.js";
 import ingestFile from "../ingest/file.js";
 import ingestPdf from "../ingest/pdf.js";
@@ -282,13 +283,16 @@ async function journalIngest(
 export async function ingestSource(root: string, source: string): Promise<IngestResult> {
   const sourceType = await detectSourceType(source);
   output.status("*", output.info(`Ingesting [${sourceType}]: ${source}`));
+  verbose(`source type: ${sourceType}`);
 
   const { title, content } = await fetchContent(source, sourceType);
+  verbose(`fetched: ${content.length} chars`);
 
   const result = enforceCharLimit(content);
   enforceMinContent(result.content);
   const document = buildDocument(title, source, result, sourceType);
   const { path: savedPath, writeStatus } = await saveSource(root, title, document, source);
+  verbose(`saved: ${savedPath} (${result.content.length} chars extracted)`);
 
   // Journal only real writes — a no-op re-ingest must not append a log line.
   if (writeStatus !== "unchanged") {

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -19,6 +19,7 @@ import { atomicWrite, safeReadFile, slugify, buildFrontmatter, parseFrontmatter 
 import { languageDirective } from "../utils/output-language.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import * as output from "../utils/output.js";
+import { verbose } from "../utils/output.js";
 import {
   QUERY_PAGE_LIMIT,
   INDEX_FILE,
@@ -444,9 +445,11 @@ export async function generateAnswer(
   }
 
   const selection = await selectRelevantPages(root, question, Boolean(options.debug));
+  verbose(`retrieval: ${selection.pages.length} page(s) selected, ${selection.chunks.length} chunk(s) used`);
   options.onPageSelection?.(selection.pages, selection.reasoning);
 
   const pagesContent = await loadSelectedPages(root, selection.pages);
+  verbose(`context pack: ${pagesContent.length} chars`);
 
   if (!pagesContent) {
     return buildEmptyResult(selection);

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -45,7 +45,7 @@ import {
 import { markOrphaned, orphanUnownedFrozenPages } from "./orphan.js";
 import { resolveLinks } from "./resolver.js";
 import { generateIndex } from "./indexgen.js";
-import { buildBudgetedCombinedContent, type SourceSlice } from "./prompt-budget.js";
+import { buildBudgetedCombinedContent, resolvePromptBudgetChars, type SourceSlice } from "./prompt-budget.js";
 import { addObsidianMeta, generateMOC } from "./obsidian.js";
 import { addModelProvenanceMeta } from "./provenance.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
@@ -60,6 +60,7 @@ import {
 import type { LintResult } from "../linter/types.js";
 import { renderMergedPageContent } from "./page-renderer.js";
 import * as output from "../utils/output.js";
+import { verbose } from "../utils/output.js";
 import { loadReviewPolicy } from "../review/config.js";
 import { evaluatePolicy, isPolicyOff } from "../review/policy.js";
 import type { HeldReason, ReviewPolicy } from "../review/policy.js";
@@ -405,6 +406,7 @@ async function runCompilePipeline(
   root: string,
   options: CompileOptions,
 ): Promise<CompileResult> {
+  const startMs = Date.now();
   const schema = await loadSchema(root);
   const reviewPolicy = await loadReviewPolicy(root);
   reportSchemaStatus(schema);
@@ -490,6 +492,7 @@ async function runCompilePipeline(
     await finalizeWiki(root, generation.writtenPages, generation.seedSlugs);
     await logCompile(root, buckets, generation, existingIds);
   }
+  verbose(`compile finished in ${Date.now() - startMs} ms`);
   return summarizeCompile(buckets, generation, extractions, options);
 }
 
@@ -632,6 +635,9 @@ async function extractForSource(
 
   const sourcePath = path.join(root, SOURCES_DIR, sourceFile);
   const sourceContent = await readFile(sourcePath, "utf-8");
+  const lines = sourceContent.split("\n").length;
+  const chars = sourceContent.length;
+  verbose(`source ${sourceFile}: ${lines} lines, ${chars} chars`);
   const existingIndex = await safeReadFile(path.join(root, INDEX_FILE));
   const concepts = await extractConcepts(sourceContent, existingIndex);
 
@@ -741,11 +747,16 @@ function mergeExtractions(
     }
   }
 
+  const budget = resolvePromptBudgetChars();
   for (const merged of bySlug.values()) {
     const slices = slicesBySlug.get(merged.slug) ?? [];
     merged.combinedContent = buildBudgetedCombinedContent(
       merged.concept.concept,
       slices,
+    );
+    verbose(
+      `concept ${merged.slug}: ${slices.length} source(s), ` +
+      `${merged.combinedContent.length} chars combined (budget ${budget})`,
     );
   }
 
@@ -1022,6 +1033,8 @@ async function writePageIfValid(
   }
 
   await atomicWrite(pagePath, content);
+  const slug = path.basename(pagePath, ".md");
+  verbose(`page ${slug}: ${content.length} chars`);
   return null;
 }
 
@@ -1032,6 +1045,7 @@ async function writePageIfValid(
  */
 async function safelyUpdateEmbeddings(root: string, changedSlugs: string[]): Promise<void> {
   try {
+    verbose(`embeddings: refreshing ${changedSlugs.length} slug(s)`);
     await updateEmbeddings(root, changedSlugs);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -190,3 +190,6 @@ export const ENV_EMBED_BATCH_SIZE = "LLMWIKI_EMBED_BATCH_SIZE";
 
 /** Env var: when set, a failed embedding refresh exits non-zero (for CI). */
 export const ENV_EMBED_STRICT = "LLMWIKI_EMBED_STRICT";
+
+/** Env var: when set to any non-empty value, enables verbose progress output. */
+export const ENV_VERBOSE = "LLMWIKI_VERBOSE";

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -9,6 +9,11 @@
  * is preserved for the `quickstart --json` code path that calls `setQuiet`
  * directly; `isQuiet()` checks the scoped value first and falls back to the
  * global flag.
+ *
+ * Verbose-mode mirrors the quiet pattern: a process-wide `verboseMode` flag
+ * plus an AsyncLocalStorage `verboseScope` for per-call-tree scoping. When
+ * verbose is active, `verbose()` emits dimmed detail lines. Quiet always wins
+ * — even if verbose is on, `isQuiet()` suppresses all output.
  */
 
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -113,4 +118,43 @@ export function note(message: string): void {
 /** Read the current process-wide quiet flag. */
 export function getQuiet(): boolean {
   return quietMode;
+}
+
+/**
+ * Process-wide verbose flag. Toggled by `--verbose` or `LLMWIKI_VERBOSE=1`.
+ * SDK callers should use `withVerbose` instead of mutating this flag directly.
+ */
+let verboseMode = false;
+
+/** ALS store scopes verbose to a single async call tree. */
+const verboseScope = new AsyncLocalStorage<boolean>();
+
+/**
+ * Run `fn` with verbose mode scoped to the current async call tree.
+ * Concurrent calls are fully isolated — no global flag is mutated.
+ */
+export function withVerbose<T>(fn: () => T): T {
+  return verboseScope.run(true, fn);
+}
+
+/**
+ * Returns true if the current async context is verbose (via ALS scope)
+ * or the process-wide verbose flag is set. The scoped value takes priority.
+ */
+export function isVerbose(): boolean {
+  return verboseScope.getStore() ?? verboseMode;
+}
+
+/** Toggle the process-wide verbose flag. */
+export function setVerbose(v: boolean): void {
+  verboseMode = v;
+}
+
+/**
+ * Print a dimmed detail line when verbose mode is on. No-op when quiet or
+ * verbose is off. Quiet always wins over verbose.
+ */
+export function verbose(message: string): void {
+  if (!isVerbose() || isQuiet()) return;
+  console.log(dim(`  · ${message}`));
 }

--- a/test/output-verbose.test.ts
+++ b/test/output-verbose.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the verbose output mode in src/utils/output.ts.
+ *
+ * Covers:
+ *  1. verbose() prints when verbose is on
+ *  2. verbose() is silent when verbose is off
+ *  3. quiet wins over verbose (quiet suppresses output even when verbose is on)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  setVerbose,
+  setQuiet,
+  verbose,
+  withVerbose,
+  withQuiet,
+  isVerbose,
+} from "../src/utils/output.js";
+
+/** Reset both flags to off between tests to avoid state leakage. */
+beforeEach(() => {
+  setVerbose(false);
+  setQuiet(false);
+});
+
+afterEach(() => {
+  setVerbose(false);
+  setQuiet(false);
+});
+
+describe("verbose()", () => {
+  it("prints a dimmed detail line when verbose is on", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      setVerbose(true);
+      verbose("hello world");
+      expect(spy).toHaveBeenCalledOnce();
+      const arg = spy.mock.calls[0][0] as string;
+      expect(arg).toContain("  · hello world");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("prints nothing when verbose is off", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      setVerbose(false);
+      verbose("silent message");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("prints nothing when quiet is on even if verbose is on", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      setVerbose(true);
+      setQuiet(true);
+      verbose("suppressed by quiet");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("withVerbose()", () => {
+  it("scopes verbose to the call tree without mutating the global flag", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      setVerbose(false);
+      let capturedInside = false;
+      withVerbose(() => {
+        capturedInside = isVerbose();
+        verbose("scoped message");
+      });
+      expect(capturedInside).toBe(true);
+      expect(isVerbose()).toBe(false); // global unchanged
+      expect(spy).toHaveBeenCalledOnce();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("quiet wins over verbose", () => {
+  it("withQuiet suppresses verbose even inside withVerbose", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      withVerbose(() => {
+        withQuiet(() => {
+          verbose("should be silent");
+        });
+      });
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/test/verbose-compile.test.ts
+++ b/test/verbose-compile.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Subprocess test for --verbose mode in `llmwiki compile`.
+ *
+ * Runs compile twice in the same aimock-backed workspace:
+ *   1. Without --verbose  → stdout must NOT contain the `  · ` marker.
+ *   2. With --verbose     → stdout MUST contain the `  · ` marker.
+ *
+ * Relies on the existing aimock/runCLI infrastructure to avoid a live LLM.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  mockOpenAIEnv,
+  useAimockLifecycle,
+  type MockClaudeHandle,
+} from "./fixtures/aimock-helper.js";
+import {
+  runCLI,
+  expectCLIExit,
+  formatCLIFailure,
+} from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("verbose-compile");
+
+/** Marker emitted by verbose() calls. */
+const VERBOSE_MARKER = "  · ";
+
+const SOURCE = "# Verbose Test\n\nA short source to verify verbose compile output.\n";
+const PAGE_BODY =
+  "Verbose mode adds per-step detail lines to compilation output for debugging.";
+
+/** Register minimal aimock responses for a single-source compile. */
+function registerMocks(handle: MockClaudeHandle): void {
+  handle.mock.onToolCall("extract_concepts", {
+    toolCalls: [
+      {
+        name: "extract_concepts",
+        arguments: {
+          concepts: [
+            {
+              concept: "Verbose Mode",
+              summary: "Per-step detail lines for debugging.",
+              is_new: true,
+              tags: ["cli"],
+              confidence: 0.9,
+            },
+          ],
+        },
+      },
+    ],
+  });
+  handle.mock.onMessage(/.*/, { content: PAGE_BODY });
+  handle.mock.onEmbedding(/.*/, { embedding: Array.from({ length: 8 }, (_, i) => i / 10) });
+}
+
+describe("--verbose flag in compile", () => {
+  it("plain compile produces no verbose marker; --verbose compile does", async () => {
+    const handle = await aimock.start();
+    registerMocks(handle);
+    const cwd = await aimock.makeWorkspace(SOURCE);
+    const env = mockOpenAIEnv(handle);
+
+    // Run without --verbose first.
+    const plain = await runCLI(["compile"], cwd, env);
+    expectCLIExit(plain, 0);
+    expect(plain.stdout, formatCLIFailure(plain)).not.toContain(VERBOSE_MARKER);
+
+    // Register mocks again for the second run (aimock queues are consumed).
+    registerMocks(handle);
+
+    // Run with --verbose.
+    const loud = await runCLI(["compile", "--verbose"], cwd, env);
+    expectCLIExit(loud, 0);
+    expect(loud.stdout, formatCLIFailure(loud)).toContain(VERBOSE_MARKER);
+  }, 30_000);
+});

--- a/test/verbose-json-purity.test.ts
+++ b/test/verbose-json-purity.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression tests: verbose output must never pollute machine-readable JSON
+ * stdout paths.
+ *
+ * Covers `llmwiki context --json --verbose` and the LLMWIKI_VERBOSE=1 env
+ * equivalent. Both must emit pure JSON on stdout (no `  · ` verbose marker
+ * lines preceding the envelope).
+ *
+ * These are subprocess tests so the real quiet-mode guard on the compiled
+ * binary is exercised — not just the in-process unit.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+
+/** Marker emitted by verbose() calls — must never appear in JSON stdout. */
+const VERBOSE_MARKER = "  · ";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "verbose-json-purity-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+/** Seed one concept page so the context pack has something to report. */
+async function seedConcept(slug: string, title: string): Promise<void> {
+  await mkdir(path.join(tmpDir, CONCEPTS_DIR), { recursive: true });
+  await writeFile(
+    path.join(tmpDir, CONCEPTS_DIR, `${slug}.md`),
+    `---\ntitle: ${title}\n---\n\nbody text here\n`,
+    "utf-8",
+  );
+}
+
+/**
+ * Assert that running context with JSON output mode produces parseable stdout
+ * with no verbose marker contamination. Shared by the --verbose flag test and
+ * the LLMWIKI_VERBOSE env-var test to avoid duplicating the assertion block.
+ */
+async function assertJsonPurity(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+): Promise<void> {
+  const result = await runCLI(args, tmpDir, envOverrides);
+  expectCLIExit(result, 0);
+  expect(result.stdout, `verbose marker leaked into stdout:\n${result.stdout}`).not.toContain(
+    VERBOSE_MARKER,
+  );
+  // Must parse as a single valid JSON object — no prefix lines.
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  expect(parsed.version).toBe(1);
+}
+
+describe("context --json --verbose: stdout stays pure JSON", () => {
+  it("JSON.parse(stdout) succeeds and no verbose marker appears on stdout", async () => {
+    await seedConcept("alpha", "Alpha");
+    await assertJsonPurity(["context", "alpha", "--json", "--verbose"]);
+  });
+
+  it("LLMWIKI_VERBOSE=1 with --json keeps stdout parseable", async () => {
+    await seedConcept("beta", "Beta");
+    await assertJsonPurity(["context", "beta", "--json"], { LLMWIKI_VERBOSE: "1" });
+  });
+
+  it("--verbose without --json still emits the verbose marker on stdout", async () => {
+    await seedConcept("gamma", "Gamma");
+    const result = await runCLI(["context", "gamma", "--verbose"], tmpDir);
+    expectCLIExit(result, 0);
+    // Human output path must NOT suppress verbose markers.
+    expect(result.stdout).toContain(VERBOSE_MARKER);
+  });
+});


### PR DESCRIPTION
## Summary

There was no way to get more detail out of `compile` (or other commands) when something looks off. This adds a `--verbose` mode that surfaces per-step detail, controllable by the `--verbose` flag or `LLMWIKI_VERBOSE=1`.

## What changed

- `src/utils/output.ts`: a verbose mechanism mirroring the existing quiet one — `setVerbose` / `isVerbose` / `withVerbose`, and `verbose(message)` which prints a dimmed `  · …` line only when verbose is on and not quiet (quiet wins).
- `--verbose` flag (and `LLMWIKI_VERBOSE` env) on the commands where extra detail helps: `compile`, `refresh`, `ingest`, `ingest-session`, `query`, `context`, `quickstart`, `export`, `import`.
- Compile instrumentation: per-source parse sizes, per-concept source-merge + prompt-budget usage, per-page generation size, embedding refresh detail, and total compile timing. Lighter detail on the other commands.

Example:
```
  · source intro.md: 42 lines, 1024 chars
  · concept chunked-retrieval: 1 source(s), 2048 chars combined (budget 200000)
  · page chunked-retrieval: 3821 chars
  · compile finished in 4523 ms
```

## Test plan

- `npm test` — green, including `output-verbose` (on/off/quiet-wins/scoping) and an aimock subprocess test asserting the `  · ` detail lines appear only with `--verbose`.
- `npx tsc --noEmit`, `npm run build`, `fallow`, and docs `broken-links` all clean.