### PR TITLE
fix(trust): confine journal directory + quarantine destination (symlink escape)

### DIFF
--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -32,7 +32,7 @@ import { readFile, writeFile, mkdir, readdir, unlink, rename } from "fs/promises
 import path from "path";
 import { LLMWIKI_DIR } from "../utils/constants.js";
 import { realpath } from "fs/promises";
-import { confineUnderRoot } from "../utils/path-confine.js";
+import { confineUnderRoot, safeRealpath, isInsideDir } from "../utils/path-confine.js";
 import { note } from "../utils/output.js";
 
 /** Sentinel recorded when a target did not exist before the batch. */
@@ -211,9 +211,40 @@ async function loadBatch(root: string, batchId: string): Promise<JournalBatch | 
   return { ...parsed, root };
 }
 
-/** Move an untrusted journal file into the quarantine subdir and warn. */
+/**
+ * Remove an untrusted journal file in place via its confined journal path when
+ * the quarantine destination cannot be safely confined (the `quarantine/` subdir
+ * is a symlink escaping root). The journal is malformed/untrusted anyway; the
+ * invariant is NEVER to write or move outside the project root, so we delete it
+ * rather than follow the escaping symlink.
+ */
+async function removeUntrustedInPlace(root: string, batchId: string): Promise<void> {
+  try {
+    const rel = await targetRelativeToRoot(journalPath(root, batchId), root);
+    const confinedJournal = await confineUnderRoot(rel, root, { mustExist: false });
+    await unlink(confinedJournal);
+  } catch {
+    // Journal path itself escapes/cannot be confined — touch nothing outside root.
+  }
+  note(`⚠ Untrusted journal ${batchId}.json could not be safely quarantined — removed.`);
+}
+
+/**
+ * Move an untrusted journal file into the quarantine subdir and warn. The
+ * destination is confined under root BEFORE any `mkdir`/`rename`, so a symlinked
+ * `quarantine/` escaping root can never receive (and thus overwrite) a moved
+ * file outside the project. If confinement fails, the journal is removed in
+ * place instead via {@link removeUntrustedInPlace}.
+ */
 async function quarantineBatch(root: string, batchId: string): Promise<void> {
-  const dest = quarantinePath(root, batchId);
+  let dest: string;
+  try {
+    const rel = await targetRelativeToRoot(quarantinePath(root, batchId), root);
+    dest = await confineUnderRoot(rel, root, { mustExist: false });
+  } catch {
+    await removeUntrustedInPlace(root, batchId);
+    return;
+  }
   await mkdir(path.dirname(dest), { recursive: true });
   await rename(journalPath(root, batchId), dest);
   note(`⚠ Untrusted journal ${batchId}.json quarantined to ${dest} — not replayed.`);
@@ -299,10 +330,30 @@ async function replayPending(root: string, batchId: string): Promise<void> {
  *
  * @param root - Absolute project root whose journal directory is replayed.
  */
+/**
+ * Resolve the journal directory's realpath and confirm it stays inside the
+ * project root's realpath. Returns the confined real dir to replay, or null to
+ * skip: null when the directory is absent (nothing pending) OR when it exists
+ * but is a symlink escaping root (filesystem tampering → fail closed). A null
+ * caused by escape is announced via {@link note} before returning.
+ */
+async function resolveConfinedJournalDir(root: string): Promise<string | null> {
+  const realDir = await safeRealpath(journalDir(root));
+  if (realDir === null) return null; // absent → nothing pending
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  if (!isInsideDir(realDir, realRoot)) {
+    note(`⚠ Journal directory escapes project root — refusing to replay (tampering).`);
+    return null;
+  }
+  return realDir;
+}
+
 export async function replayJournal(root: string): Promise<void> {
+  const confinedDir = await resolveConfinedJournalDir(root);
+  if (confinedDir === null) return; // absent or escaping → nothing safe to replay
   let files: string[];
   try {
-    files = await readdir(journalDir(root));
+    files = await readdir(confinedDir);
   } catch {
     return; // no journal directory → nothing pending
   }

--- a/test/trust-journal-confinement.test.ts
+++ b/test/trust-journal-confinement.test.ts
@@ -15,12 +15,14 @@
  * its pre-state, and replay stays idempotent.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { writeFile, readFile, mkdir, access } from "fs/promises";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { writeFile, readFile, mkdir, access, symlink, rm, mkdtemp } from "fs/promises";
+import { tmpdir } from "os";
 import path from "path";
 import { replayJournal } from "../src/trust/journal.js";
 import { LLMWIKI_DIR } from "../src/utils/constants.js";
 import { WIKI, makeTrustRoot, cleanupTrustRoot, existsUnder } from "./trust/fixture.js";
+import * as output from "../src/utils/output.js";
 
 let root: string;
 
@@ -31,6 +33,11 @@ beforeEach(async () => {
 afterEach(async () => {
   await cleanupTrustRoot(root);
 });
+
+/** Absolute path to the project's journal directory. */
+function journalDir(): string {
+  return path.join(root, LLMWIKI_DIR, "journal");
+}
 
 /** Absolute path to a journal file under the root's journal dir. */
 function journalFile(batchId: string): string {
@@ -150,5 +157,67 @@ describe("replayJournal — valid confined pending batch", () => {
     expect(await readFile(t1, "utf-8")).toBe("OLD-D");
     await replayJournal(root);
     expect(await readFile(t1, "utf-8")).toBe("OLD-D");
+  });
+});
+
+describe("replayJournal — symlinked journal directories (filesystem tampering)", () => {
+  let outsideDir: string;
+
+  beforeEach(async () => {
+    outsideDir = await mkdtemp(path.join(tmpdir(), "trust-journal-outside-"));
+  });
+
+  afterEach(async () => {
+    await rm(outsideDir, { recursive: true, force: true });
+  });
+
+  it("(a) quarantine subdir is a symlink escaping root → outside file untouched, warns", async () => {
+    const evilOutside = path.join(outsideDir, "evil.json");
+    await writeFile(evilOutside, "OUTSIDE-PRECIOUS", "utf-8");
+    await mkdir(journalDir(), { recursive: true });
+    await symlink(outsideDir, path.join(journalDir(), "quarantine"), "dir");
+    await writeFile(path.join(journalDir(), "evil.json"), "not json {{{", "utf-8");
+    const noteSpy = vi.spyOn(output, "note").mockImplementation(() => undefined);
+
+    await expect(replayJournal(root)).resolves.toBeUndefined();
+
+    expect(await readFile(evilOutside, "utf-8")).toBe("OUTSIDE-PRECIOUS");
+    expect(await exists(path.join(journalDir(), "evil.json"))).toBe(false);
+    expect(noteSpy).toHaveBeenCalled();
+    noteSpy.mockRestore();
+  });
+
+  it("(b) journal dir itself is a symlink escaping root → fails closed, touches nothing", async () => {
+    const outsideJournalFile = path.join(outsideDir, "victim.json");
+    await writeFile(outsideJournalFile, "OUTSIDE-DATA", "utf-8");
+    await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+    await symlink(outsideDir, journalDir(), "dir");
+    const noteSpy = vi.spyOn(output, "note").mockImplementation(() => undefined);
+
+    await expect(replayJournal(root)).resolves.toBeUndefined();
+
+    expect(await readFile(outsideJournalFile, "utf-8")).toBe("OUTSIDE-DATA");
+    expect(await exists(outsideJournalFile)).toBe(true);
+    noteSpy.mockRestore();
+  });
+
+  it("(c) regression: normal journal dir still quarantines malformed + reverts pending", async () => {
+    await writeJournal("malformed", "not json at all");
+    const t1 = path.join(root, WIKI, "reg.md");
+    await writeFile(t1, "OLD-REG", "utf-8");
+    await writeFile(t1, "NEW-REG", "utf-8");
+    await writeJournal(
+      "pending",
+      JSON.stringify({
+        batchId: "pending",
+        status: "pending",
+        entries: [{ targetPath: t1, preState: { absent: false, content: "OLD-REG" } }],
+      }),
+    );
+
+    await replayJournal(root);
+
+    expect(await exists(quarantineFile("malformed"))).toBe(true);
+    expect(await readFile(t1, "utf-8")).toBe("OLD-REG");
   });
 });


### PR DESCRIPTION
Closes a trust-boundary hole in the journal replay seam. Crash-recovery replay re-confines each write *target*, but the journal directory itself was never validated: a symlinked `.llmwiki/journal` or `.llmwiki/journal/quarantine` pointing outside the project let replay's `readdir`/`rename`/`unlink` (and the quarantine move of an untrusted journal) follow the link and clobber a file outside the root.

Replay now resolves and validates the journal directory's realpath before touching it (failing closed on a symlinked-escaping journal dir), and the quarantine destination is run through the same confinement discipline as replay targets before the move — falling back to removing the untrusted journal in place rather than ever writing outside the root.

Additive; default profile byte-identical.