### PR TITLE
feat(cli): Phase 3 PR5 — state reset recovery command + user docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`llmwiki state reset`** — a recovery command for a `.llmwiki/state.json` written by a newer llmwiki version. It backs the file up to `state.json.bak` and removes it so the next compile starts fresh. It refuses by default and prints what it will do; pass `--yes` to apply. The reset works even on an unreadable too-new or corrupt state file.
+
+### Changed
+
+- llmwiki now fails closed when `.llmwiki/state.json` was written by a newer llmwiki version: instead of risking a misread or overwrite of a forward-incompatible layout, commands report a clear error. Use `llmwiki state reset --yes` to back up and reset the file, or upgrade llmwiki to read the project as-is.
+
 ## [0.11.0] - 2026-06-16
 
 Extends Open Knowledge Format support beyond the CLI: in-process SDK and MCP access to the OKF round-trip, and faithful reconstruction of an imported foreign bundle's original nested paths on re-export.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,7 +74,8 @@
             "group": "Troubleshooting",
             "pages": [
               "troubleshooting/faq",
-              "troubleshooting/stale-pages"
+              "troubleshooting/stale-pages",
+              "troubleshooting/state-recovery"
             ]
           }
         ]

--- a/docs/troubleshooting/state-recovery.mdx
+++ b/docs/troubleshooting/state-recovery.mdx
@@ -1,0 +1,90 @@
+---
+title: "Recovering State Written by a Newer llmwiki Version"
+sidebarTitle: "State Recovery"
+description: "When .llmwiki/state.json was written by a newer llmwiki version, commands fail closed. Use llmwiki state reset to back up and reset the file and continue."
+---
+
+llmwiki tracks each project's compilation state in `.llmwiki/state.json`. That file carries a schema `version`, and each llmwiki build understands schema versions only up to the one it shipped with.
+
+If you run an llmwiki build against a project whose `.llmwiki/state.json` was written by a **newer** llmwiki version - for example, a teammate compiled with a newer release, or a stray newer binary touched the project - the state file declares a schema version this build does not recognize.
+
+## What "written by a newer llmwiki version" means
+
+It means `.llmwiki/state.json` has a `version` field higher than the highest version your installed llmwiki understands. The newer build may have written fields or a layout your build cannot safely interpret.
+
+When this happens, llmwiki **fails closed**. Rather than risk misreading the file - or overwriting a forward-incompatible layout on the next compile and corrupting it - commands that read state stop with a clear error instead of proceeding:
+
+```
+.llmwiki/state.json (version 3) was written by a newer llmwiki version
+(this build understands up to version 2). Upgrade llmwiki to read this project.
+```
+
+This is deliberate. The safest action when llmwiki encounters state it doesn't understand is to refuse to touch it.
+
+## Two ways forward
+
+### Upgrade llmwiki
+
+If you want to keep the existing compilation state - the recorded source hashes and the incremental-compile tracking - upgrade your llmwiki install to a version at least as new as the one that wrote the file. The newer build understands the schema and reads the project as-is.
+
+```bash
+npm install -g llm-wiki-compiler@latest
+```
+
+### Reset the state file
+
+If you are pinned to an older llmwiki and cannot upgrade, or you simply want to move forward from a clean slate, reset the state file with `llmwiki state reset`. This backs up `.llmwiki/state.json` to `.llmwiki/state.json.bak` and removes it, so the next `llmwiki compile` rebuilds state from your current `sources/`.
+
+## `llmwiki state reset`
+
+`state reset` refuses by default. Run it with no flags to see exactly what it will do without changing anything:
+
+```bash
+llmwiki state reset
+```
+
+```
+→ Will back up .llmwiki/state.json to .llmwiki/state.json.bak and remove it
+→ so the next compile starts fresh.
+→ Re-run with `--yes` to confirm.
+```
+
+When you're ready, pass `--yes` to apply the reset:
+
+```bash
+llmwiki state reset --yes
+```
+
+```
+✓ Reset .llmwiki/state.json. Backup saved to .llmwiki/state.json.bak.
+```
+
+The backup is a single atomic rename: the original bytes are preserved at `.llmwiki/state.json.bak` (overwriting any earlier backup), and the original file is removed.
+
+<Note>
+`state reset --yes` operates on the raw file bytes and never parses or validates the state. That's what makes it a reliable recovery path: it works even when the state file is too-new or otherwise unreadable - the very situation that would otherwise block you.
+</Note>
+
+If there is no state file to reset, the command says so and makes no changes:
+
+```bash
+llmwiki state reset
+```
+
+```
+✓ No state file to reset.
+```
+
+## After resetting
+
+Run a full compile to rebuild state from the current sources:
+
+```bash
+llmwiki compile
+```
+
+This regenerates `.llmwiki/state.json` at your build's schema version and produces fresh pages. Incremental compilation and [source freshness tracking](/troubleshooting/stale-pages) resume normally from there.
+
+<Tip>
+The backup at `.llmwiki/state.json.bak` is left in place. If you later upgrade llmwiki and want the original newer-version state back, you can restore it by renaming the backup to `.llmwiki/state.json` - then the upgraded build can read it directly.
+</Tip>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import reviewListCommand from "./commands/review-list.js";
 import reviewShowCommand from "./commands/review-show.js";
 import reviewApproveCommand from "./commands/review-approve.js";
 import reviewRejectCommand from "./commands/review-reject.js";
