### PR TITLE
feat(trust): Phase 3 PR6 (capstone) — non-default entity page staging + typed promotion

### DIFF
--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -1,0 +1,161 @@
+/**
+ * @file src/trust/staging.ts
+ * @description SDK-level NON-DEFAULT entity page staging loop (CLP Phase-3 PR6).
+ *
+ * Proves the full staging round-trip through the Write Planner WITHOUT any LLM:
+ *
+ *  1. {@link stageEntityPage} plans a non-default entity write via the TYPED
+ *     {@link planPageMutation}, enforces the fail-closed staged-write volume
+ *     bound ({@link assertStagedWriteBudget}) BEFORE persisting anything, builds a
+ *     {@link StagedChange} wrapping the planned mutation, and persists it as a
+ *     typed review candidate (`targetEntityType` + `trustDecision`) — the
+ *     candidate store IS the staging mechanism per the Phase-2 spec.
+ *  2. {@link promoteStagedEntityPage} re-reads that candidate, RE-PLANS the write
+ *     (so the mandatory floor + path-confinement re-run at promotion time), and
+ *     applies it through the executor so the page lands at
+ *     `wiki/<entityType>/<slug>.md`, then clears the candidate.
+ *
+ * The DEFAULT compile/review/import path is untouched: this is an additive,
+ * programmatic slice. The staged body is caller-provided (no generation).
+ */
+
+import {
+  planPageMutation,
+  type EntityRef,
+  type PlanResult,
+} from "./planner.js";
+import {
+  assertStagedWriteBudget,
+  DEFAULT_STAGED_WRITE_PER_CALL,
+  DEFAULT_STAGED_WRITE_PER_SESSION,
+  type HeldReasonCode,
+  type StagedChange,
+} from "./staged-change.js";
+import { applyApprovedMutations } from "./executor.js";
+import { isSlugSafe } from "../profile/identity.js";
+import { writeCandidate, readCandidate, deleteCandidate } from "../compiler/candidates.js";
+import type { EntityId, ProfilePack } from "../profile/types.js";
+import type { TrustDecision } from "./decision.js";
+
+/** Decisions under which the planner emitted a live-write mutation. */
+const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
+
+/** Inputs to {@link stageEntityPage}; the body is caller-provided (no LLM). */
+export interface StageEntityPageInput {
+  /** Profile entity type (the wiki subdirectory), e.g. `"papers"`. */
+  entityType: string;
+  /** Page slug (the filename stem); may be invalid — the planner decides. */
+  slug: string;
+  /** Full markdown body (frontmatter + prose) to stage verbatim. */
+  body: string;
+  /** The loaded non-default profile this page belongs to. */
+  profile: ProfilePack;
+  /** Staged writes already held this session (for the volume bound). */
+  existingStagedCount: number;
+  /** Injectable clock for deterministic `createdAt` (defaults to now). */
+  now?: () => Date;
+}
+
+/**
+ * Build the StagedChange `target` for a page. When the identity is slug-safe the
+ * plan minted a typed {@link EntityRef}, which we reuse. When it is NOT slug-safe
+ * the plan is empty (blocked) and no id was minted — we still return a typed-shape
+ * target so {@link StagedChange.target} is total, casting the raw `type/slug`
+ * (this target is never promoted: a blocked plan re-blocks on promotion).
+ */
+function buildPageTarget(entityType: string, slug: string, plan: PlanResult): EntityRef {
+  const live = plan.planned[0]?.target;
+  if (live && "id" in live) return live;
+  return { entityType, slug, id: `${entityType}/${slug}` as EntityId };
+}
+
+/**
+ * Why the change was held. A non-live-write decision is a real trust block;
+ * otherwise the entity write is routed for review by policy in this slice.
+ */
+function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
+  return LIVE_WRITE_DECISIONS.has(decision) ? ["manual-review-requested"] : ["trust-blocked"];
+}
+
+/**
+ * Stage a NON-DEFAULT entity page for review. Enforces the fail-closed staged
+ * write budget FIRST (so an overflow writes nothing), plans the write through the
+ * typed planner, captures it as a {@link StagedChange}, and persists it as a
+ * typed candidate carrying `targetEntityType` + `trustDecision`.
+ *
+ * @param root - Absolute project root.
+ * @param input - The entity page to stage (caller-provided body).
+ * @returns The persisted {@link StagedChange}.
+ * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
+ */
+export async function stageEntityPage(
+  root: string,
+  input: StageEntityPageInput,
+): Promise<StagedChange> {
+  assertStagedWriteBudget(input.existingStagedCount, 1, {
+    perCall: DEFAULT_STAGED_WRITE_PER_CALL,
+    perSession: DEFAULT_STAGED_WRITE_PER_SESSION,
+  });
+  const plan = await planPageMutation({
+    root,
+    entityType: input.entityType,
+    slug: input.slug,
+    body: input.body,
+    origin: "sdk",
+    reviewRouted: true,
+    allowOverwrite: false,
+  });
+  const candidate = await writeCandidate(root, {
+    title: input.slug,
+    slug: input.slug,
+    summary: "",
+    sources: [],
+    body: input.body,
+    targetEntityType: input.entityType,
+    trustDecision: plan.decision,
+  });
+  return {
+    id: candidate.id,
+    kind: "page",
+    target: buildPageTarget(input.entityType, input.slug, plan),
+    operation: plan.planned[0]?.operation ?? "create",
+    planned: plan.planned,
+    heldReasons: heldReasonsFor(plan.decision),
+    trustDecision: plan.decision,
+    createdAt: (input.now ? input.now() : new Date()).toISOString(),
+  };
+}
+
+/**
+ * Promote a staged entity page candidate into the live wiki. Re-reads the typed
+ * candidate, RE-PLANS the write (`allowOverwrite:true`, `origin:"review"`) so the
+ * mandatory floor + path confinement re-run, applies it through the executor so
+ * the page lands at `wiki/<entityType>/<slug>.md`, and clears the candidate.
+ *
+ * If the candidate is missing/untyped, or the re-plan blocks (empty plan), it
+ * throws and the candidate is RETAINED — nothing partial ever lands.
+ *
+ * @param root - Absolute project root.
+ * @param candidateId - The staged candidate's id.
+ * @throws {Error} When the candidate is missing, untyped, or its re-plan blocks.
+ */
+export async function promoteStagedEntityPage(root: string, candidateId: string): Promise<void> {
+  const candidate = await readCandidate(root, candidateId);
+  if (!candidate) throw new Error(`staged candidate not found: ${candidateId}`);
+  const entityType = candidate.targetEntityType;
+  if (!entityType) throw new Error(`candidate ${candidateId} is not a typed entity page`);
+  const { planned } = await planPageMutation({
+    root,
+    entityType,
+    slug: candidate.slug,
+    body: candidate.body,
+    origin: "review",
+    reviewRouted: false,
+    allowOverwrite: true,
+  });
+  if (planned.length === 0) {
+    throw new Error(`staged candidate ${candidateId} blocked by the write planner; retained`);
+  }
+  await applyApprovedMutations(root, planned);
+  await deleteCandidate(root, candidateId);
+}

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -32,13 +32,25 @@ import {
   type StagedChange,
 } from "./staged-change.js";
 import { applyApprovedMutations } from "./executor.js";
