### PR TITLE
feat(profile): Phase 3 PR2 — default raw-page mutation support (Unicode-safe)

### DIFF
--- a/src/profile/identity.ts
+++ b/src/profile/identity.ts
@@ -30,6 +30,24 @@ export function isSlugSafe(s: string): s is SlugSafe {
 }
 
 /**
+ * The DEFAULT-page identity floor: is `s` a single safe path component for a
+ * default wiki page filename?
+ *
+ * Distinct from the slug-safe EntityId grammar ({@link isSlugSafe}): default
+ * pages keep their Unicode `slugify` stems (e.g. `café-society`, `机器学习`)
+ * and, per the Phase-1 invariant, NEVER become EntityIds — so this floor allows
+ * Unicode letters/digits/hyphens (whatever `slugify` produces) while still
+ * rejecting anything that could escape or hide the file: path separators
+ * (`/`, `\`), spaces, the dot-only names `.`/`..`, and a leading-dot (hidden)
+ * name. NUL and any other separator-bearing string is rejected by the same
+ * separator test (a NUL embeds no separator but a traversal/segment always
+ * does); the dot-prefix and empty-string guards cover the remainder.
+ */
+export function isSafeFilenameComponent(s: string): boolean {
+  return s.length > 0 && !/[/\\ \0]/.test(s) && s !== "." && s !== ".." && !s.startsWith(".");
+}
+
+/**
  * Assert that `s` is slug-safe, returning it branded as SlugSafe. This is the
  * ONLY way to obtain a SlugSafe value. Throws EntityIdError otherwise.
  */

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -48,10 +48,10 @@ import {
   replayJournal,
   type JournalBatch,
 } from "./journal.js";
-import { parseEntityId } from "../profile/identity.js";
+import { parseEntityId, isSafeFilenameComponent } from "../profile/identity.js";
 import { checkResourceLimit, checkFrontmatter, type PageWriteContext } from "./checks.js";
 import { composeTrustDecision } from "./decision.js";
-import type { PlannedMutation } from "./planner.js";
+import type { PlannedMutation, EntityRef, RawPageRef } from "./planner.js";
 
 /** Decisions under which the executor is cleared to write bytes to disk. */
 const APPLY_ALLOWED_DECISIONS = new Set(["allow", "allow-with-warning"]);
@@ -128,7 +128,24 @@ async function targetExists(abs: string): Promise<boolean> {
 }
 
 /**
- * The wiki-relative page path for a page mutation's target.
+ * The wiki-relative page path for a DEFAULT page's {@link RawPageRef} target.
+ *
+ * Defense-in-depth: the executor does not trust the caller, so it RE-ASSERTS the
+ * {@link isSafeFilenameComponent} floor on both the directory and the raw slug —
+ * a hand-built mutation carrying a `..`/separator slug is rejected with a typed
+ * {@link InvalidIdentityError} BEFORE `path.join` could collapse it into a wrong
+ * in-root location (the planner's `checkDefaultIdentitySafe` guard is not on this
+ * path).
+ */
+function rawPageRelPath(target: RawPageRef): string {
+  if (!isSafeFilenameComponent(target.directory) || !isSafeFilenameComponent(target.slug)) {
+    throw new InvalidIdentityError(`directory/slug is not a safe filename component: ${target.directory}/${target.slug}`);
+  }
+  return path.join("wiki", target.directory, `${target.slug}.md`);
+}
+
+/**
+ * The wiki-relative page path for a PROFILE entity's {@link EntityRef} target.
  *
  * Defense-in-depth: the entityType/slug are re-validated by re-parsing the
  * branded `target.id` (which throws on a non-slug-safe slug half), so a
@@ -136,15 +153,27 @@ async function targetExists(abs: string): Promise<boolean> {
  * {@link InvalidIdentityError} BEFORE `path.join` could collapse it into a wrong
  * in-root location — the planner's `checkIdentitySafe` guard is not on this path.
  */
