### PR TITLE
fix(profile): fail-closed too-new reads, validate entityType identity, honest durability docs

### DIFF
--- a/src/profile/identity.ts
+++ b/src/profile/identity.ts
@@ -52,11 +52,18 @@ export function entityId(type: string, slug: string): EntityId {
 
 /**
  * Parse an EntityId back into its entity type and slug, splitting on the
- * FIRST slash. The slug half is re-validated so the result's slug is SlugSafe.
+ * FIRST slash. BOTH halves are re-validated so the result is fully slug-safe:
+ * this is the defense-in-depth floor for hand-built ids (e.g. the executor's
+ * `pageRelPath`), so an id like `"../evil"` whose entityType is `..` cannot
+ * escape its namespace via `path.join`. An id with no slash, a leading slash
+ * (empty entityType), or a non-slug-safe entityType throws EntityIdError.
  */
 export function parseEntityId(id: EntityId): { entityType: string; slug: SlugSafe } {
   const firstSlash = id.indexOf("/");
-  const entityType = id.slice(0, firstSlash);
+  if (firstSlash < 0) {
+    throw new EntityIdError(`Not a <type>/<slug> id: ${JSON.stringify(id)}`);
+  }
+  const entityType = assertSlugSafe(id.slice(0, firstSlash));
   const slug = assertSlugSafe(id.slice(firstSlash + 1));
   return { entityType, slug };
 }

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -15,7 +15,7 @@ import path from "path";
 import { readdir } from "fs/promises";
 import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
 import { countCandidates } from "../compiler/candidates.js";
-import { readStateClassified } from "../utils/state.js";
+import { readStateClassified, isPlainObject } from "../utils/state.js";
 import type { StateStatus } from "../utils/state.js";
 import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
 import { CONCEPTS_DIR, QUERIES_DIR, SOURCES_DIR } from "../utils/constants.js";
@@ -105,9 +105,14 @@ function classifyConceptPages(
   return { stalePages, orphanedPages };
 }
 
-/** Derive the last compile time from state sources, or null if no sources. */
+/**
+ * Derive the last compile time from state sources, or null if no sources.
+ * Belt-and-suspenders: a non-plain-object `sources` (e.g. a too-new state with
+ * no v1-shaped map) is coerced to `{}` so no caller can crash this read.
+ */
 function lastCompileTime(sources: Record<string, { compiledAt: string }>): string | null {
-  const times = Object.values(sources).map((s) => s.compiledAt);
+  const safe = isPlainObject(sources) ? sources : {};
+  const times = Object.values(safe).map((s) => s.compiledAt);
   return times.length > 0 ? times.sort().slice(-1)[0] : null;
 }
 
@@ -185,10 +190,15 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
     ? []
     : pendingChangesFromSnapshot(snapshot, sourceFilesOnDisk);
 
+  // A too-new state carries the RAW parsed object, which need not be v1-shaped:
+  // its `sources` may be absent. Fail closed by reading an empty map for any
+  // unusable state, so the source count and last-compile reads cannot crash.
+  const usableSources = stateUnusable ? {} : classified.state.sources;
+
   return {
     pages: { concepts: conceptSummaries.length, queries: queries.length, total: conceptSummaries.length + queries.length },
-    sources: Object.keys(classified.state.sources).length,
-    lastCompiledAt: lastCompileTime(classified.state.sources),
+    sources: Object.keys(usableSources).length,
+    lastCompiledAt: lastCompileTime(usableSources),
     stalePages: capSlugs(stalePages),
     staleCount: stalePages.length,
     orphanedPages: capSlugs(orphanedPages),

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -1,8 +1,13 @@
 /**
  * @file src/trust/executor.ts
- * @description The guarded PAGE EXECUTOR — the only path that turns an approved
+ * @description The guarded PAGE EXECUTOR — turns an approved
  * {@link PlannedMutation} plan into bytes on disk, under the CLP atomicity
  * contract ("partial application of an approved batch is a bug").
+ *
+ * STATUS: this planner/executor/journal seam is a Phase-2 FOUNDATION. No live
+ * production write path routes through it yet (no caller invokes
+ * {@link applyApprovedMutations}); the atomicity contract is realized for the
+ * page store in isolation and under test, not yet across any wired surface.
  *
  * {@link applyApprovedMutations} runs the batch behind the project lock and a
  * single-store intent journal:

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -1,8 +1,12 @@
 /**
  * @file src/trust/journal.ts
  * @description The single-store INTENT JOURNAL for the PAGE store — the
- * durability record that realizes the CLP atomicity contract: "partial
- * application of an approved mutation batch is a bug."
+ * crash-recovery record that realizes the CLP atomicity contract: "partial
+ * application of an approved mutation batch is a bug." The write-temp-then-rename
+ * idiom used here is crash-consistent within a single running kernel (a torn
+ * batch replays cleanly), but it is NOT power-loss durable: there is no `fsync`,
+ * so an unflushed rename can be lost on power failure. Durability across power
+ * loss is future work.
  *
  * A batch is journalled under `.llmwiki/journal/<batchId>.json` in two phases:
  *
@@ -140,8 +144,10 @@ export async function recordPreState(batch: JournalBatch, targetPath: string): P
 }
 
 /**
- * Mark a batch `committed` and persist it: every write has landed, so the
- * batch's intent is now durable and replay will leave it untouched.
+ * Mark a batch `committed` and persist it: every write has landed, so replay
+ * will leave it untouched. The persisted commit is crash-consistent within a
+ * running kernel but not power-loss durable (no `fsync`); durability across
+ * power loss is future work.
  *
  * @param batch - The batch whose writes have all succeeded.
  */

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -3,8 +3,9 @@
  * source file hashes and their compiled concepts. Enables incremental
  * compilation by detecting which sources have changed since last compile.
  *
- * Uses atomic writes (write to .tmp, then rename) to prevent corruption
- * from interrupted compiles.
+ * Uses atomic writes (write to .tmp, then rename) to prevent corruption from
+ * interrupted processes (crash-consistent; not guaranteed durable across power
+ * loss, as there is no fsync before the rename).
  *
  * VERSION GUARD (Phase 2, v2-aware reads): {@link KNOWN_STATE_VERSION} is the
  * highest schema version this build understands. {@link readStateClassified}
@@ -92,7 +93,7 @@ function isStringArray(value: unknown): boolean {
 }
 
 /** True when `value` is a non-null, non-array plain object. */
-function isPlainObject(value: unknown): value is Record<string, unknown> {
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 

--- a/src/viewer/snapshot.ts
+++ b/src/viewer/snapshot.ts
@@ -22,7 +22,7 @@ import { readdir, readFile, realpath } from "fs/promises";
 import path from "path";
 import { SOURCES_DIR } from "../utils/constants.js";
 import { countCandidates } from "../compiler/candidates.js";
-import { readStateClassified } from "../utils/state.js";
+import { readStateClassified, isPlainObject } from "../utils/state.js";
 import { collectViewerPages, resolveBareSlugList } from "./collect.js";
 import { extractWikilinkSlugs } from "../wiki/collect.js";
 import { isMalformedCitationEntry } from "../utils/markdown.js";
@@ -74,7 +74,11 @@ export async function buildViewerSnapshot(root: string): Promise<ViewerSnapshot>
   const annotatedPages = pages
     .map((page) => annotateCitationWarnings(page, sourceFileSet))
     .map((page) => attachFreshness(page, freshnessSnapshot));
-  const counts = buildCounts(annotatedPages, sourceFilenames, pendingReviews, classified.state);
+  // A too-new/corrupt state carries the RAW parsed object, which need not be
+  // v1-shaped (its `sources` may be absent). Feed buildCounts an empty map for
+  // any non-ok state so `compiledSources` fails closed instead of crashing.
+  const countableState = classified.status === "ok" ? classified.state : { sources: {} };
+  const counts = buildCounts(annotatedPages, sourceFilenames, pendingReviews, countableState);
   const graph = buildGraphData(annotatedPages);
   const profile = await collectProfileSummary(root);
   return {
@@ -120,6 +124,9 @@ function annotateCitationWarnings(page: ViewerPage, sourceFiles: ReadonlySet<str
  * Derive the frozen counts from the annotated page list, source filenames,
  * candidates count, and state. Concept/query counts are derived from pages
  * (the already-confined collector list) so symlinked drops don't inflate them.
+ *
+ * Belt-and-suspenders: a non-plain-object `state.sources` (e.g. a too-new state
+ * with no v1-shaped map) is coerced to `{}` so `compiledSources` cannot crash.
  */
 function buildCounts(
   pages: ViewerPage[],
@@ -127,12 +134,13 @@ function buildCounts(
   pendingReviews: number,
   state: { sources: Record<string, unknown> },
 ): ViewerCounts {
+  const sources = isPlainObject(state.sources) ? state.sources : {};
   return {
     concepts: pages.filter((p) => p.pageDirectory === "concepts").length,
     queries: pages.filter((p) => p.pageDirectory === "queries").length,
     sourceFiles: sourceFilenames.length,
     pendingReviews,
-    compiledSources: Object.keys(state.sources).length,
+    compiledSources: Object.keys(sources).length,
     stale: pages.filter((p) => p.freshness.freshnessStatus === "stale").length,
     orphaned: pages.filter((p) => p.freshness.freshnessStatus === "orphaned").length,
   };

--- a/test/profile-identity.test.ts
+++ b/test/profile-identity.test.ts
@@ -34,6 +34,29 @@ describe("entityId / parseEntityId", () => {
   it("throws when a slug half is not slug-safe", () => {
     expect(() => entityId("Papers", "x")).toThrow(EntityIdError);
   });
+
+  it("parses a well-formed type/slug id", () => {
+    expect(parseEntityId("concepts/rag" as EntityId)).toEqual({
+      entityType: "concepts",
+      slug: "rag",
+    });
+  });
+
+  it("rejects a traversal entityType so a hand-built id cannot escape the namespace", () => {
+    expect(() => parseEntityId("../evil" as EntityId)).toThrow(EntityIdError);
+  });
+
+  it("rejects a leading-slash id (empty entityType)", () => {
+    expect(() => parseEntityId("/evil" as EntityId)).toThrow(EntityIdError);
+  });
+
+  it("rejects an id with no slash (not <type>/<slug>)", () => {
+    expect(() => parseEntityId("noslash" as EntityId)).toThrow(EntityIdError);
+  });
+
+  it("rejects an uppercase (non-slug-safe) entityType", () => {
+    expect(() => parseEntityId("Concepts/rag" as EntityId)).toThrow(EntityIdError);
+  });
 });
 
 describe("stemFromBasename", () => {

--- a/test/status/collect.test.ts
+++ b/test/status/collect.test.ts
@@ -14,6 +14,22 @@ describe("collectStatus", () => {
     expect(status.lastCompiledAt).toBeNull();
   });
 
+  it("does not throw on a too-new state.json with no v1-shaped sources", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-status-toonew-"));
+    const llmwikiDir = path.join(root, ".llmwiki");
+    await mkdir(llmwikiDir, { recursive: true });
+    // A future format need not carry a v1 `sources` map. The unusable-state
+    // reads must fail closed (sources:0, lastCompiledAt:null) instead of
+    // throwing on Object.keys(undefined).
+    await writeFile(path.join(llmwikiDir, "state.json"), JSON.stringify({ version: 3 }), "utf-8");
+
+    const status: WikiStatus = await collectStatus(root);
+
+    expect(status.stateStatus).toBe("too-new");
+    expect(status.sources).toBe(0);
+    expect(status.lastCompiledAt).toBeNull();
+  });
+
   it("does not write a .bak file when state.json is corrupt", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "wiki-status-corrupt-"));
     const llmwikiDir = path.join(root, ".llmwiki");

--- a/test/viewer-snapshot.test.ts
+++ b/test/viewer-snapshot.test.ts
@@ -100,3 +100,17 @@ describe("buildViewerSnapshot — sources/ confinement", () => {
     expect(snapshot.sourceFilenames).toEqual(["ok.md"]);
   });
 });
+
+describe("buildViewerSnapshot — too-new state handling", () => {
+  it("builds a snapshot (no throw) over a too-new state with no v1-shaped sources", async () => {
+    const root = await makeTempRoot("snapshot-toonew");
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    // A future format need not carry a v1 `sources` map; buildCounts must
+    // fail closed (compiledSources:0) instead of crashing on Object.keys.
+    await writeFile(path.join(root, ".llmwiki", "state.json"), JSON.stringify({ version: 3 }));
+
+    const snapshot = await buildViewerSnapshot(root);
+    expect(snapshot.stateStatus).toBe("too-new");
+    expect(snapshot.counts.compiledSources).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes the must-fix-now findings from a principal-level audit of the Phase 2 foundation. Additive; default profile byte-identical.

- **Live crash fixed:** a `too-new` state.json (written by a newer llmwiki) carries its raw, unvalidated body, and `collectStatus` + `buildViewerSnapshot` read `state.sources` unconditionally — a future state shape without a v1 `sources` map threw an uncaught `TypeError` on the MCP status tool and the viewer (the too-new banner could never even render). These reads now fail closed to an empty source set like every sibling surface.
- **Identity hardening:** `parseEntityId` validated only the slug half of `<type>/<slug>`, leaving the entity-type half unchecked — so a directly-constructed mutation id like `../evil` could escape its entity-type namespace. Both halves are now validated, and a malformed (no-slash) id is rejected.
- **Honest docs:** durability/atomicity docstrings claimed power-loss durability the write-temp-then-rename idiom doesn't provide (no fsync) and described the planner seam as if it were on a live write path; downgraded to accurate language.

Full suite green; the 15 frozen default goldens byte-identical.