-import { isSlugSafe } from "../profile/identity.js";
 import { writeCandidate, readCandidate, deleteCandidate } from "../compiler/candidates.js";
 import type { EntityId, ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
 
 /** Decisions under which the planner emitted a live-write mutation. */
 const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
+
+/**
+ * Thrown when a caller tries to stage a page under an `entityType` that the
+ * supplied {@link ProfilePack} does not declare. Staging fails CLOSED before any
+ * planning or I/O so an unknown type can never land `wiki/<type>/<slug>.md`
+ * outside the profile schema.
+ */
+export class UnknownEntityTypeError extends Error {
+  constructor(entityType: string) {
+    super(`entity type "${entityType}" is not declared by the profile`);
+    this.name = "UnknownEntityTypeError";
+  }
+}
 
 /** Inputs to {@link stageEntityPage}; the body is caller-provided (no LLM). */
 export interface StageEntityPageInput {
@@ -78,15 +90,24 @@ function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
 }
 
 /**
- * Stage a NON-DEFAULT entity page for review. Enforces the fail-closed staged
- * write budget FIRST (so an overflow writes nothing), plans the write through the
- * typed planner, captures it as a {@link StagedChange}, and persists it as a
- * typed candidate carrying `targetEntityType` + `trustDecision`.
+ * Stage a NON-DEFAULT entity page for review. Fails CLOSED before any I/O: it
+ * first enforces the staged-write volume bound, then verifies `input.entityType`
+ * is declared by `input.profile` (throwing {@link UnknownEntityTypeError} if
+ * not), so an overflow or an unknown type writes nothing. It then plans the
+ * write through the typed planner, captures it as a {@link StagedChange}, and
+ * persists it as a typed candidate carrying `targetEntityType` + `trustDecision`.
+ *
+ * Volume bound: the PER-CALL cap (requested vs {@link DEFAULT_STAGED_WRITE_PER_CALL})
+ * is self-contained and self-enforced here. The PER-SESSION cap, however, is
+ * enforced against the caller-supplied `input.existingStagedCount` — there is no
+ * on-disk source of truth for a running session total, so keeping that count
+ * accurate across calls is the CALLER's responsibility.
  *
  * @param root - Absolute project root.
  * @param input - The entity page to stage (caller-provided body).
  * @returns The persisted {@link StagedChange}.
  * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
+ * @throws {UnknownEntityTypeError} When `entityType` is not declared by the profile.
  */
 export async function stageEntityPage(
   root: string,
@@ -96,6 +117,9 @@ export async function stageEntityPage(
     perCall: DEFAULT_STAGED_WRITE_PER_CALL,
     perSession: DEFAULT_STAGED_WRITE_PER_SESSION,
   });
+  if (!(input.entityType in input.profile.entities)) {
+    throw new UnknownEntityTypeError(input.entityType);
+  }
   const plan = await planPageMutation({
     root,
     entityType: input.entityType,

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @file test/trust-staging.test.ts
+ * @description End-to-end SDK-level test for the CLP Phase-3 NON-DEFAULT entity
+ * page staging loop (PR6 capstone).
+ *
+ * Drives `stageEntityPage` → `promoteStagedEntityPage` against the research-lite
+ * non-default profile fixture and asserts the full loop:
+ *  - staging a non-default entity page persists a typed candidate carrying
+ *    `targetEntityType` + `trustDecision`, and returns a `StagedChange` whose
+ *    target is a typed `EntityRef` (`papers/attention-is-all-you-need`);
+ *  - promotion lands the body at `wiki/papers/<slug>.md` and clears the candidate;
+ *  - the per-session volume bound fails CLOSED (no candidate written);
+ *  - a non-slug-safe identity blocks the live mutation without escaping the root;
+ *  - the DEFAULT candidate JSON shape stays clean (no typed keys) — a parity
+ *    guard complementing the frozen goldens.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, readFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  stageEntityPage,
+  promoteStagedEntityPage,
+} from "../src/trust/staging.js";
+import {
+  DEFAULT_STAGED_WRITE_PER_SESSION,
+  StagedWriteOverflowError,
+} from "../src/trust/staged-change.js";
+import { writeCandidate, listCandidates } from "../src/compiler/candidates.js";
+import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+const SLUG = "attention-is-all-you-need";
+const BODY = "---\ntitle: Attention Is All You Need\n---\n\n# Attention\n\nStaged body.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "trust-staging-"));
+  await buildResearchLiteProject(root);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Read the single candidate JSON file in the candidates dir, parsed. */
+async function readOnlyCandidate(): Promise<Record<string, unknown>> {
+  const dir = path.join(root, ".llmwiki/candidates");
+  const files = (await readdir(dir)).filter((f) => f.endsWith(".json"));
+  expect(files).toHaveLength(1);
+  return JSON.parse(await readFile(path.join(dir, files[0]!), "utf8"));
+}
+
+describe("non-default entity page staging", () => {
+  it("stages a typed candidate carrying the entity type + a typed EntityRef target", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "papers",
+      slug: SLUG,
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount: 0,
+    });
+
+    expect(staged.kind).toBe("page");
+    expect(staged.target).toMatchObject({ entityType: "papers", slug: SLUG, id: `papers/${SLUG}` });
+    const candidate = await readOnlyCandidate();
+    expect(candidate.targetEntityType).toBe("papers");
+    expect(candidate.trustDecision).toBe(staged.trustDecision);
+    expect(candidate.body).toBe(BODY);
+  });
+
+  it("promotes the staged page into wiki/<entityType>/<slug>.md and clears the candidate", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "papers",
+      slug: SLUG,
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount: 0,
+    });
+
+    await promoteStagedEntityPage(root, staged.id);
+
+    const page = path.join(root, "wiki/papers", `${SLUG}.md`);
+    expect(await readFile(page, "utf8")).toBe(BODY);
+    expect(await listCandidates(root)).toHaveLength(0);
+  });
+
+  it("fails CLOSED on the per-session volume bound, writing no candidate", async () => {
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: SLUG,
+        body: BODY,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: DEFAULT_STAGED_WRITE_PER_SESSION,
+      }),
+    ).rejects.toBeInstanceOf(StagedWriteOverflowError);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
+  });
+
+  it("blocks a non-slug-safe identity without writing an escaping path", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "papers",
+      slug: "../evil",
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount: 0,
+    });
+
+    expect(staged.planned).toHaveLength(0);
+    expect(staged.heldReasons).toContain("trust-blocked");
+    expect(existsSync(path.join(root, "wiki/evil.md"))).toBe(false);
+  });
+
+  it("keeps the DEFAULT candidate JSON clean of typed keys (parity guard)", async () => {
+    await writeCandidate(root, {
+      title: "Plain",
+      slug: "plain",
+      summary: "",
+      sources: [],
+      body: "---\ntitle: Plain\n---\nBody.",
+    });
+
+    const candidate = await readOnlyCandidate();
+    expect("targetEntityType" in candidate).toBe(false);
+    expect("trustDecision" in candidate).toBe(false);
+  });
+});

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -23,6 +23,7 @@ import os from "node:os";
 import {
   stageEntityPage,
   promoteStagedEntityPage,
+  UnknownEntityTypeError,
 } from "../src/trust/staging.js";
 import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