-function pageRelPath(mutation: PlannedMutation): string {
+function entityPageRelPath(target: EntityRef): string {
   let entityType: string;
   let slug: string;
   try {
-    ({ entityType, slug } = parseEntityId(mutation.target.id));
+    ({ entityType, slug } = parseEntityId(target.id));
   } catch (err) {
     throw new InvalidIdentityError((err as Error).message);
   }
   return path.join("wiki", entityType, `${slug}.md`);
+}
+
+/**
+ * The wiki-relative page path for a page mutation's target, discriminating the
+ * union: a DEFAULT page ({@link RawPageRef}, no `id`) takes the raw-component
+ * path; a PROFILE entity ({@link EntityRef}) takes the typed-id path. Both
+ * re-assert their identity floor as defense-in-depth.
+ */
+function pageRelPath(mutation: PlannedMutation): string {
+  const target = mutation.target;
+  if ("id" in target) return entityPageRelPath(target);
+  return rawPageRelPath(target);
 }
 
 /**

--- a/src/trust/planner.ts
+++ b/src/trust/planner.ts
@@ -27,7 +27,7 @@ import { lstat } from "fs/promises";
 import { confineUnderRoot } from "../utils/path-confine.js";
 import { runMandatoryPageChecks, type PageWriteContext } from "./checks.js";
 import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
-import { entityId, isSlugSafe } from "../profile/identity.js";
+import { entityId, isSlugSafe, isSafeFilenameComponent } from "../profile/identity.js";
 import type { EntityId } from "../profile/types.js";
 
 /** Every CLP store a mutation can target. Task 5 executes `page` only. */
@@ -49,8 +49,23 @@ export interface EntityRef {
   id: EntityId;
 }
 
-/** The store-specific target a mutation acts on. Page mutations use EntityRef. */
-export type MutationTarget = EntityRef;
+/**
+ * Reference to a DEFAULT wiki page: its directory and raw slug stem, with NO
+ * typed identity. Default pages keep their Unicode `slugify` slugs (e.g.
+ * `café-society`) and, per the Phase-1 invariant, NEVER become EntityIds — so
+ * they carry a raw stem here rather than a branded {@link EntityId}.
+ */
+export interface RawPageRef {
+  directory: string;
+  slug: string;
+}
+
+/**
+ * The store-specific target a mutation acts on. PROFILE entity pages use
+ * {@link EntityRef} (typed identity); DEFAULT pages use {@link RawPageRef} (raw
+ * stem, no typed identity).
+ */
+export type MutationTarget = EntityRef | RawPageRef;
 
 /** Where a proposed mutation came from and how it was vetted. */
 export interface MutationProvenance {
@@ -155,48 +170,119 @@ async function targetAlreadyExists(root: string, targetPath: string): Promise<bo
 }
 
 /**
- * Build the single live-write mutation for an approved page. The operation is
- * chosen by existence: a FREE target is a `create`; an already-existing target
- * (reached here only when the caller declared `allowOverwrite`, since otherwise
- * `checkTargetCollision` blocks) is an in-place `update`.
+ * Guard a DEFAULT page's raw identity: a `directory`/`slug` that is not a safe
+ * single filename component (path separator, dot-only, leading-dot, NUL, empty)
+ * yields a `block`. Like {@link checkIdentitySafe} this runs ahead of the
+ * mandatory file checks and composes via the SAME decision path — never a thrown
+ * exception — but it uses the Unicode-tolerant {@link isSafeFilenameComponent}
+ * floor (NOT the slug-safe grammar), so a non-ASCII default slug is allowed.
  */
-async function buildPageMutation(input: PlanPageInput, decision: TrustDecision): Promise<PlannedMutation> {
-  const id = entityId(input.entityType, input.slug);
-  const target: EntityRef = { entityType: input.entityType, slug: input.slug, id };
-  const exists = await targetAlreadyExists(input.root, pageTargetPath(input.entityType, input.slug));
-  return {
-    kind: "page",
-    operation: exists ? "update" : "create",
-    target,
-    body: input.body,
-    provenance: { origin: input.origin, decision, reviewRouted: input.reviewRouted },
-  };
+function checkDefaultIdentitySafe(directory: string, slug: string): TrustCheckResult {
+  const code = "invalid-identity";
+  if (isSafeFilenameComponent(directory) && isSafeFilenameComponent(slug)) {
+    return { code, verdict: "pass", message: "directory and slug are safe filename components" };
+  }
+  return { code, verdict: "block", message: `directory/slug is not a safe filename component: ${directory}/${slug}` };
+}
+
+/** The shared inputs to {@link planPageWith}, independent of target identity. */
+interface PageFloorInput {
+  root: string;
+  targetPath: string;
+  body: string;
+  origin: string;
+  reviewRouted: boolean;
+  allowOverwrite?: boolean;
 }
 
 /**
- * Plan a single page mutation: derive the target, run the mandatory checks,
- * compose the decision, and emit either one live-write mutation (on
- * allow/allow-with-warning) or none (on any block-derived decision).
+ * The shared floor→compose→build core for BOTH the typed ({@link EntityRef}) and
+ * raw ({@link RawPageRef}) page paths. Prepends the caller's identity-check
+ * result to the mandatory floor, composes the decision, and — only on a
+ * live-write decision — invokes `buildTarget` to mint the store-specific target.
+ * Factored out so the two planners never duplicate the floor/compose/existence
+ * logic (only the identity grammar and target shape differ).
+ */
+async function planPageWith(
+  input: PageFloorInput,
+  identityCheck: TrustCheckResult,
+  buildTarget: () => MutationTarget,
+): Promise<PlanResult> {
+  const ctx: PageWriteContext = {
+    root: input.root,
+    targetPath: input.targetPath,
+    body: input.body,
+    allowOverwrite: input.allowOverwrite ?? false,
+  };
+  const checks = [identityCheck, ...(await runMandatoryPageChecks(ctx))];
+  const decision = composeTrustDecision(checks, { reviewRouted: input.reviewRouted });
+  if (!LIVE_WRITE_DECISIONS.has(decision)) {
+    return { planned: [], decision, checks };
+  }
+  const exists = await targetAlreadyExists(input.root, input.targetPath);
+  const mutation: PlannedMutation = {
+    kind: "page",
+    operation: exists ? "update" : "create",
+    target: buildTarget(),
+    body: input.body,
+    provenance: { origin: input.origin, decision, reviewRouted: input.reviewRouted },
+  };
+  return { planned: [mutation], decision, checks };
+}
+
+/**
+ * Plan a single PROFILE-entity page mutation: derive the target, run the
+ * mandatory checks, compose the decision, and emit either one live-write
+ * mutation (on allow/allow-with-warning) or none (on any block-derived
+ * decision). The target is a typed {@link EntityRef} whose {@link EntityId} is
+ * minted only once the identity is known slug-safe.
  *
  * @param input - The proposed page mutation.
  * @returns The plan, composed decision, and per-check results.
  */
 export async function planPageMutation(input: PlanPageInput): Promise<PlanResult> {
   const targetPath = pageTargetPath(input.entityType, input.slug);
-  const ctx: PageWriteContext = {
-    root: input.root,
-    targetPath,
-    body: input.body,
-    allowOverwrite: input.allowOverwrite ?? false,
-  };
-  const checks = [
+  return planPageWith(
+    { ...input, targetPath },
     checkIdentitySafe(input.entityType, input.slug),
-    ...(await runMandatoryPageChecks(ctx)),
-  ];
-  const decision = composeTrustDecision(checks, { reviewRouted: input.reviewRouted });
+    () => ({ entityType: input.entityType, slug: input.slug, id: entityId(input.entityType, input.slug) }),
+  );
+}
 
-  if (!LIVE_WRITE_DECISIONS.has(decision)) {
-    return { planned: [], decision, checks };
-  }
-  return { planned: [await buildPageMutation(input, decision)], decision, checks };
+/** Inputs to {@link planDefaultPageMutation}. */
+export interface PlanDefaultPageInput {
+  /** Absolute project root the write must stay confined to. */
+  root: string;
+  /** The wiki subdirectory the page lives in (a raw filename component). */
+  directory: string;
+  /** The raw Unicode slug stem (a raw filename component; may be invalid). */
+  slug: string;
+  /** Full markdown body (frontmatter + prose). */
+  body: string;
+  /** Origin surface/actor of the proposal. */
+  origin: string;
+  /** Whether the surface stages risky writes for human review. */
+  reviewRouted: boolean;
+  /** Whether an existing target is an intended overwrite (`update`). */
+  allowOverwrite?: boolean;
+}
+
+/**
+ * Plan a single DEFAULT page mutation. Unlike {@link planPageMutation} this does
+ * NOT mint an EntityId: default pages keep their raw Unicode slug and target a
+ * {@link RawPageRef}. The identity floor is {@link isSafeFilenameComponent}
+ * (via {@link checkDefaultIdentitySafe}), the path is `wiki/<directory>/<slug>.md`,
+ * and the SAME mandatory floor + decision composition runs through
+ * {@link planPageWith}.
+ *
+ * @param input - The proposed default page mutation.
+ * @returns The plan, composed decision, and per-check results.
+ */
+export async function planDefaultPageMutation(input: PlanDefaultPageInput): Promise<PlanResult> {
+  const targetPath = pageTargetPath(input.directory, input.slug);
+  return planPageWith(
+    { ...input, targetPath },
+    checkDefaultIdentitySafe(input.directory, input.slug),
+    () => ({ directory: input.directory, slug: input.slug }),
+  );
 }

--- a/test/trust-planner-default.test.ts
+++ b/test/trust-planner-default.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @file test/trust-planner-default.test.ts
+ * @description Coverage for the DEFAULT raw-page mutation path
+ * (`planDefaultPageMutation` in `src/trust/planner.ts`) plus its executor
+ * round-trip. Default wiki pages carry Unicode `slugify` slugs (e.g.
+ * `café-society`, `机器学习`) and, per the Phase-1 invariant, NEVER become
+ * EntityIds — so this path uses a {@link RawPageRef} (raw stem, no typed id)
+ * and the {@link isSafeFilenameComponent} identity floor rather than the
+ * slug-safe EntityId grammar.
+ *
+ * The suite pins: a Unicode slug on a free target plans+writes a `create`
+ * with a RawPageRef; an existing target upserts (`update`) or blocks by
+ * `allowOverwrite`; a traversal/separator/dot/leading-dot slug is blocked at
+ * plan time AND re-rejected by the executor for a hand-built RawPageRef.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, readFile } from "fs/promises";
+import path from "path";
+import {
+  planDefaultPageMutation,
+  type PlannedMutation,
+  type RawPageRef,
+} from "../src/trust/planner.js";
+import { applyApprovedMutations } from "../src/trust/executor.js";
+import { makeTrustRoot, cleanupTrustRoot, existsUnder } from "./trust/fixture.js";
+
+let root: string;
+const GOOD_BODY = "---\ntitle: Ok\n---\n\nbody\n";
+const UNICODE_SLUG = "café-society";
+
+beforeEach(async () => {
+  root = await makeTrustRoot("trust-planner-default-");
+});
+
+afterEach(async () => {
+  await cleanupTrustRoot(root);
+});
+
+function defaultArgs(slug: string, overrides: Record<string, unknown> = {}) {
+  return {
+    root,
+    directory: "concepts",
+    slug,
+    body: GOOD_BODY,
+    origin: "agent",
+    reviewRouted: false,
+    ...overrides,
+  };
+}
+
+describe("planDefaultPageMutation — Unicode slug, free target", () => {
+  it("allows and plans one create with a RawPageRef (no id)", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG));
+    expect(out.decision).toBe("allow");
+    expect(out.planned).toHaveLength(1);
+    const target = out.planned[0].target as RawPageRef;
+    expect(target).toEqual({ directory: "concepts", slug: UNICODE_SLUG });
+    expect("id" in target).toBe(false);
+    expect(out.planned[0].operation).toBe("create");
+  });
+
+  it("executor writes wiki/concepts/<unicode>.md with the body", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG));
+    await applyApprovedMutations(root, out.planned);
+    const written = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    expect(await readFile(written, "utf-8")).toBe(GOOD_BODY);
+  });
+});
+
+describe("planDefaultPageMutation — existing target", () => {
+  it("plans an update overwriting when allowOverwrite is true", async () => {
+    const target = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    await writeFile(target, "OLD");
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { allowOverwrite: true }));
+    expect(out.decision).toBe("allow");
+    expect(out.planned[0].operation).toBe("update");
+    await applyApprovedMutations(root, out.planned);
+    expect(await readFile(target, "utf-8")).toBe(GOOD_BODY);
+  });
+
+  it("blocks (no live mutation) when allowOverwrite is false", async () => {
+    const target = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    await writeFile(target, "OLD");
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { allowOverwrite: false }));
+    expect(out.decision).toBe("deny");
+    expect(out.planned).toEqual([]);
+    expect(await readFile(target, "utf-8")).toBe("OLD");
+  });
+});
+
+describe("planDefaultPageMutation — unsafe filename components are blocked", () => {
+  const unsafe = ["../escape", "a/b", "a\\b", "with\0nul", ".", "..", ".hidden", ""];
+  for (const slug of unsafe) {
+    it(`blocks slug ${JSON.stringify(slug)} with no live mutation`, async () => {
+      const out = await planDefaultPageMutation(defaultArgs(slug));
+      expect(out.planned).toEqual([]);
+      expect(out.decision).not.toBe("allow");
+    });
+  }
+
+  it("blocks an unsafe directory component", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { directory: "../evil" }));
+    expect(out.planned).toEqual([]);
+  });
+});
+
+describe("executor re-asserts the default-page identity floor", () => {
+  it("throws invalid-identity for a hand-built RawPageRef with a `..` slug", async () => {
+    const evil: PlannedMutation = {
+      kind: "page",
+      operation: "create",
+      target: { directory: "concepts", slug: "../escape" } as RawPageRef,
+      body: GOOD_BODY,
+      provenance: { origin: "agent", decision: "allow", reviewRouted: false },
+    };
+    await expect(applyApprovedMutations(root, [evil])).rejects.toThrow(/invalid-identity/);
+    expect(await existsUnder(root, "wiki/escape.md")).toBe(false);
+  });
+});