+import { stateResetCommand } from "./commands/state-reset.js";
 import { registerRulesCommand } from "./commands/rules-register.js";
 import nextCommand from "./commands/next.js";
 import refreshCommand from "./commands/refresh.js";
@@ -173,6 +174,25 @@ reviewCommand
   .action(async (id: string) => {
     try {
       await reviewRejectCommand(id);
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+const stateCommand = program
+  .command("state")
+  .description(
+    "Back up and reset .llmwiki/state.json (recovery for a state written by a newer llmwiki version).",
+  );
+
+stateCommand
+  .command("reset")
+  .description("Back up and reset the project state file. Requires --yes to apply.")
+  .option("--yes", "Apply the reset (back up and remove the state file)")
+  .action(async (options: { yes?: boolean }) => {
+    try {
+      await stateResetCommand({ yes: options.yes });
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
       process.exit(1);

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -1,0 +1,56 @@
+/**
+ * Commander action for `llmwiki state reset` — the recovery escape hatch for a
+ * `.llmwiki/state.json` written by a NEWER llmwiki version.
+ *
+ * When a state file's schema version exceeds what this build understands, every
+ * command that reads state fails closed (it never clobbers a forward-incompatible
+ * layout). That is the safe default, but it leaves a user on an older pin with no
+ * in-app way forward. This command provides one: back up the offending state file
+ * to `state.json.bak` and remove it so the next compile starts fresh.
+ *
+ * Crucially, the `--yes` path NEVER parses or validates the state — it operates on
+ * the raw bytes — so it works even when the state is too-new or corrupt. The backup
+ * is a single atomic `rename`, which both copies and removes in one step and
+ * overwrites any prior `.bak`.
+ */
+
+import { rename } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { STATE_FILE } from "../utils/constants.js";
+import * as output from "../utils/output.js";
+
+/** Options for {@link stateResetCommand}. */
+export interface StateResetOptions {
+  /** Apply the reset. Without it, the command only prints the plan. */
+  yes?: boolean;
+}
+
+/**
+ * Back up and reset `.llmwiki/state.json`.
+ *
+ * - No state file → reports nothing to do and returns.
+ * - Without `--yes` → prints what it would do and how to confirm; changes nothing.
+ * - With `--yes` → renames the raw state file to `state.json.bak` (atomic backup +
+ *   removal, overwriting any prior `.bak`) without reading or validating it, so the
+ *   recovery works on a too-new or corrupt state. Prints the backup path.
+ */
+export async function stateResetCommand(opts: StateResetOptions = {}): Promise<void> {
+  const statePath = path.join(process.cwd(), STATE_FILE);
+  const backupPath = `${statePath}.bak`;
+
+  if (!existsSync(statePath)) {
+    output.status("✓", output.success("No state file to reset."));
+    return;
+  }
+
+  if (!opts.yes) {
+    output.status("→", `Will back up ${STATE_FILE} to ${STATE_FILE}.bak and remove it`);
+    output.status("→", "so the next compile starts fresh.");
+    output.status("→", output.dim("Re-run with `--yes` to confirm."));
+    return;
+  }
+
+  await rename(statePath, backupPath);
+  output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
+}

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @file test/state-reset-cli.test.ts
+ * @description Subprocess tests for the `llmwiki state reset` recovery command.
+ *
+ * Covers the four contract paths: a dry refusal without `--yes` (no mutation),
+ * a confirmed reset that backs up and removes the state file, the recovery case
+ * where the on-disk state was written by a NEWER llmwiki version (`{"version":3}`,
+ * which `readState` would reject) yet `--yes` still backs it up without throwing,
+ * and the no-op when there is no state file to reset.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { runCLI } from "./fixtures/run-cli.js";
+import { STATE_FILE } from "../src/utils/constants.js";
+
+let root = "";
+
+/** Write a state.json with the given JSON content under `.llmwiki/`. */
+async function seedState(content: unknown): Promise<void> {
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(path.join(root, STATE_FILE), JSON.stringify(content), "utf8");
+}
+
+const STATE_PATH = (): string => path.join(root, STATE_FILE);
+const BAK_PATH = (): string => `${STATE_PATH()}.bak`;
+
+const OK_STATE = { version: 1, indexHash: "abc", sources: {} };
+
+/**
+ * Seed `content` as state.json, run a confirmed `state reset --yes`, and assert
+ * the file was backed up and removed. Returns the parsed `.bak` contents so each
+ * caller can assert its specific backed-up payload.
+ */
+async function resetAndReadBackup(content: unknown): Promise<unknown> {
+  await seedState(content);
+  const result = await runCLI(["state", "reset", "--yes"], root);
+  expect(result.code).toBe(0);
+  expect(existsSync(STATE_PATH())).toBe(false);
+  expect(existsSync(BAK_PATH())).toBe(true);
+  return JSON.parse(await readFile(BAK_PATH(), "utf8"));
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "state-reset-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  root = "";
+});
+
+describe("state reset", () => {
+  it("without --yes prints the plan and makes no change", async () => {
+    await seedState(OK_STATE);
+    const before = await readFile(STATE_PATH(), "utf8");
+
+    const result = await runCLI(["state", "reset"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("--yes");
+    expect(await readFile(STATE_PATH(), "utf8")).toBe(before);
+    expect(existsSync(BAK_PATH())).toBe(false);
+  });
+
+  it("with --yes backs up and removes the state file", async () => {
+    expect(await resetAndReadBackup(OK_STATE)).toEqual(OK_STATE);
+  });
+
+  it("with --yes recovers a state written by a newer llmwiki version", async () => {
+    expect(await resetAndReadBackup({ version: 3 })).toEqual({ version: 3 });
+  });
+
+  it("with no state file reports nothing to reset and exits 0", async () => {
+    const result = await runCLI(["state", "reset"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("No state file to reset.");
+    expect(existsSync(BAK_PATH())).toBe(false);
+  });
+});


### PR DESCRIPTION
Stacked on PR #123 (do not merge yet). Closes the product gap the audit flagged: a state file written by a newer llmwiki version fails closed across every command, but a user on an older pin had no in-app way forward.

- **`llmwiki state reset`** — backs `.llmwiki/state.json` up to `state.json.bak` and removes it so the next compile starts fresh. Refuses by default and prints exactly what it will do; `--yes` applies. The reset operates on the raw bytes (never parses the state), so it works even on a too-new or corrupt file — which is the whole point.
- **First user docs + CHANGELOG** for the fail-closed behavior and the recovery procedure (public-facing; no internal names). The documented error string matches the real one verbatim.

Subprocess tests cover all four contract paths (dry refusal, confirmed reset, too-new recovery, no-file no-op). Default profile byte-identical; full suite green.