### PR TITLE
fix(state): Phase 3 PR4 — tolerant v2 migration (non-ASCII slugs) + mirror sync at writeState

### DIFF
--- a/src/state/migrate.ts
+++ b/src/state/migrate.ts
@@ -13,11 +13,14 @@
  *    migration never double-types a slug (no `concepts/concepts/rag`);
  *  - deterministic: minted id arrays are sorted lexicographically so repeated
  *    migrations of equal inputs serialise byte-for-byte identically;
- *  - fail-closed: a bare slug that violates the slug-safe grammar throws
- *    {@link EntityIdError} via {@link assertSlugSafe} rather than being dropped.
+ *  - tolerant: slug-safe slugs are typed; non-slug-safe slugs (e.g. the Unicode
+ *    stems `slugify` keeps, like `café-society` / `机器学习`) are kept in the
+ *    verbatim `concepts` / `frozenSlugs` mirror WITHOUT a typed id, so a
+ *    mixed-language wiki migrates instead of aborting. Widening the EntityId
+ *    grammar to cover Unicode is a deferred identity change, not done here.
  */
 
-import { entityId, assertSlugSafe } from "../profile/identity.js";
+import { entityId, isSlugSafe } from "../profile/identity.js";
 import type { EntityId } from "../profile/types.js";
 import type { SourceState, WikiState } from "../utils/types.js";
 
@@ -26,11 +29,15 @@ const CONCEPT_ENTITY_TYPE = "concepts";
 
 /**
  * Mint a sorted, deduplicated list of `concepts/<slug>` EntityIds from bare
- * concept slugs. Each slug is asserted slug-safe at mint time, so an invalid
- * slug throws rather than being silently skipped.
+ * concept slugs. Tolerant: only slug-safe slugs are typed; any slug that fails
+ * {@link isSlugSafe} (e.g. a Unicode stem) is SKIPPED here and survives via the
+ * verbatim `concepts` / `frozenSlugs` mirror it was drawn from. This is the
+ * single grammar/skip site, shared by migration and the writeState mirror sync.
  */
-function mintConceptEntities(slugs: string[]): EntityId[] {
-  const ids = slugs.map((slug) => entityId(CONCEPT_ENTITY_TYPE, assertSlugSafe(slug)));
+export function mintConceptEntities(slugs: string[]): EntityId[] {
+  const ids = slugs
+    .filter((slug) => isSlugSafe(slug))
+    .map((slug) => entityId(CONCEPT_ENTITY_TYPE, slug));
   return [...new Set(ids)].sort();
 }
 

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -24,7 +24,39 @@ import { existsSync } from "fs";
 import path from "path";
 import { LLMWIKI_DIR, STATE_FILE } from "./constants.js";
 import { note } from "./output.js";
+import { mintConceptEntities } from "../state/migrate.js";
 import type { WikiState, SourceState } from "./types.js";
+
+/** The schema version that carries the typed-ownership mirror. */
+const TYPED_MIRROR_VERSION = 2;
+
+/**
+ * Re-derive the v2 typed-ownership mirror from the v1 string lists so the two
+ * never desync, regardless of which writer produced the state. For a v2 state
+ * each source's `entities` is re-derived from its `concepts` and the top-level
+ * `frozenEntities` from `frozenSlugs`, using the SAME tolerant minting as the
+ * migration ({@link mintConceptEntities}) so non-slug-safe (e.g. Unicode) slugs
+ * are simply absent from the typed mirror rather than aborting the write.
+ *
+ * For a v1 state this is a STRICT no-op — the input is returned unchanged so the
+ * default-profile (v1) on-disk bytes are byte-identical to before.
+ *
+ * NOTE: this re-derives the CONCEPTS mirror only. A later phase that introduces
+ * non-concept typed entities must extend this to preserve those, since blindly
+ * re-deriving from `concepts` would drop them.
+ */
+export function syncEntityMirror(state: WikiState): WikiState {
+  if (state.version !== TYPED_MIRROR_VERSION) return state;
+  const sources: Record<string, SourceState> = {};
+  for (const [file, source] of Object.entries(state.sources)) {
+    sources[file] = { ...source, entities: mintConceptEntities(source.concepts) };
+  }
+  return {
+    ...state,
+    sources,
+    frozenEntities: mintConceptEntities(state.frozenSlugs ?? []),
+  };
+}
 
 function emptyState(): WikiState {
   return { version: 1, indexHash: "", sources: {} };
@@ -174,7 +206,10 @@ export async function writeState(root: string, state: WikiState): Promise<void> 
   const filePath = path.join(root, STATE_FILE);
   const tmpPath = filePath + ".tmp";
 
-  await writeFile(tmpPath, JSON.stringify(state, null, 2), "utf-8");
+  // Re-derive the v2 typed mirror at the single write choke point so no writer
+  // can persist a desynced `entities` / `frozenEntities`. No-op for v1 states.
+  const synced = syncEntityMirror(state);
+  await writeFile(tmpPath, JSON.stringify(synced, null, 2), "utf-8");
   await rename(tmpPath, filePath);
 }
 

--- a/test/state-migrate.test.ts
+++ b/test/state-migrate.test.ts
@@ -9,12 +9,13 @@
  *  - lossless upgrade (v1 fields retained, typed mirror added),
  *  - idempotency (re-migrating a v2 state is a no-op, never double-typed),
  *  - determinism (sorted output, byte-stable across repeated runs), and
- *  - fail-closed behaviour (a non-slug-safe bare slug throws, never dropped).
+ *  - tolerant behaviour (a non-slug-safe bare slug — e.g. a Unicode stem — is
+ *    kept verbatim in `concepts` / `frozenSlugs` but gets no typed id, so a
+ *    mixed-language wiki migrates instead of aborting).
  */
 
 import { describe, it, expect } from "vitest";
 import { migrateStateToV2 } from "../src/state/migrate.js";
-import { EntityIdError } from "../src/profile/identity.js";
 import type { WikiState } from "../src/utils/types.js";
 
 /** A minimal, valid v1 state used as the base fixture for the suite. */
@@ -100,16 +101,28 @@ describe("migrateStateToV2 — idempotency gate >= 2", () => {
   });
 });
 
