### PR TITLE
feat(profile): Phase 3 PR1 — create/update write intent + executor-side floor re-assertion

### DIFF
--- a/src/trust/checks.ts
+++ b/src/trust/checks.ts
@@ -14,8 +14,11 @@
  * project's existing trust primitives rather than re-deriving them:
  * - path-confinement → {@link confineUnderRoot} (rejects targets and symlinked
  *   ancestors that escape the project root);
- * - collision/no-overwrite → existence probe under the confined path (creates
- *   block on an existing target);
+ * - collision/no-overwrite → existence probe under the confined path. A target
+ *   that already exists blocks ONLY when the caller did not declare an explicit
+ *   overwrite intent (`allowOverwrite:false`); an intended upsert
+ *   (`allowOverwrite:true`) treats an existing target as a clean `update`, not a
+ *   violation;
  * - resource-limit → the per-file content cap {@link MAX_SOURCE_CHARS}, decided
  *   on raw character length BEFORE any parsing so an oversized body never gets
  *   heavy processing;
@@ -47,6 +50,13 @@ export interface PageWriteContext {
   targetPath: string;
   /** Full markdown content (frontmatter + body) to be written. */
   body: string;
+  /**
+   * Whether an existing target is an intended overwrite (`update`) rather than a
+   * collision. `false` (or omitted) keeps the strict create-only semantics:
+   * an existing target blocks. `true` lets a legitimate upsert (review-approve,
+   * compile recompile) overwrite without tripping {@link checkTargetCollision}.
+   */
+  allowOverwrite?: boolean;
 }
 
 /** A single mandatory check over a page mutation. */
@@ -73,9 +83,12 @@ export const checkPathConfinement: MandatoryPageCheck = async (ctx) => {
 };
 
 /**
- * Block when the confined target already exists: page creation is create-only
- * and never silently overwrites. A target whose own path escapes root is also
- * blocked here (a non-confinable target cannot be a safe create destination).
+ * Block when the confined target already exists AND the caller declared no
+ * overwrite intent (`allowOverwrite` falsy): a strict create never silently
+ * overwrites. When `allowOverwrite` is true, an existing target is an intended
+ * `update` and passes. A free target passes either way. A target whose own path
+ * escapes root is blocked here (a non-confinable target is not a safe write
+ * destination).
  */
 export const checkTargetCollision: MandatoryPageCheck = async (ctx) => {
   const code = "target-exists";
@@ -90,6 +103,7 @@ export const checkTargetCollision: MandatoryPageCheck = async (ctx) => {
   } catch {
     return pass(code, "target path is free");
   }
+  if (ctx.allowOverwrite) return pass(code, `target exists; intended overwrite (update): ${path.basename(abs)}`);
   return { code, verdict: "block", message: `target already exists (create-only): ${path.basename(abs)}` };
 };
 

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -25,6 +25,15 @@
  * SCOPE: Task 5 executes `kind:"page"` only. Any other {@link MutationKind} is
  * rejected with a typed `not-implemented` error, so an unhandled store can never
  * be silently no-op'd or half-applied.
+ *
+ * S5 — FULL-FLOOR RE-ASSERTION AT APPLY: the executor is where bytes hit disk,
+ * so it does not trust that plan-time checks still hold. Before every write it
+ * re-runs the mandatory floor (resource-limit + frontmatter; path-confinement is
+ * already enforced via {@link confineUnderRoot} and collision via the `create`
+ * re-probe) against a context whose `allowOverwrite` reflects the mutation's
+ * operation, and composes a {@link TrustDecision}. A non-allow decision throws a
+ * typed {@link MutationFloorError} and writes NOTHING — a hand-built mutation
+ * that bypassed the planner cannot smuggle an oversized or malformed body past.
  */
 
 import path from "path";
@@ -40,7 +49,12 @@ import {
   type JournalBatch,
 } from "./journal.js";
 import { parseEntityId } from "../profile/identity.js";
+import { checkResourceLimit, checkFrontmatter, type PageWriteContext } from "./checks.js";
+import { composeTrustDecision } from "./decision.js";
 import type { PlannedMutation } from "./planner.js";
