### PR TITLE
fix(trust,cli): Phase 3 audit bug fixes — dedup, flood bound, review-queue visibility, query-save, races

### DIFF
--- a/src/commands/query-save.ts
+++ b/src/commands/query-save.ts
@@ -1,0 +1,114 @@
+/**
+ * @file src/commands/query-save.ts
+ * @description The `query --save` write path — persists a generated answer as a
+ * `wiki/queries/<slug>.md` page and refreshes the index/embeddings so the answer
+ * is immediately retrievable.
+ *
+ * Split out of `query.ts` to keep that command file within the project size
+ * budget; the answer-generation pipeline stays in `query.ts` and calls
+ * {@link maybeSaveQueryPage} once the answer is produced.
+ */
+
+import path from "path";
+import { atomicWrite, slugify, buildFrontmatter } from "../utils/markdown.js";
+import { generateIndex } from "../compiler/indexgen.js";
+import { updateEmbeddings } from "../utils/embeddings.js";
+import { loadNonDefaultProfile } from "../profile/block.js";
+import { QUERIES_DIR } from "../utils/constants.js";
+import * as output from "../utils/output.js";
+
+/**
+ * Generate a one-line summary from the answer for use in the wiki index.
+ * Takes the first sentence (up to 120 chars) so the page-selection LLM
+ * has retrieval signal beyond just the title.
+ * @param answer - The full answer text.
+ * @returns A short summary string.
+ */
+export function summarizeAnswer(answer: string): string {
+  const firstLine = answer.trim().split(/\n/)[0] ?? "";
+  const firstSentence = firstLine.split(/(?<=[.!?])\s/)[0] ?? firstLine;
+  return firstSentence.slice(0, 120);
+}
+
+/**
+ * Save a query answer as a wiki page in the queries/ directory,
+ * then regenerate the wiki index so the answer is immediately retrievable.
+ *
+ * NOTE: This path writes directly to wiki/queries/ with NO trust-routed planner
+ * evaluation. It is gated by {@link maybeSaveQueryPage}, which DISABLES the save
+ * in profile-enabled (non-default-profile) projects; for the default profile it
+ * is the deliberate user-initiated write it has always been. Do not call this
+ * directly from a profile-enabled context — route through {@link maybeSaveQueryPage}.
+ *
+ * @param root - Absolute path to the project root directory.
+ * @param question - The original question used as the page title.
+ * @param answer - The generated answer body.
+ */
+async function saveQueryPage(root: string, question: string, answer: string): Promise<string> {
+  const slug = slugify(question);
+  const filePath = path.join(root, QUERIES_DIR, `${slug}.md`);
+
+  const frontmatter = buildFrontmatter({
+    title: question,
+    summary: summarizeAnswer(answer),
+    type: "query",
+    createdAt: new Date().toISOString(),
+  });
+
+  const document = `${frontmatter}\n\n${answer}\n`;
+  await atomicWrite(filePath, document);
+
+  output.status("+", output.success(`Saved query → ${output.source(filePath)}`));
+
+  // Regenerate the index so the saved query is immediately discoverable
+  // by the next query's page-selection step.
+  await generateIndex(root);
+
+  // Index the new query so semantic search retrieves it on the next question.
+  // Non-critical: embedding failures (e.g. missing VOYAGE_API_KEY) don't block save.
+  try {
+    await updateEmbeddings(root, [slug]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+  }
+
+  return slug;
+}
+
+/**
+ * Persist the answer as a query page when `--save` is set, EXCEPT in
+ * profile-enabled (non-default-profile) projects where the saved-query write
+ * path is not yet Trust-Guard-routed.
+ *
+ * Per CLP plan D7 / spec-07 the save is the spec-permitted DISABLED option in
+ * those projects: the answer is still returned to the caller; only the wiki
+ * write is refused, with an actionable message. Default-profile projects are
+ * unaffected and save exactly as before.
+ *
+ * @param root - Absolute project root directory.
+ * @param question - The original question (page title).
+ * @param answer - The generated answer body.
+ * @param save - Whether `--save` was requested.
+ * @returns The saved slug, or `undefined` when not saved (not requested or disabled).
+ */
+export async function maybeSaveQueryPage(
+  root: string,
+  question: string,
+  answer: string,
+  save: boolean,
+): Promise<string | undefined> {
+  if (!save) return undefined;
+  if (await loadNonDefaultProfile(root)) {
+    output.status(
+      "!",
+      output.warn(
+        "query --save is disabled in profile-enabled projects (the saved-query " +
+          "write path is not yet trust-routed). Run without --save, or use the " +
+          "default profile.",
+      ),
+    );
+    return undefined;
+  }
+  return saveQueryPage(root, question, answer);
+}

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -15,9 +15,8 @@ import { existsSync } from "fs";
 import path from "path";
 import { callClaude } from "../utils/llm.js";
 import type { LLMTool } from "../utils/provider.js";
-import { atomicWrite, safeReadFile, slugify, buildFrontmatter, parseFrontmatter } from "../utils/markdown.js";
+import { safeReadFile, slugify, parseFrontmatter } from "../utils/markdown.js";
 import { languageDirective } from "../utils/output-language.js";
-import { generateIndex } from "../compiler/indexgen.js";
 import * as output from "../utils/output.js";
 import {
   QUERY_PAGE_LIMIT,
@@ -30,10 +29,13 @@ import {
 import {
   findRelevantPages,
   findRelevantChunks,
-  updateEmbeddings,
   type ChunkEmbeddingEntry,
 } from "../utils/embeddings.js";
 import { rerankWithBm25 } from "../utils/retrieval.js";
+import { maybeSaveQueryPage } from "./query-save.js";
+// Re-exported so existing consumers/tests keep importing these from `query.js`
+// after the save path moved to `query-save.ts`.
+export { summarizeAnswer, maybeSaveQueryPage } from "./query-save.js";
 import { appendLog, formatWikilinkList } from "../utils/activity-log.js";
 import type { ChunkCitation, QueryResult, RetrievalDebug } from "../utils/types.js";
 
@@ -350,67 +352,6 @@ function buildChunkProvenance(chunks: ChunkCitation[]): string {
   return `\n\nMost relevant excerpts (from chunk-level retrieval):\n${sections.join("\n\n")}`;
 }
 
-/**
- * Generate a one-line summary from the answer for use in the wiki index.
- * Takes the first sentence (up to 120 chars) so the page-selection LLM
- * has retrieval signal beyond just the title.
- * @param answer - The full answer text.
- * @returns A short summary string.
- */
-export function summarizeAnswer(answer: string): string {
-  const firstLine = answer.trim().split(/\n/)[0] ?? "";
-  const firstSentence = firstLine.split(/(?<=[.!?])\s/)[0] ?? firstLine;
-  return firstSentence.slice(0, 120);
-}
-
-/**
- * Save a query answer as a wiki page in the queries/ directory,
- * then regenerate the wiki index so the answer is immediately retrievable.
- *
- * NOTE: This path writes directly to wiki/queries/ with NO review-policy evaluation.
- * Query saves are user-initiated and deliberately out of scope for the compile-time
- * review gate. This is a known unguarded write path that will be addressed in the
- * Security cycle. Do not add policy evaluation here without updating the spec.
- *
- * @param root - Absolute path to the project root directory.
- * @param question - The original question used as the page title.
- * @param answer - The generated answer body.
- */
-async function saveQueryPage(root: string, question: string, answer: string): Promise<string> {
-  const slug = slugify(question);
-  const filePath = path.join(root, QUERIES_DIR, `${slug}.md`);
-
-  const frontmatter = buildFrontmatter({
-    title: question,
-    summary: summarizeAnswer(answer),
-    type: "query",
-    createdAt: new Date().toISOString(),
-  });
-
-  const document = `${frontmatter}\n\n${answer}\n`;
-  await atomicWrite(filePath, document);
-
-  output.status(
-    "+",
-    output.success(`Saved query → ${output.source(filePath)}`),
-  );
-
-  // Regenerate the index so the saved query is immediately discoverable
-  // by the next query's page-selection step.
-  await generateIndex(root);
-
-  // Index the new query so semantic search retrieves it on the next question.
-  // Non-critical: embedding failures (e.g. missing VOYAGE_API_KEY) don't block save.
-  try {
-    await updateEmbeddings(root, [slug]);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
-  }
-
-  return slug;
-}
-
 /** Options for generateAnswer — programmatic-friendly. */
 interface GenerateAnswerOptions {
   /** Persist the answer as a wiki query page when set. */
@@ -452,7 +393,7 @@ export async function generateAnswer(
   }
 
   const answer = await callAnswerLLM(question, pagesContent, selection.chunks, options.onToken);
-  const saved = options.save ? await saveQueryPage(root, question, answer) : undefined;
+  const saved = await maybeSaveQueryPage(root, question, answer, Boolean(options.save));
 
   // Journal the query only after the answer is produced — matching compile,
   // which logs after finalization — so a mid-flight LLM failure records nothing.

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -59,7 +59,14 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
   if (!pagePath) return;
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
 
-  await persistCandidateSourceStates(root, candidate);
+  // The source-state tail records the approved slug into the DEFAULT
+  // `state.sources[file].concepts` list — a concepts-only structure with no
+  // typed discrimination. A TYPED candidate must skip it (mirroring
+  // routeApprovedPageWrite's typed/default branch) so a non-concept slug can
+  // never pollute concepts state. Default candidates keep the existing path.
+  if (!candidate.targetEntityType) {
+    await persistCandidateSourceStates(root, candidate);
+  }
   await refreshWikiAfterApproval(root, candidate.slug);
   await deleteCandidate(root, id);
   output.status("✓", output.dim(`Candidate ${id} cleared.`));

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -11,6 +11,16 @@
  * the lock (TOCTOU guard) — if it disappears between the fast-fail check and
  * lock acquisition (e.g. a concurrent reject ran first), the approval aborts
  * cleanly rather than writing a page from a stale in-memory snapshot.
+ *
+ * ATOMICITY (scope — do not over-promise). Only the PAGE BYTE-WRITE is journalled
+ * and atomic (via the planner/executor batch). The post-write tail —
+ * source-state persist, index/MOC/embeddings refresh, and `deleteCandidate` —
+ * runs under the SAME lock but is NOT part of the journal batch: it is
+ * best-effort and IDEMPOTENT / re-derivable. A crash anywhere in the tail leaves
+ * the page written but the candidate possibly un-cleared; recovery is simply
+ * re-running `approve` (idempotent) or a `refresh` (which re-derives the index,
+ * MOC, embeddings, and source state). The whole operation is NOT a single atomic
+ * transaction; only the page write is.
  */
 
 import path from "path";

--- a/src/commands/review-list.ts
+++ b/src/commands/review-list.ts
@@ -19,6 +19,21 @@ function formatReasons(candidate: ReviewCandidate): string {
   return candidate.heldReasons.map((r) => r.code).join(", ");
 }
 
+/**
+ * Typed-target suffix for a candidate row.
+ *
+ * Typed candidates (those carrying `targetEntityType`) land in
+ * `wiki/<targetEntityType>/` instead of the default `wiki/concepts/`. Surfacing
+ * the typed slug keeps the human review gate honest: a staged `papers/foo` must
+ * not look identical to a default concept. Default candidates (no
+ * `targetEntityType`) return "" so their output stays byte-identical.
+ */
+function typedTargetSuffix(candidate: ReviewCandidate): string {
+  return candidate.targetEntityType
+    ? ` → ${candidate.targetEntityType}/${candidate.slug}`
+    : "";
+}
+
 /** List every pending candidate from .llmwiki/candidates/. */
 export default async function reviewListCommand(): Promise<void> {
   output.header("Pending review candidates");
@@ -33,7 +48,11 @@ export default async function reviewListCommand(): Promise<void> {
     const sources = candidate.sources.join(", ");
     const mode = `${formatMode(candidate)}: ${formatReasons(candidate)}`;
     const meta = output.dim(`${candidate.generatedAt} | ${mode} | sources: ${sources}`);
-    output.status("?", `${output.info(candidate.id)} → ${candidate.slug} ${meta}`);
+    const typedTarget = typedTargetSuffix(candidate);
+    output.status(
+      "?",
+      `${output.info(candidate.id)} → ${candidate.slug}${typedTarget} ${meta}`,
+    );
   }
 
   output.status(

--- a/src/commands/review-show.ts
+++ b/src/commands/review-show.ts
@@ -15,8 +15,26 @@ function candidateReasons(candidate: ReviewCandidate): string[] {
     .map((reason) => reason.detail ? `${reason.code} (${reason.detail})` : reason.code);
 }
 
+/**
+ * Print the resolved on-disk target for a typed candidate.
+ *
+ * Typed candidates (carrying `targetEntityType`) land in
+ * `wiki/<targetEntityType>/<slug>.md` rather than the default
+ * `wiki/concepts/`. Surfacing the resolved path lets a human reviewer see where
+ * approval will write before they approve. Default candidates (no
+ * `targetEntityType`) print nothing here so their output stays byte-identical.
+ */
+function printTypedTarget(candidate: ReviewCandidate): void {
+  if (!candidate.targetEntityType) return;
+  output.status(
+    "i",
+    output.dim(`Target:    wiki/${candidate.targetEntityType}/${candidate.slug}.md`),
+  );
+}
+
 /** Print review metadata added by policy-aware candidate generation. */
 function printReviewMetadata(candidate: ReviewCandidate): void {
+  printTypedTarget(candidate);
   output.status("i", output.dim(`review:    ${candidate.reviewMode}`));
   output.status("i", output.dim(`reasons:   ${candidateReasons(candidate).join(", ")}`));
   if (candidate.okfPath) {

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -22,7 +22,7 @@
  * from a benign ABSENT `.llmwiki` (nothing to reset → exit 0).
  */
 
-import { rename, realpath } from "fs/promises";
+import { rename, realpath, lstat } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { LLMWIKI_DIR, STATE_FILE } from "../utils/constants.js";
@@ -121,10 +121,45 @@ async function runConfirmedReset(root: string): Promise<void> {
 }
 
 /**
+ * True when the backup destination is safe to overwrite via `rename`.
+ *
+ * Clobbering a REGULAR-FILE `.bak` is intended (a prior backup), and an absent
+ * `.bak` is fine. But a DIRECTORY `.bak` makes `rename` throw a raw, unactionable
+ * `EISDIR` (→ exit 1 with `Error: EISDIR`); any other non-regular type is equally
+ * unwriteable. We detect those up front with `lstat` (no symlink follow — a
+ * symlink `.bak` is replaced, not written through, so it stays allowed) and
+ * refuse cleanly instead. Returns false (with an actionable message emitted) when
+ * the path exists and is not a regular file.
+ *
+ * @param bakPath - The `state.json.bak` destination path.
+ * @returns True if the rename may proceed; false if it must be refused.
+ */
+async function backupDestinationIsWriteable(bakPath: string): Promise<boolean> {
+  let st;
+  try {
+    st = await lstat(bakPath);
+  } catch {
+    return true; // absent → safe to create
+  }
+  if (st.isFile()) return true; // a prior backup → intended clobber
+  output.status(
+    "!",
+    output.warn(
+      `cannot back up: ${STATE_FILE}.bak exists and is not a regular file; remove it and retry`,
+    ),
+  );
+  return false;
+}
+
+/**
  * Back up and remove the confined state file. Resolves the state path UNDER the
  * confined `.llmwiki` dir (so a symlinked parent cannot redirect the rename) and
  * renames the RAW bytes to `state.json.bak` without reading or validating them,
  * so recovery works on a too-new or corrupt state.
+ *
+ * Refuses CLEANLY (exit 1, no crash) when `state.json.bak` exists and is not a
+ * regular file (e.g. a directory), instead of letting `rename` throw a raw
+ * `EISDIR`. The state file is left untouched in that case.
  *
  * @param root - Absolute project root directory.
  * @param confinedDir - The validated `.llmwiki` real directory.
@@ -136,7 +171,12 @@ async function backupStateFile(root: string, confinedDir: string): Promise<void>
     return;
   }
   const confinedState = await confineUnderRoot(statePath, root, { mustExist: false });
-  await rename(confinedState, `${confinedState}.bak`);
+  const bakPath = `${confinedState}.bak`;
+  if (!(await backupDestinationIsWriteable(bakPath))) {
+    process.exitCode = 1; // clean actionable refusal, not a raw EISDIR crash
+    return;
+  }
+  await rename(confinedState, bakPath);
   output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
 }
 

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -139,6 +139,25 @@ function buildCandidateId(slug: string): string {
   return `${slug}-${suffix}`;
 }
 
+/**
+ * The FULL target identity of a candidate: the tuple of where the approved page
+ * lands AND its slug. Two candidates are duplicates only when BOTH components
+ * match. For a DEFAULT concepts candidate the type component is the constant
+ * `"concepts"`, so dedup on this key behaves EXACTLY as a slug-only dedup did —
+ * default candidate behavior stays byte-identical. A typed candidate
+ * (`targetEntityType`) or an OKF query candidate (`targetDirectory`) keys on its
+ * own directory, so `papers/foo` and `ideas/foo` never collapse into one file.
+ * @param candidate - The candidate (or draft) whose target identity is built.
+ */
+function candidateTargetKey(candidate: {
+  targetEntityType?: string;
+  targetDirectory?: string;
+  slug: string;
+}): string {
+  const target = candidate.targetEntityType ?? candidate.targetDirectory ?? "concepts";
+  return `${target}/${candidate.slug}`;
+}
+
 /** Build the typed unsafe-id error for a candidate file id. */
 function unsafeCandidateId(id: string): Error {
   return new UnsafeCandidateIdError("id", id);
@@ -186,7 +205,7 @@ export async function writeCandidate(
   draft: CandidateDraft,
 ): Promise<ReviewCandidate> {
   if (!isSafeFilenameComponent(draft.slug)) throw new UnsafeCandidateIdError("slug", draft.slug);
-  const { canonicalId, duplicateIds } = await findSlugDuplicates(root, draft.slug);
+  const { canonicalId, duplicateIds } = await findIdentityDuplicates(root, candidateTargetKey(draft));
   const candidate: ReviewCandidate = {
     id: canonicalId ?? buildCandidateId(draft.slug),
     title: draft.title,
@@ -214,17 +233,22 @@ export async function writeCandidate(
 }
 
 /**
- * Collect all candidate ids matching a slug and return the canonical (earliest)
- * id plus the list of extra duplicate ids to remove.
+ * Collect all candidate ids matching a FULL target identity (target-type + slug,
+ * via {@link candidateTargetKey}) and return the canonical (earliest) id plus the
+ * list of extra duplicate ids to remove. Keying on the full identity — not slug
+ * alone — keeps two distinct typed targets that share a slug (`papers/foo` vs
+ * `ideas/foo`) as SEPARATE candidates, so neither is silently dropped, while a
+ * DEFAULT concepts candidate (constant `concepts/` prefix) dedups exactly as
+ * before.
  * @param root - Project root directory.
- * @param slug - The page slug to search for.
+ * @param targetKey - The full target identity to match (see {@link candidateTargetKey}).
  */
-async function findSlugDuplicates(
+async function findIdentityDuplicates(
   root: string,
-  slug: string,
+  targetKey: string,
 ): Promise<{ canonicalId: string | null; duplicateIds: string[] }> {
   const all = await listCandidates(root);
-  const matching = all.filter((c) => c.slug === slug);
+  const matching = all.filter((c) => candidateTargetKey(c) === targetKey);
   if (matching.length === 0) return { canonicalId: null, duplicateIds: [] };
   // Preserve the first match as canonical (listCandidates sorts by generatedAt).
   const [canonical, ...extras] = matching;
@@ -493,15 +517,20 @@ export async function deleteCandidate(root: string, id: string): Promise<boolean
 }
 
 /**
- * Delete ALL pending candidate files for a slug.
+ * Delete ALL pending candidate files for a DEFAULT concepts slug.
  *
  * When duplicates exist (e.g. legacy or hand-dropped files) the direct-write
  * reconcile path must remove every file matching the slug, not just the first
- * canonical one, so no stale duplicates remain after a page is written directly.
+ * canonical one, so no stale duplicates remain after a concepts page is written
+ * directly. Matches on the FULL `concepts/<slug>` identity (via
+ * {@link candidateTargetKey}) so a typed `papers/<slug>` candidate that merely
+ * shares the slug is NOT collaterally deleted when a default concepts page is
+ * reconciled — the default caller only writes concepts, so its behavior is
+ * unchanged.
  */
 export async function deleteCandidateBySlug(root: string, slug: string): Promise<boolean> {
   const all = await listCandidates(root);
-  const matching = all.filter((c) => c.slug === slug);
+  const matching = all.filter((c) => candidateTargetKey(c) === `concepts/${slug}`);
   if (matching.length === 0) return false;
   for (const candidate of matching) {
     await deleteCandidate(root, candidate.id);

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -40,7 +40,7 @@ import type { TrustDecision } from "../trust/decision.js";
 const ID_SUFFIX_BYTES = 4;
 
 /** Input shape for creating a new candidate (id + timestamp generated here). */
-interface CandidateDraft {
+export interface CandidateDraft {
   title: string;
   slug: string;
   summary: string;

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -24,7 +24,17 @@ export function computeFreshness(page: PageFreshnessInput, snapshot: FreshnessSn
   };
 }
 
-/** Source-derived freshness status, per the spec's ordered ownership algorithm. */
+/**
+ * Source-derived freshness status, per the spec's ordered ownership algorithm.
+ *
+ * SCOPED LIMITATION (typed entity pages). Source ownership is recorded only for
+ * DEFAULT concepts (in `state.sources[file].concepts`). TYPED entity pages
+ * (non-concepts produced by a non-default profile, e.g. `papers/`, `ideas/`)
+ * have no source ownership entry, so `ownersOf` returns empty and they are
+ * INTENTIONALLY classified `unverified` — and therefore excluded from orphan
+ * pruning — in this phase. This is a known, scoped limitation: typed-page
+ * source ownership (and orphan pruning) is deferred to a later phase.
+ */
 function classify(page: PageFreshnessInput, snapshot: FreshnessSnapshot): FreshnessStatus {
   if (snapshot.stateStatus !== "ok") return "unverified";
   // Query pages are generated answers, not source projections — always unverified,

--- a/src/trust/checks.ts
+++ b/src/trust/checks.ts
@@ -125,6 +125,36 @@ export const checkResourceLimit: MandatoryPageCheck = async (ctx) => {
 };
 
 /**
+ * Thrown by {@link assertBodyWithinResourceLimit} when a body exceeds
+ * {@link MAX_SOURCE_CHARS}. Lets pre-parse entry points (staging, promotion)
+ * reject an oversized body with a TYPED error BEFORE any frontmatter parse —
+ * mirroring the executor-side {@link checkResourceLimit} floor (same cap, same
+ * message wording) so the two agree. The planner's floor stays as the executor
+ * -side guarantee (defense in depth).
+ */
+export class ResourceLimitError extends Error {
+  constructor(chars: number) {
+    super(`body ${chars} chars exceeds cap of ${MAX_SOURCE_CHARS}`);
+    this.name = "ResourceLimitError";
+  }
+}
+
+/**
+ * Reject a body whose character length exceeds {@link MAX_SOURCE_CHARS} BEFORE
+ * any frontmatter parse. A pure `.length` compare — costs nothing — so a giant
+ * all-frontmatter payload can never burn parse time before the cap rejects it.
+ * A body within the cap is a no-op. Restores the "reject before parsing"
+ * guarantee at the staging/promotion entry points.
+ * @param body - The full markdown body to length-check.
+ * @throws {ResourceLimitError} When `body.length` exceeds the cap.
+ */
+export function assertBodyWithinResourceLimit(body: string): void {
+  if (body.length > MAX_SOURCE_CHARS) {
+    throw new ResourceLimitError(body.length);
+  }
+}
+
+/**
  * Block a body whose frontmatter block is present but malformed (invalid YAML
  * or a non-mapping scalar/array), reusing {@link parseFrontmatterStatus}. A body
  * with no frontmatter block or with clean frontmatter passes.

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -9,6 +9,14 @@
  * already-held review lock. The atomicity contract (and journal replay) is now
  * realized on that live path; other CLP write surfaces are still future work.
  *
+ * ATOMICITY SCOPE (honest boundary). The journal batch covers ONLY the page
+ * byte-writes in the plan. It does NOT extend to a consumer's post-write tail —
+ * e.g. `review approve`'s source-state persist, index/MOC/embeddings refresh, and
+ * candidate deletion run under the same lock but OUTSIDE this batch, and are
+ * best-effort + idempotent/re-derivable rather than journalled. "The approved
+ * batch applies atomically" means the PAGE BYTES, not the whole approve
+ * operation.
+ *
  * {@link applyApprovedMutations} runs the batch behind the project lock and a
  * single-store intent journal:
  *  1. acquire the PID-based project lock (same discipline as compile/review);

--- a/src/trust/promote.ts
+++ b/src/trust/promote.ts
@@ -32,6 +32,7 @@ import {
   EntityFieldContractError,
 } from "../profile/field-contract.js";
 import { parseFrontmatter } from "../utils/markdown.js";
+import { assertBodyWithinResourceLimit } from "./checks.js";
 import type { EntityTypeDef } from "../profile/types.js";
 import type { ReviewCandidate } from "../utils/types.js";
 
@@ -79,9 +80,14 @@ function typedPagePath(entityType: string, slug: string): string {
  * violated. Promotion then fails CLOSED and the candidate is RETAINED (the caller
  * deletes only after a successful apply), so a contract-violating page never lands.
  *
+ * The raw body-length cap is enforced FIRST (before the frontmatter parse) so a
+ * giant all-frontmatter candidate body is rejected by `.length` alone, never
+ * burning parse time — the "reject before parsing" guarantee.
+ *
  * @param entityType - The (already type-checked) profile entity type.
  * @param candidate - The typed candidate whose body frontmatter is validated.
  * @param def - The resolved entity type definition supplying the contract.
+ * @throws {ResourceLimitError} When the candidate body exceeds the resource cap.
  * @throws {EntityFieldContractError} When the frontmatter violates the contract.
  */
 function assertCandidateFieldContract(
@@ -89,6 +95,7 @@ function assertCandidateFieldContract(
   candidate: ReviewCandidate,
   def: EntityTypeDef,
 ): void {
+  assertBodyWithinResourceLimit(candidate.body);
   const { meta } = parseFrontmatter(candidate.body);
   const violations = validateEntityFields(meta, def);
   if (violations.length > 0) {

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -31,13 +31,14 @@ import {
   type StagedChange,
 } from "./staged-change.js";
 import { promoteCandidateUnderLock } from "./promote.js";
-import { writeCandidate } from "../compiler/candidates.js";
+import { writeCandidate, countCandidates } from "../compiler/candidates.js";
 import { loadNonDefaultProfile } from "../profile/block.js";
 import {
   validateEntityFields,
   EntityFieldContractError,
 } from "../profile/field-contract.js";
 import { parseFrontmatter } from "../utils/markdown.js";
+import { assertBodyWithinResourceLimit } from "./checks.js";
 import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
 
@@ -50,10 +51,15 @@ export { EntityFieldContractError } from "../profile/field-contract.js";
  * before any planning or I/O — when the contract is violated, so a contract-
  * violating typed page never persists a candidate. A clean body is a no-op.
  *
+ * The raw body-length cap is enforced FIRST (before the frontmatter parse) so a
+ * giant all-frontmatter payload is rejected by `.length` alone, never burning
+ * parse time — the "reject before parsing" guarantee.
+ *
  * @param entityType - The (already type-checked) profile entity type.
  * @param slug - The page slug (for the error message only).
  * @param body - The full markdown body whose frontmatter is validated.
  * @param profile - The profile whose entity definition supplies the contract.
+ * @throws {ResourceLimitError} When the body exceeds the resource cap.
  * @throws {EntityFieldContractError} When the frontmatter violates the contract.
  */
 function assertFieldContract(
@@ -62,6 +68,7 @@ function assertFieldContract(
   body: string,
   profile: ProfilePack,
 ): void {
+  assertBodyWithinResourceLimit(body);
   const { meta } = parseFrontmatter(body);
   const violations = validateEntityFields(meta, profile.entities[entityType]!);
   if (violations.length > 0) {
@@ -144,10 +151,12 @@ function buildPageTarget(plan: PlanResult): EntityRef {
  * persists NOTHING, so a blocked write never lands an un-promotable candidate.
  *
  * Volume bound: the PER-CALL cap (requested vs {@link DEFAULT_STAGED_WRITE_PER_CALL})
- * is self-contained and self-enforced here. The PER-SESSION cap, however, is
- * enforced against the caller-supplied `input.existingStagedCount` — there is no
- * on-disk source of truth for a running session total, so keeping that count
- * accurate across calls is the CALLER's responsibility.
+ * is self-contained and self-enforced here. The PER-SESSION cap is enforced
+ * against the REAL number of candidates ON DISK ({@link countCandidates}), not a
+ * caller hint — so an SDK caller passing `existingStagedCount: 0` on every call
+ * can never bypass the per-session cap by under-reporting. The caller hint is
+ * still honored as a floor (`max(onDisk, hint)`) so a count the caller knows
+ * about but has not yet flushed to disk also counts against the budget.
  *
  * @param root - Absolute project root.
  * @param input - The entity page to stage (caller-provided body).
@@ -161,7 +170,9 @@ export async function stageEntityPage(
   root: string,
   input: StageEntityPageInput,
 ): Promise<StagedChange> {
-  assertStagedWriteBudget(input.existingStagedCount, 1, {
+  const onDisk = await countCandidates(root);
+  const sessionCount = Math.max(onDisk, input.existingStagedCount);
+  assertStagedWriteBudget(sessionCount, 1, {
     perCall: DEFAULT_STAGED_WRITE_PER_CALL,
     perSession: DEFAULT_STAGED_WRITE_PER_SESSION,
   });
@@ -238,9 +249,10 @@ export class StagingRequiresProfileError extends Error {
 /**
  * @experimental
  * SDK staging input: the entity page to stage WITHOUT the `ProfilePack` — the SDK
- * loads the active non-default profile itself. `existingStagedCount` is the
- * caller's per-session bookkeeping (defaults to 0); the per-session cap is the
- * caller's responsibility, consistent with {@link stageEntityPage}.
+ * loads the active non-default profile itself. `existingStagedCount` (defaults to
+ * 0) is only a FLOOR hint; the per-session cap is enforced against the real
+ * on-disk candidate count by {@link stageEntityPage}, so a caller cannot bypass
+ * it by passing 0.
  */
 export interface SdkStageEntityPageInput {
   /** Profile entity type (the wiki subdirectory), e.g. `"papers"`. */

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,7 +4,7 @@
  * for wiki pages.
  */
 
-import { writeFile, rename, readFile, mkdir } from "fs/promises";
+import { writeFile, rename, readFile, mkdir, lstat } from "fs/promises";
 import path from "path";
 import yaml from "js-yaml";
 import type {
@@ -128,9 +128,30 @@ export function parseFrontmatterStatus(content: string): {
   return { meta, body: match[2], hasFrontmatterBlock: true, malformedFrontmatter };
 }
 
-/** Atomically write a file (write to .tmp, then rename). */
+/**
+ * Atomically write a file (write to .tmp, then rename).
+ *
+ * Defense against the confine→write race (S3): callers resolve `filePath` with
+ * `confineUnderRoot(..., {mustExist:false})`, which returns a LEXICAL path after
+ * checking the nearest EXISTING ancestor. Between that check and this write, the
+ * final directory can be swapped for a symlink that escapes the project root, so
+ * the rename would land outside root. `atomicWrite` lacks root context, so it
+ * fails CLOSED on the actual escape vector: immediately before writing, it
+ * `lstat`s the parent directory and refuses if it is a SYMLINK. Project writes
+ * always target real directories, so this never rejects a legitimate write; it
+ * matches the wider trust model (a symlinked dir is never trusted).
+ *
+ * @param filePath - Absolute destination path (its parent must be a real dir).
+ * @param content - File contents to write.
+ * @throws If the resolved parent directory is a symlink (confine→write escape).
+ */
 export async function atomicWrite(filePath: string, content: string): Promise<void> {
-  await mkdir(path.dirname(filePath), { recursive: true });
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const dirStat = await lstat(dir);
+  if (dirStat.isSymbolicLink()) {
+    throw new Error(`refusing to write through a symlinked directory: ${dir}`);
+  }
   const tmpPath = filePath + ".tmp";
   await writeFile(tmpPath, content, "utf-8");
   await rename(tmpPath, filePath);

--- a/test/atomic-write-confine-race.test.ts
+++ b/test/atomic-write-confine-race.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @file test/atomic-write-confine-race.test.ts
+ * @description FIX S3 — close the confine→write TOCTOU window in `atomicWrite`.
+ *
+ * Callers resolve a write target with `confineUnderRoot(..., {mustExist:false})`,
+ * which returns a LEXICAL path after checking the nearest EXISTING ancestor.
+ * Between that check and the rename, the final directory can be swapped for a
+ * symlink that escapes the project root, so the write would land outside.
+ *
+ * `atomicWrite` lacks root context, so it fails CLOSED on the actual escape
+ * vector: it refuses to write when its parent directory is a SYMLINK. This test
+ * mirrors the confirmed exploit — confine a path under a real dir, replace that
+ * dir with a symlink to an out-of-tree location, then attempt the write — and
+ * asserts nothing is written outside the project.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, rename, symlink, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { confineUnderRoot } from "../src/utils/path-confine.js";
+import { atomicWrite } from "../src/utils/markdown.js";
+
+let root = "";
+let outside = "";
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  if (outside) await rm(outside, { recursive: true, force: true });
+  root = outside = "";
+});
+
+describe("atomicWrite confine→write race (S3)", () => {
+  it("refuses to write through a final dir swapped to an escaping symlink", async () => {
+    root = await mkdtemp(path.join(tmpdir(), "s3-root-"));
+    outside = await mkdtemp(path.join(tmpdir(), "s3-out-"));
+    await mkdir(path.join(root, "concepts"), { recursive: true });
+
+    // Confinement passes against the REAL dir (the legitimate pre-write state).
+    const target = await confineUnderRoot("concepts/leak.md", root, { mustExist: false });
+
+    // Race: swap the confined parent dir for a symlink that escapes root.
+    await rename(path.join(root, "concepts"), path.join(root, "concepts.real"));
+    await symlink(outside, path.join(root, "concepts"), "dir");
+
+    await expect(atomicWrite(target, "secret")).rejects.toThrow(/symlink/i);
+    expect(existsSync(path.join(outside, "leak.md"))).toBe(false); // nothing escaped
+    expect(await readdir(outside)).toHaveLength(0);
+  });
+
+  it("still writes normally into a real directory", async () => {
+    root = await mkdtemp(path.join(tmpdir(), "s3-ok-"));
+    await mkdir(path.join(root, "concepts"), { recursive: true });
+    const target = path.join(root, "concepts", "page.md");
+    await atomicWrite(target, "body");
+    expect(existsSync(target)).toBe(true);
+  });
+});

--- a/test/candidate-identity-dedup.test.ts
+++ b/test/candidate-identity-dedup.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @file test/candidate-identity-dedup.test.ts
+ * @description Cross-entity-type candidate dedup (FIX #2 — data loss).
+ *
+ * Candidate duplicate detection must key on the FULL target identity
+ * (target-type + slug), not slug alone. Staging `papers/foo` then `ideas/foo`
+ * must persist TWO candidate files — neither silently dropped — while writing
+ * the SAME `papers/foo` twice canonicalizes to one (same-type same-slug IS a
+ * duplicate). A DEFAULT concepts candidate (no typed target) dedups EXACTLY as
+ * before: two concepts candidates for one slug collapse to a single file.
+ */
+
+import { describe, it, expect } from "vitest";
+import { listCandidates, writeCandidate } from "../src/compiler/candidates.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+/** Build a typed candidate draft for an entity type + slug. */
+function typedDraft(entityType: string, slug: string, body: string) {
+  return { title: slug, slug, summary: "", sources: [], body, targetEntityType: entityType };
+}
+
+/** Build a DEFAULT concepts candidate draft (no typed target). */
+function conceptsDraft(slug: string, body: string) {
+  return { title: slug, slug, summary: "", sources: [], body };
+}
+
+/** Write two candidate drafts in order and return every persisted candidate. */
+async function writeBothThenList(
+  firstDraft: Parameters<typeof writeCandidate>[1],
+  secondDraft: Parameters<typeof writeCandidate>[1],
+) {
+  const first = await writeCandidate(root.dir, firstDraft);
+  await writeCandidate(root.dir, secondDraft);
+  return { first, all: await listCandidates(root.dir) };
+}
+
+/**
+ * Write two drafts that share one target identity, then assert they collapse to
+ * a SINGLE canonical file (same id, latest body wins).
+ */
+async function expectCollapsesToOne(
+  firstDraft: Parameters<typeof writeCandidate>[1],
+  secondDraft: Parameters<typeof writeCandidate>[1],
+): Promise<void> {
+  const { first, all } = await writeBothThenList(firstDraft, secondDraft);
+  expect(all).toHaveLength(1);
+  expect(all[0]?.id).toBe(first.id);
+  expect(all[0]?.body).toBe(secondDraft.body);
+}
+
+describe("candidate dedup keys on full target identity (FIX #2)", () => {
+  it("keeps papers/foo and ideas/foo as TWO distinct candidates", async () => {
+    const { all } = await writeBothThenList(
+      typedDraft("papers", "foo", "paper body"),
+      typedDraft("ideas", "foo", "idea body"),
+    );
+    expect(all).toHaveLength(2);
+    const byType = Object.fromEntries(all.map((c) => [c.targetEntityType, c.body]));
+    expect(byType).toEqual({ papers: "paper body", ideas: "idea body" });
+  });
+
+  it("canonicalizes the SAME papers/foo written twice to one file (same identity)", async () => {
+    await expectCollapsesToOne(typedDraft("papers", "foo", "v1"), typedDraft("papers", "foo", "v2"));
+  });
+
+  it("dedups two DEFAULT concepts candidates for one slug to one file (unchanged)", async () => {
+    await expectCollapsesToOne(conceptsDraft("topic", "first"), conceptsDraft("topic", "second"));
+  });
+
+  it("keeps a typed papers/foo and a default concepts foo as distinct", async () => {
+    const { all } = await writeBothThenList(
+      conceptsDraft("foo", "concept body"),
+      typedDraft("papers", "foo", "paper body"),
+    );
+    expect(all).toHaveLength(2);
+  });
+});

--- a/test/query-save-profile-gate.test.ts
+++ b/test/query-save-profile-gate.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @file test/query-save-profile-gate.test.ts
+ * @description FIX #6 — `query --save` must be DISABLED in profile-enabled
+ * (non-default-profile) projects, where the saved-query write path is not yet
+ * Trust-Guard-routed (CLP plan D7 / spec-07). In a default project it still
+ * saves exactly as before.
+ *
+ * These tests drive `maybeSaveQueryPage` directly (the gate that wraps
+ * `saveQueryPage`) so they exercise the real save/disable decision without the
+ * full LLM answer pipeline.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync } from "fs";
+import { readdir } from "fs/promises";
+import path from "path";
+import { maybeSaveQueryPage } from "../src/commands/query.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { buildResearchLiteProject } from "./fixtures/profile-fixtures.js";
+
+const QUESTION = "What is attention?";
+const ANSWER = "Attention is a weighting mechanism over a sequence.";
+
+describe("query --save profile gate", () => {
+  let root: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot("qsave-gate");
+    originalCwd = process.cwd();
+    process.chdir(root);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
+  it("DEFAULT project: --save writes a queries page (unchanged)", async () => {
+    const slug = await maybeSaveQueryPage(root, QUESTION, ANSWER, true);
+    expect(slug).toBeDefined();
+    expect(existsSync(path.join(root, "wiki/queries", `${slug}.md`))).toBe(true);
+  });
+
+  it("profile-enabled project: --save does NOT write a queries page", async () => {
+    await buildResearchLiteProject(root);
+    const slug = await maybeSaveQueryPage(root, QUESTION, ANSWER, true);
+    expect(slug).toBeUndefined();
+    const queries = await readdir(path.join(root, "wiki/queries"));
+    expect(queries).toHaveLength(0);
+  });
+
+  it("save=false never writes regardless of profile", async () => {
+    const slug = await maybeSaveQueryPage(root, QUESTION, ANSWER, false);
+    expect(slug).toBeUndefined();
+    const queries = await readdir(path.join(root, "wiki/queries"));
+    expect(queries).toHaveLength(0);
+  });
+});

--- a/test/review-approve-typed.test.ts
+++ b/test/review-approve-typed.test.ts
@@ -18,6 +18,7 @@ import path from "path";
 import os from "os";
 import { writeCandidate } from "../src/compiler/candidates.js";
 import reviewApproveCommand from "../src/commands/review-approve.js";
+import { readState } from "../src/utils/state.js";
 import { CANDIDATES_DIR } from "../src/utils/constants.js";
 import { buildResearchLiteProject } from "./fixtures/profile-fixtures.js";
 
@@ -147,5 +148,38 @@ describe("review approve — typed candidates skip the default title validator",
     await reviewApproveCommand(candidate.id);
 
     expectRefused("wiki/concepts", candidate.id);
+  });
+});
+
+/** A sourceStates map carrying one source entry for `src.md`. */
+const SOURCE_STATES = {
+  "src.md": { hash: "h1", concepts: [], compiledAt: "2026-01-01T00:00:00.000Z" },
+};
+
+describe("review approve — state tail skipped for typed candidates (F4)", () => {
+  it("does NOT write a typed candidate's slug into any source's concepts list", async () => {
+    await buildResearchLiteProject(root);
+    const candidate = await writeCandidate(root, {
+      title: SLUG, slug: SLUG, summary: "", sources: ["src.md"], body: BODY,
+      targetEntityType: "papers", sourceStates: SOURCE_STATES,
+    });
+
+    await reviewApproveCommand(candidate.id);
+
+    await expectApproved("wiki/papers", candidate.id, BODY);
+    const state = await readState(root);
+    expect(state.sources).toEqual({}); // no concepts pollution from the typed slug
+  });
+
+  it("still persists source states for a DEFAULT candidate (unchanged)", async () => {
+    const candidate = await writeCandidate(root, {
+      title: SLUG, slug: SLUG, summary: "", sources: ["src.md"], body: BODY,
+      sourceStates: SOURCE_STATES,
+    });
+
+    await reviewApproveCommand(candidate.id);
+
+    const state = await readState(root);
+    expect(state.sources["src.md"]?.concepts).toEqual([SLUG]);
   });
 });

--- a/test/review-candidate-metadata.test.ts
+++ b/test/review-candidate-metadata.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { writeCandidate, readCandidate } from "../src/compiler/candidates.js";
+import type { CandidateDraft } from "../src/compiler/candidates.js";
 import reviewListCommand from "../src/commands/review-list.js";
 import reviewShowCommand from "../src/commands/review-show.js";
 import { useTempRoot } from "./fixtures/temp-root.js";
@@ -30,6 +31,34 @@ function collectLogOutput(spy: ReturnType<typeof vi.spyOn>): string {
   return spy.mock.calls.map((args) => args.join(" ")).join("\n");
 }
 
+/**
+ * Write a candidate from `draft`, then run `review list` + `review show <id>`
+ * with console captured, returning the combined stdout. Shared by the display
+ * tests so the seed → spy → render → collect boilerplate lives in one place.
+ */
+async function renderListAndShow(rootDir: string, draft: CandidateDraft): Promise<string> {
+  const candidate = await writeCandidate(rootDir, draft);
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  await reviewListCommand();
+  await reviewShowCommand(candidate.id);
+  return collectLogOutput(logSpy);
+}
+
+/** A `policy`-held candidate draft body shared by the metadata + display tests. */
+function policyDraft(): CandidateDraft {
+  return {
+    title: "Policy Held",
+    slug: "policy-held",
+    summary: "Held by policy.",
+    sources: [],
+    body: BODY,
+    reviewMode: "policy",
+    heldReasons: [{ code: "low-confidence", detail: "confidence 0.2 < 0.5" }],
+    confidence: 0.2,
+    contradicted: false,
+  };
+}
+
 describe("review candidate metadata", () => {
   it("defaults writeCandidate metadata to forced manual review", async () => {
     const candidate = await writeCandidate(root.dir, {
@@ -45,27 +74,36 @@ describe("review candidate metadata", () => {
   });
 
   it("round-trips policy metadata and displays it in list/show", async () => {
-    const candidate = await writeCandidate(root.dir, {
-      title: "Policy Held",
-      slug: "policy-held",
-      summary: "Held by policy.",
-      sources: [],
-      body: BODY,
-      reviewMode: "policy",
-      heldReasons: [{ code: "low-confidence", detail: "confidence 0.2 < 0.5" }],
-      confidence: 0.2,
-      contradicted: false,
-    });
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    await reviewListCommand();
-    await reviewShowCommand(candidate.id);
-
-    const output = collectLogOutput(logSpy);
+    const output = await renderListAndShow(root.dir, policyDraft());
     expect(output).toContain("policy: low-confidence");
     expect(output).toContain("confidence 0.2 < 0.5");
     expect(output).toContain("confidence: 0.2");
     expect(output).toContain("contradicted: false");
+  });
+
+  it("surfaces the typed target in list/show for a typed candidate (FIX #4)", async () => {
+    const output = await renderListAndShow(root.dir, {
+      title: "Transformer",
+      slug: "transformer",
+      summary: "A paper.",
+      sources: [],
+      body: BODY,
+      targetEntityType: "papers",
+    });
+    expect(output).toContain("→ papers/transformer");
+    expect(output).toContain("Target:    wiki/papers/transformer.md");
+  });
+
+  it("default candidate list/show output omits the typed target line (FIX #4)", async () => {
+    const output = await renderListAndShow(root.dir, {
+      title: "Default Concept",
+      slug: "default-concept",
+      summary: "A concept.",
+      sources: [],
+      body: BODY,
+    });
+    expect(output).not.toContain("Target:");
+    expect(output).toContain("→ default-concept ");
   });
 });
 

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -101,6 +101,18 @@ describe("state reset", () => {
     await rm(outside, { recursive: true, force: true });
   });
 
+  it("refuses cleanly when state.json.bak is a directory (no raw EISDIR)", async () => {
+    await seedState(OK_STATE);
+    await mkdir(BAK_PATH(), { recursive: true }); // .bak is a DIRECTORY
+
+    const result = await runCLI(["state", "reset", "--yes"], root);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout + result.stderr).not.toMatch(/EISDIR/);
+    expect(result.stdout + result.stderr).toMatch(/not a regular file/i);
+    expect(existsSync(STATE_PATH())).toBe(true); // state untouched
+  });
+
   it("refuses cleanly when the project lock is held by a live holder", async () => {
     await seedState(OK_STATE);
     // A lock naming THIS (live) process PID is not stale, so acquireLock fails.

--- a/test/trust-promote.test.ts
+++ b/test/trust-promote.test.ts
@@ -24,8 +24,9 @@ import {
   promoteStagedEntityPage,
 } from "../src/trust/staging.js";
 import { CandidateProfileError } from "../src/trust/promote.js";
-import { deleteCandidate } from "../src/compiler/candidates.js";
-import { PROFILE_FILE } from "../src/utils/constants.js";
+import { ResourceLimitError } from "../src/trust/checks.js";
+import { writeCandidate, deleteCandidate } from "../src/compiler/candidates.js";
+import { MAX_SOURCE_CHARS, PROFILE_FILE } from "../src/utils/constants.js";
 import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
 
 let root = "";
@@ -76,6 +77,21 @@ describe("lock-safe typed promotion", () => {
     await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(trimmed), "utf8");
 
     await expect(promoteStagedEntityPage(root, id)).rejects.toBeInstanceOf(CandidateProfileError);
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+  });
+});
+
+describe("promotion length-guard runs before frontmatter parse (FIX #5)", () => {
+  it("rejects an oversized all-frontmatter body with ResourceLimitError, not a field-contract error", async () => {
+    // All-frontmatter body > the cap: a yaml.load would burn ~1s; the length
+    // guard must fire FIRST, so the error is ResourceLimitError (not parse-driven).
+    const huge = `---\ntitle: ${"x".repeat(MAX_SOURCE_CHARS + 1)}\n---\n`;
+    const candidate = await writeCandidate(root, {
+      title: SLUG, slug: SLUG, summary: "", sources: [], body: huge,
+      targetEntityType: "papers",
+    });
+
+    await expect(promoteStagedEntityPage(root, candidate.id)).rejects.toBeInstanceOf(ResourceLimitError);
     expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
   });
 });

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, readFile, readdir } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, readFile, readdir, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -31,7 +31,9 @@ import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
   StagedWriteOverflowError,
 } from "../src/trust/staged-change.js";
-import { writeCandidate, listCandidates } from "../src/compiler/candidates.js";
+import { ResourceLimitError } from "../src/trust/checks.js";
+import { MAX_SOURCE_CHARS } from "../src/utils/constants.js";
+import { writeCandidate, listCandidates, countCandidates } from "../src/compiler/candidates.js";
 import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
 
 let root = "";
@@ -49,6 +51,26 @@ beforeEach(async () => {
 afterEach(async () => {
   await rm(root, { recursive: true, force: true });
 });
+
+/**
+ * Seed `count` minimal valid candidate JSON files directly to disk (each a
+ * distinct slug), so {@link countCandidates} reports exactly `count` without
+ * routing through the staging budget. Models a session that has already landed
+ * candidates on disk.
+ */
+async function seedCandidatesOnDisk(count: number): Promise<void> {
+  const dir = path.join(root, ".llmwiki/candidates");
+  await mkdir(dir, { recursive: true });
+  for (let i = 0; i < count; i++) {
+    const id = `seed-${i}-abcd0000`;
+    const record = {
+      id, title: `t${i}`, slug: `seed-${i}`, summary: "", sources: [], body: "b",
+      generatedAt: "2026-01-01T00:00:00.000Z", reviewMode: "forced",
+      heldReasons: [{ code: "manual-review-requested" }],
+    };
+    await writeFile(path.join(dir, `${id}.json`), JSON.stringify(record), "utf8");
+  }
+}
 
 /** Read the single candidate JSON file in the candidates dir, parsed. */
 async function readOnlyCandidate(): Promise<Record<string, unknown>> {
@@ -159,5 +181,52 @@ describe("non-default entity page staging", () => {
     const candidate = await readOnlyCandidate();
     expect("targetEntityType" in candidate).toBe(false);
     expect("trustDecision" in candidate).toBe(false);
+  });
+});
+
+describe("per-session flood bound is derived from disk (FIX #3)", () => {
+  /** Stage one papers page, returning the rejection promise (no await). */
+  function stageOne(existingStagedCount: number): Promise<unknown> {
+    return stageEntityPage(root, {
+      entityType: "papers",
+      slug: SLUG,
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount,
+    });
+  }
+
+  it("rejects when the on-disk count is at the cap EVEN IF the caller passes 0", async () => {
+    await seedCandidatesOnDisk(DEFAULT_STAGED_WRITE_PER_SESSION);
+
+    await expect(stageOne(0)).rejects.toBeInstanceOf(StagedWriteOverflowError);
+    // The exploit count is unchanged: no new candidate landed.
+    expect(await countCandidates(root)).toBe(DEFAULT_STAGED_WRITE_PER_SESSION);
+  });
+
+  it("still stages normally when the on-disk count is under the cap", async () => {
+    await seedCandidatesOnDisk(1);
+
+    const staged = await stageOne(0);
+    expect(staged).toMatchObject({ kind: "page" });
+    expect(await countCandidates(root)).toBe(2);
+  });
+});
+
+describe("staging length-guard runs before frontmatter parse (FIX #5)", () => {
+  it("rejects an oversized all-frontmatter body with ResourceLimitError, writing no candidate", async () => {
+    // All-frontmatter body > cap: the length guard must fire BEFORE yaml.load,
+    // so the thrown error is ResourceLimitError, not EntityFieldContractError.
+    const huge = `---\ntitle: ${"x".repeat(MAX_SOURCE_CHARS + 1)}\n---\n`;
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: SLUG,
+        body: huge,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(ResourceLimitError);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 });


### PR DESCRIPTION
Stacked on PR #127 (do not merge yet). Closes the must-fix bug findings from a four-lens principal audit of the Phase 3 stack. Default profile byte-identical; existing tests pass unchanged.

- **Data loss fixed:** candidate dedup keyed on slug ONLY collapsed two different-entity-type candidates sharing a slug into one (silently dropping a staged page). Dedup now keys on the full target identity `(entityType/directory, slug)`; default concepts behavior unchanged.
- **Flood DoS fixed:** the per-session staged-write cap trusted a caller-supplied count the SDK defaulted to 0, so it never bit. It now reads the on-disk candidate count, so the cap is real.
- **Parse-before-cap fixed:** the field-contract YAML parse ran before the resource-limit check on the staging/promote path; a raw length guard now rejects oversized bodies before any parsing.
- **Human-gate visibility:** `review list`/`review show` now surface a candidate's typed target (`wiki/<entityType>/<slug>.md`), so a reviewer can see where a staged typed page will land instead of it looking like a concept.
- **query --save** is now refused in profile-enabled projects (its saved-page write isn't trust-routed yet), per the trust contract — the answer still prints; default projects are unchanged.
- **Confine→write race closed:** the shared atomic-write primitive now refuses a symlinked target directory, closing a local-tamper window between path confinement and the write across every confined caller.
- **Graceful failures + honest docs:** `state reset` gives an actionable message instead of a raw EISDIR when the backup path is a directory; approve/executor docstrings now state only the page write is journalled (the post-write tail is best-effort/idempotent); freshness documents that typed pages are intentionally unverified this phase.

Full suite green (2020).