-describe("migrateStateToV2 — fail-closed", () => {
-  it("throws on a bare slug with spaces rather than silently dropping it", () => {
+describe("migrateStateToV2 — tolerant of non-slug-safe slugs", () => {
+  it("does not throw and skips typing a non-ASCII (Unicode) source slug", () => {
     const v1 = v1Fixture();
-    v1.sources["a.md"].concepts = ["Bad Slug"];
-    expect(() => migrateStateToV2(v1)).toThrow(EntityIdError);
+    v1.sources["a.md"].concepts = ["café-society", "机器学习", "rag"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.sources["a.md"].entities).toEqual(["concepts/rag"]);
+    expect(v2.sources["a.md"].concepts).toEqual(["café-society", "机器学习", "rag"]);
   });
 
-  it("throws on an uppercase frozen slug rather than silently dropping it", () => {
+  it("keeps a non-slug-safe frozen slug verbatim but mints no typed id for it", () => {
     const v1 = v1Fixture();
-    v1.frozenSlugs = ["UPPER"];
-    expect(() => migrateStateToV2(v1)).toThrow(EntityIdError);
+    v1.frozenSlugs = ["café-society", "机器学习", "rag"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.frozenEntities).toEqual(["concepts/rag"]);
+    expect(v2.frozenSlugs).toEqual(["café-society", "机器学习", "rag"]);
+  });
+
+  it("skips a slug with spaces / uppercase rather than throwing", () => {
+    const v1 = v1Fixture();
+    v1.sources["a.md"].concepts = ["Bad Slug", "UPPER", "ok"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.sources["a.md"].entities).toEqual(["concepts/ok"]);
+    expect(v2.sources["a.md"].concepts).toEqual(["Bad Slug", "UPPER", "ok"]);
   });
 });

--- a/test/state-sync-mirror.test.ts
+++ b/test/state-sync-mirror.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the v2 typed-mirror re-derivation at the writeState choke point.
+ *
+ * Phase 3 wires {@link syncEntityMirror} into {@link writeState} so that every
+ * persisted v2 state has `entities` / `frozenEntities` re-derived from the v1
+ * `concepts` / `frozenSlugs` lists — no writer can leave the mirror stale. The
+ * key parity guarantee is pinned here too: writing a v1 (default-profile) state
+ * is BYTE-IDENTICAL to before, with no typed-mirror keys added.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { writeState, syncEntityMirror } from "../src/utils/state.js";
+import { STATE_FILE } from "../src/utils/constants.js";
+import type { WikiState } from "../src/utils/types.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "state-sync-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Read and parse the persisted state.json. */
+async function readPersisted(): Promise<WikiState> {
+  return JSON.parse(await readFile(path.join(root, STATE_FILE), "utf-8"));
+}
+
+/** A v2 state whose typed mirror is intentionally stale/missing. */
+function staleV2(): WikiState {
+  return {
+    version: 2,
+    indexHash: "i",
+    sources: { "a.md": { hash: "h", concepts: ["rag", "x"], compiledAt: "T" } },
+    frozenSlugs: ["rag", "old"],
+    frozenEntities: ["concepts/rag", "concepts/old", "concepts/stale"],
+  };
+}
+
+describe("syncEntityMirror — v2 re-derivation", () => {
+  it("re-derives source entities from the current concepts", () => {
+    const synced = syncEntityMirror(staleV2());
+    expect(synced.sources["a.md"].entities).toEqual(["concepts/rag", "concepts/x"]);
+  });
+
+  it("shrinks frozenEntities to match a smaller frozenSlugs (no stale entry)", () => {
+    const state = staleV2();
+    state.frozenSlugs = ["rag"];
+    const synced = syncEntityMirror(state);
+    expect(synced.frozenEntities).toEqual(["concepts/rag"]);
+  });
+
+  it("skips non-slug-safe (Unicode) concepts when re-deriving the mirror", () => {
+    const state = staleV2();
+    state.sources["a.md"].concepts = ["café-society", "rag"];
+    const synced = syncEntityMirror(state);
+    expect(synced.sources["a.md"].entities).toEqual(["concepts/rag"]);
+  });
+
+  it("returns a v1 state unchanged (strict no-op)", () => {
+    const v1: WikiState = { version: 1, indexHash: "i", sources: {}, frozenSlugs: ["rag"] };
+    expect(syncEntityMirror(v1)).toBe(v1);
+  });
+});
+
+describe("writeState — persists a consistent v2 mirror", () => {
+  it("writes entities matching the changed concepts", async () => {
+    await writeState(root, staleV2());
+    const persisted = await readPersisted();
+    expect(persisted.sources["a.md"].entities).toEqual(["concepts/rag", "concepts/x"]);
+  });
+
+  it("writes a frozenEntities with no stale entry after unfreezing", async () => {
+    const state = staleV2();
+    state.frozenSlugs = ["rag"];
+    await writeState(root, state);
+    expect((await readPersisted()).frozenEntities).toEqual(["concepts/rag"]);
+  });
+});
+
+describe("writeState — v1 is byte-identical (parity)", () => {
+  it("adds no entities / frozenEntities keys to a persisted v1 state", async () => {
+    const v1: WikiState = {
+      version: 1,
+      indexHash: "i",
+      sources: { "a.md": { hash: "h", concepts: ["rag"], compiledAt: "T" } },
+      frozenSlugs: ["rag"],
+    };
+    await writeState(root, v1);
+    const raw = await readFile(path.join(root, STATE_FILE), "utf-8");
+    expect(raw).toBe(JSON.stringify(v1, null, 2));
+    expect(raw).not.toContain("entities");
+    expect(raw).not.toContain("frozenEntities");
+  });
+});


### PR DESCRIPTION
Stacked on PR #122 (do not merge yet). Two state-v2 correctness fixes from the audit (latent until typed ownership is wired, but they de-risk it).

- **Tolerant migration:** v1→v2 migration previously threw on any non-ASCII slug (the typed-id grammar is ASCII, but `slugify` keeps Unicode), aborting the whole upgrade for non-English wikis. It now types only slug-safe slugs and keeps the rest verbatim in the `concepts`/`frozenSlugs` mirror (no typed id). Decision recorded: widening the entity-id grammar to Unicode is a deferred, broader identity change.
- **Mirror sync:** the typed `entities`/`frozenEntities` mirror is now re-derived from the v1 fields at the `writeState` choke point, so it can't desync when a v2 state is written by a writer that only knows v1 fields (which previously left stale/wrong `frozenEntities`).

Strict no-op for v1 (default), so default profile byte-identical; full suite green.