@@ -96,6 +97,19 @@ describe("non-default entity page staging", () => {
         existingStagedCount: DEFAULT_STAGED_WRITE_PER_SESSION,
       }),
     ).rejects.toBeInstanceOf(StagedWriteOverflowError);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
+  });
+
+  it("rejects an entityType not declared by the profile, writing no candidate", async () => {
+    await expect(
+      stageEntityPage(root, {
+        entityType: "bogus",
+        slug: SLUG,
+        body: BODY,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(UnknownEntityTypeError);
     expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 


### PR DESCRIPTION
Top of the stacked Phase 3 PRs (do not merge yet). Proves the full non-default write loop end-to-end through the planner — the payoff of the whole seam.

- **`stageEntityPage`** plans a non-default entity page write through the typed planner (minting a `<entityType>/<slug>` id), enforces the staged-write volume bound first (fail-closed on overflow), and persists it as a typed review candidate carrying its `targetEntityType` + trust decision.
- **`promoteStagedEntityPage`** re-plans (so the mandatory floor + path-confinement re-run at promotion) and applies through the executor, landing the page at `wiki/<entityType>/<slug>.md`, then clears the candidate. A floor block leaves the candidate retained.

SDK-level only (no LLM/generation — the body is caller-provided); driven by a small non-default profile fixture (papers/ideas/experiments). The default review/compile flows are completely untouched (omitted-for-default); default profile byte-identical; full suite green.

Follow-on (next phase): non-default *generation* (configured page production) and wiring staging into a CLI/MCP surface.