### PR TITLE
feat(profile): Phase 3 PR3 (keystone) — route review-approve through the write planner

### DIFF
--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -14,10 +14,9 @@
  */
 
 import path from "path";
-import {
-  atomicWrite,
-  validateWikiPage,
-} from "../utils/markdown.js";
+import { validateWikiPage } from "../utils/markdown.js";
+import { planDefaultPageMutation } from "../trust/planner.js";
+import { applyApprovedMutationsLocked } from "../trust/executor.js";
 import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
@@ -51,15 +50,53 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
     return;
   }
 
+  if (!(await routeApprovedPageWrite(root, candidate, id))) return;
+
   const dir = candidate.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
   const pagePath = path.join(root, dir, `${candidate.slug}.md`);
-  await atomicWrite(pagePath, candidate.body);
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
 
   await persistCandidateSourceStates(root, candidate);
   await refreshWikiAfterApproval(root, candidate.slug);
   await deleteCandidate(root, id);
   output.status("✓", output.dim(`Candidate ${id} cleared.`));
+}
+
+/**
+ * Route the candidate's page write through the write planner/executor (CLP
+ * Invariant 4) instead of a direct file write, preserving byte-for-byte parity:
+ * the planner derives the SAME `wiki/<dir>/<slug>.md` absolute path and the
+ * executor writes the candidate body verbatim under the ALREADY-HELD review lock
+ * (so no nested-lock deadlock), running journal replay to recover any crashed
+ * batch on this path.
+ *
+ * `allowOverwrite` is true so re-approving an existing page upserts via `update`
+ * rather than colliding. Returns true when the write landed; on a blocked plan
+ * (the mandatory floor refused, e.g. an oversized body) it surfaces an approval
+ * FAILURE — exit code 1, candidate retained, nothing written — and returns false.
+ */
+async function routeApprovedPageWrite(
+  root: string,
+  candidate: ReviewCandidate,
+  id: string,
+): Promise<boolean> {
+  const directory = candidate.targetDirectory === "queries" ? "queries" : "concepts";
+  const { planned } = await planDefaultPageMutation({
+    root,
+    directory,
+    slug: candidate.slug,
+    body: candidate.body,
+    origin: "review",
+    reviewRouted: false,
+    allowOverwrite: true,
+  });
+  if (planned.length === 0) {
+    output.status("!", output.error(`Candidate ${id} blocked by the write planner; not approved.`));
+    process.exitCode = 1;
+    return false;
+  }
+  await applyApprovedMutationsLocked(root, planned);
+  return true;
 }
 
 /**

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -4,10 +4,10 @@
  * {@link PlannedMutation} plan into bytes on disk, under the CLP atomicity
  * contract ("partial application of an approved batch is a bug").
  *
- * STATUS: this planner/executor/journal seam is a Phase-2 FOUNDATION. No live
- * production write path routes through it yet (no caller invokes
- * {@link applyApprovedMutations}); the atomicity contract is realized for the
- * page store in isolation and under test, not yet across any wired surface.
+ * STATUS: the `review approve` page write is the FIRST production consumer of
+ * this seam — it routes through {@link applyApprovedMutationsLocked} under its
+ * already-held review lock. The atomicity contract (and journal replay) is now
+ * realized on that live path; other CLP write surfaces are still future work.
  *
  * {@link applyApprovedMutations} runs the batch behind the project lock and a
  * single-store intent journal:
@@ -228,16 +228,42 @@ async function applyBatch(
 }
 
 /**
- * Apply an approved plan to disk atomically. Acquires the project lock, journals
- * every target's pre-state before writing, applies each page mutation, then
- * commits the journal — releasing the lock in `finally`. A non-page kind throws
- * `not-implemented`. A mid-batch failure leaves a `pending` journal for
- * {@link replayJournal} to revert to the full pre-state.
+ * Apply an approved plan to disk atomically WHILE THE CALLER ALREADY HOLDS the
+ * project lock — the lock-free core shared with {@link applyApprovedMutations}.
  *
- * Self-recovery: BEFORE opening the new batch (but AFTER the lock is held), it
- * runs {@link replayJournal}, so a `pending` journal left dangling by a prior
- * crash is reverted under the same lock before this batch begins — the atomicity
- * guarantee no longer depends on an external caller invoking replay.
+ * The caller MUST already hold the project lock; this function acquires NOTHING,
+ * so it can run inside an outer locked region (e.g. `review approve`, which holds
+ * the review lock across its whole mutation) WITHOUT a nested-acquire deadlock.
+ *
+ * Self-recovery: BEFORE opening the new batch it runs {@link replayJournal}, so a
+ * `pending` journal left dangling by a prior crash is reverted under the SAME
+ * held lock before this batch begins. A non-page kind throws `not-implemented`; a
+ * mid-batch failure leaves a `pending` journal for replay to revert to the full
+ * pre-state.
+ *
+ * @param root - Absolute project root.
+ * @param planned - The approved mutations to apply.
+ * @param opts - Optional injectable write primitive (for fault injection).
+ */
+export async function applyApprovedMutationsLocked(
+  root: string,
+  planned: PlannedMutation[],
+  opts: ApplyOptions = {},
+): Promise<void> {
+  const writeOne = opts.writeOne ?? atomicWrite;
+  // Recover any dangling pending batch from a prior crash under the held lock.
+  await replayJournal(root);
+  const batch = await openBatch(root);
+  await applyBatch(root, planned, batch, writeOne);
+  await commitBatch(batch);
+}
+
+/**
+ * Apply an approved plan to disk atomically, acquiring the project lock itself.
+ * Acquires the PID-based project lock, delegates the journalled batch to
+ * {@link applyApprovedMutationsLocked} (replay → open → apply → commit), then
+ * releases the lock in `finally`. There is ONE batch implementation; this is the
+ * self-locking entry point for callers that do NOT already hold the lock.
  *
  * @param root - Absolute project root.
  * @param planned - The approved mutations to apply.
@@ -248,15 +274,10 @@ export async function applyApprovedMutations(
   planned: PlannedMutation[],
   opts: ApplyOptions = {},
 ): Promise<void> {
-  const writeOne = opts.writeOne ?? atomicWrite;
   const acquired = await acquireLock(root);
   if (!acquired) throw new Error("could not acquire project lock for mutation batch");
   try {
-    // Recover any dangling pending batch from a prior crash under the held lock.
-    await replayJournal(root);
-    const batch = await openBatch(root);
-    await applyBatch(root, planned, batch, writeOne);
-    await commitBatch(batch);
+    await applyApprovedMutationsLocked(root, planned, opts);
   } finally {
     await releaseLock(root);
   }

--- a/test/review-approve-planner.test.ts
+++ b/test/review-approve-planner.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @file test/review-approve-planner.test.ts
+ * @description Reroute-specific coverage for `review approve` once its page
+ * write goes through the write planner/executor (CLP Invariant 4) instead of a
+ * direct `atomicWrite`. The byte/stdout PARITY of the happy path is pinned by
+ * the existing `test/review.test.ts` "review approve command" suite (which must
+ * still pass unchanged); this file pins the behaviours the reroute newly
+ * activates: Unicode slugs (only possible because PR2's typed planner is
+ * bypassed for default pages), upsert-on-overwrite, loud failure when the
+ * mandatory resource-limit floor blocks the body, and crashed-batch journal
+ * replay under the already-held review lock.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { writeFile, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { writeCandidate } from "../src/compiler/candidates.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import { openBatch, recordPreState, type JournalBatch } from "../src/trust/journal.js";
+import { CANDIDATES_DIR, CONCEPTS_DIR, MAX_SOURCE_CHARS } from "../src/utils/constants.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+/** A frontmatter+body page string that passes validateWikiPage, for `slug`. */
+function validBody(slug: string): string {
+  return [
+    "---",
+    `title: ${slug}`,
+    'summary: "A summary"',
+    "sources:",
+    '  - "source.md"',
+    'createdAt: "2026-01-01T00:00:00.000Z"',
+    'updatedAt: "2026-01-01T00:00:00.000Z"',
+    "tags: []",
+    "aliases: []",
+    "---",
+    "",
+    `Body for ${slug}.`,
+    "",
+  ].join("\n");
+}
+
+/** Write a pending candidate whose body is the valid page for its slug. */
+function draftFor(slug: string, body = validBody(slug)) {
+  return { title: slug, slug, summary: "A summary", sources: ["source.md"], body };
+}
+
+/** Absolute wiki page / candidate-record paths for a slug under the temp root. */
+const pageFor = (slug: string) => path.join(root.dir, CONCEPTS_DIR, `${slug}.md`);
+const recordFor = (id: string) => path.join(root.dir, CANDIDATES_DIR, `${id}.json`);
+
+/**
+ * Seed a candidate for `slug` (body defaults to its valid page), silence both
+ * console streams, run approve, and return the candidate id — the shared arrange
+ * step so each reroute test asserts only its own outcome.
+ */
+async function approveDraft(slug: string, body?: string): Promise<string> {
+  const candidate = await writeCandidate(root.dir, draftFor(slug, body ?? validBody(slug)));
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  await reviewApproveCommand(candidate.id);
+  return candidate.id;
+}
+
+describe("review approve — planner reroute", () => {
+  it("approves a Unicode-slug candidate and writes wiki/concepts/café-society.md", async () => {
+    const slug = "café-society";
+    const id = await approveDraft(slug);
+    expect(await readFile(pageFor(slug), "utf-8")).toBe(validBody(slug));
+    expect(existsSync(recordFor(id))).toBe(false);
+  });
+
+  it("re-approves an existing page via update without a create collision", async () => {
+    const slug = "reapprove";
+    await writeFile(pageFor(slug), "stale prior bytes\n");
+    await approveDraft(slug);
+    expect(await readFile(pageFor(slug), "utf-8")).toBe(validBody(slug));
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("fails loudly and retains the candidate when the body exceeds the resource-limit floor", async () => {
+    const slug = "oversized";
+    const filler = "\n" + "x".repeat(MAX_SOURCE_CHARS); // valid frontmatter, oversized total
+    const id = await approveDraft(slug, validBody(slug) + filler);
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(pageFor(slug))).toBe(false);
+    expect(existsSync(recordFor(id))).toBe(true);
+    process.exitCode = 0;
+  });
+
+  it("replays a dangling pending journal on the next approve (crashed-batch recovery)", async () => {
+    // Plant the journal under the SAME root form the command uses (process.cwd,
+    // the realpath of root.dir) so the crashed batch is the one approve replays.
+    const cmdRoot = process.cwd();
+    const orphan = path.join(cmdRoot, CONCEPTS_DIR, "orphan.md");
+    await writeFile(orphan, "pre-batch bytes\n");
+    const batch: JournalBatch = await openBatch(cmdRoot);
+    await recordPreState(batch, orphan); // pending, never committed → a crashed batch
+    await writeFile(orphan, "torn post-crash bytes\n"); // simulate a half-applied write
+
+    await approveDraft("trigger");
+
+    // The approve ran replayJournal under the review lock → orphan reverted to pre-batch bytes.
+    expect(await readFile(orphan, "utf-8")).toBe("pre-batch bytes\n");
+  });
+});

--- a/test/trust-planner-default.test.ts
+++ b/test/trust-planner-default.test.ts
@@ -22,7 +22,8 @@ import {
   type PlannedMutation,
   type RawPageRef,
 } from "../src/trust/planner.js";
-import { applyApprovedMutations } from "../src/trust/executor.js";
+import { applyApprovedMutations, applyApprovedMutationsLocked } from "../src/trust/executor.js";
+import { acquireLock, releaseLock } from "../src/utils/lock.js";
 import { makeTrustRoot, cleanupTrustRoot, existsUnder } from "./trust/fixture.js";
 
 let root: string;
@@ -102,6 +103,20 @@ describe("planDefaultPageMutation — unsafe filename components are blocked", (
   it("blocks an unsafe directory component", async () => {
     const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { directory: "../evil" }));
     expect(out.planned).toEqual([]);
+  });
+});
+
+describe("applyApprovedMutationsLocked — lock-free core for an outer locked region", () => {
+  it("writes the page when the CALLER already holds the lock (no nested acquire)", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG));
+    expect(await acquireLock(root)).toBe(true); // simulate the held review lock
+    try {
+      await applyApprovedMutationsLocked(root, out.planned);
+    } finally {
+      await releaseLock(root);
+    }
+    const target = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    expect(await readFile(target, "utf-8")).toBe(GOOD_BODY);
   });
 });
 


### PR DESCRIPTION
Stacked on PR #121 (do not merge yet). The KEYSTONE: gives the write planner its first real production consumer and proves the parity-preserving executor.

- `review approve` now plans its page write through `planDefaultPageMutation` and applies it through the executor (under the review command's existing lock, via a new lock-free `applyApprovedMutationsLocked` so there's no nested-lock deadlock). Same bytes, same path, same stdout/exit — only the write mechanism changes.
- The mandatory floor (path-confinement, collision, resource-limit, frontmatter) now governs an approval; a body that fails it makes approval fail loudly with the candidate retained, rather than writing unchecked.
- `replayJournal` now runs on the approve path, so a crash mid-write is recovered under the review lock.

Every existing review-approve test passes unchanged (the parity proof); default profile byte-identical; full suite green. A follow-on can extend the same rerouting to the compile batch write.