### PR TITLE
fix(trust,cli,sdk): Phase 3 stack hardening — close review-queue + trust-boundary holes

### DIFF
--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -22,6 +22,7 @@ import {
   CandidateProfileError,
   CandidatePromotionBlockedError,
 } from "../trust/promote.js";
+import { EntityFieldContractError } from "../profile/field-contract.js";
 import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
@@ -90,8 +91,9 @@ async function routeApprovedPageWrite(
 /**
  * Route a TYPED candidate through the profile-validated typed planner. Refuses
  * (exit 1, candidate retained) when the project has no profile, the type is no
- * longer declared, or the re-plan blocks — never a silent fall back to concepts.
- * Returns the absolute `wiki/<entityType>/<slug>.md` path on success.
+ * longer declared, the body violates the declared field contract, or the re-plan
+ * blocks — never a silent fall back to concepts. Returns the absolute
+ * `wiki/<entityType>/<slug>.md` path on success.
  */
 async function routeTypedPageWrite(
   root: string,
@@ -102,7 +104,11 @@ async function routeTypedPageWrite(
     const relPath = await applyTypedCandidate(root, candidate);
     return path.join(root, relPath);
   } catch (err) {
-    if (err instanceof CandidateProfileError || err instanceof CandidatePromotionBlockedError) {
+    if (
+      err instanceof CandidateProfileError ||
+      err instanceof CandidatePromotionBlockedError ||
+      err instanceof EntityFieldContractError
+    ) {
       output.status("!", output.error(`Candidate ${id} not approved: ${err.message}`));
       process.exitCode = 1;
       return null;

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -17,6 +17,11 @@ import path from "path";
 import { validateWikiPage } from "../utils/markdown.js";
 import { planDefaultPageMutation } from "../trust/planner.js";
 import { applyApprovedMutationsLocked } from "../trust/executor.js";
+import {
+  applyTypedCandidate,
+  CandidateProfileError,
+  CandidatePromotionBlockedError,
+} from "../trust/promote.js";
 import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
@@ -50,10 +55,8 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
     return;
   }
 
-  if (!(await routeApprovedPageWrite(root, candidate, id))) return;
-
-  const dir = candidate.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
-  const pagePath = path.join(root, dir, `${candidate.slug}.md`);
+  const pagePath = await routeApprovedPageWrite(root, candidate, id);
+  if (!pagePath) return;
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
 
   await persistCandidateSourceStates(root, candidate);
@@ -64,22 +67,61 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
 
 /**
  * Route the candidate's page write through the write planner/executor (CLP
- * Invariant 4) instead of a direct file write, preserving byte-for-byte parity:
- * the planner derives the SAME `wiki/<dir>/<slug>.md` absolute path and the
- * executor writes the candidate body verbatim under the ALREADY-HELD review lock
- * (so no nested-lock deadlock), running journal replay to recover any crashed
- * batch on this path.
+ * Invariant 4) and return the ABSOLUTE page path it landed at, or `null` on a
+ * refusal (exit code 1, candidate retained, nothing written).
  *
- * `allowOverwrite` is true so re-approving an existing page upserts via `update`
- * rather than colliding. Returns true when the write landed; on a blocked plan
- * (the mandatory floor refused, e.g. an oversized body) it surfaces an approval
- * FAILURE — exit code 1, candidate retained, nothing written — and returns false.
+ * A candidate carrying `targetEntityType` (staged via the typed planner) routes
+ * through {@link applyTypedCandidate} so it lands at `wiki/<entityType>/<slug>.md`
+ * — NOT silently in concepts. A candidate without a typed target keeps the
+ * EXISTING default concepts/queries path byte-for-byte. Both run under the
+ * ALREADY-HELD review lock (no nested-lock deadlock).
  */
 async function routeApprovedPageWrite(
   root: string,
   candidate: ReviewCandidate,
   id: string,
-): Promise<boolean> {
+): Promise<string | null> {
+  if (candidate.targetEntityType) {
+    return routeTypedPageWrite(root, candidate, id);
+  }
+  return routeDefaultPageWrite(root, candidate, id);
+}
+
+/**
+ * Route a TYPED candidate through the profile-validated typed planner. Refuses
+ * (exit 1, candidate retained) when the project has no profile, the type is no
+ * longer declared, or the re-plan blocks — never a silent fall back to concepts.
+ * Returns the absolute `wiki/<entityType>/<slug>.md` path on success.
+ */
+async function routeTypedPageWrite(
+  root: string,
+  candidate: ReviewCandidate,
+  id: string,
+): Promise<string | null> {
+  try {
+    const relPath = await applyTypedCandidate(root, candidate);
+    return path.join(root, relPath);
+  } catch (err) {
+    if (err instanceof CandidateProfileError || err instanceof CandidatePromotionBlockedError) {
+      output.status("!", output.error(`Candidate ${id} not approved: ${err.message}`));
+      process.exitCode = 1;
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Route a DEFAULT candidate (no typed target) through the concepts/queries
+ * planner exactly as before, preserving byte-for-byte parity. `allowOverwrite`
+ * is true so re-approving upserts via `update`. Returns the absolute
+ * `wiki/<dir>/<slug>.md` path on success, or `null` on a blocked plan.
+ */
+async function routeDefaultPageWrite(
+  root: string,
+  candidate: ReviewCandidate,
+  id: string,
+): Promise<string | null> {
   const directory = candidate.targetDirectory === "queries" ? "queries" : "concepts";
   const { planned } = await planDefaultPageMutation({
     root,
@@ -93,10 +135,11 @@ async function routeApprovedPageWrite(
   if (planned.length === 0) {
     output.status("!", output.error(`Candidate ${id} blocked by the write planner; not approved.`));
     process.exitCode = 1;
-    return false;
+    return null;
   }
   await applyApprovedMutationsLocked(root, planned);
-  return true;
+  const dir = candidate.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
+  return path.join(root, dir, `${candidate.slug}.md`);
 }
 
 /**

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -44,17 +44,16 @@ export default async function reviewApproveCommand(id: string): Promise<void> {
  *
  * Re-reads the candidate under the lock so that a concurrent reject that ran
  * between the pre-lock fast-fail and lock acquisition is detected. Aborts with
- * exit code 1 if the candidate has disappeared or fails page validation.
+ * exit code 1 if the candidate has disappeared. Page-body validation is routed
+ * per target: DEFAULT candidates are gated by the title-requiring
+ * {@link validateWikiPage} (in {@link routeDefaultPageWrite}); TYPED candidates
+ * skip it and instead rely on {@link applyTypedCandidate}'s profile-aware
+ * field-contract validation, since non-default entity types need not require a
+ * `title`.
  */
 async function approveUnderLock(root: string, id: string): Promise<void> {
   const candidate = await readCandidateUnderLock(root, id);
   if (!candidate) return;
-
-  if (!validateWikiPage(candidate.body)) {
-    output.status("!", output.error(`Candidate ${id} failed page validation; not approved.`));
-    process.exitCode = 1;
-    return;
-  }
 
   const pagePath = await routeApprovedPageWrite(root, candidate, id);
   if (!pagePath) return;
@@ -119,15 +118,23 @@ async function routeTypedPageWrite(
 
 /**
  * Route a DEFAULT candidate (no typed target) through the concepts/queries
- * planner exactly as before, preserving byte-for-byte parity. `allowOverwrite`
- * is true so re-approving upserts via `update`. Returns the absolute
- * `wiki/<dir>/<slug>.md` path on success, or `null` on a blocked plan.
+ * planner exactly as before, preserving byte-for-byte parity. The
+ * title-requiring {@link validateWikiPage} gate runs HERE — only for default
+ * candidates — so a body that fails it is refused with the SAME message and exit
+ * code 1 as before. `allowOverwrite` is true so re-approving upserts via
+ * `update`. Returns the absolute `wiki/<dir>/<slug>.md` path on success, or
+ * `null` on a failed validation / blocked plan.
  */
 async function routeDefaultPageWrite(
   root: string,
   candidate: ReviewCandidate,
   id: string,
 ): Promise<string | null> {
+  if (!validateWikiPage(candidate.body)) {
+    output.status("!", output.error(`Candidate ${id} failed page validation; not approved.`));
+    process.exitCode = 1;
+    return null;
+  }
   const directory = candidate.targetDirectory === "queries" ? "queries" : "concepts";
   const { planned } = await planDefaultPageMutation({
     root,

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -12,12 +12,21 @@
  * the raw bytes — so it works even when the state is too-new or corrupt. The backup
  * is a single atomic `rename`, which both copies and removes in one step and
  * overwrites any prior `.bak`.
+ *
+ * SAFETY (mirrors the journal-dir trust boundary). The reset acquires the project
+ * LOCK before touching state, so it can never race a concurrent compile/writeState;
+ * if the lock is held it refuses cleanly rather than forcing. It also CONFINES the
+ * `.llmwiki` dir to the project root's realpath — a symlinked `.llmwiki` (or a
+ * state file whose parent escapes root) fails CLOSED and nothing outside root is
+ * moved or clobbered.
  */
 
-import { rename } from "fs/promises";
+import { rename, realpath } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { STATE_FILE } from "../utils/constants.js";
+import { LLMWIKI_DIR, STATE_FILE } from "../utils/constants.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { safeRealpath, isInsideDir, confineUnderRoot } from "../utils/path-confine.js";
 import * as output from "../utils/output.js";
 
 /** Options for {@link stateResetCommand}. */
@@ -27,30 +36,102 @@ export interface StateResetOptions {
 }
 
 /**
- * Back up and reset `.llmwiki/state.json`.
+ * Resolve the confined `.llmwiki` directory for `root`, mirroring the journal-dir
+ * trust boundary: its realpath must be a REAL directory that stays inside the
+ * project root's realpath. Returns the confined real dir, or null to FAIL CLOSED
+ * — null when `.llmwiki` is absent (nothing to reset) OR when it exists but is a
+ * symlink/path escaping root (filesystem tampering). An escape is announced.
  *
- * - No state file → reports nothing to do and returns.
- * - Without `--yes` → prints what it would do and how to confirm; changes nothing.
- * - With `--yes` → renames the raw state file to `state.json.bak` (atomic backup +
- *   removal, overwriting any prior `.bak`) without reading or validating it, so the
- *   recovery works on a too-new or corrupt state. Prints the backup path.
+ * @param root - Absolute project root directory.
+ * @returns The confined `.llmwiki` real directory, or null to fail closed.
  */
-export async function stateResetCommand(opts: StateResetOptions = {}): Promise<void> {
-  const statePath = path.join(process.cwd(), STATE_FILE);
-  const backupPath = `${statePath}.bak`;
+async function resolveConfinedLlmwikiDir(root: string): Promise<string | null> {
+  const realDir = await safeRealpath(path.join(root, LLMWIKI_DIR));
+  if (realDir === null) return null; // absent → nothing to reset
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  if (!isInsideDir(realDir, realRoot)) {
+    output.status("!", output.warn(`${LLMWIKI_DIR} escapes the project root — refusing to reset (tampering).`));
+    return null;
+  }
+  return realDir;
+}
 
+/**
+ * Dry-run path (no `--yes`): report the no-op when there is no state file, else
+ * print the plan and how to confirm. Changes nothing.
+ *
+ * @param root - Absolute project root directory.
+ */
+function reportResetPlan(root: string): void {
+  if (!existsSync(path.join(root, STATE_FILE))) {
+    output.status("✓", output.success("No state file to reset."));
+    return;
+  }
+  output.status("→", `Will back up ${STATE_FILE} to ${STATE_FILE}.bak and remove it`);
+  output.status("→", "so the next compile starts fresh.");
+  output.status("→", output.dim("Re-run with `--yes` to confirm."));
+}
+
+/**
+ * Confirmed path (`--yes`): acquire the lock (refusing cleanly if held), validate
+ * `.llmwiki` is a real in-root directory, back up the raw state file, and always
+ * release the lock.
+ *
+ * @param root - Absolute project root directory.
+ */
+async function runConfirmedReset(root: string): Promise<void> {
+  const acquired = await acquireLock(root);
+  if (!acquired) {
+    output.status("!", output.warn("Another llmwiki process is using this project; not resetting."));
+    return;
+  }
+  try {
+    const confinedDir = await resolveConfinedLlmwikiDir(root);
+    if (confinedDir === null) return; // absent or escaping → nothing safe to reset
+    await backupStateFile(root, confinedDir);
+  } finally {
+    await releaseLock(root);
+  }
+}
+
+/**
+ * Back up and remove the confined state file. Resolves the state path UNDER the
+ * confined `.llmwiki` dir (so a symlinked parent cannot redirect the rename) and
+ * renames the RAW bytes to `state.json.bak` without reading or validating them,
+ * so recovery works on a too-new or corrupt state.
+ *
+ * @param root - Absolute project root directory.
+ * @param confinedDir - The validated `.llmwiki` real directory.
+ */
+async function backupStateFile(root: string, confinedDir: string): Promise<void> {
+  const statePath = path.join(confinedDir, path.basename(STATE_FILE));
   if (!existsSync(statePath)) {
     output.status("✓", output.success("No state file to reset."));
     return;
   }
+  const confinedState = await confineUnderRoot(statePath, root, { mustExist: false });
+  await rename(confinedState, `${confinedState}.bak`);
+  output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
+}
 
+/**
+ * Back up and reset `.llmwiki/state.json`.
+ *
+ * - No state file → reports nothing to do and returns.
+ * - Without `--yes` → prints what it would do and how to confirm; changes nothing.
+ * - With `--yes` → acquires the project lock (refusing cleanly if another process
+ *   holds it), validates `.llmwiki` is a real in-root directory (failing closed on
+ *   a symlink escaping root), then renames the raw state file to `state.json.bak`
+ *   (atomic backup + removal) without reading or validating it. Prints the backup
+ *   path. The lock is always released.
+ *
+ * @param opts - `{ yes }` — apply the reset when true, else print the plan.
+ */
+export async function stateResetCommand(opts: StateResetOptions = {}): Promise<void> {
+  const root = process.cwd();
   if (!opts.yes) {
-    output.status("→", `Will back up ${STATE_FILE} to ${STATE_FILE}.bak and remove it`);
-    output.status("→", "so the next compile starts fresh.");
-    output.status("→", output.dim("Re-run with `--yes` to confirm."));
+    reportResetPlan(root);
     return;
   }
-
-  await rename(statePath, backupPath);
-  output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
+  await runConfirmedReset(root);
 }

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -18,7 +18,8 @@
  * if the lock is held it refuses cleanly rather than forcing. It also CONFINES the
  * `.llmwiki` dir to the project root's realpath — a symlinked `.llmwiki` (or a
  * state file whose parent escapes root) fails CLOSED and nothing outside root is
- * moved or clobbered.
+ * moved or clobbered. A confinement refusal is a FAILURE (exit code 1), distinct
+ * from a benign ABSENT `.llmwiki` (nothing to reset → exit 0).
  */
 
 import { rename, realpath } from "fs/promises";
@@ -36,24 +37,40 @@ export interface StateResetOptions {
 }
 
 /**
+ * The outcome of confining the `.llmwiki` directory under the project root:
+ *  - `ok`     — a REAL in-root directory; carries the confined real `dir`.
+ *  - `absent` — no `.llmwiki` directory at all (nothing to reset; a no-op success).
+ *  - `escape` — `.llmwiki` exists but its realpath escapes root (filesystem
+ *               tampering); a confinement REFUSAL, which must exit non-zero.
+ *
+ * Distinguishing `absent` from `escape` is what lets the caller exit 0 for the
+ * benign no-op yet exit 1 for the tampering refusal — collapsing both to `null`
+ * (the prior behavior) made a refusal masquerade as success.
+ */
+type LlmwikiDirResolution =
+  | { kind: "ok"; dir: string }
+  | { kind: "absent" }
+  | { kind: "escape" };
+
+/**
  * Resolve the confined `.llmwiki` directory for `root`, mirroring the journal-dir
  * trust boundary: its realpath must be a REAL directory that stays inside the
- * project root's realpath. Returns the confined real dir, or null to FAIL CLOSED
- * — null when `.llmwiki` is absent (nothing to reset) OR when it exists but is a
- * symlink/path escaping root (filesystem tampering). An escape is announced.
+ * project root's realpath. Returns a tagged {@link LlmwikiDirResolution} so the
+ * caller can tell a benign ABSENT dir (no-op, exit 0) apart from an ESCAPING one
+ * (tampering refusal, exit non-zero). An escape is announced here.
  *
  * @param root - Absolute project root directory.
- * @returns The confined `.llmwiki` real directory, or null to fail closed.
+ * @returns The tagged resolution: `ok` (with the real dir), `absent`, or `escape`.
  */
-async function resolveConfinedLlmwikiDir(root: string): Promise<string | null> {
+async function resolveConfinedLlmwikiDir(root: string): Promise<LlmwikiDirResolution> {
   const realDir = await safeRealpath(path.join(root, LLMWIKI_DIR));
-  if (realDir === null) return null; // absent → nothing to reset
+  if (realDir === null) return { kind: "absent" }; // absent → nothing to reset
   const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
   if (!isInsideDir(realDir, realRoot)) {
     output.status("!", output.warn(`${LLMWIKI_DIR} escapes the project root — refusing to reset (tampering).`));
-    return null;
+    return { kind: "escape" };
   }
-  return realDir;
+  return { kind: "ok", dir: realDir };
 }
 
 /**
@@ -82,15 +99,22 @@ function reportResetPlan(root: string): void {
  * @param root - Absolute project root directory.
  */
 async function runConfirmedReset(root: string): Promise<void> {
-  const confinedDir = await resolveConfinedLlmwikiDir(root);
-  if (confinedDir === null) return; // absent or escaping → nothing safe to reset, no lock created
+  const resolution = await resolveConfinedLlmwikiDir(root);
+  if (resolution.kind === "absent") {
+    output.status("✓", output.success("No state file to reset."));
+    return; // benign no-op → exit 0, no lock created
+  }
+  if (resolution.kind === "escape") {
+    process.exitCode = 1; // confinement refusal is a FAILURE
+    return; // warning already announced, no lock created
+  }
   const acquired = await acquireLock(root);
   if (!acquired) {
     output.status("!", output.warn("Another llmwiki process is using this project; not resetting."));
     return;
   }
   try {
-    await backupStateFile(root, confinedDir);
+    await backupStateFile(root, resolution.dir);
   } finally {
     await releaseLock(root);
   }

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -73,21 +73,23 @@ function reportResetPlan(root: string): void {
 }
 
 /**
- * Confirmed path (`--yes`): acquire the lock (refusing cleanly if held), validate
- * `.llmwiki` is a real in-root directory, back up the raw state file, and always
- * release the lock.
+ * Confirmed path (`--yes`): validate `.llmwiki` is a real in-root directory FIRST
+ * (a read-only realpath check) so a symlinked-escaping `.llmwiki` is rejected
+ * before `acquireLock` would itself create a lock file through the symlink; only
+ * then acquire the lock (refusing cleanly if held), back up the raw state file,
+ * and always release the lock.
  *
  * @param root - Absolute project root directory.
  */
 async function runConfirmedReset(root: string): Promise<void> {
+  const confinedDir = await resolveConfinedLlmwikiDir(root);
+  if (confinedDir === null) return; // absent or escaping → nothing safe to reset, no lock created
   const acquired = await acquireLock(root);
   if (!acquired) {
     output.status("!", output.warn("Another llmwiki process is using this project; not resetting."));
     return;
   }
   try {
-    const confinedDir = await resolveConfinedLlmwikiDir(root);
-    if (confinedDir === null) return; // absent or escaping → nothing safe to reset
     await backupStateFile(root, confinedDir);
   } finally {
     await releaseLock(root);

--- a/src/compiler/candidate-store-paths.ts
+++ b/src/compiler/candidate-store-paths.ts
@@ -1,0 +1,106 @@
+/**
+ * @file src/compiler/candidate-store-paths.ts
+ * @description Realpath-confinement helpers for the review candidate store.
+ *
+ * The candidate store persists one JSON file per candidate under
+ * `.llmwiki/candidates/` (and archives rejected ones under `…/archive/`). Path
+ * resolution here is the single trust boundary for that store: it must reject a
+ * SYMLINKED `.llmwiki/candidates` (or a symlinked `.llmwiki`) that would redirect
+ * every read/write/delete/archive OUTSIDE the project root — the same
+ * containing-directory escape class already closed for the intent journal
+ * (`resolveConfinedJournalDir`) and `state reset`.
+ *
+ * Two primitives, both fail-closed:
+ *
+ *  - {@link confinedCandidateFilePath} confines a single candidate FILE path under
+ *    root via {@link confineUnderRoot} (which realpath-confines the nearest
+ *    existing ancestor). For a NORMAL (real) candidates dir the confined path
+ *    equals the lexical `path.join` result → default candidate JSON stays
+ *    byte-identical. A symlinked containing dir is detected and THROWS.
+ *  - {@link resolveConfinedCandidatesDir} resolves the candidates/archive DIRECTORY
+ *    realpath for listing/scanning: returns null when the dir is ABSENT (today's
+ *    "no candidates" behavior) and THROWS when it EXISTS but escapes root, so a
+ *    list/scan never `readdir`s through an escaping symlink.
+ */
+
+import path from "path";
+import {
+  confineUnderRoot,
+  safeRealpath,
+  isInsideDir,
+} from "../utils/path-confine.js";
+import { isSafeFilenameComponent } from "../profile/identity.js";
+
+/**
+ * Thrown when the candidate store's containing directory (`.llmwiki/candidates`
+ * or `…/archive`, or the `.llmwiki` parent) is a symlink/path that escapes the
+ * project root, so a read/write/delete/archive/list would operate OUTSIDE the
+ * project. Fails CLOSED before any I/O. A NORMAL real directory never trips this.
+ */
+export class UnsafeCandidateDirError extends Error {
+  constructor(dir: string) {
+    super(`candidate store directory escapes the project root: ${JSON.stringify(dir)}`);
+    this.name = "UnsafeCandidateDirError";
+  }
+}
+
+/** Extension used for all candidate JSON files. */
+const CANDIDATE_EXT = ".json";
+
+/**
+ * Resolve the confined absolute path of the candidate file `${id}.json` under
+ * `dir` (relative to `root`). Asserts `id` is a single safe filename component,
+ * then confines the FINAL file path under root via {@link confineUnderRoot} — so a
+ * symlinked containing dir (whose realpath is the nearest existing ancestor) is
+ * detected and rejected. A normal real dir yields the byte-identical lexical path.
+ *
+ * @param root - Absolute project root directory.
+ * @param dir - Candidates subdir (pending or archive) relative to root.
+ * @param id - Candidate id (the filename stem); must be a safe path component.
+ * @param onUnsafeId - Called to build the typed error thrown for an unsafe id.
+ * @returns The confined absolute candidate file path.
+ * @throws The error from `onUnsafeId` when `id` is not a safe path component.
+ * @throws {UnsafeCandidateDirError} When the containing dir escapes root.
+ */
+export async function confinedCandidateFilePath(
+  root: string,
+  dir: string,
+  id: string,
+  onUnsafeId: (id: string) => Error,
+): Promise<string> {
+  if (!isSafeFilenameComponent(id)) throw onUnsafeId(id);
+  // Confine the project-RELATIVE path so confinement is invariant to which
+  // symlink form of root it is resolved under (e.g. `/var/...` vs the canonical
+  // `/private/var/...` on macOS); an absolute target would otherwise resolve to
+  // the non-canonical form and spuriously read as escaping.
+  const relPath = path.join(dir, `${id}${CANDIDATE_EXT}`);
+  try {
+    return await confineUnderRoot(relPath, root, { mustExist: false });
+  } catch {
+    throw new UnsafeCandidateDirError(path.join(root, dir));
+  }
+}
+
+/**
+ * Resolve the candidates/archive DIRECTORY's realpath for listing/scanning,
+ * mirroring `resolveConfinedJournalDir`. Returns null when the directory is
+ * ABSENT (nothing to list — today's empty-list behavior) and THROWS
+ * {@link UnsafeCandidateDirError} when it EXISTS but its realpath escapes root, so
+ * a list/scan NEVER `readdir`s through an escaping symlink.
+ *
+ * @param root - Absolute project root directory.
+ * @param dir - Candidates subdir (pending or archive) relative to root.
+ * @returns The confined real directory, or null when absent.
+ * @throws {UnsafeCandidateDirError} When the dir exists but escapes root.
+ */
+export async function resolveConfinedCandidatesDir(
+  root: string,
+  dir: string,
+): Promise<string | null> {
+  const target = path.join(root, dir);
+  const realDir = await safeRealpath(target);
+  if (realDir === null) return null; // absent → nothing to list
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  if (!isInsideDir(realDir, realRoot)) throw new UnsafeCandidateDirError(target);
+  return realDir;
+}

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -16,6 +16,7 @@ import { unlink } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { randomBytes } from "crypto";
+import { isSafeFilenameComponent } from "../profile/identity.js";
 import { atomicWrite, safeReadFile } from "../utils/markdown.js";
 import {
   listCandidateFileIds,
@@ -118,20 +119,52 @@ const VALID_TRUST_DECISIONS: TrustDecision[] = [
   "deny",
 ];
 
+/**
+ * Thrown when a candidate id or slug is not a single safe path component, so a
+ * traversal-bearing value (e.g. `../evil`) can never be joined into a candidate
+ * file path that escapes `.llmwiki/candidates/`. Default slugs from `slugify`
+ * are already filename-safe, so this never fires on the default path.
+ */
+export class UnsafeCandidateIdError extends Error {
+  constructor(kind: "id" | "slug", value: string) {
+    super(`unsafe candidate ${kind}: ${JSON.stringify(value)} is not a single safe path component`);
+    this.name = "UnsafeCandidateIdError";
+  }
+}
+
 /** Build a deterministic-but-unique id from a slug and a short random suffix. */
 function buildCandidateId(slug: string): string {
   const suffix = randomBytes(ID_SUFFIX_BYTES).toString("hex");
   return `${slug}-${suffix}`;
 }
 
+/**
+ * Resolve a candidate file path under `dir`, asserting `id` is a single safe
+ * filename component AND that the joined path stays lexically confined under the
+ * candidates directory. Defense in depth: a safe id (the default case) yields a
+ * byte-identical path to `path.join`, so default parity is preserved; an unsafe
+ * id (traversal) throws {@link UnsafeCandidateIdError} before any I/O.
+ * @param root - Project root directory.
+ * @param dir - Candidates subdir (pending or archive) relative to root.
+ * @param id - Candidate id to embed as the filename stem.
+ */
+function resolveCandidatePath(root: string, dir: string, id: string): string {
+  if (!isSafeFilenameComponent(id)) throw new UnsafeCandidateIdError("id", id);
+  const base = path.join(root, dir);
+  const filePath = path.join(base, `${id}${CANDIDATE_EXT}`);
+  const prefix = base.endsWith(path.sep) ? base : base + path.sep;
+  if (!filePath.startsWith(prefix)) throw new UnsafeCandidateIdError("id", id);
+  return filePath;
+}
+
 /** Absolute path to a candidate's JSON file. */
 function candidatePath(root: string, id: string): string {
-  return path.join(root, CANDIDATES_DIR, `${id}${CANDIDATE_EXT}`);
+  return resolveCandidatePath(root, CANDIDATES_DIR, id);
 }
 
 /** Absolute path to the archived JSON file for a rejected candidate. */
 function archivePath(root: string, id: string): string {
-  return path.join(root, CANDIDATES_ARCHIVE_DIR, `${id}${CANDIDATE_EXT}`);
+  return resolveCandidatePath(root, CANDIDATES_ARCHIVE_DIR, id);
 }
 
 /**
@@ -149,6 +182,7 @@ export async function writeCandidate(
   root: string,
   draft: CandidateDraft,
 ): Promise<ReviewCandidate> {
+  if (!isSafeFilenameComponent(draft.slug)) throw new UnsafeCandidateIdError("slug", draft.slug);
   const { canonicalId, duplicateIds } = await findSlugDuplicates(root, draft.slug);
   const candidate: ReviewCandidate = {
     id: canonicalId ?? buildCandidateId(draft.slug),

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -22,6 +22,10 @@ import {
   listCandidateFileIds,
   moveCandidateToArchive,
 } from "../utils/candidate-store.js";
+import {
+  confinedCandidateFilePath,
+  resolveConfinedCandidatesDir,
+} from "./candidate-store-paths.js";
 import * as output from "../utils/output.js";
 import {
   CANDIDATES_DIR,
@@ -34,9 +38,6 @@ import type { TrustDecision } from "../trust/decision.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
 const ID_SUFFIX_BYTES = 4;
-
-/** Filesystem extension used for candidate JSON files. */
-const CANDIDATE_EXT = ".json";
 
 /** Input shape for creating a new candidate (id + timestamp generated here). */
 interface CandidateDraft {
@@ -138,32 +139,34 @@ function buildCandidateId(slug: string): string {
   return `${slug}-${suffix}`;
 }
 
+/** Build the typed unsafe-id error for a candidate file id. */
+function unsafeCandidateId(id: string): Error {
+  return new UnsafeCandidateIdError("id", id);
+}
+
 /**
  * Resolve a candidate file path under `dir`, asserting `id` is a single safe
- * filename component AND that the joined path stays lexically confined under the
- * candidates directory. Defense in depth: a safe id (the default case) yields a
- * byte-identical path to `path.join`, so default parity is preserved; an unsafe
- * id (traversal) throws {@link UnsafeCandidateIdError} before any I/O.
+ * filename component AND REALPATH-confining the result under the project root via
+ * {@link confinedCandidateFilePath}. Defense in depth: a safe id under a NORMAL
+ * (real) candidates dir yields a byte-identical path to `path.join`, so default
+ * parity is preserved; an unsafe id throws {@link UnsafeCandidateIdError}, and a
+ * symlinked containing dir escaping root throws {@link UnsafeCandidateDirError} —
+ * both before any I/O.
  * @param root - Project root directory.
  * @param dir - Candidates subdir (pending or archive) relative to root.
  * @param id - Candidate id to embed as the filename stem.
  */
-function resolveCandidatePath(root: string, dir: string, id: string): string {
-  if (!isSafeFilenameComponent(id)) throw new UnsafeCandidateIdError("id", id);
-  const base = path.join(root, dir);
-  const filePath = path.join(base, `${id}${CANDIDATE_EXT}`);
-  const prefix = base.endsWith(path.sep) ? base : base + path.sep;
-  if (!filePath.startsWith(prefix)) throw new UnsafeCandidateIdError("id", id);
-  return filePath;
+function resolveCandidatePath(root: string, dir: string, id: string): Promise<string> {
+  return confinedCandidateFilePath(root, dir, id, unsafeCandidateId);
 }
 
-/** Absolute path to a candidate's JSON file. */
-function candidatePath(root: string, id: string): string {
+/** Absolute confined path to a candidate's JSON file. */
+function candidatePath(root: string, id: string): Promise<string> {
   return resolveCandidatePath(root, CANDIDATES_DIR, id);
 }
 
-/** Absolute path to the archived JSON file for a rejected candidate. */
-function archivePath(root: string, id: string): string {
+/** Absolute confined path to the archived JSON file for a rejected candidate. */
+function archivePath(root: string, id: string): Promise<string> {
   return resolveCandidatePath(root, CANDIDATES_ARCHIVE_DIR, id);
 }
 
@@ -205,7 +208,7 @@ export async function writeCandidate(
     ...(draft.trustDecision ? { trustDecision: draft.trustDecision } : {}),
   };
 
-  await atomicWrite(candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
+  await atomicWrite(await candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
   await deleteDuplicates(root, duplicateIds);
   return candidate;
 }
@@ -313,7 +316,7 @@ export async function readCandidate(
   root: string,
   id: string,
 ): Promise<ReviewCandidate | null> {
-  const raw = await safeReadFile(candidatePath(root, id));
+  const raw = await safeReadFile(await candidatePath(root, id));
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as ReviewCandidate;
@@ -457,7 +460,8 @@ function isValidCandidate(value: unknown): value is ReviewCandidate {
  * @returns All pending review candidates.
  */
 export async function listCandidates(root: string): Promise<ReviewCandidate[]> {
-  const dir = path.join(root, CANDIDATES_DIR);
+  const dir = await resolveConfinedCandidatesDir(root, CANDIDATES_DIR);
+  if (dir === null) return []; // absent candidates dir → nothing pending
   const ids = await listCandidateFileIds(dir);
   const candidates: ReviewCandidate[] = [];
   for (const id of ids) {
@@ -482,7 +486,7 @@ export async function countCandidates(root: string): Promise<number> {
 
 /** Remove a pending candidate from disk. Returns false when nothing existed to remove. */
 export async function deleteCandidate(root: string, id: string): Promise<boolean> {
-  const filePath = candidatePath(root, id);
+  const filePath = await candidatePath(root, id);
   if (!existsSync(filePath)) return false;
   await unlink(filePath);
   return true;
@@ -513,5 +517,5 @@ export async function deleteCandidateBySlug(root: string, slug: string): Promise
  * @returns True when the candidate was found and archived.
  */
 export async function archiveCandidate(root: string, id: string): Promise<boolean> {
-  return moveCandidateToArchive(candidatePath(root, id), archivePath(root, id));
+  return moveCandidateToArchive(await candidatePath(root, id), await archivePath(root, id));
 }

--- a/src/compiler/rule-candidates.ts
+++ b/src/compiler/rule-candidates.ts
@@ -12,15 +12,18 @@
  * evidence, lowercase status/confidence. Do not reshape it for local use.
  */
 
-import path from "path";
 import { createHash } from "node:crypto";
 import { atomicWrite, safeReadFile, slugify } from "../utils/markdown.js";
 import {
-  CANDIDATE_JSON_EXT,
   candidateFileId,
   listCandidateFileIds,
   moveCandidateToArchive,
 } from "../utils/candidate-store.js";
+import {
+  confinedCandidateFilePath,
+  resolveConfinedCandidatesDir,
+} from "./candidate-store-paths.js";
+import { UnsafeCandidateIdError } from "./candidates.js";
 import {
   RULE_CANDIDATES_DIR,
   RULE_CANDIDATES_ARCHIVE_DIR,
@@ -42,14 +45,26 @@ const STATUS_VALUES: readonly RuleStatus[] = ["proposed", "approved", "rejected"
 /** Runtime evidence shape checker for a tagged evidence variant. */
 type EvidenceShapeChecker = (ref: Record<string, unknown>) => string | null;
 
-/** Absolute path to a rule candidate's JSON file. */
-function ruleCandidatePath(root: string, id: string): string {
-  return path.join(root, RULE_CANDIDATES_DIR, `${id}${CANDIDATE_JSON_EXT}`);
+/** Build the typed unsafe-id error for a rule-candidate file id. */
+function unsafeRuleCandidateId(id: string): Error {
+  return new UnsafeCandidateIdError("id", id);
 }
 
-/** Absolute path to the archived JSON file for a rejected rule candidate. */
-function ruleArchivePath(root: string, id: string): string {
-  return path.join(root, RULE_CANDIDATES_ARCHIVE_DIR, `${id}${CANDIDATE_JSON_EXT}`);
+/**
+ * Absolute, REALPATH-confined path to a rule candidate's JSON file. Asserts
+ * `id` is a single safe filename component and confines the result under the
+ * project root via the shared {@link confinedCandidateFilePath} — so a symlinked
+ * `.llmwiki/rule-candidates` (or `.llmwiki`) escaping root throws
+ * {@link UnsafeCandidateDirError} before any I/O. A NORMAL real dir yields the
+ * byte-identical lexical path, so default rule behavior is unchanged.
+ */
+function ruleCandidatePath(root: string, id: string): Promise<string> {
+  return confinedCandidateFilePath(root, RULE_CANDIDATES_DIR, id, unsafeRuleCandidateId);
+}
+
+/** Absolute, REALPATH-confined path to the archived JSON file for a rejected rule candidate. */
+function ruleArchivePath(root: string, id: string): Promise<string> {
+  return confinedCandidateFilePath(root, RULE_CANDIDATES_ARCHIVE_DIR, id, unsafeRuleCandidateId);
 }
 
 /** the rule importer contract caps (mirrored from the rule-import contract rule_candidate_validation.rs). */
@@ -314,7 +329,7 @@ export async function writeRuleCandidate(
   candidate: RuleCandidate,
 ): Promise<string> {
   const fileId = candidateFileId(candidate.id);
-  const target = ruleCandidatePath(root, fileId);
+  const target = await ruleCandidatePath(root, fileId);
   await atomicWrite(target, JSON.stringify(candidate, null, 2));
   return target;
 }
@@ -329,7 +344,7 @@ export async function readRuleCandidate(
   root: string,
   fileId: string,
 ): Promise<RuleCandidate | null> {
-  const raw = await safeReadFile(ruleCandidatePath(root, fileId));
+  const raw = await safeReadFile(await ruleCandidatePath(root, fileId));
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw);
@@ -345,7 +360,8 @@ export async function readRuleCandidate(
  * @param root - Project root directory.
  */
 export async function listRuleCandidates(root: string): Promise<RuleCandidate[]> {
-  const dir = path.join(root, RULE_CANDIDATES_DIR);
+  const dir = await resolveConfinedCandidatesDir(root, RULE_CANDIDATES_DIR);
+  if (dir === null) return []; // absent rule-candidates dir → nothing pending
   const fileIds = await listCandidateFileIds(dir);
   const candidates: RuleCandidate[] = [];
   for (const fileId of fileIds) {
@@ -375,7 +391,7 @@ export async function setRuleCandidateStatus(
   if (!candidate) return null;
   const updated: RuleCandidate = { ...candidate, status };
   await atomicWrite(
-    ruleCandidatePath(root, fileId),
+    await ruleCandidatePath(root, fileId),
     JSON.stringify(updated, null, 2),
   );
   return updated;
@@ -392,7 +408,7 @@ export async function archiveRuleCandidate(
   fileId: string,
 ): Promise<boolean> {
   return moveCandidateToArchive(
-    ruleCandidatePath(root, fileId),
-    ruleArchivePath(root, fileId),
+    await ruleCandidatePath(root, fileId),
+    await ruleArchivePath(root, fileId),
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,33 @@ export type { OkfExportReport } from "./export/okf/run.js";
 export type { OkfImportReport, OkfImportSkip, OkfImportedPage } from "./import/run.js";
 export { LockUnavailableError, QueueFullError } from "./import/run-errors.js";
 
+// @experimental — programmatic non-default entity-page staging loop. The
+// `createWiki()` facade exposes `stageEntityPage`/`promoteStagedPage`; these are
+// the input/return types consumers need. The lower-level `stageEntityPage(root,…)`
+// and `promoteCandidateUnderLock` forms stay internal. API may change.
+export type { SdkStageEntityPageInput } from "./trust/staging.js";
+export { StagingRequiresProfileError } from "./trust/staging.js";
+export type {
+  StagedChange,
+  CandidateKind,
+  HeldReasonCode,
+  RelationRef,
+  ArtifactRef,
+  WorkflowRunRef,
+} from "./trust/staged-change.js";
+// Planner sub-types named by `StagedChange.target` / `.planned` so the staged
+// surface is fully nameable by consumers (the typed `EntityRef` target especially).
+export type {
+  EntityRef,
+  RawPageRef,
+  MutationTarget,
+  MutationOperation,
+  MutationKind,
+  PlannedMutation,
+  MutationProvenance,
+} from "./trust/planner.js";
+export type { TrustDecision } from "./trust/decision.js";
+
 // Profile pack TYPES only — the loader stays internal (no `loadProfile` export).
 export type {
   ProfilePack,

--- a/src/profile/collect.ts
+++ b/src/profile/collect.ts
@@ -30,13 +30,8 @@
 import { scanEntityDir, type RawEntityScan } from "../wiki/collect.js";
 import { isDefaultProfile } from "./default.js";
 import { isSlugSafe, assertSlugSafe, entityId, suggestSlugFromBasename } from "./identity.js";
-import type {
-  ProfilePack,
-  EntityPage,
-  EntityTypeDef,
-  FieldDef,
-  FieldType,
-} from "./types.js";
+import { validateEntityFields } from "./field-contract.js";
+import type { ProfilePack, EntityPage, EntityTypeDef } from "./types.js";
 
 /** Error raised only for the programming-error default-profile guard. */
 export class EntityCollectError extends Error {
@@ -87,28 +82,11 @@ function declaredSlug(frontmatter: Record<string, unknown>): string | undefined 
 }
 
 /**
- * Compute the de-duplicated set of required field names for an entity type: the
- * UNION of the entity-level `requiredFields` array and every field whose own
- * `FieldDef.required === true`. Returned as a `Set` so a field declared required
- * BOTH ways yields exactly one missing-field problem, never two.
- */
-function requiredFieldNames(def: EntityTypeDef): Set<string> {
-  const names = new Set<string>(def.requiredFields ?? []);
-  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
-    if (fieldDef.required === true) names.add(name);
-  }
-  return names;
-}
-
-/**
- * Validate a slug-safe page against its entity type's declared field contract,
- * pushing a `field-violation` problem for each missing required field and, for
- * each PRESENT field value, every declared-type / enum / min-max mismatch. A
- * field is required when it is in `def.requiredFields` OR carries
- * `FieldDef.required === true` (the union, de-duplicated). The page is NOT
+ * Validate a slug-safe page against its entity type's declared field contract via
+ * the SHARED {@link validateEntityFields} (the SAME implementation the typed write
+ * gates use), wrapping each PATH-FREE message into a `field-violation` problem
+ * tagged with the entity type and the offending `filePath`. The page is NOT
  * dropped — a contract violation is surfaced, not fatal — and this NEVER throws.
- * Messages are PATH-FREE (the offending path lives only on the structured
- * `filePath` field).
  */
 function checkFieldContract(
   entityType: string,
@@ -116,115 +94,9 @@ function checkFieldContract(
   scan: RawEntityScan,
   problems: EntityProblem[],
 ): void {
-  const fm = scan.frontmatter;
-  for (const field of requiredFieldNames(def)) {
-    if (!(field in fm)) {
-      problems.push({
-        kind: "field-violation",
-        entityType,
-        filePath: scan.filePath,
-        message: `Required field ${JSON.stringify(field)} is missing from frontmatter.`,
-      });
-    }
+  for (const message of validateEntityFields(scan.frontmatter, def)) {
+    problems.push({ kind: "field-violation", entityType, filePath: scan.filePath, message });
   }
-  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
-    checkFieldValue(entityType, name, fieldDef, scan, problems);
-  }
-}
-
-/**
- * Validate one present field value against its declared type, enum membership,
- * and numeric min/max. A missing value is not validated here (required-presence
- * is handled separately). Each mismatch becomes one PATH-FREE `field-violation`.
- */
-function checkFieldValue(
-  entityType: string,
-  name: string,
-  fieldDef: FieldDef,
-  scan: RawEntityScan,
-  problems: EntityProblem[],
-): void {
-  const value = scan.frontmatter[name];
-  if (value === undefined) return;
-  const typeError = describeTypeMismatch(name, fieldDef, value);
-  if (typeError) {
-    pushFieldViolation(entityType, scan.filePath, typeError, problems);
-    return;
-  }
-  const rangeError = describeRangeViolation(name, fieldDef, value);
-  if (rangeError) pushFieldViolation(entityType, scan.filePath, rangeError, problems);
-}
-
-/** Append a `field-violation` problem carrying a PATH-FREE message. */
-function pushFieldViolation(
-  entityType: string,
-  filePath: string,
-  message: string,
-  problems: EntityProblem[],
-): void {
-  problems.push({ kind: "field-violation", entityType, filePath, message });
-}
-
-/**
- * Return a PATH-FREE message when `value` does not match `fieldDef.type`
- * (including enum membership), or `undefined` when the type is satisfied.
- */
-function describeTypeMismatch(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
-  if (matchesDeclaredType(fieldDef, value)) return undefined;
-  if (fieldDef.type === "enum") {
-    return (
-      `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not one of ` +
-      `${JSON.stringify(fieldDef.enum ?? [])}.`
-    );
-  }
-  return `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not a valid ${fieldDef.type}.`;
-}
-
-/** True when `value` is a string parseable as a date, or a valid `Date`. */
-function isValidDate(value: unknown): boolean {
-  // YAML parses an unquoted ISO date into a JS `Date`; a quoted value stays a
-  // string. Accept either, provided it denotes a valid instant.
-  if (value instanceof Date) return !Number.isNaN(value.getTime());
-  return typeof value === "string" && !Number.isNaN(Date.parse(value));
-}
-
-/**
- * Per-field-type value predicates (enum excluded — it needs the `FieldDef`).
- * A lookup table keeps {@link matchesDeclaredType} flat instead of a wide
- * switch that would trip the complexity gate.
- */
-const TYPE_PREDICATES: Record<Exclude<FieldType, "enum">, (value: unknown) => boolean> = {
-  string: (v) => typeof v === "string",
-  slug: (v) => typeof v === "string" && isSlugSafe(v),
-  integer: (v) => Number.isInteger(v),
-  number: (v) => typeof v === "number" && Number.isFinite(v),
-  boolean: (v) => typeof v === "boolean",
-  date: isValidDate,
-  "string[]": (v) => Array.isArray(v) && v.every((item) => typeof item === "string"),
-};
-
-/** True when `value` satisfies the declared `FieldDef.type` (enum included). */
-function matchesDeclaredType(fieldDef: FieldDef, value: unknown): boolean {
-  if (fieldDef.type === "enum") {
-    return typeof value === "string" && (fieldDef.enum?.includes(value) ?? false);
-  }
-  return TYPE_PREDICATES[fieldDef.type](value);
-}
-
-/**
- * Return a PATH-FREE message when a numeric `value` falls outside the declared
- * `[min, max]`, or `undefined` when in range or when no bound applies. Only
- * meaningful after the value has passed its numeric type check.
- */
-function describeRangeViolation(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
-  if (typeof value !== "number") return undefined;
-  if (fieldDef.min !== undefined && value < fieldDef.min) {
-    return `Field ${JSON.stringify(name)} value ${value} is below min ${fieldDef.min}.`;
-  }
-  if (fieldDef.max !== undefined && value > fieldDef.max) {
-    return `Field ${JSON.stringify(name)} value ${value} exceeds max ${fieldDef.max}.`;
-  }
-  return undefined;
 }
 
 /**

--- a/src/profile/field-contract.ts
+++ b/src/profile/field-contract.ts
@@ -1,0 +1,161 @@
+/**
+ * @file src/profile/field-contract.ts
+ * @description The single, PURE per-page field-contract validator for a profile
+ * entity type — shared by the read-surface collector ({@link collectEntityPages}
+ * in `collect.ts`) and the typed WRITE gates (`stageEntityPage`,
+ * `applyTypedCandidate`), so both enforce ONE implementation (DRY).
+ *
+ * Given a page's parsed frontmatter and the resolved {@link EntityTypeDef}, it
+ * returns a list of PATH-FREE field-violation messages: one per missing required
+ * field, and one per present field value that mismatches its declared type, enum
+ * membership, or numeric min/max. It is pure (no I/O), never throws, and carries
+ * no path/entity-type context — callers attach that when they wrap each message
+ * into their own problem/error shape.
+ */
+
+import { isSlugSafe } from "./identity.js";
+import type { EntityTypeDef, FieldDef, FieldType } from "./types.js";
+
+/**
+ * Thrown by the typed WRITE gates (staging / promotion) when a candidate body's
+ * frontmatter violates its entity type's declared field contract — a missing
+ * required field, or a type/enum/range mismatch. Fails CLOSED so a contract-
+ * violating typed page is never staged or promoted (on the READ surfaces the same
+ * violations are non-fatal problems, not throws). Carries the structured list of
+ * PATH-FREE violation messages so callers can surface exactly what failed.
+ */
+export class EntityFieldContractError extends Error {
+  /** The PATH-FREE field-violation messages that caused the refusal. */
+  readonly violations: string[];
+
+  constructor(entityType: string, slug: string, violations: string[]) {
+    super(
+      `typed page ${entityType}/${slug} violates the profile field contract: ` +
+        `${violations.join(" ")}`,
+    );
+    this.name = "EntityFieldContractError";
+    this.violations = violations;
+  }
+}
+
+/**
+ * Compute the de-duplicated set of required field names for an entity type: the
+ * UNION of the entity-level `requiredFields` array and every field whose own
+ * `FieldDef.required === true`. Returned as a `Set` so a field declared required
+ * BOTH ways yields exactly one missing-field message, never two.
+ */
+function requiredFieldNames(def: EntityTypeDef): Set<string> {
+  const names = new Set<string>(def.requiredFields ?? []);
+  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
+    if (fieldDef.required === true) names.add(name);
+  }
+  return names;
+}
+
+/** True when `value` is a string parseable as a date, or a valid `Date`. */
+function isValidDate(value: unknown): boolean {
+  // YAML parses an unquoted ISO date into a JS `Date`; a quoted value stays a
+  // string. Accept either, provided it denotes a valid instant.
+  if (value instanceof Date) return !Number.isNaN(value.getTime());
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+/**
+ * Per-field-type value predicates (enum excluded — it needs the `FieldDef`).
+ * A lookup table keeps {@link matchesDeclaredType} flat instead of a wide switch.
+ */
+const TYPE_PREDICATES: Record<Exclude<FieldType, "enum">, (value: unknown) => boolean> = {
+  string: (v) => typeof v === "string",
+  slug: (v) => typeof v === "string" && isSlugSafe(v),
+  integer: (v) => Number.isInteger(v),
+  number: (v) => typeof v === "number" && Number.isFinite(v),
+  boolean: (v) => typeof v === "boolean",
+  date: isValidDate,
+  "string[]": (v) => Array.isArray(v) && v.every((item) => typeof item === "string"),
+};
+
+/** True when `value` satisfies the declared `FieldDef.type` (enum included). */
+function matchesDeclaredType(fieldDef: FieldDef, value: unknown): boolean {
+  if (fieldDef.type === "enum") {
+    return typeof value === "string" && (fieldDef.enum?.includes(value) ?? false);
+  }
+  return TYPE_PREDICATES[fieldDef.type](value);
+}
+
+/**
+ * Return a PATH-FREE message when `value` does not match `fieldDef.type`
+ * (including enum membership), or `undefined` when the type is satisfied.
+ */
+function describeTypeMismatch(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
+  if (matchesDeclaredType(fieldDef, value)) return undefined;
+  if (fieldDef.type === "enum") {
+    return (
+      `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not one of ` +
+      `${JSON.stringify(fieldDef.enum ?? [])}.`
+    );
+  }
+  return `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not a valid ${fieldDef.type}.`;
+}
+
+/**
+ * Return a PATH-FREE message when a numeric `value` falls outside the declared
+ * `[min, max]`, or `undefined` when in range or when no bound applies. Only
+ * meaningful after the value has passed its numeric type check.
+ */
+function describeRangeViolation(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
+  if (typeof value !== "number") return undefined;
+  if (fieldDef.min !== undefined && value < fieldDef.min) {
+    return `Field ${JSON.stringify(name)} value ${value} is below min ${fieldDef.min}.`;
+  }
+  if (fieldDef.max !== undefined && value > fieldDef.max) {
+    return `Field ${JSON.stringify(name)} value ${value} exceeds max ${fieldDef.max}.`;
+  }
+  return undefined;
+}
+
+/** Append every violation message for one present field value to `out`. */
+function collectFieldValueViolations(
+  name: string,
+  fieldDef: FieldDef,
+  value: unknown,
+  out: string[],
+): void {
+  if (value === undefined) return; // presence is handled by the required check
+  const typeError = describeTypeMismatch(name, fieldDef, value);
+  if (typeError) {
+    out.push(typeError);
+    return;
+  }
+  const rangeError = describeRangeViolation(name, fieldDef, value);
+  if (rangeError) out.push(rangeError);
+}
+
+/**
+ * Validate a page's parsed frontmatter against its entity type's declared field
+ * contract, returning a list of PATH-FREE violation messages (empty when the page
+ * satisfies the contract). One message per missing required field, plus one per
+ * present field value that mismatches its declared type / enum / numeric bound.
+ *
+ * A field is required when it appears in `def.requiredFields` OR carries
+ * `FieldDef.required === true` (the union, de-duplicated). Pure and total — no
+ * I/O, never throws, carries no path/entity-type context.
+ *
+ * @param frontmatter - The page's parsed frontmatter record.
+ * @param def - The resolved entity type definition to validate against.
+ * @returns Zero or more PATH-FREE field-violation messages.
+ */
+export function validateEntityFields(
+  frontmatter: Record<string, unknown>,
+  def: EntityTypeDef,
+): string[] {
+  const violations: string[] = [];
+  for (const field of requiredFieldNames(def)) {
+    if (!(field in frontmatter)) {
+      violations.push(`Required field ${JSON.stringify(field)} is missing from frontmatter.`);
+    }
+  }
+  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
+    collectFieldValueViolations(name, fieldDef, frontmatter[name], violations);
+  }
+  return violations;
+}

--- a/src/sdk/staging-facade.ts
+++ b/src/sdk/staging-facade.ts
@@ -1,0 +1,35 @@
+/**
+ * @file src/sdk/staging-facade.ts
+ * @description The EXPERIMENTAL non-default staging slice of the `Wiki` facade,
+ * factored out of `src/sdk/wiki.ts` so the high-fan-in facade module stays lean.
+ *
+ * Both methods run silently under the caller-supplied quiet wrapper and load the
+ * active non-default profile INTERNALLY — the consumer never passes a
+ * `ProfilePack`. They delegate to the trust-layer staging helpers, which fail
+ * CLOSED (`StagingRequiresProfileError`) on a project with no non-default profile.
+ *
+ * @experimental Foundation API — the shape may change in a future minor release.
+ */
+
+import { stageEntityPageForProject, promoteStagedEntityPage } from "../trust/staging.js";
+import type { Wiki } from "./types.js";
+
+/** The experimental staging methods the `Wiki` facade composes in. */
+export type StagingFacadeSlice = Pick<Wiki, "stageEntityPage" | "promoteStagedPage">;
+
+/**
+ * Build the experimental staging slice of the `Wiki` facade bound to `root`.
+ *
+ * @param root - Normalized absolute project root.
+ * @param runQuiet - The facade's quiet-scoping wrapper (output suppressed).
+ * @returns The `stageEntityPage` / `promoteStagedPage` methods.
+ */
+export function buildStagingFacade(
+  root: string,
+  runQuiet: <T>(fn: () => Promise<T>) => Promise<T>,
+): StagingFacadeSlice {
+  return {
+    stageEntityPage: (input) => runQuiet(() => stageEntityPageForProject(root, input)),
+    promoteStagedPage: (candidateId) => runQuiet(() => promoteStagedEntityPage(root, candidateId)),
+  };
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -20,6 +20,8 @@ import type { JsonExportDocument, ExportJsonOptions } from "../export/json-expor
 import type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "../sources/store.js";
 import type { OkfExportReport } from "../export/okf/run.js";
 import type { OkfImportReport } from "../import/run.js";
+import type { SdkStageEntityPageInput } from "../trust/staging.js";
+import type { StagedChange } from "../trust/staged-change.js";
 
 /** Options for `createWiki`. */
 export interface CreateWikiOptions {
@@ -165,4 +167,26 @@ export interface Wiki {
    * latency/cost); `dryRun:true` writes nothing.
    */
   importOkf(dir: string, opts?: { trusted?: boolean; dryRun?: boolean }): Promise<OkfImportReport>;
+  /**
+   * @experimental
+   * Stage a NON-DEFAULT entity page for review. The SDK loads the active
+   * non-default profile internally — the caller passes no `ProfilePack`. Throws
+   * `StagingRequiresProfileError` when the project has no non-default profile
+   * (staging targets a typed `wiki/<entityType>/<slug>.md` path that only a
+   * non-default profile declares). `existingStagedCount` is the caller's
+   * per-session bookkeeping (defaults to 0). No LLM required.
+   *
+   * Foundation API — the shape may change in a future minor release.
+   */
+  stageEntityPage(input: SdkStageEntityPageInput): Promise<StagedChange>;
+  /**
+   * @experimental
+   * Promote a staged entity page candidate into the live wiki under one held
+   * lock: re-reads the candidate, re-validates its type against the active
+   * profile, re-plans + applies, and clears the candidate. The page lands at
+   * `wiki/<entityType>/<slug>.md`, or nothing does. No LLM required.
+   *
+   * Foundation API — the shape may change in a future minor release.
+   */
+  promoteStagedPage(candidateId: string): Promise<void>;
 }

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -38,6 +38,7 @@ import { getPage, listPages } from "../pages/list.js";
 import { listSources, getSource, deleteSource } from "../sources/store.js";
 import { runOkfExport } from "../export/okf/run.js";
 import { runOkfImport } from "../import/run.js";
+import { buildStagingFacade } from "./staging-facade.js";
 import type { CreateWikiOptions, Wiki, SdkCompileOptions } from "./types.js";
 
 /**
@@ -131,5 +132,8 @@ export function createWiki(options: CreateWikiOptions): Wiki {
     exportOkf: (opts = {}) => runQuiet(() => runOkfExport(root, opts)),
 
     importOkf: (dir, opts = {}) => runQuiet(() => runOkfImport(root, dir, opts)),
+
+    // @experimental non-default staging slice — factored into staging-facade.ts.
+    ...buildStagingFacade(root, runQuiet),
   };
 }

--- a/src/trust/promote.ts
+++ b/src/trust/promote.ts
@@ -1,0 +1,136 @@
+/**
+ * @file src/trust/promote.ts
+ * @description The single under-lock promotion routine for a TYPED entity-page
+ * candidate, shared by the SDK staging helper and `review approve`'s typed
+ * branch (CLP Phase-3 hardening, DRY).
+ *
+ * Promoting a typed candidate must (a) re-validate the candidate's declared
+ * `targetEntityType` against the CURRENTLY-loaded profile — the profile may have
+ * changed since the candidate was staged — and (b) re-plan + apply the write
+ * under the SAME held lock as the candidate re-read and delete, so a concurrent
+ * reject between read and apply cannot race. This module owns that contract once:
+ *
+ *  - {@link applyTypedCandidate} is the LOCK-FREE core (caller already holds the
+ *    project lock): load + validate the active profile, re-plan via the typed
+ *    {@link planPageMutation}, apply via {@link applyApprovedMutationsLocked}, and
+ *    return the wiki-relative `wiki/<entityType>/<slug>.md` path. It NEVER deletes
+ *    the candidate — the caller owns that, since `review approve` deletes only
+ *    after its source-state/index refresh tail.
+ *  - {@link promoteCandidateUnderLock} is the SELF-LOCKING SDK entry point: it
+ *    acquires the lock, RE-READS the candidate (aborting if a concurrent reject
+ *    removed it), runs {@link applyTypedCandidate}, deletes the candidate, and
+ *    releases the lock in `finally`.
+ */
+
+import { loadNonDefaultProfile } from "../profile/block.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { planPageMutation } from "./planner.js";
+import { applyApprovedMutationsLocked } from "./executor.js";
+import { readCandidate, deleteCandidate } from "../compiler/candidates.js";
+import type { ReviewCandidate } from "../utils/types.js";
+
+/**
+ * Thrown when a typed candidate cannot be promoted because the active profile no
+ * longer declares (or never declared) its `targetEntityType` — e.g. a default
+ * project with no profile, or a profile edited since staging. Promotion fails
+ * CLOSED so a typed page can never land outside the current profile schema, and
+ * the candidate is RETAINED for the caller to surface. Distinct from a blocked
+ * plan ({@link CandidatePromotionBlockedError}).
+ */
+export class CandidateProfileError extends Error {
+  constructor(entityType: string, reason: "no-profile" | "undeclared") {
+    const detail =
+      reason === "no-profile"
+        ? "the project has no non-default profile"
+        : `the active profile does not declare entity type "${entityType}"`;
+    super(`cannot promote typed candidate: ${detail}`);
+    this.name = "CandidateProfileError";
+  }
+}
+
+/**
+ * Thrown when the typed re-plan blocks at promotion time (empty plan — e.g. the
+ * mandatory floor refused an oversized body). The candidate is RETAINED; nothing
+ * partial ever lands.
+ */
+export class CandidatePromotionBlockedError extends Error {
+  constructor(entityType: string, slug: string) {
+    super(`typed candidate ${entityType}/${slug} blocked by the write planner; retained`);
+    this.name = "CandidatePromotionBlockedError";
+  }
+}
+
+/** The wiki-relative page path a typed candidate promotes to. */
+function typedPagePath(entityType: string, slug: string): string {
+  return `wiki/${entityType}/${slug}.md`;
+}
+
+/**
+ * Validate a typed candidate's `targetEntityType` against the active profile and
+ * re-plan + apply its write — the LOCK-FREE promotion core. The caller MUST
+ * already hold the project lock (so this never nests an acquire). Loads the
+ * active non-default profile, refuses if it is absent or no longer declares the
+ * type, re-plans via the typed planner (so the mandatory floor + path-confinement
+ * re-run at promotion time), and applies under the held lock. Returns the
+ * wiki-relative page path the body landed at.
+ *
+ * @param root - Absolute project root.
+ * @param candidate - The typed candidate (must carry `targetEntityType`).
+ * @returns The `wiki/<entityType>/<slug>.md` path the page was written to.
+ * @throws {CandidateProfileError} When no profile declares the type.
+ * @throws {CandidatePromotionBlockedError} When the re-plan blocks (empty plan).
+ */
+export async function applyTypedCandidate(
+  root: string,
+  candidate: ReviewCandidate,
+): Promise<string> {
+  const entityType = candidate.targetEntityType!;
+  const loaded = await loadNonDefaultProfile(root);
+  if (!loaded) throw new CandidateProfileError(entityType, "no-profile");
+  if (!(entityType in loaded.profile.entities)) {
+    throw new CandidateProfileError(entityType, "undeclared");
+  }
+  const { planned } = await planPageMutation({
+    root,
+    entityType,
+    slug: candidate.slug,
+    body: candidate.body,
+    origin: "review",
+    reviewRouted: false,
+    allowOverwrite: true,
+  });
+  if (planned.length === 0) {
+    throw new CandidatePromotionBlockedError(entityType, candidate.slug);
+  }
+  await applyApprovedMutationsLocked(root, planned);
+  return typedPagePath(entityType, candidate.slug);
+}
+
+/**
+ * Promote a typed staged candidate into the live wiki under ONE held lock:
+ * acquire → re-read (abort if a concurrent reject removed it) → validate profile
+ * + re-plan + apply via {@link applyTypedCandidate} → delete → release. The
+ * candidate read, the apply, and the delete all happen inside the same locked
+ * region so no concurrent reject/approve can race the promotion.
+ *
+ * @param root - Absolute project root.
+ * @param candidateId - The staged candidate's id.
+ * @throws {Error} When the lock cannot be acquired or the candidate is missing/untyped.
+ * @throws {CandidateProfileError} When the profile no longer declares the type.
+ * @throws {CandidatePromotionBlockedError} When the re-plan blocks.
+ */
+export async function promoteCandidateUnderLock(root: string, candidateId: string): Promise<void> {
+  const acquired = await acquireLock(root);
+  if (!acquired) throw new Error("could not acquire project lock for candidate promotion");
+  try {
+    const candidate = await readCandidate(root, candidateId);
+    if (!candidate) throw new Error(`staged candidate not found: ${candidateId}`);
+    if (!candidate.targetEntityType) {
+      throw new Error(`candidate ${candidateId} is not a typed entity page`);
+    }
+    await applyTypedCandidate(root, candidate);
+    await deleteCandidate(root, candidateId);
+  } finally {
+    await releaseLock(root);
+  }
+}

--- a/src/trust/promote.ts
+++ b/src/trust/promote.ts
@@ -27,6 +27,12 @@ import { acquireLock, releaseLock } from "../utils/lock.js";
 import { planPageMutation } from "./planner.js";
 import { applyApprovedMutationsLocked } from "./executor.js";
 import { readCandidate, deleteCandidate } from "../compiler/candidates.js";
+import {
+  validateEntityFields,
+  EntityFieldContractError,
+} from "../profile/field-contract.js";
+import { parseFrontmatter } from "../utils/markdown.js";
+import type { EntityTypeDef } from "../profile/types.js";
 import type { ReviewCandidate } from "../utils/types.js";
 
 /**
@@ -66,6 +72,31 @@ function typedPagePath(entityType: string, slug: string): string {
 }
 
 /**
+ * Validate a typed candidate's body frontmatter against its entity type's
+ * declared field contract via the SHARED {@link validateEntityFields} (the same
+ * validator staging and the read-surface collector use), throwing
+ * {@link EntityFieldContractError} BEFORE the re-plan/apply when the contract is
+ * violated. Promotion then fails CLOSED and the candidate is RETAINED (the caller
+ * deletes only after a successful apply), so a contract-violating page never lands.
+ *
+ * @param entityType - The (already type-checked) profile entity type.
+ * @param candidate - The typed candidate whose body frontmatter is validated.
+ * @param def - The resolved entity type definition supplying the contract.
+ * @throws {EntityFieldContractError} When the frontmatter violates the contract.
+ */
+function assertCandidateFieldContract(
+  entityType: string,
+  candidate: ReviewCandidate,
+  def: EntityTypeDef,
+): void {
+  const { meta } = parseFrontmatter(candidate.body);
+  const violations = validateEntityFields(meta, def);
+  if (violations.length > 0) {
+    throw new EntityFieldContractError(entityType, candidate.slug, violations);
+  }
+}
+
+/**
  * Validate a typed candidate's `targetEntityType` against the active profile and
  * re-plan + apply its write — the LOCK-FREE promotion core. The caller MUST
  * already hold the project lock (so this never nests an acquire). Loads the
@@ -78,6 +109,7 @@ function typedPagePath(entityType: string, slug: string): string {
  * @param candidate - The typed candidate (must carry `targetEntityType`).
  * @returns The `wiki/<entityType>/<slug>.md` path the page was written to.
  * @throws {CandidateProfileError} When no profile declares the type.
+ * @throws {EntityFieldContractError} When the body frontmatter violates the field contract.
  * @throws {CandidatePromotionBlockedError} When the re-plan blocks (empty plan).
  */
 export async function applyTypedCandidate(
@@ -90,6 +122,7 @@ export async function applyTypedCandidate(
   if (!(entityType in loaded.profile.entities)) {
     throw new CandidateProfileError(entityType, "undeclared");
   }
+  assertCandidateFieldContract(entityType, candidate, loaded.profile.entities[entityType]!);
   const { planned } = await planPageMutation({
     root,
     entityType,

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -33,8 +33,41 @@ import {
 import { promoteCandidateUnderLock } from "./promote.js";
 import { writeCandidate } from "../compiler/candidates.js";
 import { loadNonDefaultProfile } from "../profile/block.js";
+import {
+  validateEntityFields,
+  EntityFieldContractError,
+} from "../profile/field-contract.js";
+import { parseFrontmatter } from "../utils/markdown.js";
 import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
+
+export { EntityFieldContractError } from "../profile/field-contract.js";
+
+/**
+ * Validate a staged page body's frontmatter against its entity type's declared
+ * field contract via the SHARED {@link validateEntityFields} (the same validator
+ * the read-surface collector uses), throwing {@link EntityFieldContractError} —
+ * before any planning or I/O — when the contract is violated, so a contract-
+ * violating typed page never persists a candidate. A clean body is a no-op.
+ *
+ * @param entityType - The (already type-checked) profile entity type.
+ * @param slug - The page slug (for the error message only).
+ * @param body - The full markdown body whose frontmatter is validated.
+ * @param profile - The profile whose entity definition supplies the contract.
+ * @throws {EntityFieldContractError} When the frontmatter violates the contract.
+ */
+function assertFieldContract(
+  entityType: string,
+  slug: string,
+  body: string,
+  profile: ProfilePack,
+): void {
+  const { meta } = parseFrontmatter(body);
+  const violations = validateEntityFields(meta, profile.entities[entityType]!);
+  if (violations.length > 0) {
+    throw new EntityFieldContractError(entityType, slug, violations);
+  }
+}
 
 /**
  * Thrown when a caller tries to stage a page under an `entityType` that the
@@ -100,7 +133,10 @@ function buildPageTarget(plan: PlanResult): EntityRef {
  * Stage a NON-DEFAULT entity page for review. Fails CLOSED before any I/O: it
  * first enforces the staged-write volume bound, then verifies `input.entityType`
  * is declared by `input.profile` (throwing {@link UnknownEntityTypeError} if
- * not), so an overflow or an unknown type writes nothing. It then plans the
+ * not), then validates the body's frontmatter against the entity type's declared
+ * FIELD contract (throwing {@link EntityFieldContractError} on a missing required
+ * field / enum / range violation), so an overflow, an unknown type, or a contract
+ * violation writes nothing. It then plans the
  * write through the typed planner, captures it as a {@link StagedChange}, and
  * persists it as a typed candidate carrying `targetEntityType` + `trustDecision`.
  * If the typed plan is BLOCKED (no live-write mutation — e.g. a non-slug-safe
@@ -118,6 +154,7 @@ function buildPageTarget(plan: PlanResult): EntityRef {
  * @returns The persisted {@link StagedChange}.
  * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
  * @throws {UnknownEntityTypeError} When `entityType` is not declared by the profile.
+ * @throws {EntityFieldContractError} When the body's frontmatter violates the profile field contract.
  * @throws {BlockedStagedWriteError} When the typed plan is blocked (no live write).
  */
 export async function stageEntityPage(
@@ -131,6 +168,7 @@ export async function stageEntityPage(
   if (!(input.entityType in input.profile.entities)) {
     throw new UnknownEntityTypeError(input.entityType);
   }
+  assertFieldContract(input.entityType, input.slug, input.body, input.profile);
   const plan = await planPageMutation({
     root,
     entityType: input.entityType,

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -28,16 +28,12 @@ import {
   assertStagedWriteBudget,
   DEFAULT_STAGED_WRITE_PER_CALL,
   DEFAULT_STAGED_WRITE_PER_SESSION,
-  type HeldReasonCode,
   type StagedChange,
 } from "./staged-change.js";
-import { applyApprovedMutations } from "./executor.js";
-import { writeCandidate, readCandidate, deleteCandidate } from "../compiler/candidates.js";
-import type { EntityId, ProfilePack } from "../profile/types.js";
+import { promoteCandidateUnderLock } from "./promote.js";
+import { writeCandidate } from "../compiler/candidates.js";
+import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
-
-/** Decisions under which the planner emitted a live-write mutation. */
-const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
 
 /**
  * Thrown when a caller tries to stage a page under an `entityType` that the
@@ -49,6 +45,24 @@ export class UnknownEntityTypeError extends Error {
   constructor(entityType: string) {
     super(`entity type "${entityType}" is not declared by the profile`);
     this.name = "UnknownEntityTypeError";
+  }
+}
+
+/**
+ * Thrown when staging a page whose typed plan was BLOCKED by the Write Planner
+ * (no live-write mutation — e.g. a non-slug-safe slug like `../evil`, or an
+ * oversized body). Staging fails CLOSED so a blocked/unsafe page NEVER persists
+ * a candidate that a later `review approve` could try to promote: the decision
+ * is surfaced here and nothing is written.
+ */
+export class BlockedStagedWriteError extends Error {
+  /** The non-live-write decision the planner reached for the blocked write. */
+  readonly decision: TrustDecision;
+
+  constructor(entityType: string, slug: string, decision: TrustDecision) {
+    super(`staged page ${entityType}/${slug} blocked by the write planner (${decision}); nothing written`);
+    this.name = "BlockedStagedWriteError";
+    this.decision = decision;
   }
 }
 
@@ -69,24 +83,16 @@ export interface StageEntityPageInput {
 }
 
 /**
- * Build the StagedChange `target` for a page. When the identity is slug-safe the
- * plan minted a typed {@link EntityRef}, which we reuse. When it is NOT slug-safe
- * the plan is empty (blocked) and no id was minted — we still return a typed-shape
- * target so {@link StagedChange.target} is total, casting the raw `type/slug`
- * (this target is never promoted: a blocked plan re-blocks on promotion).
+ * Build the StagedChange `target` for a page from the live mutation the planner
+ * emitted. Staging only persists a candidate for a live-write plan (a blocked
+ * plan throws {@link BlockedStagedWriteError} before this runs), so the planned
+ * mutation always carries a minted typed {@link EntityRef}.
  */
-function buildPageTarget(entityType: string, slug: string, plan: PlanResult): EntityRef {
+function buildPageTarget(plan: PlanResult): EntityRef {
   const live = plan.planned[0]?.target;
   if (live && "id" in live) return live;
-  return { entityType, slug, id: `${entityType}/${slug}` as EntityId };
-}
-
-/**
- * Why the change was held. A non-live-write decision is a real trust block;
- * otherwise the entity write is routed for review by policy in this slice.
- */
-function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
-  return LIVE_WRITE_DECISIONS.has(decision) ? ["manual-review-requested"] : ["trust-blocked"];
+  // Unreachable: stageEntityPage throws on an empty plan before building a target.
+  throw new Error("internal: staged plan has no live mutation target");
 }
 
 /**
@@ -96,6 +102,9 @@ function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
  * not), so an overflow or an unknown type writes nothing. It then plans the
  * write through the typed planner, captures it as a {@link StagedChange}, and
  * persists it as a typed candidate carrying `targetEntityType` + `trustDecision`.
+ * If the typed plan is BLOCKED (no live-write mutation — e.g. a non-slug-safe
+ * slug or an oversized body), it throws {@link BlockedStagedWriteError} and
+ * persists NOTHING, so a blocked write never lands an un-promotable candidate.
  *
  * Volume bound: the PER-CALL cap (requested vs {@link DEFAULT_STAGED_WRITE_PER_CALL})
  * is self-contained and self-enforced here. The PER-SESSION cap, however, is
@@ -108,6 +117,7 @@ function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
  * @returns The persisted {@link StagedChange}.
  * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
  * @throws {UnknownEntityTypeError} When `entityType` is not declared by the profile.
+ * @throws {BlockedStagedWriteError} When the typed plan is blocked (no live write).
  */
 export async function stageEntityPage(
   root: string,
@@ -129,6 +139,9 @@ export async function stageEntityPage(
     reviewRouted: true,
     allowOverwrite: false,
   });
+  if (plan.planned.length === 0) {
+    throw new BlockedStagedWriteError(input.entityType, input.slug, plan.decision);
+  }
   const candidate = await writeCandidate(root, {
     title: input.slug,
     slug: input.slug,
@@ -141,45 +154,30 @@ export async function stageEntityPage(
   return {
     id: candidate.id,
     kind: "page",
-    target: buildPageTarget(input.entityType, input.slug, plan),
-    operation: plan.planned[0]?.operation ?? "create",
+    target: buildPageTarget(plan),
+    operation: plan.planned[0]!.operation,
     planned: plan.planned,
-    heldReasons: heldReasonsFor(plan.decision),
+    heldReasons: ["manual-review-requested"],
     trustDecision: plan.decision,
     createdAt: (input.now ? input.now() : new Date()).toISOString(),
   };
 }
 
 /**
- * Promote a staged entity page candidate into the live wiki. Re-reads the typed
- * candidate, RE-PLANS the write (`allowOverwrite:true`, `origin:"review"`) so the
- * mandatory floor + path confinement re-run, applies it through the executor so
- * the page lands at `wiki/<entityType>/<slug>.md`, and clears the candidate.
- *
- * If the candidate is missing/untyped, or the re-plan blocks (empty plan), it
- * throws and the candidate is RETAINED — nothing partial ever lands.
+ * Promote a staged entity page candidate into the live wiki by delegating to the
+ * shared {@link promoteCandidateUnderLock} routine — the SAME under-lock read →
+ * validate-profile → re-plan → apply → delete sequence `review approve` uses for
+ * its typed branch (DRY). Holding ONE lock across read+apply+delete closes the
+ * concurrent-reject race, and re-validating the candidate's `targetEntityType`
+ * against the freshly-loaded profile refuses a type the profile no longer
+ * declares — the page lands at `wiki/<entityType>/<slug>.md` or nothing does.
  *
  * @param root - Absolute project root.
  * @param candidateId - The staged candidate's id.
- * @throws {Error} When the candidate is missing, untyped, or its re-plan blocks.
+ * @throws {Error} When the candidate is missing or untyped.
+ * @throws {CandidateProfileError} When the profile no longer declares the type.
+ * @throws {CandidatePromotionBlockedError} When the re-plan blocks (empty plan).
  */
 export async function promoteStagedEntityPage(root: string, candidateId: string): Promise<void> {
-  const candidate = await readCandidate(root, candidateId);
-  if (!candidate) throw new Error(`staged candidate not found: ${candidateId}`);
-  const entityType = candidate.targetEntityType;
-  if (!entityType) throw new Error(`candidate ${candidateId} is not a typed entity page`);
-  const { planned } = await planPageMutation({
-    root,
-    entityType,
-    slug: candidate.slug,
-    body: candidate.body,
-    origin: "review",
-    reviewRouted: false,
-    allowOverwrite: true,
-  });
-  if (planned.length === 0) {
-    throw new Error(`staged candidate ${candidateId} blocked by the write planner; retained`);
-  }
-  await applyApprovedMutations(root, planned);
-  await deleteCandidate(root, candidateId);
+  await promoteCandidateUnderLock(root, candidateId);
 }

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -32,6 +32,7 @@ import {
 } from "./staged-change.js";
 import { promoteCandidateUnderLock } from "./promote.js";
 import { writeCandidate } from "../compiler/candidates.js";
+import { loadNonDefaultProfile } from "../profile/block.js";
 import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
 
@@ -180,4 +181,63 @@ export async function stageEntityPage(
  */
 export async function promoteStagedEntityPage(root: string, candidateId: string): Promise<void> {
   await promoteCandidateUnderLock(root, candidateId);
+}
+
+/**
+ * @experimental
+ * Thrown when the SDK staging entry point is called on a project that has NO
+ * non-default profile. Staging targets a typed `wiki/<entityType>/<slug>.md`
+ * path, which only a non-default profile declares — so a default project cannot
+ * stage. Fails CLOSED before any planning or I/O.
+ */
+export class StagingRequiresProfileError extends Error {
+  constructor() {
+    super("staging requires a non-default profile; this project has none");
+    this.name = "StagingRequiresProfileError";
+  }
+}
+
+/**
+ * @experimental
+ * SDK staging input: the entity page to stage WITHOUT the `ProfilePack` — the SDK
+ * loads the active non-default profile itself. `existingStagedCount` is the
+ * caller's per-session bookkeeping (defaults to 0); the per-session cap is the
+ * caller's responsibility, consistent with {@link stageEntityPage}.
+ */
+export interface SdkStageEntityPageInput {
+  /** Profile entity type (the wiki subdirectory), e.g. `"papers"`. */
+  entityType: string;
+  /** Page slug (the filename stem); may be invalid — the planner decides. */
+  slug: string;
+  /** Full markdown body (frontmatter + prose) to stage verbatim. */
+  body: string;
+  /** Staged writes already held this session (for the volume bound). Defaults to 0. */
+  existingStagedCount?: number;
+}
+
+/**
+ * @experimental
+ * SDK entry point for staging a non-default entity page: loads the active
+ * non-default profile INTERNALLY (throwing {@link StagingRequiresProfileError}
+ * when the project has none) and delegates to {@link stageEntityPage}. The caller
+ * never passes a {@link ProfilePack} — the SDK owns it.
+ *
+ * @param root - Absolute project root.
+ * @param input - The entity page to stage (no profile; body caller-provided).
+ * @returns The persisted {@link StagedChange}.
+ * @throws {StagingRequiresProfileError} When the project has no non-default profile.
+ */
+export async function stageEntityPageForProject(
+  root: string,
+  input: SdkStageEntityPageInput,
+): Promise<StagedChange> {
+  const loaded = await loadNonDefaultProfile(root);
+  if (!loaded) throw new StagingRequiresProfileError();
+  return stageEntityPage(root, {
+    entityType: input.entityType,
+    slug: input.slug,
+    body: input.body,
+    profile: loaded.profile,
+    existingStagedCount: input.existingStagedCount ?? 0,
+  });
 }

--- a/src/utils/candidate-store.ts
+++ b/src/utils/candidate-store.ts
@@ -15,7 +15,7 @@ import path from "path";
 import { safeReadFile } from "./markdown.js";
 
 /** Extension used for all candidate JSON files. */
-export const CANDIDATE_JSON_EXT = ".json";
+const CANDIDATE_JSON_EXT = ".json";
 
 /**
  * Turn a dotted candidate id into a single filesystem-safe path segment.

--- a/test/candidate-id-safety.test.ts
+++ b/test/candidate-id-safety.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @file test/candidate-id-safety.test.ts
+ * @description Path-traversal hardening for candidate ids/slugs (FIX #2).
+ *
+ * `writeCandidate` builds a candidate id as `${slug}-${hex}` and the path
+ * helpers join that id straight into `.llmwiki/candidates/`. A traversal-bearing
+ * slug (`../evil`) would make the id a path-escape string. These tests pin that:
+ *  - `writeCandidate` REFUSES an unsafe slug (typed error, nothing written);
+ *  - a normal safe candidate still round-trips identically (byte-for-byte body);
+ *  - no file is ever written outside the candidates dir.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdir, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import {
+  writeCandidate,
+  readCandidate,
+  UnsafeCandidateIdError,
+} from "../src/compiler/candidates.js";
+import { CANDIDATES_DIR } from "../src/utils/constants.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+const BODY = "---\ntitle: Safe\n---\n\nBody.\n";
+
+/** A safe candidate draft for `slug` with a fixed body. */
+function draftFor(slug: string) {
+  return { title: slug, slug, summary: "", sources: [], body: BODY };
+}
+
+describe("candidate id/slug path-traversal safety", () => {
+  it("refuses an unsafe traversal slug and writes nothing", async () => {
+    await expect(writeCandidate(root.dir, draftFor("../evil"))).rejects.toBeInstanceOf(
+      UnsafeCandidateIdError,
+    );
+    const dir = path.join(root.dir, CANDIDATES_DIR);
+    const files = existsSync(dir) ? await readdir(dir) : [];
+    expect(files.filter((f) => f.endsWith(".json"))).toHaveLength(0);
+  });
+
+  it("refuses a slug containing a path separator and writes nothing", async () => {
+    await expect(writeCandidate(root.dir, draftFor("nested/evil"))).rejects.toBeInstanceOf(
+      UnsafeCandidateIdError,
+    );
+    expect(existsSync(path.join(root.dir, "nested"))).toBe(false);
+  });
+
+  it("does not escape the candidates dir for a deep traversal slug", async () => {
+    await expect(
+      writeCandidate(root.dir, draftFor("../../outside")),
+    ).rejects.toBeInstanceOf(UnsafeCandidateIdError);
+    expect(existsSync(path.join(path.dirname(root.dir), "outside.json"))).toBe(false);
+  });
+
+  it("round-trips a normal safe candidate identically", async () => {
+    const created = await writeCandidate(root.dir, draftFor("attention-rag"));
+    expect(created.id).toMatch(/^attention-rag-[0-9a-f]{8}$/);
+    const loaded = await readCandidate(root.dir, created.id);
+    expect(loaded?.body).toBe(BODY);
+    const file = path.join(root.dir, CANDIDATES_DIR, `${created.id}.json`);
+    expect(JSON.parse(await readFile(file, "utf8")).slug).toBe("attention-rag");
+  });
+});

--- a/test/candidate-store-confinement.test.ts
+++ b/test/candidate-store-confinement.test.ts
@@ -18,10 +18,9 @@
  * while a NORMAL candidates dir still round-trips a candidate identically.
  */
 
-import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, readdir, symlink, writeFile } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
+import { mkdir, readdir, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import {
   writeCandidate,
   readCandidate,
@@ -31,9 +30,9 @@ import {
 } from "../src/compiler/candidates.js";
 import { UnsafeCandidateDirError } from "../src/compiler/candidate-store-paths.js";
 import { LLMWIKI_DIR } from "../src/utils/constants.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
 
-let root = "";
-let outside = "";
+const ctx = useConfinementRoots("candidate");
 
 const BODY = "---\ntitle: Safe\n---\n\nBody.\n";
 
@@ -44,68 +43,57 @@ function draftFor(slug: string) {
 
 /** Make `.llmwiki/candidates` a SYMLINK to the out-of-tree `outside` dir. */
 async function symlinkCandidatesOutside(): Promise<void> {
-  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
-  await symlink(outside, path.join(root, LLMWIKI_DIR, "candidates"), "dir");
+  await mkdir(path.join(ctx.root, LLMWIKI_DIR), { recursive: true });
+  await symlink(ctx.outside, path.join(ctx.root, LLMWIKI_DIR, "candidates"), "dir");
 }
 
 /** Names of entries currently in the out-of-tree dir. */
 async function outsideEntries(): Promise<string[]> {
-  return readdir(outside);
+  return readdir(ctx.outside);
 }
-
-beforeEach(async () => {
-  root = await mkdtemp(path.join(os.tmpdir(), "candidate-confine-"));
-  outside = await mkdtemp(path.join(os.tmpdir(), "candidate-outside-"));
-});
-
-afterEach(async () => {
-  if (root) await rm(root, { recursive: true, force: true });
-  if (outside) await rm(outside, { recursive: true, force: true });
-  root = outside = "";
-});
 
 describe("candidate store — symlinked candidates dir (filesystem tampering)", () => {
   it("writeCandidate REFUSES and creates nothing outside root", async () => {
     await symlinkCandidatesOutside();
-    await expect(writeCandidate(root, draftFor("safe"))).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(writeCandidate(ctx.root, draftFor("safe"))).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toHaveLength(0);
   });
 
   it("readCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
-    await writeFile(path.join(outside, "planted.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "planted.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(readCandidate(root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(readCandidate(ctx.root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["planted.json"]);
   });
 
   it("deleteCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
-    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "victim.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(deleteCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(deleteCandidate(ctx.root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["victim.json"]);
   });
 
   it("archiveCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
-    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "victim.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(archiveCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(archiveCandidate(ctx.root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["victim.json"]);
   });
 
   it("listCandidates over the symlinked dir fails closed, never reading through it", async () => {
-    await writeFile(path.join(outside, "leak.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "leak.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(listCandidates(root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(listCandidates(ctx.root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["leak.json"]);
   });
 });
 
 describe("candidate store — normal dir regression", () => {
   it("round-trips a candidate identically through a REAL candidates dir", async () => {
-    const created = await writeCandidate(root, draftFor("attention-rag"));
+    const created = await writeCandidate(ctx.root, draftFor("attention-rag"));
     expect(created.id).toMatch(/^attention-rag-[0-9a-f]{8}$/);
-    const loaded = await readCandidate(root, created.id);
+    const loaded = await readCandidate(ctx.root, created.id);
     expect(loaded?.body).toBe(BODY);
-    expect(await listCandidates(root)).toHaveLength(1);
+    expect(await listCandidates(ctx.root)).toHaveLength(1);
   });
 });

--- a/test/candidate-store-confinement.test.ts
+++ b/test/candidate-store-confinement.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @file test/candidate-store-confinement.test.ts
+ * @description Fail-closed coverage for candidate-store directory confinement
+ * (Phase-3 hardening, FIX #1).
+ *
+ * Before this guard, `resolveCandidatePath` validated only the candidate id and a
+ * LEXICAL prefix — it never REALPATH-confined the candidates directory. So a
+ * symlinked `.llmwiki/candidates -> /tmp/outside` made `writeCandidate` (and
+ * read/delete/archive/list) operate OUTSIDE the project root.
+ *
+ * The store now resolves every candidate path through `confineUnderRoot`, which
+ * realpath-confines the nearest existing ancestor under root, and lists/scans the
+ * candidates directory only after a realpath dir check that fails CLOSED on an
+ * existing-but-escaping symlink (absent dir → empty, never a write through it).
+ *
+ * These tests mirror `test/trust-journal-confinement.test.ts`: a symlinked
+ * candidates dir refuses every operation and leaves the out-of-tree dir empty,
+ * while a NORMAL candidates dir still round-trips a candidate identically.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, readdir, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  writeCandidate,
+  readCandidate,
+  deleteCandidate,
+  archiveCandidate,
+  listCandidates,
+} from "../src/compiler/candidates.js";
+import { UnsafeCandidateDirError } from "../src/compiler/candidate-store-paths.js";
+import { LLMWIKI_DIR } from "../src/utils/constants.js";
+
+let root = "";
+let outside = "";
+
+const BODY = "---\ntitle: Safe\n---\n\nBody.\n";
+
+/** A safe candidate draft for `slug` with a fixed body. */
+function draftFor(slug: string) {
+  return { title: slug, slug, summary: "", sources: [], body: BODY };
+}
+
+/** Make `.llmwiki/candidates` a SYMLINK to the out-of-tree `outside` dir. */
+async function symlinkCandidatesOutside(): Promise<void> {
+  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+  await symlink(outside, path.join(root, LLMWIKI_DIR, "candidates"), "dir");
+}
+
+/** Names of entries currently in the out-of-tree dir. */
+async function outsideEntries(): Promise<string[]> {
+  return readdir(outside);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "candidate-confine-"));
+  outside = await mkdtemp(path.join(os.tmpdir(), "candidate-outside-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  if (outside) await rm(outside, { recursive: true, force: true });
+  root = outside = "";
+});
+
+describe("candidate store — symlinked candidates dir (filesystem tampering)", () => {
+  it("writeCandidate REFUSES and creates nothing outside root", async () => {
+    await symlinkCandidatesOutside();
+    await expect(writeCandidate(root, draftFor("safe"))).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toHaveLength(0);
+  });
+
+  it("readCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(outside, "planted.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(readCandidate(root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["planted.json"]);
+  });
+
+  it("deleteCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(deleteCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["victim.json"]);
+  });
+
+  it("archiveCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(archiveCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["victim.json"]);
+  });
+
+  it("listCandidates over the symlinked dir fails closed, never reading through it", async () => {
+    await writeFile(path.join(outside, "leak.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(listCandidates(root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["leak.json"]);
+  });
+});
+
+describe("candidate store — normal dir regression", () => {
+  it("round-trips a candidate identically through a REAL candidates dir", async () => {
+    const created = await writeCandidate(root, draftFor("attention-rag"));
+    expect(created.id).toMatch(/^attention-rag-[0-9a-f]{8}$/);
+    const loaded = await readCandidate(root, created.id);
+    expect(loaded?.body).toBe(BODY);
+    expect(await listCandidates(root)).toHaveLength(1);
+  });
+});

--- a/test/fixtures/confinement-roots.ts
+++ b/test/fixtures/confinement-roots.ts
@@ -1,0 +1,50 @@
+/**
+ * @file test/fixtures/confinement-roots.ts
+ * @description Shared tmp-root lifecycle for candidate-store confinement tests.
+ *
+ * Both the concept-store and rule-store confinement suites need the same pair
+ * of out-of-tree temp directories — an in-project `root` and an `outside`
+ * directory a symlink can be pointed at — created in `beforeEach` and removed in
+ * `afterEach`. Extracting the lifecycle here removes the duplicated boilerplate
+ * (flagged by fallow) while keeping each suite's symlink/assertion logic local.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { beforeEach, afterEach } from "vitest";
+
+/**
+ * Mutable context populated by {@link useConfinementRoots}. `root` is the
+ * in-project root; `outside` is an out-of-tree dir a symlink can target.
+ */
+export interface ConfinementRoots {
+  /** Absolute path of the current test's in-project temp root. */
+  root: string;
+  /** Absolute path of the current test's out-of-tree (escape-target) dir. */
+  outside: string;
+}
+
+/**
+ * Register beforeEach/afterEach hooks that create and tear down the `root` and
+ * `outside` temp directories for a confinement suite.
+ *
+ * @param label - Short prefix used to name both temp directories.
+ * @returns Mutable context whose fields are set fresh for each test.
+ */
+export function useConfinementRoots(label: string): ConfinementRoots {
+  const ctx: ConfinementRoots = { root: "", outside: "" };
+
+  beforeEach(async () => {
+    ctx.root = await mkdtemp(path.join(os.tmpdir(), `${label}-confine-`));
+    ctx.outside = await mkdtemp(path.join(os.tmpdir(), `${label}-outside-`));
+  });
+
+  afterEach(async () => {
+    if (ctx.root) await rm(ctx.root, { recursive: true, force: true });
+    if (ctx.outside) await rm(ctx.outside, { recursive: true, force: true });
+    ctx.root = ctx.outside = "";
+  });
+
+  return ctx;
+}

--- a/test/review-approve-typed.test.ts
+++ b/test/review-approve-typed.test.ts
@@ -45,15 +45,40 @@ afterEach(async () => {
 
 /** Write a typed `papers` candidate for SLUG and return its id. */
 async function stageTypedCandidate(entityType = "papers"): Promise<string> {
+  return stageTypedCandidateBody(BODY, entityType);
+}
+
+/** Write a typed candidate with an explicit body + type, returning its id. */
+async function stageTypedCandidateBody(body: string, entityType: string): Promise<string> {
   const candidate = await writeCandidate(root, {
     title: SLUG,
     slug: SLUG,
     summary: "",
     sources: [],
-    body: BODY,
+    body,
     targetEntityType: entityType,
   });
   return candidate.id;
+}
+
+/**
+ * Assert a candidate was REFUSED: the page at `pageRelDir/<slug>.md` was not
+ * written, the candidate `id` is retained, and the process exit code is 1.
+ */
+function expectRefused(pageRelDir: string, id: string): void {
+  expect(existsSync(path.join(root, pageRelDir, `${SLUG}.md`))).toBe(false);
+  expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
+  expect(process.exitCode).toBe(1);
+}
+
+/**
+ * Assert a candidate was APPROVED: the page at `pageRelDir/<slug>.md` holds
+ * exactly `body`, the candidate `id` is cleared, and the exit code is 0.
+ */
+async function expectApproved(pageRelDir: string, id: string, body: string): Promise<void> {
+  expect(await readFile(path.join(root, pageRelDir, `${SLUG}.md`), "utf8")).toBe(body);
+  expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(false);
+  expect(process.exitCode ?? 0).toBe(0);
 }
 
 describe("review approve — typed entity routing", () => {
@@ -63,10 +88,8 @@ describe("review approve — typed entity routing", () => {
 
     await reviewApproveCommand(id);
 
-    expect(await readFile(path.join(root, "wiki/papers", `${SLUG}.md`), "utf8")).toBe(BODY);
+    await expectApproved("wiki/papers", id, BODY);
     expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
-    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(false);
-    expect(process.exitCode ?? 0).toBe(0);
   });
 
   it("refuses a typed candidate in a DEFAULT project (no profile) and retains it", async () => {
@@ -74,10 +97,8 @@ describe("review approve — typed entity routing", () => {
 
     await reviewApproveCommand(id);
 
-    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+    expectRefused("wiki/papers", id);
     expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
-    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
-    expect(process.exitCode).toBe(1);
   });
 
   it("refuses a typed candidate whose type is undeclared by the profile and retains it", async () => {
@@ -86,8 +107,45 @@ describe("review approve — typed entity routing", () => {
 
     await reviewApproveCommand(id);
 
-    expect(existsSync(path.join(root, "wiki/bogus", `${SLUG}.md`))).toBe(false);
-    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
-    expect(process.exitCode).toBe(1);
+    expectRefused("wiki/bogus", id);
+  });
+});
+
+/** A valid `experiments` body: required `runtime` field, NO `title`. */
+const NO_TITLE_EXPERIMENT_BODY = "---\nruntime: cpu\n---\n\n# Ablation\n\nBody.\n";
+/** A `papers` body missing its required `title` field. */
+const NO_TITLE_PAPER_BODY = "---\nvenue: NeurIPS\n---\n\n# Paper\n\nBody.\n";
+
+describe("review approve — typed candidates skip the default title validator", () => {
+  it("approves a typed experiments candidate with valid fields but no title", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidateBody(NO_TITLE_EXPERIMENT_BODY, "experiments");
+
+    await reviewApproveCommand(id);
+
+    await expectApproved("wiki/experiments", id, NO_TITLE_EXPERIMENT_BODY);
+  });
+
+  it("still refuses a typed candidate that violates its field contract", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidateBody(NO_TITLE_PAPER_BODY, "papers");
+
+    await reviewApproveCommand(id);
+
+    expectRefused("wiki/papers", id);
+  });
+
+  it("still rejects a DEFAULT candidate missing its title via validateWikiPage", async () => {
+    const candidate = await writeCandidate(root, {
+      title: SLUG,
+      slug: SLUG,
+      summary: "",
+      sources: [],
+      body: NO_TITLE_PAPER_BODY,
+    });
+
+    await reviewApproveCommand(candidate.id);
+
+    expectRefused("wiki/concepts", candidate.id);
   });
 });

--- a/test/review-approve-typed.test.ts
+++ b/test/review-approve-typed.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @file test/review-approve-typed.test.ts
+ * @description Typed-target routing for `review approve <id>` (FIX #1).
+ *
+ * A candidate carrying `targetEntityType` (staged via the typed planner) must be
+ * routed by `review approve` through the TYPED planner — landing at
+ * `wiki/<entityType>/<slug>.md`, NOT silently in `wiki/concepts/`. A typed
+ * candidate in a DEFAULT project (no profile) or with an undeclared type is
+ * REFUSED (exit 1, candidate retained). A default candidate (no typed target)
+ * keeps the existing concepts path; that parity is pinned by review.test.ts and
+ * review-approve-planner.test.ts, which must still pass unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import os from "os";
+import { writeCandidate } from "../src/compiler/candidates.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import { CANDIDATES_DIR } from "../src/utils/constants.js";
+import { buildResearchLiteProject } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+let originalCwd = "";
+
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\n# Linear Attention\n\nBody.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "review-typed-"));
+  originalCwd = process.cwd();
+  process.chdir(root);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = 0;
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  process.exitCode = 0;
+});
+
+/** Write a typed `papers` candidate for SLUG and return its id. */
+async function stageTypedCandidate(entityType = "papers"): Promise<string> {
+  const candidate = await writeCandidate(root, {
+    title: SLUG,
+    slug: SLUG,
+    summary: "",
+    sources: [],
+    body: BODY,
+    targetEntityType: entityType,
+  });
+  return candidate.id;
+}
+
+describe("review approve — typed entity routing", () => {
+  it("routes a typed papers candidate to wiki/papers/<slug>.md and clears it", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidate();
+
+    await reviewApproveCommand(id);
+
+    expect(await readFile(path.join(root, "wiki/papers", `${SLUG}.md`), "utf8")).toBe(BODY);
+    expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(false);
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("refuses a typed candidate in a DEFAULT project (no profile) and retains it", async () => {
+    const id = await stageTypedCandidate();
+
+    await reviewApproveCommand(id);
+
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses a typed candidate whose type is undeclared by the profile and retains it", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidate("bogus");
+
+    await reviewApproveCommand(id);
+
+    expect(existsSync(path.join(root, "wiki/bogus", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/test/rule-candidate-store-confinement.test.ts
+++ b/test/rule-candidate-store-confinement.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @file test/rule-candidate-store-confinement.test.ts
+ * @description Fail-closed coverage for RULE-candidate-store directory
+ * confinement (Phase-3 hardening), mirroring
+ * `test/candidate-store-confinement.test.ts` for the sibling concept store.
+ *
+ * Before this guard, `ruleCandidatePath`/`ruleArchivePath` did a bare
+ * `path.join(root, RULE_CANDIDATES_DIR, …)` with NO realpath confinement, then
+ * wrote via `atomicWrite` and `readdir`-ed the directory. So a symlinked
+ * `.llmwiki/rule-candidates -> /tmp/outside` redirected every
+ * write/read/list/archive OUTSIDE the project root — the identical
+ * containing-directory escape already closed for the concept store.
+ *
+ * The rule store now routes every path through the SAME shared confinement
+ * helpers (`candidate-store-paths.ts`): a symlinked rule-candidates dir refuses
+ * every operation and leaves the out-of-tree dir untouched, while a NORMAL dir
+ * still round-trips a candidate identically.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, readdir, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  buildRuleCandidate,
+  buildRuleSlug,
+  writeRuleCandidate,
+  readRuleCandidate,
+  listRuleCandidates,
+  archiveRuleCandidate,
+} from "../src/compiler/rule-candidates.js";
+import { candidateFileId } from "../src/utils/candidate-store.js";
+import { UnsafeCandidateDirError } from "../src/compiler/candidate-store-paths.js";
+import { LLMWIKI_DIR } from "../src/utils/constants.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+import type { RuleCandidate } from "../src/utils/rule-types.js";
+
+const ctx = useConfinementRoots("rule-cand");
+
+const FIXED_NOW = "2026-05-31T00:00:00.000Z";
+
+/** A valid RuleCandidate for `title` in the `process` category. */
+function candidateFor(title: string): RuleCandidate {
+  const slug = buildRuleSlug(title, `${title}|when|then`);
+  return buildRuleCandidate(
+    {
+      category: "process",
+      slug,
+      title,
+      description: "desc",
+      when: "a thing happens",
+      then: "warn",
+      evidence: [{ kind: "file", path: "guide.md" }],
+      provenance: { source: "llm-wiki-compiler" },
+      confidence: "high",
+    },
+    FIXED_NOW,
+  );
+}
+
+/** Make `.llmwiki/rule-candidates` a SYMLINK to the out-of-tree `outside` dir. */
+async function symlinkRuleDirOutside(): Promise<void> {
+  await mkdir(path.join(ctx.root, LLMWIKI_DIR), { recursive: true });
+  await symlink(ctx.outside, path.join(ctx.root, LLMWIKI_DIR, "rule-candidates"), "dir");
+}
+
+/** Names of entries currently in the out-of-tree dir. */
+async function outsideEntries(): Promise<string[]> {
+  return readdir(ctx.outside);
+}
+
+describe("rule-candidate store — symlinked rule-candidates dir (tampering)", () => {
+  it("writeRuleCandidate REFUSES and creates nothing outside root", async () => {
+    await symlinkRuleDirOutside();
+    await expect(writeRuleCandidate(ctx.root, candidateFor("Require tests"))).rejects.toBeInstanceOf(
+      UnsafeCandidateDirError,
+    );
+    expect(await outsideEntries()).toHaveLength(0);
+  });
+
+  it("readRuleCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(ctx.outside, "planted.json"), "{}", "utf8");
+    await symlinkRuleDirOutside();
+    await expect(readRuleCandidate(ctx.root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["planted.json"]);
+  });
+
+  it("archiveRuleCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(ctx.outside, "victim.json"), "{}", "utf8");
+    await symlinkRuleDirOutside();
+    await expect(archiveRuleCandidate(ctx.root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["victim.json"]);
+  });
+
+  it("listRuleCandidates over the symlinked dir fails closed, never reading through it", async () => {
+    await writeFile(path.join(ctx.outside, "leak.json"), "{}", "utf8");
+    await symlinkRuleDirOutside();
+    await expect(listRuleCandidates(ctx.root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["leak.json"]);
+  });
+});
+
+describe("rule-candidate store — normal dir regression", () => {
+  it("round-trips a rule candidate identically through a REAL dir", async () => {
+    const candidate = candidateFor("Require tests");
+    const written = await writeRuleCandidate(ctx.root, candidate);
+    expect(written).toContain(
+      path.join(".llmwiki/rule-candidates", `${candidateFileId(candidate.id)}.json`),
+    );
+    const loaded = await readRuleCandidate(ctx.root, candidateFileId(candidate.id));
+    expect(loaded).toEqual(candidate);
+    expect(await listRuleCandidates(ctx.root)).toHaveLength(1);
+  });
+});

--- a/test/sdk/staging.test.ts
+++ b/test/sdk/staging.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @file test/sdk/staging.test.ts
+ * @description Tests the EXPERIMENTAL `createWiki()` staging methods, which load
+ * the active non-default profile INTERNALLY (the caller passes no ProfilePack).
+ *
+ * Over a project WITH a non-default profile, `stageEntityPage` creates a typed
+ * candidate and `promoteStagedPage` lands the body at `wiki/<entityType>/<slug>.md`.
+ * Over a DEFAULT project (no profile), `stageEntityPage` throws the clear
+ * "requires a non-default profile" error.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { createWiki } from "../../src/sdk/wiki.js";
+import { StagingRequiresProfileError } from "../../src/trust/staging.js";
+import { buildResearchLiteProject } from "../fixtures/profile-fixtures.js";
+
+let root = "";
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\nStaged body.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "sdk-staging-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("createWiki staging (experimental)", () => {
+  it("stages then promotes a typed page through the SDK facade", async () => {
+    await buildResearchLiteProject(root);
+    const wiki = createWiki({ root });
+
+    const staged = await wiki.stageEntityPage({ entityType: "papers", slug: SLUG, body: BODY });
+    expect(staged.target).toMatchObject({ entityType: "papers", slug: SLUG, id: `papers/${SLUG}` });
+
+    await wiki.promoteStagedPage(staged.id);
+    expect(await readFile(path.join(root, "wiki/papers", `${SLUG}.md`), "utf8")).toBe(BODY);
+  });
+
+  it("throws the requires-a-non-default-profile error on a default project", async () => {
+    const wiki = createWiki({ root });
+    await expect(
+      wiki.stageEntityPage({ entityType: "papers", slug: SLUG, body: BODY }),
+    ).rejects.toBeInstanceOf(StagingRequiresProfileError);
+  });
+});

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -94,6 +94,7 @@ describe("state reset", () => {
 
     const result = await runCLI(["state", "reset", "--yes"], root);
 
+    expect(result.code).not.toBe(0); // a confinement refusal is a FAILURE, not a no-op
     expect(result.stdout + result.stderr).toMatch(/escapes the project root/);
     expect(existsSync(outsideState)).toBe(true); // not moved
     expect(existsSync(`${outsideState}.bak`)).toBe(false); // not clobbered

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -7,15 +7,19 @@
  * where the on-disk state was written by a NEWER llmwiki version (`{"version":3}`,
  * which `readState` would reject) yet `--yes` still backs it up without throwing,
  * and the no-op when there is no state file to reset.
+ *
+ * Plus two hardening paths: a `.llmwiki` that is a SYMLINK to an out-of-tree dir
+ * fails CLOSED (the outside state file is never moved/clobbered), and a reset
+ * while the project LOCK is held by a live holder refuses cleanly.
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, writeFile, readFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { runCLI } from "./fixtures/run-cli.js";
-import { STATE_FILE } from "../src/utils/constants.js";
+import { STATE_FILE, LLMWIKI_DIR, LOCK_FILE } from "../src/utils/constants.js";
 
 let root = "";
 
@@ -79,6 +83,33 @@ describe("state reset", () => {
 
     expect(result.code).toBe(0);
     expect(result.stdout + result.stderr).toContain("No state file to reset.");
+    expect(existsSync(BAK_PATH())).toBe(false);
+  });
+
+  it("fails closed when .llmwiki is a symlink to an out-of-tree dir", async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), "state-reset-outside-"));
+    const outsideState = path.join(outside, "state.json");
+    await writeFile(outsideState, JSON.stringify({ version: 3 }), "utf8");
+    await symlink(outside, path.join(root, LLMWIKI_DIR), "dir");
+
+    const result = await runCLI(["state", "reset", "--yes"], root);
+
+    expect(result.stdout + result.stderr).toMatch(/escapes the project root/);
+    expect(existsSync(outsideState)).toBe(true); // not moved
+    expect(existsSync(`${outsideState}.bak`)).toBe(false); // not clobbered
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  it("refuses cleanly when the project lock is held by a live holder", async () => {
+    await seedState(OK_STATE);
+    // A lock naming THIS (live) process PID is not stale, so acquireLock fails.
+    await writeFile(path.join(root, LOCK_FILE), String(process.pid), "utf8");
+
+    const result = await runCLI(["state", "reset", "--yes"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/another llmwiki process|using this project/i);
+    expect(existsSync(STATE_PATH())).toBe(true); // untouched
     expect(existsSync(BAK_PATH())).toBe(false);
   });
 });

--- a/test/trust-promote.test.ts
+++ b/test/trust-promote.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @file test/trust-promote.test.ts
+ * @description Lock-safe typed promotion guards (FIX #3).
+ *
+ * `promoteCandidateUnderLock` (the shared routine behind both the SDK staging
+ * helper and `review approve`'s typed branch) re-reads the candidate, loads +
+ * validates the active profile, re-plans, applies, and deletes — ALL under one
+ * held lock. These tests pin the two race/staleness guards:
+ *  - concurrent-reject: the candidate vanishes between stage and promote →
+ *    promote aborts cleanly, no page written;
+ *  - profile-staleness: the active profile no longer declares the staged type →
+ *    promote refuses (CandidateProfileError), candidate retained;
+ * and the happy path: the page lands at `wiki/<entityType>/<slug>.md` and the
+ * candidate is cleared.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  stageEntityPage,
+  promoteStagedEntityPage,
+} from "../src/trust/staging.js";
+import { CandidateProfileError } from "../src/trust/promote.js";
+import { deleteCandidate } from "../src/compiler/candidates.js";
+import { PROFILE_FILE } from "../src/utils/constants.js";
+import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\nBody.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "trust-promote-"));
+  await buildResearchLiteProject(root);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Stage a fresh (non-colliding) typed `papers` candidate and return its id. */
+async function stage(): Promise<string> {
+  const staged = await stageEntityPage(root, {
+    entityType: "papers",
+    slug: SLUG,
+    body: BODY,
+    profile: RESEARCH_LITE_PROFILE,
+    existingStagedCount: 0,
+  });
+  return staged.id;
+}
+
+describe("lock-safe typed promotion", () => {
+  it("promotes the happy path to wiki/papers/<slug>.md and clears the candidate", async () => {
+    const id = await stage();
+    await promoteStagedEntityPage(root, id);
+    const page = path.join(root, "wiki/papers", `${SLUG}.md`);
+    expect(existsSync(page)).toBe(true);
+  });
+
+  it("aborts cleanly when the candidate was rejected between stage and promote", async () => {
+    const id = await stage();
+    await deleteCandidate(root, id); // concurrent reject
+
+    await expect(promoteStagedEntityPage(root, id)).rejects.toThrow(/not found/);
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+  });
+
+  it("refuses promotion when the profile no longer declares the staged type", async () => {
+    const id = await stage();
+    // Rewrite the profile so `papers` is no longer a declared entity type.
+    const trimmed = { ...RESEARCH_LITE_PROFILE, entities: { experiments: RESEARCH_LITE_PROFILE.entities.experiments } };
+    await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(trimmed), "utf8");
+
+    await expect(promoteStagedEntityPage(root, id)).rejects.toBeInstanceOf(CandidateProfileError);
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+  });
+});

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -25,6 +25,7 @@ import {
   promoteStagedEntityPage,
   UnknownEntityTypeError,
   BlockedStagedWriteError,
+  EntityFieldContractError,
 } from "../src/trust/staging.js";
 import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
@@ -129,6 +130,20 @@ describe("non-default entity page staging", () => {
     ).rejects.toBeInstanceOf(BlockedStagedWriteError);
 
     expect(existsSync(path.join(root, "wiki/evil.md"))).toBe(false);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
+  });
+
+  it("refuses a typed page missing a required field, writing NO candidate", async () => {
+    const noTitle = "---\nvenue: NeurIPS\n---\n\n# Body\n\nNo title field.\n";
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: SLUG,
+        body: noTitle,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(EntityFieldContractError);
     expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -24,6 +24,7 @@ import {
   stageEntityPage,
   promoteStagedEntityPage,
   UnknownEntityTypeError,
+  BlockedStagedWriteError,
 } from "../src/trust/staging.js";
 import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
@@ -33,8 +34,11 @@ import { writeCandidate, listCandidates } from "../src/compiler/candidates.js";
 import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
 
 let root = "";
-const SLUG = "attention-is-all-you-need";
-const BODY = "---\ntitle: Attention Is All You Need\n---\n\n# Attention\n\nStaged body.\n";
+// A FRESH slug not pre-seeded by buildResearchLiteProject, so the typed plan is
+// a live `create` (a seeded slug would collide under allowOverwrite:false and
+// route to stage-for-review — a blocked plan that now writes no candidate).
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\n# Attention\n\nStaged body.\n";
 
 beforeEach(async () => {
   root = await mkdtemp(path.join(os.tmpdir(), "trust-staging-"));
@@ -113,18 +117,19 @@ describe("non-default entity page staging", () => {
     expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 
-  it("blocks a non-slug-safe identity without writing an escaping path", async () => {
-    const staged = await stageEntityPage(root, {
-      entityType: "papers",
-      slug: "../evil",
-      body: BODY,
-      profile: RESEARCH_LITE_PROFILE,
-      existingStagedCount: 0,
-    });
+  it("blocks a non-slug-safe identity, writing NO candidate and no escaping path", async () => {
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: "../evil",
+        body: BODY,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(BlockedStagedWriteError);
 
-    expect(staged.planned).toHaveLength(0);
-    expect(staged.heldReasons).toContain("trust-blocked");
     expect(existsSync(path.join(root, "wiki/evil.md"))).toBe(false);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 
   it("keeps the DEFAULT candidate JSON clean of typed keys (parity guard)", async () => {


### PR DESCRIPTION
Top of the Phase 3 stack (do not merge yet). Closes five findings from an independent review of the full stack before it's merge-ready.

- **Typed candidates approve to the right place.** The canonical `review approve <id>` previously ignored a candidate's `targetEntityType`, so a staged `papers` candidate landed in `wiki/concepts/`. Approve now loads and validates the active profile and routes a typed candidate through the typed planner to `wiki/<entityType>/<slug>.md` (or refuses if the project has no such entity type) — and the default concepts/queries path stays byte-identical.
- **Candidate ids can't escape the candidate store.** Candidate ids were slug-derived path segments, so an unsafe slug could traverse out of `.llmwiki/candidates/`. Ids are now validated as single safe path components and confined before every read/write/delete/archive; an unsafe slug is refused at creation, and a blocked stage no longer persists a candidate at all.
- **Promotion is race- and profile-safe.** Staged promotion now re-reads the candidate, re-validates the active profile, re-plans, applies, and deletes — all under one project lock — so a concurrent reject or a profile change after staging can't promote into a stale target. The SDK helper and `review approve` share one under-lock routine.
- **`state reset` is locked and confined.** It now acquires the project lock and validates `.llmwiki`'s realpath stays in the project (failing closed on a symlink escape) before touching anything — the same containing-directory trust boundary recently fixed for the journal. Confinement is checked before the lock so a symlinked `.llmwiki` can't even get a lock file written through it.
- **The staging loop is reachable.** `createWiki()` gains experimental `stageEntityPage`/`promoteStagedPage` methods that load the active profile internally, plus the public types, so non-default staging is usable by package consumers.

Default profile byte-identical; existing review-approve tests pass unchanged; full suite green.