### PR TITLE
docs: document per-page health distribution in eval harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Do not use llmwiki as a general static-site generator, a heavy ontology database
 - **Local viewer.** `llmwiki view` opens a read-only browser UI with search, page metadata, graph exploration, source-freshness badges, and citation chips.
 - **Review policy.** Generated pages can be auto-held for review when confidence, contradiction, schema, or provenance rules trip.
 - **Freshness repair.** `llmwiki lint` and `llmwiki next` surface stale/orphaned pages; `llmwiki refresh --stale` repairs changed knowledge without compiling unrelated new sources.
-- **Eval harness.** `llmwiki eval` reports health score, citation coverage/precision, corpus stats, regression deltas, and optional judge-model citation support.
+- **Eval harness.** `llmwiki eval` reports health score, a per-page health distribution that flags the worst pages, citation coverage/precision, corpus stats, regression deltas, and optional judge-model citation support.
 - **MCP server.** `llmwiki serve` exposes ingest, compile, query, lint, read, status, eval, context-pack, and OKF exchange tools to MCP-compatible agents.
 - **SDK.** `createWiki({ root })` drives ingest, compile, query, context, status, export, eval, and OKF import/export from TypeScript without shelling out.
 - **Open Knowledge Format exchange.** Export and import OKF bundles for portable, markdown-native knowledge exchange. External OKF imports are staged through the review queue by default; trusted bundles can be written live explicitly.

--- a/docs/cli/lint-eval.mdx
+++ b/docs/cli/lint-eval.mdx
@@ -83,7 +83,7 @@ llmwiki eval --suite full      # fast + LLM-as-judge citation support
 Aggregates all lint rules into a single number. Errors (broken citations, broken wikilinks, duplicate concepts) cost more than warnings. A score of 100 means the lint pass found nothing.
 
 **Page health distribution**
-Breaks the corpus health score down per page, so you can see *which* pages need attention rather than just that something is wrong. Each page is scored with the same rules as the overall health score - a page's score is the health score it would receive if it were the only page in the wiki - and sorted into four tiers: `healthy` (90–100), `adequate` (70–89), `needs_work` (50–69), and `broken` (0–49). The report shows the tier counts plus the worst pages with their top issues, so a maintainer knows where to start. The full per-page list is available in the JSON report.
+Breaks the corpus health score down per page, so you can see *which* pages need attention rather than just that something is wrong. Each page is scored by summing the lint deductions attributed to that page, using the same weights as the overall health score, then sorted into four tiers: `healthy` (90–100), `adequate` (70–89), `needs_work` (50–69), and `broken` (0–49). The report shows the tier counts plus the worst pages with their top issues, so a maintainer knows where to start. The full per-page list is available in the JSON report.
 
 **Citation coverage**
 The fraction of prose paragraphs that carry at least one `^[...]` citation marker. Higher is better; uncited prose is harder to verify and maintain.

--- a/docs/cli/lint-eval.mdx
+++ b/docs/cli/lint-eval.mdx
@@ -70,7 +70,7 @@ llmwiki eval --suite full      # fast + LLM-as-judge citation support
 
 | Suite | What runs | LLM credentials needed? |
 |-------|-----------|------------------------|
-| `fast` (default) | Health score, citation coverage and precision, source utilization, corpus stats, regression deltas | No |
+| `fast` (default) | Health score, per-page health distribution, citation coverage and precision, source utilization, corpus stats, regression deltas | No |
 | `full` | Everything in `fast`, plus LLM-as-judge citation support scoring for a sample of claim/source pairs | Yes |
 
 <Note>
@@ -81,6 +81,9 @@ llmwiki eval --suite full      # fast + LLM-as-judge citation support
 
 **Health score (0–100)**
 Aggregates all lint rules into a single number. Errors (broken citations, broken wikilinks, duplicate concepts) cost more than warnings. A score of 100 means the lint pass found nothing.
+
+**Page health distribution**
+Breaks the corpus health score down per page, so you can see *which* pages need attention rather than just that something is wrong. Each page is scored with the same rules as the overall health score - a page's score is the health score it would receive if it were the only page in the wiki - and sorted into four tiers: `healthy` (90–100), `adequate` (70–89), `needs_work` (50–69), and `broken` (0–49). The report shows the tier counts plus the worst pages with their top issues, so a maintainer knows where to start. The full per-page list is available in the JSON report.
 
 **Citation coverage**
 The fraction of prose paragraphs that carry at least one `^[...]` citation marker. Higher is better; uncited prose is harder to verify and maintain.


### PR DESCRIPTION
Documents the per-page health distribution that #96 adds to `llmwiki eval`: the README eval-harness bullet, the eval suite table, and a new "Page health distribution" entry under "What eval measures" (tiers, worst-pages output, and the full per-page list in JSON).

Should merge after #96, since the docs site auto-deploys on merge to main.