--- a/test/trust-planner.test.ts
+++ b/test/trust-planner.test.ts
@@ -19,7 +19,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { writeFile, readFile } from "fs/promises";
 import path from "path";
-import { planPageMutation, type PlannedMutation } from "../src/trust/planner.js";
+import {
+  planPageMutation,
+  planDefaultPageMutation,
+  type PlannedMutation,
+  type RawPageRef,
+} from "../src/trust/planner.js";
 import { applyApprovedMutations } from "../src/trust/executor.js";
 import { replayJournal, openBatch, recordPreState } from "../src/trust/journal.js";
 import { entityId } from "../src/profile/identity.js";


### PR DESCRIPTION
Stacked on PR #120 (do not merge yet). Lets the write planner handle DEFAULT pages, whose slugs come from `slugify` (Unicode) and per the Phase-1 invariant never become typed entity ids.

- New `isSafeFilenameComponent` identity floor for default pages: allows Unicode letters/digits/hyphens, rejects path separators, NUL, dot-only, and leading-dot (hidden) names — distinct from the ASCII slug-safe grammar used to mint entity ids.
- New `RawPageRef` target + `planDefaultPageMutation`: plans a default page write from a raw `<dir>/<slug>.md` path with no entity id, running the same mandatory floor (collision/resource/frontmatter) and create/update intent as the typed path. The shared floor→compose→build core is factored so the typed and default paths don't duplicate it.
- The executor derives the path for either target shape and re-asserts the filename floor for raw pages (defense-in-depth).

This is the prerequisite for routing the default review-approve write through the planner without refusing non-ASCII pages. Still unwired; default profile byte-identical, full suite green.