+
+/** Decisions under which the executor is cleared to write bytes to disk. */
+const APPLY_ALLOWED_DECISIONS = new Set(["allow", "allow-with-warning"]);
 
 /** A single page write. Injectable so tests can fault-inject a failure. */
 export type WriteOne = (filePath: string, content: string) => Promise<void>;
@@ -89,6 +103,20 @@ class InvalidIdentityError extends Error {
   }
 }
 
+/**
+ * Thrown when a mutation fails the mandatory trust floor re-asserted at apply
+ * time (S5): an oversized body, malformed frontmatter, or any block-composing
+ * floor result. Refusing here — at the byte-writing boundary — means a
+ * hand-built mutation that never passed the planner cannot reach disk. Callers
+ * match on the typed `mutation-floor:` message prefix.
+ */
+class MutationFloorError extends Error {
+  constructor(reason: string) {
+    super(`mutation-floor: refused before write: ${reason}`);
+    this.name = "MutationFloorError";
+  }
+}
+
 /** True when something exists at `abs` (regular file, dir, or symlink). */
 async function targetExists(abs: string): Promise<boolean> {
   try {
@@ -120,9 +148,32 @@ function pageRelPath(mutation: PlannedMutation): string {
 }
 
 /**
- * Apply every page mutation in the batch under an already-open journal: record
- * each target's pre-state, then write it. Throws on the first non-page kind or
- * the first failing write, leaving the journal uncommitted for replay.
+ * Re-assert the mandatory trust floor for one mutation at apply time (S5),
+ * against a context whose `allowOverwrite` mirrors the operation (`update`
+ * overwrites; `create` does not). Runs the floor checks not already enforced on
+ * this path — resource-limit and frontmatter — and composes them; a non-allow
+ * decision throws {@link MutationFloorError} so nothing is written.
+ */
+async function assertFloorAtApply(root: string, mutation: PlannedMutation, abs: string): Promise<void> {
+  const ctx: PageWriteContext = {
+    root,
+    targetPath: abs,
+    body: mutation.body,
+    allowOverwrite: mutation.operation === "update",
+  };
+  const checks = await Promise.all([checkResourceLimit(ctx), checkFrontmatter(ctx)]);
+  const decision = composeTrustDecision(checks, { reviewRouted: false });
+  if (!APPLY_ALLOWED_DECISIONS.has(decision)) {
+    const reason = checks.find((c) => c.verdict === "block")?.message ?? decision;
+    throw new MutationFloorError(reason);
+  }
+}
+
+/**
+ * Apply every page mutation in the batch under an already-open journal:
+ * re-assert the trust floor (S5), record each target's pre-state, then write it.
+ * Throws on the first non-page kind, floor violation, or failing write, leaving
+ * the journal uncommitted for replay.
  *
  * A `create` target is RE-PROBED under the lock (the planner's collision check
  * runs before the lock): if it now exists, abort with {@link CreateCollisionError}
@@ -141,6 +192,7 @@ async function applyBatch(
     if (mutation.operation === "create" && (await targetExists(abs))) {
       throw new CreateCollisionError(abs);
     }
+    await assertFloorAtApply(root, mutation, abs);
     await recordPreState(batch, abs);
     await writeOne(abs, mutation.body);
   }

--- a/src/trust/planner.ts
+++ b/src/trust/planner.ts
@@ -23,6 +23,8 @@
  */
 
 import path from "path";
+import { lstat } from "fs/promises";
+import { confineUnderRoot } from "../utils/path-confine.js";
 import { runMandatoryPageChecks, type PageWriteContext } from "./checks.js";
 import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
 import { entityId, isSlugSafe } from "../profile/identity.js";
@@ -92,6 +94,12 @@ export interface PlanPageInput {
   origin: string;
   /** Whether the surface stages risky writes for human review. */
   reviewRouted: boolean;
+  /**
+   * Whether an existing target is an intended overwrite (`update`) rather than a
+   * collision. A legitimate upserting caller (review-approve, compile recompile)
+   * passes `true`; a strict create-only caller passes `false` (the default).
+   */
+  allowOverwrite?: boolean;
 }
 
 /** The planner's output: the plan, the composed decision, and the raw checks. */
@@ -130,18 +138,35 @@ function checkIdentitySafe(entityType: string, slug: string): TrustCheckResult {
   return { code, verdict: "block", message: `entity type/slug is not slug-safe: ${entityType}/${slug}` };
 }
 
+/** True when a confinable target already exists on disk under `root`. */
+async function targetAlreadyExists(root: string, targetPath: string): Promise<boolean> {
+  let abs: string;
+  try {
+    abs = await confineUnderRoot(targetPath, root, { mustExist: false });
+  } catch {
+    return false;
+  }
+  try {
+    await lstat(abs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Build the single live-write mutation for an approved page. Phase 2 page
- * mutations are CREATE-ONLY: a colliding (already-existing) target is blocked
- * upstream by `checkTargetCollision`, so an approved page is always a fresh
- * `create`. In-place `update` of an existing page is a later phase.
+ * Build the single live-write mutation for an approved page. The operation is
+ * chosen by existence: a FREE target is a `create`; an already-existing target
+ * (reached here only when the caller declared `allowOverwrite`, since otherwise
+ * `checkTargetCollision` blocks) is an in-place `update`.
  */
 async function buildPageMutation(input: PlanPageInput, decision: TrustDecision): Promise<PlannedMutation> {
   const id = entityId(input.entityType, input.slug);
   const target: EntityRef = { entityType: input.entityType, slug: input.slug, id };
+  const exists = await targetAlreadyExists(input.root, pageTargetPath(input.entityType, input.slug));
   return {
     kind: "page",
-    operation: "create",
+    operation: exists ? "update" : "create",
     target,
     body: input.body,
     provenance: { origin: input.origin, decision, reviewRouted: input.reviewRouted },
@@ -158,7 +183,12 @@ async function buildPageMutation(input: PlanPageInput, decision: TrustDecision):
  */
 export async function planPageMutation(input: PlanPageInput): Promise<PlanResult> {
   const targetPath = pageTargetPath(input.entityType, input.slug);
-  const ctx: PageWriteContext = { root: input.root, targetPath, body: input.body };
+  const ctx: PageWriteContext = {
+    root: input.root,
+    targetPath,
+    body: input.body,
+    allowOverwrite: input.allowOverwrite ?? false,
+  };
   const checks = [
     checkIdentitySafe(input.entityType, input.slug),
     ...(await runMandatoryPageChecks(ctx)),

--- a/test/trust-checks.test.ts
+++ b/test/trust-checks.test.ts
@@ -78,6 +78,12 @@ describe("checkTargetCollision", () => {
     const res = await checkTargetCollision(ctx(`${WIKI}/free.md`));
     expect(res.verdict).toBe("pass");
   });
+
+  it("passes an existing target when allowOverwrite is true (intended update)", async () => {
+    await writeFile(path.join(root, WIKI, "dup.md"), GOOD_BODY);
+    const res = await checkTargetCollision({ ...ctx(`${WIKI}/dup.md`), allowOverwrite: true });
+    expect(res.verdict).toBe("pass");
+  });
 });
 
 describe("checkResourceLimit", () => {

--- a/test/trust-planner.test.ts
+++ b/test/trust-planner.test.ts
@@ -23,6 +23,7 @@ import { planPageMutation, type PlannedMutation } from "../src/trust/planner.js"
 import { applyApprovedMutations } from "../src/trust/executor.js";
 import { replayJournal, openBatch, recordPreState } from "../src/trust/journal.js";
 import { entityId } from "../src/profile/identity.js";
+import { MAX_SOURCE_CHARS } from "../src/utils/constants.js";
 import {
   WIKI,
   makeTrustRoot,
@@ -76,6 +77,30 @@ describe("planPageMutation — decision→plan mapping", () => {
   });
 });
 
+describe("planPageMutation — create vs update intent", () => {
+  it("plans a create for a free target regardless of allowOverwrite", async () => {
+    const out = await planPageMutation(planArgs("free", { allowOverwrite: true }));
+    expect(out.decision).toBe("allow");
+    expect(out.planned).toHaveLength(1);
+    expect(out.planned[0].operation).toBe("create");
+  });
+
+  it("plans an update (decision allow) for an existing target when allowOverwrite", async () => {
+    await writeFile(path.join(root, WIKI, "exists.md"), GOOD_BODY);
+    const out = await planPageMutation(planArgs("exists", { allowOverwrite: true }));
+    expect(out.decision).toBe("allow");
+    expect(out.planned).toHaveLength(1);
+    expect(out.planned[0].operation).toBe("update");
+  });
+
+  it("blocks (no live mutation) for an existing target when allowOverwrite is false", async () => {
+    await writeFile(path.join(root, WIKI, "exists.md"), GOOD_BODY);
+    const out = await planPageMutation(planArgs("exists", { allowOverwrite: false }));
+    expect(out.decision).toBe("deny");
+    expect(out.planned).toEqual([]);
+  });
+});
+
 /** Build a page-create PlannedMutation targeting `<WIKI>/<slug>.md`. */
 async function plannedFor(slug: string): Promise<PlannedMutation> {
   const out = await planPageMutation(planArgs(slug));
@@ -110,6 +135,47 @@ describe("applyApprovedMutations — create-collision re-probe under lock", () =
 
     // The pre-existing file is untouched — never overwritten by the create.
     expect(await readFile(target, "utf-8")).toBe("CONCURRENT");
+  });
+});
+
+/** Hand-build an `update` mutation targeting `<WIKI>/<slug>.md` with `body`. */
+function updateMutation(slug: string, body: string): PlannedMutation {
+  return {
+    kind: "page",
+    operation: "update",
+    target: { entityType: "concepts", slug, id: entityId("concepts", slug) },
+    body,
+    provenance: {
+      origin: "agent",
+      decision: "allow",
+      reviewRouted: false,
+    },
+  };
+}
+
+describe("applyApprovedMutations — update overwrites an existing target", () => {
+  it("overwrites without a create-collision error", async () => {
+    const target = path.join(root, WIKI, "exists.md");
+    await writeFile(target, "OLD");
+    const update = updateMutation("exists", GOOD_BODY);
+    await applyApprovedMutations(root, [update]);
+    expect(await readFile(target, "utf-8")).toBe(GOOD_BODY);
+  });
+});
+
+describe("applyApprovedMutations — S5 full-floor re-assertion", () => {
+  it("refuses an OVERSIZED body with MutationFloorError and writes nothing", async () => {
+    const huge = "x".repeat(MAX_SOURCE_CHARS + 1);
+    const update = updateMutation("big", huge);
+    await expect(applyApprovedMutations(root, [update])).rejects.toThrow(/mutation-floor/);
+    expect(await existsUnder(root, `${WIKI}/big.md`)).toBe(false);
+  });
+
+  it("refuses MALFORMED frontmatter with MutationFloorError and writes nothing", async () => {
+    const bad = "---\ntitle: : : bad\n  nope\n---\n\nbody\n";
+    const update = updateMutation("malformed", bad);
+    await expect(applyApprovedMutations(root, [update])).rejects.toThrow(/mutation-floor/);
+    expect(await existsUnder(root, `${WIKI}/malformed.md`)).toBe(false);
   });
 });
 


### PR DESCRIPTION
First of the stacked Phase 3 PRs (do not merge yet). Prepares the write planner to take a real consumer.

- The planner derives the mutation operation from target existence (`create` for a free target, `update` for an existing one) and honors an explicit `allowOverwrite` intent, so the mandatory no-overwrite floor blocks only an *unintended* overwrite — legitimate upserts (recompile, re-approval) are permitted.
- The executor re-runs the full mandatory floor (resource-limit + frontmatter) per mutation at apply time, refusing with a typed error before any bytes hit disk.

Additive and still unwired into production paths; default profile byte-identical, full suite green.