### PR TITLE
fix(profile): harden Phase 2 — confine journal replay, fail-closed state validation, wire typed candidate fields

### DIFF
--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -29,6 +29,7 @@ import {
 import type { ReviewCandidate, SourceState } from "../utils/types.js";
 import type { HeldReason, PolicyHeldReasonCode, ReviewMode } from "../review/policy.js";
 import type { LintResult } from "../linter/types.js";
+import type { TrustDecision } from "../trust/decision.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
 const ID_SUFFIX_BYTES = 4;
@@ -76,6 +77,19 @@ interface CandidateDraft {
   confidence?: number;
   /** True when the generated page frontmatter declares contradictions. */
   contradicted?: boolean;
+  /**
+   * Typed entity directory the approved page routes to under a configurable
+   * profile (e.g. `"papers"`). Phase-2 typed-staging metadata; OMITTED for
+   * default-profile candidates, so default candidate JSON stays byte-identical.
+   */
+  targetEntityType?: string;
+  /**
+   * Trust Guard decision attached to this candidate at generation time, so
+   * reviewers see how the write was routed. Phase-2 typed-staging metadata;
+   * OMITTED for default-profile candidates, so default candidate JSON stays
+   * byte-identical.
+   */
+  trustDecision?: TrustDecision;
 }
 
 /** Default metadata for legacy `compile --review` callers. */
@@ -93,6 +107,15 @@ const VALID_HELD_REASON_CODES: PolicyHeldReasonCode[] = [
   "all",
   "manual-review-requested",
   "imported-okf",
+];
+
+/** All valid TrustDecision values — mirrors the closed union in trust/decision.ts. */
+const VALID_TRUST_DECISIONS: TrustDecision[] = [
+  "allow",
+  "allow-with-warning",
+  "stage-for-review",
+  "quarantine",
+  "deny",
 ];
 
 /** Build a deterministic-but-unique id from a slug and a short random suffix. */
@@ -144,6 +167,8 @@ export async function writeCandidate(
     ...(draft.contradicted !== undefined ? { contradicted: draft.contradicted } : {}),
     ...(draft.targetDirectory ? { targetDirectory: draft.targetDirectory } : {}),
     ...(draft.okfPath ? { okfPath: draft.okfPath } : {}),
+    ...(draft.targetEntityType ? { targetEntityType: draft.targetEntityType } : {}),
+    ...(draft.trustDecision ? { trustDecision: draft.trustDecision } : {}),
   };
 
   await atomicWrite(candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
@@ -299,7 +324,23 @@ function sanitizeCandidate(candidate: ReviewCandidate): ReviewCandidate {
   const result: ReviewCandidate = { ...candidate, generatedAt, reviewMode, heldReasons };
   if (sourceStates !== undefined) result.sourceStates = sourceStates;
   else delete result.sourceStates;
+  sanitizeTypedTarget(result);
   return result;
+}
+
+/**
+ * Validate the Phase-2 typed-staging fields in place. Drops `targetEntityType`
+ * unless it's a string and `trustDecision` unless it's a valid TrustDecision,
+ * so a hand-edited or malformed candidate file can never carry junk metadata.
+ * @param candidate - The candidate to sanitize (mutated in place).
+ */
+function sanitizeTypedTarget(candidate: ReviewCandidate): void {
+  if (typeof candidate.targetEntityType !== "string") {
+    delete candidate.targetEntityType;
+  }
+  if (!VALID_TRUST_DECISIONS.includes(candidate.trustDecision as TrustDecision)) {
+    delete candidate.trustDecision;
+  }
 }
 
 /** Filter `heldReasons` to only entries with a valid code shape; default when empty. */

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -27,6 +27,9 @@
 import { readFile, writeFile, mkdir, readdir, unlink, rename } from "fs/promises";
 import path from "path";
 import { LLMWIKI_DIR } from "../utils/constants.js";
+import { realpath } from "fs/promises";
+import { confineUnderRoot } from "../utils/path-confine.js";
+import { note } from "../utils/output.js";
 
 /** Sentinel recorded when a target did not exist before the batch. */
 const ABSENT = { absent: true } as const;
@@ -68,6 +71,11 @@ function journalDir(root: string): string {
 /** Absolute path to a batch's journal file. */
 function journalPath(root: string, batchId: string): string {
   return path.join(journalDir(root), `${batchId}.json`);
+}
+
+/** Absolute path a quarantined (untrusted) journal file is moved to. */
+function quarantinePath(root: string, batchId: string): string {
+  return path.join(journalDir(root), "quarantine", `${batchId}.json`);
 }
 
 /** Read a file's bytes, or `null` when it does not exist. */
@@ -142,43 +150,136 @@ export async function commitBatch(batch: JournalBatch): Promise<void> {
   await persist(batch);
 }
 
-/** Revert one target to its recorded pre-state (restore bytes or delete). */
-async function revertEntry(entry: JournalEntry): Promise<void> {
+/**
+ * Revert one target to its recorded pre-state (restore bytes or delete), writing
+ * to `confinedPath` — the result of re-confining `entry.targetPath` under root,
+ * so replay can never act on a path that escapes the project.
+ */
+async function revertEntry(entry: JournalEntry, confinedPath: string): Promise<void> {
   if (entry.preState.absent) {
     try {
-      await unlink(entry.targetPath);
+      await unlink(confinedPath);
     } catch {
       // Already absent — the pre-state is already satisfied.
     }
     return;
   }
-  await mkdir(path.dirname(entry.targetPath), { recursive: true });
-  await writeFile(entry.targetPath, entry.preState.content, "utf-8");
+  await mkdir(path.dirname(confinedPath), { recursive: true });
+  await writeFile(confinedPath, entry.preState.content, "utf-8");
 }
 
-/** Parse a single journal file, returning null on any malformed/unreadable file. */
+/** Validate one parsed entry has a string `targetPath` and a well-formed `preState`. */
+function isValidEntry(entry: unknown): entry is JournalEntry {
+  if (typeof entry !== "object" || entry === null) return false;
+  const { targetPath, preState } = entry as Record<string, unknown>;
+  if (typeof targetPath !== "string") return false;
+  if (typeof preState !== "object" || preState === null) return false;
+  const { absent, content } = preState as Record<string, unknown>;
+  if (absent === true) return content === undefined;
+  return absent === false && typeof content === "string";
+}
+
+/**
+ * Validate a parsed journal payload is a well-formed batch: a `status` of
+ * `"pending"`/`"committed"` and an `entries` array of valid entries. A malformed
+ * payload is untrusted and must NOT be replayed.
+ */
+function isValidBatchShape(parsed: unknown): parsed is Omit<JournalBatch, "root"> {
+  if (typeof parsed !== "object" || parsed === null) return false;
+  const { status, entries } = parsed as Record<string, unknown>;
+  if (status !== "pending" && status !== "committed") return false;
+  return Array.isArray(entries) && entries.every(isValidEntry);
+}
+
+/** Parse a single journal file, returning null on unreadable/malformed/unshaped input. */
 async function loadBatch(root: string, batchId: string): Promise<JournalBatch | null> {
   const raw = await readOrNull(journalPath(root, batchId));
   if (raw === null) return null;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as Omit<JournalBatch, "root">;
-    return { ...parsed, root };
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  if (!isValidBatchShape(parsed)) return null;
+  return { ...parsed, root };
 }
 
-/** Revert a pending batch to its full pre-state, then delete its journal file. */
-async function resolvePending(batch: JournalBatch): Promise<void> {
+/** Move an untrusted journal file into the quarantine subdir and warn. */
+async function quarantineBatch(root: string, batchId: string): Promise<void> {
+  const dest = quarantinePath(root, batchId);
+  await mkdir(path.dirname(dest), { recursive: true });
+  await rename(journalPath(root, batchId), dest);
+  note(`⚠ Untrusted journal ${batchId}.json quarantined to ${dest} — not replayed.`);
+}
+
+/**
+ * Express `targetPath` relative to `root` so confinement is invariant to which
+ * symlink form of root it was recorded under (e.g. `/var/...` vs the canonical
+ * `/private/var/...` on macOS). An absolute target under either the literal or
+ * the realpath'd root is reduced to its in-root remainder; a target that lies
+ * outside both forms is returned unchanged so {@link confineUnderRoot} rejects it.
+ */
+async function targetRelativeToRoot(targetPath: string, root: string): Promise<string> {
+  if (!path.isAbsolute(targetPath)) return targetPath;
+  const realRoot = (await realpath(root).catch(() => null)) ?? path.resolve(root);
+  for (const base of [path.resolve(root), realRoot]) {
+    const rel = path.relative(base, targetPath);
+    if (rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel)) return rel;
+  }
+  return targetPath;
+}
+
+/**
+ * Re-confine every entry's target under root, returning the confined absolute
+ * paths in entry order, or null if ANY target escapes root (whole batch untrusted).
+ */
+async function confineTargets(batch: JournalBatch): Promise<string[] | null> {
+  const confined: string[] = [];
   for (const entry of batch.entries) {
-    await revertEntry(entry);
+    try {
+      const rel = await targetRelativeToRoot(entry.targetPath, batch.root);
+      confined.push(await confineUnderRoot(rel, batch.root, { mustExist: false }));
+    } catch {
+      return null; // a target escapes root → untrusted batch
+    }
+  }
+  return confined;
+}
+
+/** Revert a pending batch to its full pre-state (confined paths), then delete its journal. */
+async function resolvePending(batch: JournalBatch, confinedPaths: string[]): Promise<void> {
+  for (let i = 0; i < batch.entries.length; i++) {
+    await revertEntry(batch.entries[i], confinedPaths[i]);
   }
   await unlink(journalPath(batch.root, batch.batchId));
+}
+
+/** Replay (or quarantine) one pending batch loaded from `batchId`. */
+async function replayPending(root: string, batchId: string): Promise<void> {
+  const batch = await loadBatch(root, batchId);
+  if (batch === null) {
+    await quarantineBatch(root, batchId); // unreadable JSON or malformed shape
+    return;
+  }
+  if (batch.status !== "pending") return; // committed → leave untouched
+  const confinedPaths = await confineTargets(batch);
+  if (confinedPaths === null) {
+    await quarantineBatch(root, batchId); // a target escapes root
+    return;
+  }
+  await resolvePending(batch, confinedPaths);
 }
 
 /**
  * Crash-recovery seam: revert every `pending`-but-not-`committed` batch to its
  * full pre-state, then resolve it. A `committed` batch is left untouched.
+ *
+ * FAIL CLOSED: a journal file that is unparseable, structurally malformed, or
+ * names ANY target that escapes the project root is QUARANTINED (moved under
+ * `.llmwiki/journal/quarantine/`) and never replayed — so a crafted or corrupted
+ * journal can never drive a write/delete outside the root. Every surviving target
+ * is re-confined via {@link confineUnderRoot} before it is touched.
  *
  * Idempotent: reverting a pending batch deletes its journal file, so a second
  * call finds no pending batches and does nothing. A missing journal directory
@@ -201,9 +302,6 @@ export async function replayJournal(root: string): Promise<void> {
   }
   for (const file of files) {
     if (!file.endsWith(".json")) continue;
-    const batch = await loadBatch(root, file.replace(/\.json$/, ""));
-    if (batch !== null && batch.status === "pending") {
-      await resolvePending(batch);
-    }
+    await replayPending(root, file.replace(/\.json$/, ""));
   }
 }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -80,22 +80,72 @@ export async function readStateClassified(root: string): Promise<ClassifiedState
   if (!existsSync(filePath)) return { status: "missing", state: emptyState() };
   try {
     const raw = await readFile(filePath, "utf-8");
-    return classifyParsedState(JSON.parse(raw) as WikiState);
+    return classifyParsedState(JSON.parse(raw));
   } catch {
     return { status: "corrupt", state: emptyState() };
   }
 }
 
+/** True when `value` is an array whose every element is a string. */
+function isStringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/** True when `value` is a non-null, non-array plain object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True when one `sources` entry has the required source-state shape. */
+function isValidSourceEntry(entry: unknown): boolean {
+  if (!isPlainObject(entry)) return false;
+  if (typeof entry.hash !== "string" || typeof entry.compiledAt !== "string") return false;
+  if (!isStringArray(entry.concepts)) return false;
+  if ("entities" in entry && !isStringArray(entry.entities)) return false;
+  return true;
+}
+
+/** True when every optional top-level frozen list, if present, is a string array. */
+function hasValidFrozenLists(parsed: Record<string, unknown>): boolean {
+  if ("frozenSlugs" in parsed && !isStringArray(parsed.frozenSlugs)) return false;
+  if ("frozenEntities" in parsed && !isStringArray(parsed.frozenEntities)) return false;
+  return true;
+}
+
 /**
- * Classify a successfully parsed state. Fails closed on a newer-than-known
- * `version` by returning `too-new` with the parsed state carried intact — no
- * reset and no disk write, so read-only callers can surface the condition.
+ * True when `parsed` is a structurally valid {@link WikiState}: a plain object
+ * with a string `indexHash`, a plain-object `sources` map whose every value is a
+ * valid source entry, and (when present) string-array `frozenSlugs` /
+ * `frozenEntities`. Unknown EXTRA fields are tolerated so a future format that
+ * adds fields is not falsely rejected here. `version` is validated separately by
+ * {@link classifyParsedState}.
  */
-function classifyParsedState(state: WikiState): ClassifiedState {
-  if ((state.version as number) > KNOWN_STATE_VERSION) {
-    return { status: "too-new", state };
+function isValidWikiStateShape(parsed: unknown): boolean {
+  if (!isPlainObject(parsed)) return false;
+  if (typeof parsed.indexHash !== "string") return false;
+  if (!isPlainObject(parsed.sources)) return false;
+  if (!Object.values(parsed.sources).every(isValidSourceEntry)) return false;
+  return hasValidFrozenLists(parsed);
+}
+
+/**
+ * Classify a successfully parsed state, failing closed on anything this build
+ * cannot safely treat as healthy:
+ *  1. an integer `version` ABOVE the known max ⇒ `too-new` (carried intact, NOT
+ *     deep-validated — a future format may legitimately differ in shape);
+ *  2. an integer `version` in the known range (1..KNOWN) AND a valid shape ⇒ `ok`;
+ *  3. anything else (non-integer/out-of-range version, or malformed shape) ⇒
+ *     `corrupt`, routing it into the existing `.bak`/empty-state recovery path.
+ */
+function classifyParsedState(parsed: unknown): ClassifiedState {
+  const version = isPlainObject(parsed) ? parsed.version : undefined;
+  const empty = { status: "corrupt" as const, state: emptyState() };
+  if (typeof version !== "number" || !Number.isInteger(version)) return empty;
+  if (version > KNOWN_STATE_VERSION) return { status: "too-new", state: parsed as WikiState };
+  if (version >= 1 && isValidWikiStateShape(parsed)) {
+    return { status: "ok", state: parsed as WikiState };
   }
-  return { status: "ok", state };
+  return empty;
 }
 
 /** Read .llmwiki/state.json, recovering from corruption gracefully (writes a .bak). */

--- a/test/state-shape-validation.test.ts
+++ b/test/state-shape-validation.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @file test/state-shape-validation.test.ts
+ * @description Fail-closed regression tests for parseable-but-malformed
+ * `.llmwiki/state.json`. Before this guard, a state object that PARSED as JSON
+ * but had a structurally invalid shape (e.g. `sources: null`) classified as
+ * `ok`, then crashed read surfaces such as `collectStatus` with
+ * "Cannot convert undefined or null to object".
+ *
+ * `classifyParsedState` now shape-validates a known-version state and routes
+ * any malformed-but-parseable file into the existing `corrupt` recovery path,
+ * while leaving a genuinely too-new (future-version) file as `too-new` —
+ * without deep-validating a format this build does not understand.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readStateClassified } from "../src/utils/state.js";
+import { collectStatus } from "../src/status/collect.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+import { writeRawTestStateJson, writeTestStateJson } from "./fixtures/state-json.js";
+
+const MALFORMED_NULL_SOURCES = '{"version":2,"indexHash":"","sources":null}';
+
+describe("classifyParsedState — shape validation", () => {
+  const env = useLintTempRoot("state-shape-validation");
+
+  it("(a) classifies {version:2,sources:null} as corrupt and does not crash collectStatus", async () => {
+    await writeRawTestStateJson(env.dir, MALFORMED_NULL_SOURCES);
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("corrupt");
+    expect(result.state.sources).toEqual({});
+
+    const status = await collectStatus(env.dir);
+    expect(status.stateStatus).toBe("corrupt");
+  });
+
+  it('(b) classifies {version:"10"} and {version:1.5} as corrupt, not too-new', async () => {
+    await writeRawTestStateJson(env.dir, '{"version":"10","indexHash":"","sources":{}}');
+    expect((await readStateClassified(env.dir)).status).toBe("corrupt");
+
+    await writeRawTestStateJson(env.dir, '{"version":1.5,"indexHash":"","sources":{}}');
+    expect((await readStateClassified(env.dir)).status).toBe("corrupt");
+  });
+
+  it("(b2) classifies version:0 as corrupt", async () => {
+    await writeRawTestStateJson(env.dir, '{"version":0,"indexHash":"","sources":{}}');
+    expect((await readStateClassified(env.dir)).status).toBe("corrupt");
+  });
+
+  it("(c) classifies a valid v1 state as ok", async () => {
+    await writeTestStateJson(env.dir, {
+      version: 1,
+      indexHash: "h",
+      sources: { "a.md": { hash: "h", concepts: ["x"], compiledAt: "t" } },
+    });
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("ok");
+    expect(result.state.sources["a.md"].hash).toBe("h");
+  });
+
+  it("(c) classifies a valid v2 state (with entities) as ok", async () => {
+    await writeTestStateJson(env.dir, {
+      version: 2,
+      indexHash: "h",
+      sources: {
+        "a.md": { hash: "h", concepts: ["x"], compiledAt: "t", entities: ["concepts/x"] },
+      },
+      frozenSlugs: ["y"],
+      frozenEntities: ["concepts/y"],
+    });
+    expect((await readStateClassified(env.dir)).status).toBe("ok");
+  });
+
+  it("(d) classifies a too-new {version:3, valid shape} as too-new", async () => {
+    await writeRawTestStateJson(env.dir, '{"version":3,"indexHash":"h3","sources":{}}');
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("too-new");
+    expect(result.state.version).toBe(3);
+  });
+
+  it("(d2) classifies a too-new {version:3} even with a bad shape as too-new (not deep-validated)", async () => {
+    await writeRawTestStateJson(env.dir, '{"version":3,"indexHash":"","sources":null}');
+    expect((await readStateClassified(env.dir)).status).toBe("too-new");
+  });
+});

--- a/test/trust-candidate-typed.test.ts
+++ b/test/trust-candidate-typed.test.ts
@@ -6,27 +6,28 @@
  * (`trustDecision`). These fields exist ONLY for configurable (non-default)
  * profiles; default-profile candidates must never populate them.
  *
- * These tests pin three guarantees:
- *  (a) a candidate WITH the new fields round-trips through the candidate
- *      serialization (`JSON.stringify(candidate, null, 2)`) → `readCandidate`
- *      with both fields intact;
- *  (b) PARITY GUARD — a candidate created WITHOUT the new fields, serialized via
- *      the SAME path, produces JSON with neither key present, proving that
+ * These tests pin four guarantees, all exercising the PRODUCTION writer
+ * (`writeCandidate`) and reader (`readCandidate`) rather than hand-edited JSON:
+ *  (a) a draft WITH the new fields round-trips through `writeCandidate` →
+ *      `readCandidate` with both fields intact;
+ *  (b) PARITY GUARD — a default draft (no typed fields) persisted via
+ *      `writeCandidate` produces JSON with neither key present, proving that
  *      `undefined` optional fields never leak into the persisted bytes;
- *  (c) `review list` rendering for a default candidate is byte-identical whether
- *      or not the (absent) typed fields are part of the model.
+ *  (c) a candidate file with a MALFORMED `trustDecision` value is sanitized
+ *      (the field dropped) on read;
+ *  (d) `review list` rendering for a default candidate never surfaces the
+ *      (absent) typed fields.
  */
 
 import { describe, it, expect, vi } from "vitest";
 import path from "path";
-import { writeFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import {
   writeCandidate,
   readCandidate,
 } from "../src/compiler/candidates.js";
 import reviewListCommand from "../src/commands/review-list.js";
 import { CANDIDATES_DIR } from "../src/utils/constants.js";
-import type { ReviewCandidate } from "../src/utils/types.js";
 import type { TrustDecision } from "../src/trust/decision.js";
 import { useTempRoot } from "./fixtures/temp-root.js";
 
@@ -42,10 +43,10 @@ const BODY = [
   "Body.",
 ].join("\n");
 
-/** Persist a full ReviewCandidate via the exact serialization writeCandidate uses. */
-async function persistCandidate(dir: string, candidate: ReviewCandidate): Promise<void> {
-  const file = path.join(dir, CANDIDATES_DIR, `${candidate.id}.json`);
-  await writeFile(file, JSON.stringify(candidate, null, 2));
+/** Read a candidate's persisted JSON as a plain object. */
+async function readCandidateJson(dir: string, id: string): Promise<Record<string, unknown>> {
+  const file = path.join(dir, CANDIDATES_DIR, `${id}.json`);
+  return JSON.parse(await readFile(file, "utf8"));
 }
 
 /** Join all logged args from a console spy into a single string. */
@@ -54,41 +55,53 @@ function collectLog(spy: ReturnType<typeof vi.spyOn>): string {
 }
 
 describe("typed-target metadata on page candidates", () => {
-  it("(a) round-trips targetEntityType + trustDecision with the fields intact", async () => {
-    const base = await writeCandidate(root.dir, {
+  it("(a) writeCandidate persists + round-trips targetEntityType + trustDecision", async () => {
+    const decision: TrustDecision = "stage-for-review";
+    const created = await writeCandidate(root.dir, {
       title: "Typed Target",
       slug: "typed-target",
       summary: "A typed candidate.",
       sources: [],
       body: BODY,
-    });
-    const decision: TrustDecision = "stage-for-review";
-    const typed: ReviewCandidate = {
-      ...base,
       targetEntityType: "papers",
       trustDecision: decision,
-    };
-    await persistCandidate(root.dir, typed);
+    });
 
-    const loaded = await readCandidate(root.dir, base.id);
+    const loaded = await readCandidate(root.dir, created.id);
     expect(loaded?.targetEntityType).toBe("papers");
     expect(loaded?.trustDecision).toBe("stage-for-review");
   });
 
-  it("(b) PARITY GUARD: a default candidate serializes with neither key present", async () => {
-    const candidate = await writeCandidate(root.dir, {
+  it("(b) PARITY GUARD: a default draft persists JSON with neither key present", async () => {
+    const created = await writeCandidate(root.dir, {
       title: "Default",
       slug: "default-candidate",
       summary: "No typed fields.",
       sources: [],
       body: BODY,
     });
-    const parsed = JSON.parse(JSON.stringify(candidate, null, 2));
-    expect("targetEntityType" in parsed).toBe(false);
-    expect("trustDecision" in parsed).toBe(false);
+    const persisted = await readCandidateJson(root.dir, created.id);
+    expect("targetEntityType" in persisted).toBe(false);
+    expect("trustDecision" in persisted).toBe(false);
   });
 
-  it("(c) review list rendering is unchanged for a default candidate", async () => {
+  it("(c) sanitizes a malformed trustDecision value on read (field dropped)", async () => {
+    const created = await writeCandidate(root.dir, {
+      title: "Malformed",
+      slug: "malformed-decision",
+      summary: "Bad decision value.",
+      sources: [],
+      body: BODY,
+    });
+    const file = path.join(root.dir, CANDIDATES_DIR, `${created.id}.json`);
+    const onDisk = { ...(await readCandidateJson(root.dir, created.id)), trustDecision: "bogus" };
+    await writeFile(file, JSON.stringify(onDisk));
+
+    const loaded = await readCandidate(root.dir, created.id);
+    expect(loaded?.trustDecision).toBeUndefined();
+  });
+
+  it("(d) review list rendering is unchanged for a default candidate", async () => {
     await writeCandidate(root.dir, {
       title: "Default",
       slug: "default-candidate",

--- a/test/trust-journal-confinement.test.ts
+++ b/test/trust-journal-confinement.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @file test/trust-journal-confinement.test.ts
+ * @description Fail-closed coverage for journal-replay path confinement.
+ *
+ * Before this guard, `replayJournal` parsed `.llmwiki/journal/*.json` with a
+ * loose cast and acted on `entry.targetPath` verbatim — so a crafted or
+ * corrupted journal whose `targetPath` escaped the project root (with
+ * `preState.absent:true`) made replay DELETE a file OUTSIDE the project, and a
+ * structurally malformed journal could drive arbitrary writes.
+ *
+ * Replay now (1) shape-validates each batch on load, (2) re-confines every
+ * target under root via `confineUnderRoot`, and (3) QUARANTINES (moves to
+ * `.llmwiki/journal/quarantine/`) and refuses to replay any journal that fails
+ * either check. A fully-valid, fully-confined pending batch still reverts to
+ * its pre-state, and replay stays idempotent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, readFile, mkdir, access } from "fs/promises";
+import path from "path";
+import { replayJournal } from "../src/trust/journal.js";
+import { LLMWIKI_DIR } from "../src/utils/constants.js";
+import { WIKI, makeTrustRoot, cleanupTrustRoot, existsUnder } from "./trust/fixture.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await makeTrustRoot("trust-journal-confine-");
+});
+
+afterEach(async () => {
+  await cleanupTrustRoot(root);
+});
+
+/** Absolute path to a journal file under the root's journal dir. */
+function journalFile(batchId: string): string {
+  return path.join(root, LLMWIKI_DIR, "journal", `${batchId}.json`);
+}
+
+/** Path the quarantine mechanism moves an untrusted journal to. */
+function quarantineFile(batchId: string): string {
+  return path.join(root, LLMWIKI_DIR, "journal", "quarantine", `${batchId}.json`);
+}
+
+/** Write a raw journal JSON string for `batchId` (creating the journal dir). */
+async function writeJournal(batchId: string, raw: string): Promise<void> {
+  await mkdir(path.dirname(journalFile(batchId)), { recursive: true });
+  await writeFile(journalFile(batchId), raw, "utf-8");
+}
+
+/** True when a path exists on disk. */
+async function exists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Assert an untrusted journal was quarantined and never replayed: the named
+ * `outside` file still holds `content`, the original journal file is gone, and a
+ * quarantine copy exists.
+ */
+async function expectQuarantined(batchId: string, outside: string, content: string): Promise<void> {
+  expect(await readFile(outside, "utf-8")).toBe(content);
+  expect(await exists(journalFile(batchId))).toBe(false);
+  expect(await exists(quarantineFile(batchId))).toBe(true);
+}
+
+describe("replayJournal — escaping target (crafted journal)", () => {
+  it("(a) does NOT delete an outside file, quarantines the journal", async () => {
+    const outside = path.join(root, "..", `escape-${path.basename(root)}.md`);
+    await writeFile(outside, "PRECIOUS", "utf-8");
+    const batchId = "evil";
+    await writeJournal(
+      batchId,
+      JSON.stringify({
+        batchId,
+        status: "pending",
+        entries: [{ targetPath: outside, preState: { absent: true } }],
+      }),
+    );
+
+    await replayJournal(root);
+
+    await expectQuarantined(batchId, outside, "PRECIOUS");
+  });
+});
+
+describe("replayJournal — malformed journal (bad shape)", () => {
+  it("(b) quarantines and does not replay; outside file untouched", async () => {
+    const outside = path.join(root, "..", `keep-${path.basename(root)}.md`);
+    await writeFile(outside, "KEEP", "utf-8");
+    const batchId = "bad-shape";
+    // `entries` is not an array of well-formed entries.
+    await writeJournal(batchId, JSON.stringify({ batchId, status: "pending", entries: "nope" }));
+
+    await replayJournal(root);
+
+    await expectQuarantined(batchId, outside, "KEEP");
+  });
+});
+
+describe("replayJournal — valid confined pending batch", () => {
+  it("(c) still reverts confined targets to pre-state", async () => {
+    const t1 = path.join(root, WIKI, "exists.md");
+    const t2 = path.join(root, WIKI, "fresh.md");
+    await writeFile(t1, "OLD-1", "utf-8");
+    await writeFile(t1, "NEW-1", "utf-8"); // simulate the partial write before crash
+    await writeFile(t2, "NEW-2", "utf-8");
+
+    const batchId = "good";
+    await writeJournal(
+      batchId,
+      JSON.stringify({
+        batchId,
+        status: "pending",
+        entries: [
+          { targetPath: t1, preState: { absent: false, content: "OLD-1" } },
+          { targetPath: t2, preState: { absent: true } },
+        ],
+      }),
+    );
+
+    await replayJournal(root);
+
+    expect(await readFile(t1, "utf-8")).toBe("OLD-1");
+    expect(await existsUnder(root, `${WIKI}/fresh.md`)).toBe(false);
+    expect(await exists(journalFile(batchId))).toBe(false);
+    expect(await exists(quarantineFile(batchId))).toBe(false);
+  });
+
+  it("(d) is idempotent — a second replay is a no-op", async () => {
+    const t1 = path.join(root, WIKI, "d.md");
+    await writeFile(t1, "OLD-D", "utf-8");
+    await writeFile(t1, "NEW-D", "utf-8");
+    const batchId = "idem";
+    await writeJournal(
+      batchId,
+      JSON.stringify({
+        batchId,
+        status: "pending",
+        entries: [{ targetPath: t1, preState: { absent: false, content: "OLD-D" } }],
+      }),
+    );
+
+    await replayJournal(root);
+    expect(await readFile(t1, "utf-8")).toBe("OLD-D");
+    await replayJournal(root);
+    expect(await readFile(t1, "utf-8")).toBe("OLD-D");
+  });
+});


### PR DESCRIPTION
Closes three holes found while reviewing the Phase 2 foundation, before later phases build on the seam. All additive; the default profile stays byte-identical (frozen parity goldens unchanged).

- **Journal replay is now path-confined and shape-validated.** Crash-recovery replay previously acted on target paths read from `.llmwiki/journal/*.json` with no validation or confinement, so a crafted or corrupted journal could unlink/write outside the project root. Replay now validates each batch's shape, re-confines every target under the project root before touching it, and quarantines + reports an untrusted journal instead of replaying it.
- **Malformed-but-parseable `state.json` now fails closed.** Parsed state was classified healthy after only a version check, so a shape like `{"version":2,"sources":null}` passed through and crashed downstream read surfaces. State shape is now validated; malformed input classifies as corrupt (the existing fail-closed recovery path), while valid v1/v2 states are unchanged and a newer-version state still fails closed as before.
- **Typed staging metadata is wired through the production candidate writer.** `targetEntityType`/`trustDecision` could only be set by editing JSON by hand; the candidate draft and writer now carry them (omitted entirely for default candidates) and sanitize them on read, with a production-path test.

Full suite green; the 15 frozen default goldens are byte-identical.