### PR TITLE
feat(profile): typed pages in the wiki index + honest read-integration status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`llmwiki state reset`** — a recovery command for a `.llmwiki/state.json` written by a newer llmwiki version. It backs the file up to `state.json.bak` and removes it so the next compile starts fresh. It refuses by default and prints what it will do; pass `--yes` to apply. The reset works even on an unreadable too-new or corrupt state file.
+
+### Changed
+
+- llmwiki now fails closed when `.llmwiki/state.json` was written by a newer llmwiki version: instead of risking a misread or overwrite of a forward-incompatible layout, commands report a clear error. Use `llmwiki state reset --yes` to back up and reset the file, or upgrade llmwiki to read the project as-is.
+
 ## [0.11.0] - 2026-06-16
 
 Extends Open Knowledge Format support beyond the CLI: in-process SDK and MCP access to the OKF round-trip, and faithful reconstruction of an imported foreign bundle's original nested paths on re-export.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,7 +74,8 @@
             "group": "Troubleshooting",
             "pages": [
               "troubleshooting/faq",
-              "troubleshooting/stale-pages"
+              "troubleshooting/stale-pages",
+              "troubleshooting/state-recovery"
             ]
           }
         ]

--- a/docs/troubleshooting/state-recovery.mdx
+++ b/docs/troubleshooting/state-recovery.mdx
@@ -1,0 +1,90 @@
+---
+title: "Recovering State Written by a Newer llmwiki Version"
+sidebarTitle: "State Recovery"
+description: "When .llmwiki/state.json was written by a newer llmwiki version, commands fail closed. Use llmwiki state reset to back up and reset the file and continue."
+---
+
+llmwiki tracks each project's compilation state in `.llmwiki/state.json`. That file carries a schema `version`, and each llmwiki build understands schema versions only up to the one it shipped with.
+
+If you run an llmwiki build against a project whose `.llmwiki/state.json` was written by a **newer** llmwiki version - for example, a teammate compiled with a newer release, or a stray newer binary touched the project - the state file declares a schema version this build does not recognize.
+
+## What "written by a newer llmwiki version" means
+
+It means `.llmwiki/state.json` has a `version` field higher than the highest version your installed llmwiki understands. The newer build may have written fields or a layout your build cannot safely interpret.
+
+When this happens, llmwiki **fails closed**. Rather than risk misreading the file - or overwriting a forward-incompatible layout on the next compile and corrupting it - commands that read state stop with a clear error instead of proceeding:
+
+```
+.llmwiki/state.json (version 3) was written by a newer llmwiki version
+(this build understands up to version 2). Upgrade llmwiki to read this project.
+```
+
+This is deliberate. The safest action when llmwiki encounters state it doesn't understand is to refuse to touch it.
+
+## Two ways forward
+
+### Upgrade llmwiki
+
+If you want to keep the existing compilation state - the recorded source hashes and the incremental-compile tracking - upgrade your llmwiki install to a version at least as new as the one that wrote the file. The newer build understands the schema and reads the project as-is.
+
+```bash
+npm install -g llm-wiki-compiler@latest
+```
+
+### Reset the state file
+
+If you are pinned to an older llmwiki and cannot upgrade, or you simply want to move forward from a clean slate, reset the state file with `llmwiki state reset`. This backs up `.llmwiki/state.json` to `.llmwiki/state.json.bak` and removes it, so the next `llmwiki compile` rebuilds state from your current `sources/`.
+
+## `llmwiki state reset`
+
+`state reset` refuses by default. Run it with no flags to see exactly what it will do without changing anything:
+
+```bash
+llmwiki state reset
+```
+
+```
+→ Will back up .llmwiki/state.json to .llmwiki/state.json.bak and remove it
+→ so the next compile starts fresh.
+→ Re-run with `--yes` to confirm.
+```
+
+When you're ready, pass `--yes` to apply the reset:
+
+```bash
+llmwiki state reset --yes
+```
+
+```
+✓ Reset .llmwiki/state.json. Backup saved to .llmwiki/state.json.bak.
+```
+
+The backup is a single atomic rename: the original bytes are preserved at `.llmwiki/state.json.bak` (overwriting any earlier backup), and the original file is removed.
+
+<Note>
+`state reset --yes` operates on the raw file bytes and never parses or validates the state. That's what makes it a reliable recovery path: it works even when the state file is too-new or otherwise unreadable - the very situation that would otherwise block you.
+</Note>
+
+If there is no state file to reset, the command says so and makes no changes:
+
+```bash
+llmwiki state reset
+```
+
+```
+✓ No state file to reset.
+```
+
+## After resetting
+
+Run a full compile to rebuild state from the current sources:
+
+```bash
+llmwiki compile
+```
+
+This regenerates `.llmwiki/state.json` at your build's schema version and produces fresh pages. Incremental compilation and [source freshness tracking](/troubleshooting/stale-pages) resume normally from there.
+
+<Tip>
+The backup at `.llmwiki/state.json.bak` is left in place. If you later upgrade llmwiki and want the original newer-version state back, you can restore it by renaming the backup to `.llmwiki/state.json` - then the upgraded build can read it directly.
+</Tip>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import reviewListCommand from "./commands/review-list.js";
 import reviewShowCommand from "./commands/review-show.js";
 import reviewApproveCommand from "./commands/review-approve.js";
 import reviewRejectCommand from "./commands/review-reject.js";
+import { stateResetCommand } from "./commands/state-reset.js";
 import { registerRulesCommand } from "./commands/rules-register.js";
 import nextCommand from "./commands/next.js";
 import refreshCommand from "./commands/refresh.js";
@@ -173,6 +174,25 @@ reviewCommand
   .action(async (id: string) => {
     try {
       await reviewRejectCommand(id);
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+const stateCommand = program
+  .command("state")
+  .description(
+    "Back up and reset .llmwiki/state.json (recovery for a state written by a newer llmwiki version).",
+  );
+
+stateCommand
+  .command("reset")
+  .description("Back up and reset the project state file. Requires --yes to apply.")
+  .option("--yes", "Apply the reset (back up and remove the state file)")
+  .action(async (options: { yes?: boolean }) => {
+    try {
+      await stateResetCommand({ yes: options.yes });
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
       process.exit(1);

--- a/src/commands/query-save.ts
+++ b/src/commands/query-save.ts
@@ -1,0 +1,114 @@
+/**
+ * @file src/commands/query-save.ts
+ * @description The `query --save` write path — persists a generated answer as a
+ * `wiki/queries/<slug>.md` page and refreshes the index/embeddings so the answer
+ * is immediately retrievable.
+ *
+ * Split out of `query.ts` to keep that command file within the project size
+ * budget; the answer-generation pipeline stays in `query.ts` and calls
+ * {@link maybeSaveQueryPage} once the answer is produced.
+ */
+
+import path from "path";
+import { atomicWrite, slugify, buildFrontmatter } from "../utils/markdown.js";
+import { generateIndex } from "../compiler/indexgen.js";
+import { updateEmbeddings } from "../utils/embeddings.js";
+import { loadNonDefaultProfile } from "../profile/block.js";
+import { QUERIES_DIR } from "../utils/constants.js";
+import * as output from "../utils/output.js";
+
+/**
+ * Generate a one-line summary from the answer for use in the wiki index.
+ * Takes the first sentence (up to 120 chars) so the page-selection LLM
+ * has retrieval signal beyond just the title.
+ * @param answer - The full answer text.
+ * @returns A short summary string.
+ */
+export function summarizeAnswer(answer: string): string {
+  const firstLine = answer.trim().split(/\n/)[0] ?? "";
+  const firstSentence = firstLine.split(/(?<=[.!?])\s/)[0] ?? firstLine;
+  return firstSentence.slice(0, 120);
+}
+
+/**
+ * Save a query answer as a wiki page in the queries/ directory,
+ * then regenerate the wiki index so the answer is immediately retrievable.
+ *
+ * NOTE: This path writes directly to wiki/queries/ with NO trust-routed planner
+ * evaluation. It is gated by {@link maybeSaveQueryPage}, which DISABLES the save
+ * in profile-enabled (non-default-profile) projects; for the default profile it
+ * is the deliberate user-initiated write it has always been. Do not call this
+ * directly from a profile-enabled context — route through {@link maybeSaveQueryPage}.
+ *
+ * @param root - Absolute path to the project root directory.
+ * @param question - The original question used as the page title.
+ * @param answer - The generated answer body.
+ */
+async function saveQueryPage(root: string, question: string, answer: string): Promise<string> {
+  const slug = slugify(question);
+  const filePath = path.join(root, QUERIES_DIR, `${slug}.md`);
+
+  const frontmatter = buildFrontmatter({
+    title: question,
+    summary: summarizeAnswer(answer),
+    type: "query",
+    createdAt: new Date().toISOString(),
+  });
+
+  const document = `${frontmatter}\n\n${answer}\n`;
+  await atomicWrite(filePath, document);
+
+  output.status("+", output.success(`Saved query → ${output.source(filePath)}`));
+
+  // Regenerate the index so the saved query is immediately discoverable
+  // by the next query's page-selection step.
+  await generateIndex(root);
+
+  // Index the new query so semantic search retrieves it on the next question.
+  // Non-critical: embedding failures (e.g. missing VOYAGE_API_KEY) don't block save.
+  try {
+    await updateEmbeddings(root, [slug]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+  }
+
+  return slug;
+}
+
+/**
+ * Persist the answer as a query page when `--save` is set, EXCEPT in
+ * profile-enabled (non-default-profile) projects where the saved-query write
+ * path is not yet Trust-Guard-routed.
+ *
+ * Per CLP plan D7 / spec-07 the save is the spec-permitted DISABLED option in
+ * those projects: the answer is still returned to the caller; only the wiki
+ * write is refused, with an actionable message. Default-profile projects are
+ * unaffected and save exactly as before.
+ *
+ * @param root - Absolute project root directory.
+ * @param question - The original question (page title).
+ * @param answer - The generated answer body.
+ * @param save - Whether `--save` was requested.
+ * @returns The saved slug, or `undefined` when not saved (not requested or disabled).
+ */
+export async function maybeSaveQueryPage(
+  root: string,
+  question: string,
+  answer: string,
+  save: boolean,
+): Promise<string | undefined> {
+  if (!save) return undefined;
+  if (await loadNonDefaultProfile(root)) {
+    output.status(
+      "!",
+      output.warn(
+        "query --save is disabled in profile-enabled projects (the saved-query " +
+          "write path is not yet trust-routed). Run without --save, or use the " +
+          "default profile.",
+      ),
+    );
+    return undefined;
+  }
+  return saveQueryPage(root, question, answer);
+}

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -15,9 +15,8 @@ import { existsSync } from "fs";
 import path from "path";
 import { callClaude } from "../utils/llm.js";
 import type { LLMTool } from "../utils/provider.js";
-import { atomicWrite, safeReadFile, slugify, buildFrontmatter, parseFrontmatter } from "../utils/markdown.js";
+import { safeReadFile, slugify, parseFrontmatter } from "../utils/markdown.js";
 import { languageDirective } from "../utils/output-language.js";
-import { generateIndex } from "../compiler/indexgen.js";
 import * as output from "../utils/output.js";
 import {
   QUERY_PAGE_LIMIT,
@@ -30,10 +29,13 @@ import {
 import {
   findRelevantPages,
   findRelevantChunks,
-  updateEmbeddings,
   type ChunkEmbeddingEntry,
 } from "../utils/embeddings.js";
 import { rerankWithBm25 } from "../utils/retrieval.js";
+import { maybeSaveQueryPage } from "./query-save.js";
+// Re-exported so existing consumers/tests keep importing these from `query.js`
+// after the save path moved to `query-save.ts`.
+export { summarizeAnswer, maybeSaveQueryPage } from "./query-save.js";
 import { appendLog, formatWikilinkList } from "../utils/activity-log.js";
 import type { ChunkCitation, QueryResult, RetrievalDebug } from "../utils/types.js";
 
@@ -350,67 +352,6 @@ function buildChunkProvenance(chunks: ChunkCitation[]): string {
   return `\n\nMost relevant excerpts (from chunk-level retrieval):\n${sections.join("\n\n")}`;
 }
 
-/**
- * Generate a one-line summary from the answer for use in the wiki index.
- * Takes the first sentence (up to 120 chars) so the page-selection LLM
- * has retrieval signal beyond just the title.
- * @param answer - The full answer text.
- * @returns A short summary string.
- */
-export function summarizeAnswer(answer: string): string {
-  const firstLine = answer.trim().split(/\n/)[0] ?? "";
-  const firstSentence = firstLine.split(/(?<=[.!?])\s/)[0] ?? firstLine;
-  return firstSentence.slice(0, 120);
-}
-
-/**
- * Save a query answer as a wiki page in the queries/ directory,
- * then regenerate the wiki index so the answer is immediately retrievable.
- *
- * NOTE: This path writes directly to wiki/queries/ with NO review-policy evaluation.
- * Query saves are user-initiated and deliberately out of scope for the compile-time
- * review gate. This is a known unguarded write path that will be addressed in the
- * Security cycle. Do not add policy evaluation here without updating the spec.
- *
- * @param root - Absolute path to the project root directory.
- * @param question - The original question used as the page title.
- * @param answer - The generated answer body.
- */
-async function saveQueryPage(root: string, question: string, answer: string): Promise<string> {
-  const slug = slugify(question);
-  const filePath = path.join(root, QUERIES_DIR, `${slug}.md`);
-
-  const frontmatter = buildFrontmatter({
-    title: question,
-    summary: summarizeAnswer(answer),
-    type: "query",
-    createdAt: new Date().toISOString(),
-  });
-
-  const document = `${frontmatter}\n\n${answer}\n`;
-  await atomicWrite(filePath, document);
-
-  output.status(
-    "+",
-    output.success(`Saved query → ${output.source(filePath)}`),
-  );
-
-  // Regenerate the index so the saved query is immediately discoverable
-  // by the next query's page-selection step.
-  await generateIndex(root);
-
-  // Index the new query so semantic search retrieves it on the next question.
-  // Non-critical: embedding failures (e.g. missing VOYAGE_API_KEY) don't block save.
-  try {
-    await updateEmbeddings(root, [slug]);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
-  }
-
-  return slug;
-}
-
 /** Options for generateAnswer — programmatic-friendly. */
 interface GenerateAnswerOptions {
   /** Persist the answer as a wiki query page when set. */
@@ -452,7 +393,7 @@ export async function generateAnswer(
   }
 
   const answer = await callAnswerLLM(question, pagesContent, selection.chunks, options.onToken);
-  const saved = options.save ? await saveQueryPage(root, question, answer) : undefined;
+  const saved = await maybeSaveQueryPage(root, question, answer, Boolean(options.save));
 
   // Journal the query only after the answer is produced — matching compile,
   // which logs after finalization — so a mid-flight LLM failure records nothing.

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -22,6 +22,7 @@ import {
   CandidateProfileError,
   CandidatePromotionBlockedError,
 } from "../trust/promote.js";
+import { EntityFieldContractError } from "../profile/field-contract.js";
 import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
@@ -90,8 +91,9 @@ async function routeApprovedPageWrite(
 /**
  * Route a TYPED candidate through the profile-validated typed planner. Refuses
  * (exit 1, candidate retained) when the project has no profile, the type is no
- * longer declared, or the re-plan blocks — never a silent fall back to concepts.
- * Returns the absolute `wiki/<entityType>/<slug>.md` path on success.
+ * longer declared, the body violates the declared field contract, or the re-plan
+ * blocks — never a silent fall back to concepts. Returns the absolute
+ * `wiki/<entityType>/<slug>.md` path on success.
  */
 async function routeTypedPageWrite(
   root: string,
@@ -102,7 +104,11 @@ async function routeTypedPageWrite(
     const relPath = await applyTypedCandidate(root, candidate);
     return path.join(root, relPath);
   } catch (err) {
-    if (err instanceof CandidateProfileError || err instanceof CandidatePromotionBlockedError) {
+    if (
+      err instanceof CandidateProfileError ||
+      err instanceof CandidatePromotionBlockedError ||
+      err instanceof EntityFieldContractError
+    ) {
       output.status("!", output.error(`Candidate ${id} not approved: ${err.message}`));
       process.exitCode = 1;
       return null;

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -17,6 +17,11 @@ import path from "path";
 import { validateWikiPage } from "../utils/markdown.js";
 import { planDefaultPageMutation } from "../trust/planner.js";
 import { applyApprovedMutationsLocked } from "../trust/executor.js";
+import {
+  applyTypedCandidate,
+  CandidateProfileError,
+  CandidatePromotionBlockedError,
+} from "../trust/promote.js";
 import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
@@ -50,10 +55,8 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
     return;
   }
 
-  if (!(await routeApprovedPageWrite(root, candidate, id))) return;
-
-  const dir = candidate.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
-  const pagePath = path.join(root, dir, `${candidate.slug}.md`);
+  const pagePath = await routeApprovedPageWrite(root, candidate, id);
+  if (!pagePath) return;
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
 
   await persistCandidateSourceStates(root, candidate);
@@ -64,22 +67,61 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
 
 /**
  * Route the candidate's page write through the write planner/executor (CLP
- * Invariant 4) instead of a direct file write, preserving byte-for-byte parity:
- * the planner derives the SAME `wiki/<dir>/<slug>.md` absolute path and the
- * executor writes the candidate body verbatim under the ALREADY-HELD review lock
- * (so no nested-lock deadlock), running journal replay to recover any crashed
- * batch on this path.
+ * Invariant 4) and return the ABSOLUTE page path it landed at, or `null` on a
+ * refusal (exit code 1, candidate retained, nothing written).
  *
- * `allowOverwrite` is true so re-approving an existing page upserts via `update`
- * rather than colliding. Returns true when the write landed; on a blocked plan
- * (the mandatory floor refused, e.g. an oversized body) it surfaces an approval
- * FAILURE — exit code 1, candidate retained, nothing written — and returns false.
+ * A candidate carrying `targetEntityType` (staged via the typed planner) routes
+ * through {@link applyTypedCandidate} so it lands at `wiki/<entityType>/<slug>.md`
+ * — NOT silently in concepts. A candidate without a typed target keeps the
+ * EXISTING default concepts/queries path byte-for-byte. Both run under the
+ * ALREADY-HELD review lock (no nested-lock deadlock).
  */
 async function routeApprovedPageWrite(
   root: string,
   candidate: ReviewCandidate,
   id: string,
-): Promise<boolean> {
+): Promise<string | null> {
+  if (candidate.targetEntityType) {
+    return routeTypedPageWrite(root, candidate, id);
+  }
+  return routeDefaultPageWrite(root, candidate, id);
+}
+
+/**
+ * Route a TYPED candidate through the profile-validated typed planner. Refuses
+ * (exit 1, candidate retained) when the project has no profile, the type is no
+ * longer declared, or the re-plan blocks — never a silent fall back to concepts.
+ * Returns the absolute `wiki/<entityType>/<slug>.md` path on success.
+ */
+async function routeTypedPageWrite(
+  root: string,
+  candidate: ReviewCandidate,
+  id: string,
+): Promise<string | null> {
+  try {
+    const relPath = await applyTypedCandidate(root, candidate);
+    return path.join(root, relPath);
+  } catch (err) {
+    if (err instanceof CandidateProfileError || err instanceof CandidatePromotionBlockedError) {
+      output.status("!", output.error(`Candidate ${id} not approved: ${err.message}`));
+      process.exitCode = 1;
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Route a DEFAULT candidate (no typed target) through the concepts/queries
+ * planner exactly as before, preserving byte-for-byte parity. `allowOverwrite`
+ * is true so re-approving upserts via `update`. Returns the absolute
+ * `wiki/<dir>/<slug>.md` path on success, or `null` on a blocked plan.
+ */
+async function routeDefaultPageWrite(
+  root: string,
+  candidate: ReviewCandidate,
+  id: string,
+): Promise<string | null> {
   const directory = candidate.targetDirectory === "queries" ? "queries" : "concepts";
   const { planned } = await planDefaultPageMutation({
     root,
@@ -93,10 +135,11 @@ async function routeApprovedPageWrite(
   if (planned.length === 0) {
     output.status("!", output.error(`Candidate ${id} blocked by the write planner; not approved.`));
     process.exitCode = 1;
-    return false;
+    return null;
   }
   await applyApprovedMutationsLocked(root, planned);
-  return true;
+  const dir = candidate.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
+  return path.join(root, dir, `${candidate.slug}.md`);
 }
 
 /**

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -118,6 +118,7 @@ async function routeTypedPageWrite(
 ): Promise<string | null> {
   try {
     const relPath = await applyTypedCandidate(root, candidate);
+    noteTypedReadIntegrationPending(relPath);
     return path.join(root, relPath);
   } catch (err) {
     if (
@@ -131,6 +132,25 @@ async function routeTypedPageWrite(
     }
     throw err;
   }
+}
+
+/**
+ * Emit a one-line, non-error informational NOTE after a typed page is written,
+ * making the half-integration LOUD + HONEST: a typed entity page is now in
+ * `status`, JSON export, and the wiki index, but is NOT YET part of interlinking,
+ * semantic search/embeddings, the MOC, or the viewer (those are planned). The
+ * note never touches the exit code — a successful typed approval still exits 0.
+ *
+ * @param relPath - The project-relative `wiki/<entityType>/<slug>.md` path.
+ */
+function noteTypedReadIntegrationPending(relPath: string): void {
+  output.status(
+    "i",
+    output.info(
+      `Typed page ${relPath} written. Note: typed entity pages are not yet ` +
+        `included in interlinking, semantic search, or the viewer (planned).`,
+    ),
+  );
 }
 
 /**

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -59,7 +59,14 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
   if (!pagePath) return;
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
 
-  await persistCandidateSourceStates(root, candidate);
+  // The source-state tail records the approved slug into the DEFAULT
+  // `state.sources[file].concepts` list — a concepts-only structure with no
+  // typed discrimination. A TYPED candidate must skip it (mirroring
+  // routeApprovedPageWrite's typed/default branch) so a non-concept slug can
+  // never pollute concepts state. Default candidates keep the existing path.
+  if (!candidate.targetEntityType) {
+    await persistCandidateSourceStates(root, candidate);
+  }
   await refreshWikiAfterApproval(root, candidate.slug);
   await deleteCandidate(root, id);
   output.status("✓", output.dim(`Candidate ${id} cleared.`));

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -44,17 +44,16 @@ export default async function reviewApproveCommand(id: string): Promise<void> {
  *
  * Re-reads the candidate under the lock so that a concurrent reject that ran
  * between the pre-lock fast-fail and lock acquisition is detected. Aborts with
- * exit code 1 if the candidate has disappeared or fails page validation.
+ * exit code 1 if the candidate has disappeared. Page-body validation is routed
+ * per target: DEFAULT candidates are gated by the title-requiring
+ * {@link validateWikiPage} (in {@link routeDefaultPageWrite}); TYPED candidates
+ * skip it and instead rely on {@link applyTypedCandidate}'s profile-aware
+ * field-contract validation, since non-default entity types need not require a
+ * `title`.
  */
 async function approveUnderLock(root: string, id: string): Promise<void> {
   const candidate = await readCandidateUnderLock(root, id);
   if (!candidate) return;
-
-  if (!validateWikiPage(candidate.body)) {
-    output.status("!", output.error(`Candidate ${id} failed page validation; not approved.`));
-    process.exitCode = 1;
-    return;
-  }
 
   const pagePath = await routeApprovedPageWrite(root, candidate, id);
   if (!pagePath) return;
@@ -119,15 +118,23 @@ async function routeTypedPageWrite(
 
 /**
  * Route a DEFAULT candidate (no typed target) through the concepts/queries
- * planner exactly as before, preserving byte-for-byte parity. `allowOverwrite`
- * is true so re-approving upserts via `update`. Returns the absolute
- * `wiki/<dir>/<slug>.md` path on success, or `null` on a blocked plan.
+ * planner exactly as before, preserving byte-for-byte parity. The
+ * title-requiring {@link validateWikiPage} gate runs HERE — only for default
+ * candidates — so a body that fails it is refused with the SAME message and exit
+ * code 1 as before. `allowOverwrite` is true so re-approving upserts via
+ * `update`. Returns the absolute `wiki/<dir>/<slug>.md` path on success, or
+ * `null` on a failed validation / blocked plan.
  */
 async function routeDefaultPageWrite(
   root: string,
   candidate: ReviewCandidate,
   id: string,
 ): Promise<string | null> {
+  if (!validateWikiPage(candidate.body)) {
+    output.status("!", output.error(`Candidate ${id} failed page validation; not approved.`));
+    process.exitCode = 1;
+    return null;
+  }
   const directory = candidate.targetDirectory === "queries" ? "queries" : "concepts";
   const { planned } = await planDefaultPageMutation({
     root,

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -11,6 +11,16 @@
  * the lock (TOCTOU guard) — if it disappears between the fast-fail check and
  * lock acquisition (e.g. a concurrent reject ran first), the approval aborts
  * cleanly rather than writing a page from a stale in-memory snapshot.
+ *
+ * ATOMICITY (scope — do not over-promise). Only the PAGE BYTE-WRITE is journalled
+ * and atomic (via the planner/executor batch). The post-write tail —
+ * source-state persist, index/MOC/embeddings refresh, and `deleteCandidate` —
+ * runs under the SAME lock but is NOT part of the journal batch: it is
+ * best-effort and IDEMPOTENT / re-derivable. A crash anywhere in the tail leaves
+ * the page written but the candidate possibly un-cleared; recovery is simply
+ * re-running `approve` (idempotent) or a `refresh` (which re-derives the index,
+ * MOC, embeddings, and source state). The whole operation is NOT a single atomic
+ * transaction; only the page write is.
  */
 
 import path from "path";

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -14,10 +14,9 @@
  */
 
 import path from "path";
-import {
-  atomicWrite,
-  validateWikiPage,
-} from "../utils/markdown.js";
+import { validateWikiPage } from "../utils/markdown.js";
+import { planDefaultPageMutation } from "../trust/planner.js";
+import { applyApprovedMutationsLocked } from "../trust/executor.js";
 import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
@@ -51,15 +50,53 @@ async function approveUnderLock(root: string, id: string): Promise<void> {
     return;
   }
 
+  if (!(await routeApprovedPageWrite(root, candidate, id))) return;
+
   const dir = candidate.targetDirectory === "queries" ? QUERIES_DIR : CONCEPTS_DIR;
   const pagePath = path.join(root, dir, `${candidate.slug}.md`);
-  await atomicWrite(pagePath, candidate.body);
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
 
   await persistCandidateSourceStates(root, candidate);
   await refreshWikiAfterApproval(root, candidate.slug);
   await deleteCandidate(root, id);
   output.status("✓", output.dim(`Candidate ${id} cleared.`));
+}
+
+/**
+ * Route the candidate's page write through the write planner/executor (CLP
+ * Invariant 4) instead of a direct file write, preserving byte-for-byte parity:
+ * the planner derives the SAME `wiki/<dir>/<slug>.md` absolute path and the
+ * executor writes the candidate body verbatim under the ALREADY-HELD review lock
+ * (so no nested-lock deadlock), running journal replay to recover any crashed
+ * batch on this path.
+ *
+ * `allowOverwrite` is true so re-approving an existing page upserts via `update`
+ * rather than colliding. Returns true when the write landed; on a blocked plan
+ * (the mandatory floor refused, e.g. an oversized body) it surfaces an approval
+ * FAILURE — exit code 1, candidate retained, nothing written — and returns false.
+ */
+async function routeApprovedPageWrite(
+  root: string,
+  candidate: ReviewCandidate,
+  id: string,
+): Promise<boolean> {
+  const directory = candidate.targetDirectory === "queries" ? "queries" : "concepts";
+  const { planned } = await planDefaultPageMutation({
+    root,
+    directory,
+    slug: candidate.slug,
+    body: candidate.body,
+    origin: "review",
+    reviewRouted: false,
+    allowOverwrite: true,
+  });
+  if (planned.length === 0) {
+    output.status("!", output.error(`Candidate ${id} blocked by the write planner; not approved.`));
+    process.exitCode = 1;
+    return false;
+  }
+  await applyApprovedMutationsLocked(root, planned);
+  return true;
 }
 
 /**

--- a/src/commands/review-list.ts
+++ b/src/commands/review-list.ts
@@ -19,6 +19,21 @@ function formatReasons(candidate: ReviewCandidate): string {
   return candidate.heldReasons.map((r) => r.code).join(", ");
 }
 
+/**
+ * Typed-target suffix for a candidate row.
+ *
+ * Typed candidates (those carrying `targetEntityType`) land in
+ * `wiki/<targetEntityType>/` instead of the default `wiki/concepts/`. Surfacing
+ * the typed slug keeps the human review gate honest: a staged `papers/foo` must
+ * not look identical to a default concept. Default candidates (no
+ * `targetEntityType`) return "" so their output stays byte-identical.
+ */
+function typedTargetSuffix(candidate: ReviewCandidate): string {
+  return candidate.targetEntityType
+    ? ` → ${candidate.targetEntityType}/${candidate.slug}`
+    : "";
+}
+
 /** List every pending candidate from .llmwiki/candidates/. */
 export default async function reviewListCommand(): Promise<void> {
   output.header("Pending review candidates");
@@ -33,7 +48,11 @@ export default async function reviewListCommand(): Promise<void> {
     const sources = candidate.sources.join(", ");
     const mode = `${formatMode(candidate)}: ${formatReasons(candidate)}`;
     const meta = output.dim(`${candidate.generatedAt} | ${mode} | sources: ${sources}`);
-    output.status("?", `${output.info(candidate.id)} → ${candidate.slug} ${meta}`);
+    const typedTarget = typedTargetSuffix(candidate);
+    output.status(
+      "?",
+      `${output.info(candidate.id)} → ${candidate.slug}${typedTarget} ${meta}`,
+    );
   }
 
   output.status(

--- a/src/commands/review-show.ts
+++ b/src/commands/review-show.ts
@@ -15,8 +15,26 @@ function candidateReasons(candidate: ReviewCandidate): string[] {
     .map((reason) => reason.detail ? `${reason.code} (${reason.detail})` : reason.code);
 }
 
+/**
+ * Print the resolved on-disk target for a typed candidate.
+ *
+ * Typed candidates (carrying `targetEntityType`) land in
+ * `wiki/<targetEntityType>/<slug>.md` rather than the default
+ * `wiki/concepts/`. Surfacing the resolved path lets a human reviewer see where
+ * approval will write before they approve. Default candidates (no
+ * `targetEntityType`) print nothing here so their output stays byte-identical.
+ */
+function printTypedTarget(candidate: ReviewCandidate): void {
+  if (!candidate.targetEntityType) return;
+  output.status(
+    "i",
+    output.dim(`Target:    wiki/${candidate.targetEntityType}/${candidate.slug}.md`),
+  );
+}
+
 /** Print review metadata added by policy-aware candidate generation. */
 function printReviewMetadata(candidate: ReviewCandidate): void {
+  printTypedTarget(candidate);
   output.status("i", output.dim(`review:    ${candidate.reviewMode}`));
   output.status("i", output.dim(`reasons:   ${candidateReasons(candidate).join(", ")}`));
   if (candidate.okfPath) {

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -12,12 +12,21 @@
  * the raw bytes — so it works even when the state is too-new or corrupt. The backup
  * is a single atomic `rename`, which both copies and removes in one step and
  * overwrites any prior `.bak`.
+ *
+ * SAFETY (mirrors the journal-dir trust boundary). The reset acquires the project
+ * LOCK before touching state, so it can never race a concurrent compile/writeState;
+ * if the lock is held it refuses cleanly rather than forcing. It also CONFINES the
+ * `.llmwiki` dir to the project root's realpath — a symlinked `.llmwiki` (or a
+ * state file whose parent escapes root) fails CLOSED and nothing outside root is
+ * moved or clobbered.
  */
 
-import { rename } from "fs/promises";
+import { rename, realpath } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { STATE_FILE } from "../utils/constants.js";
+import { LLMWIKI_DIR, STATE_FILE } from "../utils/constants.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { safeRealpath, isInsideDir, confineUnderRoot } from "../utils/path-confine.js";
 import * as output from "../utils/output.js";
 
 /** Options for {@link stateResetCommand}. */
@@ -27,30 +36,102 @@ export interface StateResetOptions {
 }
 
 /**
- * Back up and reset `.llmwiki/state.json`.
+ * Resolve the confined `.llmwiki` directory for `root`, mirroring the journal-dir
+ * trust boundary: its realpath must be a REAL directory that stays inside the
+ * project root's realpath. Returns the confined real dir, or null to FAIL CLOSED
+ * — null when `.llmwiki` is absent (nothing to reset) OR when it exists but is a
+ * symlink/path escaping root (filesystem tampering). An escape is announced.
  *
- * - No state file → reports nothing to do and returns.
- * - Without `--yes` → prints what it would do and how to confirm; changes nothing.
- * - With `--yes` → renames the raw state file to `state.json.bak` (atomic backup +
- *   removal, overwriting any prior `.bak`) without reading or validating it, so the
- *   recovery works on a too-new or corrupt state. Prints the backup path.
+ * @param root - Absolute project root directory.
+ * @returns The confined `.llmwiki` real directory, or null to fail closed.
  */
-export async function stateResetCommand(opts: StateResetOptions = {}): Promise<void> {
-  const statePath = path.join(process.cwd(), STATE_FILE);
-  const backupPath = `${statePath}.bak`;
+async function resolveConfinedLlmwikiDir(root: string): Promise<string | null> {
+  const realDir = await safeRealpath(path.join(root, LLMWIKI_DIR));
+  if (realDir === null) return null; // absent → nothing to reset
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  if (!isInsideDir(realDir, realRoot)) {
+    output.status("!", output.warn(`${LLMWIKI_DIR} escapes the project root — refusing to reset (tampering).`));
+    return null;
+  }
+  return realDir;
+}
 
+/**
+ * Dry-run path (no `--yes`): report the no-op when there is no state file, else
+ * print the plan and how to confirm. Changes nothing.
+ *
+ * @param root - Absolute project root directory.
+ */
+function reportResetPlan(root: string): void {
+  if (!existsSync(path.join(root, STATE_FILE))) {
+    output.status("✓", output.success("No state file to reset."));
+    return;
+  }
+  output.status("→", `Will back up ${STATE_FILE} to ${STATE_FILE}.bak and remove it`);
+  output.status("→", "so the next compile starts fresh.");
+  output.status("→", output.dim("Re-run with `--yes` to confirm."));
+}
+
+/**
+ * Confirmed path (`--yes`): acquire the lock (refusing cleanly if held), validate
+ * `.llmwiki` is a real in-root directory, back up the raw state file, and always
+ * release the lock.
+ *
+ * @param root - Absolute project root directory.
+ */
+async function runConfirmedReset(root: string): Promise<void> {
+  const acquired = await acquireLock(root);
+  if (!acquired) {
+    output.status("!", output.warn("Another llmwiki process is using this project; not resetting."));
+    return;
+  }
+  try {
+    const confinedDir = await resolveConfinedLlmwikiDir(root);
+    if (confinedDir === null) return; // absent or escaping → nothing safe to reset
+    await backupStateFile(root, confinedDir);
+  } finally {
+    await releaseLock(root);
+  }
+}
+
+/**
+ * Back up and remove the confined state file. Resolves the state path UNDER the
+ * confined `.llmwiki` dir (so a symlinked parent cannot redirect the rename) and
+ * renames the RAW bytes to `state.json.bak` without reading or validating them,
+ * so recovery works on a too-new or corrupt state.
+ *
+ * @param root - Absolute project root directory.
+ * @param confinedDir - The validated `.llmwiki` real directory.
+ */
+async function backupStateFile(root: string, confinedDir: string): Promise<void> {
+  const statePath = path.join(confinedDir, path.basename(STATE_FILE));
   if (!existsSync(statePath)) {
     output.status("✓", output.success("No state file to reset."));
     return;
   }
+  const confinedState = await confineUnderRoot(statePath, root, { mustExist: false });
+  await rename(confinedState, `${confinedState}.bak`);
+  output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
+}
 
+/**
+ * Back up and reset `.llmwiki/state.json`.
+ *
+ * - No state file → reports nothing to do and returns.
+ * - Without `--yes` → prints what it would do and how to confirm; changes nothing.
+ * - With `--yes` → acquires the project lock (refusing cleanly if another process
+ *   holds it), validates `.llmwiki` is a real in-root directory (failing closed on
+ *   a symlink escaping root), then renames the raw state file to `state.json.bak`
+ *   (atomic backup + removal) without reading or validating it. Prints the backup
+ *   path. The lock is always released.
+ *
+ * @param opts - `{ yes }` — apply the reset when true, else print the plan.
+ */
+export async function stateResetCommand(opts: StateResetOptions = {}): Promise<void> {
+  const root = process.cwd();
   if (!opts.yes) {
-    output.status("→", `Will back up ${STATE_FILE} to ${STATE_FILE}.bak and remove it`);
-    output.status("→", "so the next compile starts fresh.");
-    output.status("→", output.dim("Re-run with `--yes` to confirm."));
+    reportResetPlan(root);
     return;
   }
-
-  await rename(statePath, backupPath);
-  output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
+  await runConfirmedReset(root);
 }

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -1,0 +1,56 @@
+/**
+ * Commander action for `llmwiki state reset` — the recovery escape hatch for a
+ * `.llmwiki/state.json` written by a NEWER llmwiki version.
+ *
+ * When a state file's schema version exceeds what this build understands, every
+ * command that reads state fails closed (it never clobbers a forward-incompatible
+ * layout). That is the safe default, but it leaves a user on an older pin with no
+ * in-app way forward. This command provides one: back up the offending state file
+ * to `state.json.bak` and remove it so the next compile starts fresh.
+ *
+ * Crucially, the `--yes` path NEVER parses or validates the state — it operates on
+ * the raw bytes — so it works even when the state is too-new or corrupt. The backup
+ * is a single atomic `rename`, which both copies and removes in one step and
+ * overwrites any prior `.bak`.
+ */
+
+import { rename } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { STATE_FILE } from "../utils/constants.js";
+import * as output from "../utils/output.js";
+
+/** Options for {@link stateResetCommand}. */
+export interface StateResetOptions {
+  /** Apply the reset. Without it, the command only prints the plan. */
+  yes?: boolean;
+}
+
+/**
+ * Back up and reset `.llmwiki/state.json`.
+ *
+ * - No state file → reports nothing to do and returns.
+ * - Without `--yes` → prints what it would do and how to confirm; changes nothing.
+ * - With `--yes` → renames the raw state file to `state.json.bak` (atomic backup +
+ *   removal, overwriting any prior `.bak`) without reading or validating it, so the
+ *   recovery works on a too-new or corrupt state. Prints the backup path.
+ */
+export async function stateResetCommand(opts: StateResetOptions = {}): Promise<void> {
+  const statePath = path.join(process.cwd(), STATE_FILE);
+  const backupPath = `${statePath}.bak`;
+
+  if (!existsSync(statePath)) {
+    output.status("✓", output.success("No state file to reset."));
+    return;
+  }
+
+  if (!opts.yes) {
+    output.status("→", `Will back up ${STATE_FILE} to ${STATE_FILE}.bak and remove it`);
+    output.status("→", "so the next compile starts fresh.");
+    output.status("→", output.dim("Re-run with `--yes` to confirm."));
+    return;
+  }
+
+  await rename(statePath, backupPath);
+  output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
+}

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -111,6 +111,7 @@ async function runConfirmedReset(root: string): Promise<void> {
   const acquired = await acquireLock(root);
   if (!acquired) {
     output.status("!", output.warn("Another llmwiki process is using this project; not resetting."));
+    process.exitCode = 1; // requested reset did NOT happen → non-zero exit (no false success)
     return;
   }
   try {

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -18,7 +18,8 @@
  * if the lock is held it refuses cleanly rather than forcing. It also CONFINES the
  * `.llmwiki` dir to the project root's realpath — a symlinked `.llmwiki` (or a
  * state file whose parent escapes root) fails CLOSED and nothing outside root is
- * moved or clobbered.
+ * moved or clobbered. A confinement refusal is a FAILURE (exit code 1), distinct
+ * from a benign ABSENT `.llmwiki` (nothing to reset → exit 0).
  */
 
 import { rename, realpath } from "fs/promises";
@@ -36,24 +37,40 @@ export interface StateResetOptions {
 }
 
 /**
+ * The outcome of confining the `.llmwiki` directory under the project root:
+ *  - `ok`     — a REAL in-root directory; carries the confined real `dir`.
+ *  - `absent` — no `.llmwiki` directory at all (nothing to reset; a no-op success).
+ *  - `escape` — `.llmwiki` exists but its realpath escapes root (filesystem
+ *               tampering); a confinement REFUSAL, which must exit non-zero.
+ *
+ * Distinguishing `absent` from `escape` is what lets the caller exit 0 for the
+ * benign no-op yet exit 1 for the tampering refusal — collapsing both to `null`
+ * (the prior behavior) made a refusal masquerade as success.
+ */
+type LlmwikiDirResolution =
+  | { kind: "ok"; dir: string }
+  | { kind: "absent" }
+  | { kind: "escape" };
+
+/**
  * Resolve the confined `.llmwiki` directory for `root`, mirroring the journal-dir
  * trust boundary: its realpath must be a REAL directory that stays inside the
- * project root's realpath. Returns the confined real dir, or null to FAIL CLOSED
- * — null when `.llmwiki` is absent (nothing to reset) OR when it exists but is a
- * symlink/path escaping root (filesystem tampering). An escape is announced.
+ * project root's realpath. Returns a tagged {@link LlmwikiDirResolution} so the
+ * caller can tell a benign ABSENT dir (no-op, exit 0) apart from an ESCAPING one
+ * (tampering refusal, exit non-zero). An escape is announced here.
  *
  * @param root - Absolute project root directory.
- * @returns The confined `.llmwiki` real directory, or null to fail closed.
+ * @returns The tagged resolution: `ok` (with the real dir), `absent`, or `escape`.
  */
-async function resolveConfinedLlmwikiDir(root: string): Promise<string | null> {
+async function resolveConfinedLlmwikiDir(root: string): Promise<LlmwikiDirResolution> {
   const realDir = await safeRealpath(path.join(root, LLMWIKI_DIR));
-  if (realDir === null) return null; // absent → nothing to reset
+  if (realDir === null) return { kind: "absent" }; // absent → nothing to reset
   const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
   if (!isInsideDir(realDir, realRoot)) {
     output.status("!", output.warn(`${LLMWIKI_DIR} escapes the project root — refusing to reset (tampering).`));
-    return null;
+    return { kind: "escape" };
   }
-  return realDir;
+  return { kind: "ok", dir: realDir };
 }
 
 /**
@@ -82,15 +99,22 @@ function reportResetPlan(root: string): void {
  * @param root - Absolute project root directory.
  */
 async function runConfirmedReset(root: string): Promise<void> {
-  const confinedDir = await resolveConfinedLlmwikiDir(root);
-  if (confinedDir === null) return; // absent or escaping → nothing safe to reset, no lock created
+  const resolution = await resolveConfinedLlmwikiDir(root);
+  if (resolution.kind === "absent") {
+    output.status("✓", output.success("No state file to reset."));
+    return; // benign no-op → exit 0, no lock created
+  }
+  if (resolution.kind === "escape") {
+    process.exitCode = 1; // confinement refusal is a FAILURE
+    return; // warning already announced, no lock created
+  }
   const acquired = await acquireLock(root);
   if (!acquired) {
     output.status("!", output.warn("Another llmwiki process is using this project; not resetting."));
     return;
   }
   try {
-    await backupStateFile(root, confinedDir);
+    await backupStateFile(root, resolution.dir);
   } finally {
     await releaseLock(root);
   }

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -73,21 +73,23 @@ function reportResetPlan(root: string): void {
 }
 
 /**
- * Confirmed path (`--yes`): acquire the lock (refusing cleanly if held), validate
- * `.llmwiki` is a real in-root directory, back up the raw state file, and always
- * release the lock.
+ * Confirmed path (`--yes`): validate `.llmwiki` is a real in-root directory FIRST
+ * (a read-only realpath check) so a symlinked-escaping `.llmwiki` is rejected
+ * before `acquireLock` would itself create a lock file through the symlink; only
+ * then acquire the lock (refusing cleanly if held), back up the raw state file,
+ * and always release the lock.
  *
  * @param root - Absolute project root directory.
  */
 async function runConfirmedReset(root: string): Promise<void> {
+  const confinedDir = await resolveConfinedLlmwikiDir(root);
+  if (confinedDir === null) return; // absent or escaping → nothing safe to reset, no lock created
   const acquired = await acquireLock(root);
   if (!acquired) {
     output.status("!", output.warn("Another llmwiki process is using this project; not resetting."));
     return;
   }
   try {
-    const confinedDir = await resolveConfinedLlmwikiDir(root);
-    if (confinedDir === null) return; // absent or escaping → nothing safe to reset
     await backupStateFile(root, confinedDir);
   } finally {
     await releaseLock(root);

--- a/src/commands/state-reset.ts
+++ b/src/commands/state-reset.ts
@@ -22,7 +22,7 @@
  * from a benign ABSENT `.llmwiki` (nothing to reset → exit 0).
  */
 
-import { rename, realpath } from "fs/promises";
+import { rename, realpath, lstat } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { LLMWIKI_DIR, STATE_FILE } from "../utils/constants.js";
@@ -121,10 +121,45 @@ async function runConfirmedReset(root: string): Promise<void> {
 }
 
 /**
+ * True when the backup destination is safe to overwrite via `rename`.
+ *
+ * Clobbering a REGULAR-FILE `.bak` is intended (a prior backup), and an absent
+ * `.bak` is fine. But a DIRECTORY `.bak` makes `rename` throw a raw, unactionable
+ * `EISDIR` (→ exit 1 with `Error: EISDIR`); any other non-regular type is equally
+ * unwriteable. We detect those up front with `lstat` (no symlink follow — a
+ * symlink `.bak` is replaced, not written through, so it stays allowed) and
+ * refuse cleanly instead. Returns false (with an actionable message emitted) when
+ * the path exists and is not a regular file.
+ *
+ * @param bakPath - The `state.json.bak` destination path.
+ * @returns True if the rename may proceed; false if it must be refused.
+ */
+async function backupDestinationIsWriteable(bakPath: string): Promise<boolean> {
+  let st;
+  try {
+    st = await lstat(bakPath);
+  } catch {
+    return true; // absent → safe to create
+  }
+  if (st.isFile()) return true; // a prior backup → intended clobber
+  output.status(
+    "!",
+    output.warn(
+      `cannot back up: ${STATE_FILE}.bak exists and is not a regular file; remove it and retry`,
+    ),
+  );
+  return false;
+}
+
+/**
  * Back up and remove the confined state file. Resolves the state path UNDER the
  * confined `.llmwiki` dir (so a symlinked parent cannot redirect the rename) and
  * renames the RAW bytes to `state.json.bak` without reading or validating them,
  * so recovery works on a too-new or corrupt state.
+ *
+ * Refuses CLEANLY (exit 1, no crash) when `state.json.bak` exists and is not a
+ * regular file (e.g. a directory), instead of letting `rename` throw a raw
+ * `EISDIR`. The state file is left untouched in that case.
  *
  * @param root - Absolute project root directory.
  * @param confinedDir - The validated `.llmwiki` real directory.
@@ -136,7 +171,12 @@ async function backupStateFile(root: string, confinedDir: string): Promise<void>
     return;
   }
   const confinedState = await confineUnderRoot(statePath, root, { mustExist: false });
-  await rename(confinedState, `${confinedState}.bak`);
+  const bakPath = `${confinedState}.bak`;
+  if (!(await backupDestinationIsWriteable(bakPath))) {
+    process.exitCode = 1; // clean actionable refusal, not a raw EISDIR crash
+    return;
+  }
+  await rename(confinedState, bakPath);
   output.status("✓", output.success(`Reset ${STATE_FILE}. Backup saved to ${STATE_FILE}.bak.`));
 }
 

--- a/src/compiler/candidate-store-paths.ts
+++ b/src/compiler/candidate-store-paths.ts
@@ -1,0 +1,106 @@
+/**
+ * @file src/compiler/candidate-store-paths.ts
+ * @description Realpath-confinement helpers for the review candidate store.
+ *
+ * The candidate store persists one JSON file per candidate under
+ * `.llmwiki/candidates/` (and archives rejected ones under `…/archive/`). Path
+ * resolution here is the single trust boundary for that store: it must reject a
+ * SYMLINKED `.llmwiki/candidates` (or a symlinked `.llmwiki`) that would redirect
+ * every read/write/delete/archive OUTSIDE the project root — the same
+ * containing-directory escape class already closed for the intent journal
+ * (`resolveConfinedJournalDir`) and `state reset`.
+ *
+ * Two primitives, both fail-closed:
+ *
+ *  - {@link confinedCandidateFilePath} confines a single candidate FILE path under
+ *    root via {@link confineUnderRoot} (which realpath-confines the nearest
+ *    existing ancestor). For a NORMAL (real) candidates dir the confined path
+ *    equals the lexical `path.join` result → default candidate JSON stays
+ *    byte-identical. A symlinked containing dir is detected and THROWS.
+ *  - {@link resolveConfinedCandidatesDir} resolves the candidates/archive DIRECTORY
+ *    realpath for listing/scanning: returns null when the dir is ABSENT (today's
+ *    "no candidates" behavior) and THROWS when it EXISTS but escapes root, so a
+ *    list/scan never `readdir`s through an escaping symlink.
+ */
+
+import path from "path";
+import {
+  confineUnderRoot,
+  safeRealpath,
+  isInsideDir,
+} from "../utils/path-confine.js";
+import { isSafeFilenameComponent } from "../profile/identity.js";
+
+/**
+ * Thrown when the candidate store's containing directory (`.llmwiki/candidates`
+ * or `…/archive`, or the `.llmwiki` parent) is a symlink/path that escapes the
+ * project root, so a read/write/delete/archive/list would operate OUTSIDE the
+ * project. Fails CLOSED before any I/O. A NORMAL real directory never trips this.
+ */
+export class UnsafeCandidateDirError extends Error {
+  constructor(dir: string) {
+    super(`candidate store directory escapes the project root: ${JSON.stringify(dir)}`);
+    this.name = "UnsafeCandidateDirError";
+  }
+}
+
+/** Extension used for all candidate JSON files. */
+const CANDIDATE_EXT = ".json";
+
+/**
+ * Resolve the confined absolute path of the candidate file `${id}.json` under
+ * `dir` (relative to `root`). Asserts `id` is a single safe filename component,
+ * then confines the FINAL file path under root via {@link confineUnderRoot} — so a
+ * symlinked containing dir (whose realpath is the nearest existing ancestor) is
+ * detected and rejected. A normal real dir yields the byte-identical lexical path.
+ *
+ * @param root - Absolute project root directory.
+ * @param dir - Candidates subdir (pending or archive) relative to root.
+ * @param id - Candidate id (the filename stem); must be a safe path component.
+ * @param onUnsafeId - Called to build the typed error thrown for an unsafe id.
+ * @returns The confined absolute candidate file path.
+ * @throws The error from `onUnsafeId` when `id` is not a safe path component.
+ * @throws {UnsafeCandidateDirError} When the containing dir escapes root.
+ */
+export async function confinedCandidateFilePath(
+  root: string,
+  dir: string,
+  id: string,
+  onUnsafeId: (id: string) => Error,
+): Promise<string> {
+  if (!isSafeFilenameComponent(id)) throw onUnsafeId(id);
+  // Confine the project-RELATIVE path so confinement is invariant to which
+  // symlink form of root it is resolved under (e.g. `/var/...` vs the canonical
+  // `/private/var/...` on macOS); an absolute target would otherwise resolve to
+  // the non-canonical form and spuriously read as escaping.
+  const relPath = path.join(dir, `${id}${CANDIDATE_EXT}`);
+  try {
+    return await confineUnderRoot(relPath, root, { mustExist: false });
+  } catch {
+    throw new UnsafeCandidateDirError(path.join(root, dir));
+  }
+}
+
+/**
+ * Resolve the candidates/archive DIRECTORY's realpath for listing/scanning,
+ * mirroring `resolveConfinedJournalDir`. Returns null when the directory is
+ * ABSENT (nothing to list — today's empty-list behavior) and THROWS
+ * {@link UnsafeCandidateDirError} when it EXISTS but its realpath escapes root, so
+ * a list/scan NEVER `readdir`s through an escaping symlink.
+ *
+ * @param root - Absolute project root directory.
+ * @param dir - Candidates subdir (pending or archive) relative to root.
+ * @returns The confined real directory, or null when absent.
+ * @throws {UnsafeCandidateDirError} When the dir exists but escapes root.
+ */
+export async function resolveConfinedCandidatesDir(
+  root: string,
+  dir: string,
+): Promise<string | null> {
+  const target = path.join(root, dir);
+  const realDir = await safeRealpath(target);
+  if (realDir === null) return null; // absent → nothing to list
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  if (!isInsideDir(realDir, realRoot)) throw new UnsafeCandidateDirError(target);
+  return realDir;
+}

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -139,6 +139,25 @@ function buildCandidateId(slug: string): string {
   return `${slug}-${suffix}`;
 }
 
+/**
+ * The FULL target identity of a candidate: the tuple of where the approved page
+ * lands AND its slug. Two candidates are duplicates only when BOTH components
+ * match. For a DEFAULT concepts candidate the type component is the constant
+ * `"concepts"`, so dedup on this key behaves EXACTLY as a slug-only dedup did —
+ * default candidate behavior stays byte-identical. A typed candidate
+ * (`targetEntityType`) or an OKF query candidate (`targetDirectory`) keys on its
+ * own directory, so `papers/foo` and `ideas/foo` never collapse into one file.
+ * @param candidate - The candidate (or draft) whose target identity is built.
+ */
+function candidateTargetKey(candidate: {
+  targetEntityType?: string;
+  targetDirectory?: string;
+  slug: string;
+}): string {
+  const target = candidate.targetEntityType ?? candidate.targetDirectory ?? "concepts";
+  return `${target}/${candidate.slug}`;
+}
+
 /** Build the typed unsafe-id error for a candidate file id. */
 function unsafeCandidateId(id: string): Error {
   return new UnsafeCandidateIdError("id", id);
@@ -186,7 +205,7 @@ export async function writeCandidate(
   draft: CandidateDraft,
 ): Promise<ReviewCandidate> {
   if (!isSafeFilenameComponent(draft.slug)) throw new UnsafeCandidateIdError("slug", draft.slug);
-  const { canonicalId, duplicateIds } = await findSlugDuplicates(root, draft.slug);
+  const { canonicalId, duplicateIds } = await findIdentityDuplicates(root, candidateTargetKey(draft));
   const candidate: ReviewCandidate = {
     id: canonicalId ?? buildCandidateId(draft.slug),
     title: draft.title,
@@ -214,17 +233,22 @@ export async function writeCandidate(
 }
 
 /**
- * Collect all candidate ids matching a slug and return the canonical (earliest)
- * id plus the list of extra duplicate ids to remove.
+ * Collect all candidate ids matching a FULL target identity (target-type + slug,
+ * via {@link candidateTargetKey}) and return the canonical (earliest) id plus the
+ * list of extra duplicate ids to remove. Keying on the full identity — not slug
+ * alone — keeps two distinct typed targets that share a slug (`papers/foo` vs
+ * `ideas/foo`) as SEPARATE candidates, so neither is silently dropped, while a
+ * DEFAULT concepts candidate (constant `concepts/` prefix) dedups exactly as
+ * before.
  * @param root - Project root directory.
- * @param slug - The page slug to search for.
+ * @param targetKey - The full target identity to match (see {@link candidateTargetKey}).
  */
-async function findSlugDuplicates(
+async function findIdentityDuplicates(
   root: string,
-  slug: string,
+  targetKey: string,
 ): Promise<{ canonicalId: string | null; duplicateIds: string[] }> {
   const all = await listCandidates(root);
-  const matching = all.filter((c) => c.slug === slug);
+  const matching = all.filter((c) => candidateTargetKey(c) === targetKey);
   if (matching.length === 0) return { canonicalId: null, duplicateIds: [] };
   // Preserve the first match as canonical (listCandidates sorts by generatedAt).
   const [canonical, ...extras] = matching;
@@ -493,15 +517,20 @@ export async function deleteCandidate(root: string, id: string): Promise<boolean
 }
 
 /**
- * Delete ALL pending candidate files for a slug.
+ * Delete ALL pending candidate files for a DEFAULT concepts slug.
  *
  * When duplicates exist (e.g. legacy or hand-dropped files) the direct-write
  * reconcile path must remove every file matching the slug, not just the first
- * canonical one, so no stale duplicates remain after a page is written directly.
+ * canonical one, so no stale duplicates remain after a concepts page is written
+ * directly. Matches on the FULL `concepts/<slug>` identity (via
+ * {@link candidateTargetKey}) so a typed `papers/<slug>` candidate that merely
+ * shares the slug is NOT collaterally deleted when a default concepts page is
+ * reconciled — the default caller only writes concepts, so its behavior is
+ * unchanged.
  */
 export async function deleteCandidateBySlug(root: string, slug: string): Promise<boolean> {
   const all = await listCandidates(root);
-  const matching = all.filter((c) => c.slug === slug);
+  const matching = all.filter((c) => candidateTargetKey(c) === `concepts/${slug}`);
   if (matching.length === 0) return false;
   for (const candidate of matching) {
     await deleteCandidate(root, candidate.id);

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -40,7 +40,7 @@ import type { TrustDecision } from "../trust/decision.js";
 const ID_SUFFIX_BYTES = 4;
 
 /** Input shape for creating a new candidate (id + timestamp generated here). */
-interface CandidateDraft {
+export interface CandidateDraft {
   title: string;
   slug: string;
   summary: string;

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -274,10 +274,21 @@ export async function readCandidateBySlug(
   return candidates.find((candidate) => candidate.slug === slug) ?? null;
 }
 
-/** Collect every slug currently pending review. */
-export async function listPendingCandidateSlugs(root: string): Promise<Set<string>> {
+/**
+ * Collect the slugs of pending candidates whose approval lands in a
+ * link-resolvable directory (default concepts/queries). Typed candidates
+ * (those carrying `targetEntityType`) are EXCLUDED: typed pages are not part
+ * of the concepts/queries wikilink interlinking system (see
+ * {@link file://./../sdk/types.ts}), so approving one would NOT make a
+ * `[[link]]` resolve. Including their slugs here would wrongly demote a real
+ * broken wikilink to an info-level "awaiting review" — hiding a link that
+ * stays broken after approval.
+ */
+export async function listLinkResolvablePendingSlugs(root: string): Promise<Set<string>> {
   const candidates = await listCandidates(root);
-  return new Set(candidates.map((candidate) => candidate.slug));
+  return new Set(
+    candidates.filter((candidate) => !candidate.targetEntityType).map((candidate) => candidate.slug),
+  );
 }
 
 /**

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -16,6 +16,7 @@ import { unlink } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { randomBytes } from "crypto";
+import { isSafeFilenameComponent } from "../profile/identity.js";
 import { atomicWrite, safeReadFile } from "../utils/markdown.js";
 import {
   listCandidateFileIds,
@@ -118,20 +119,52 @@ const VALID_TRUST_DECISIONS: TrustDecision[] = [
   "deny",
 ];
 
+/**
+ * Thrown when a candidate id or slug is not a single safe path component, so a
+ * traversal-bearing value (e.g. `../evil`) can never be joined into a candidate
+ * file path that escapes `.llmwiki/candidates/`. Default slugs from `slugify`
+ * are already filename-safe, so this never fires on the default path.
+ */
+export class UnsafeCandidateIdError extends Error {
+  constructor(kind: "id" | "slug", value: string) {
+    super(`unsafe candidate ${kind}: ${JSON.stringify(value)} is not a single safe path component`);
+    this.name = "UnsafeCandidateIdError";
+  }
+}
+
 /** Build a deterministic-but-unique id from a slug and a short random suffix. */
 function buildCandidateId(slug: string): string {
   const suffix = randomBytes(ID_SUFFIX_BYTES).toString("hex");
   return `${slug}-${suffix}`;
 }
 
+/**
+ * Resolve a candidate file path under `dir`, asserting `id` is a single safe
+ * filename component AND that the joined path stays lexically confined under the
+ * candidates directory. Defense in depth: a safe id (the default case) yields a
+ * byte-identical path to `path.join`, so default parity is preserved; an unsafe
+ * id (traversal) throws {@link UnsafeCandidateIdError} before any I/O.
+ * @param root - Project root directory.
+ * @param dir - Candidates subdir (pending or archive) relative to root.
+ * @param id - Candidate id to embed as the filename stem.
+ */
+function resolveCandidatePath(root: string, dir: string, id: string): string {
+  if (!isSafeFilenameComponent(id)) throw new UnsafeCandidateIdError("id", id);
+  const base = path.join(root, dir);
+  const filePath = path.join(base, `${id}${CANDIDATE_EXT}`);
+  const prefix = base.endsWith(path.sep) ? base : base + path.sep;
+  if (!filePath.startsWith(prefix)) throw new UnsafeCandidateIdError("id", id);
+  return filePath;
+}
+
 /** Absolute path to a candidate's JSON file. */
 function candidatePath(root: string, id: string): string {
-  return path.join(root, CANDIDATES_DIR, `${id}${CANDIDATE_EXT}`);
+  return resolveCandidatePath(root, CANDIDATES_DIR, id);
 }
 
 /** Absolute path to the archived JSON file for a rejected candidate. */
 function archivePath(root: string, id: string): string {
-  return path.join(root, CANDIDATES_ARCHIVE_DIR, `${id}${CANDIDATE_EXT}`);
+  return resolveCandidatePath(root, CANDIDATES_ARCHIVE_DIR, id);
 }
 
 /**
@@ -149,6 +182,7 @@ export async function writeCandidate(
   root: string,
   draft: CandidateDraft,
 ): Promise<ReviewCandidate> {
+  if (!isSafeFilenameComponent(draft.slug)) throw new UnsafeCandidateIdError("slug", draft.slug);
   const { canonicalId, duplicateIds } = await findSlugDuplicates(root, draft.slug);
   const candidate: ReviewCandidate = {
     id: canonicalId ?? buildCandidateId(draft.slug),

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -22,6 +22,10 @@ import {
   listCandidateFileIds,
   moveCandidateToArchive,
 } from "../utils/candidate-store.js";
+import {
+  confinedCandidateFilePath,
+  resolveConfinedCandidatesDir,
+} from "./candidate-store-paths.js";
 import * as output from "../utils/output.js";
 import {
   CANDIDATES_DIR,
@@ -34,9 +38,6 @@ import type { TrustDecision } from "../trust/decision.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
 const ID_SUFFIX_BYTES = 4;
-
-/** Filesystem extension used for candidate JSON files. */
-const CANDIDATE_EXT = ".json";
 
 /** Input shape for creating a new candidate (id + timestamp generated here). */
 interface CandidateDraft {
@@ -138,32 +139,34 @@ function buildCandidateId(slug: string): string {
   return `${slug}-${suffix}`;
 }
 
+/** Build the typed unsafe-id error for a candidate file id. */
+function unsafeCandidateId(id: string): Error {
+  return new UnsafeCandidateIdError("id", id);
+}
+
 /**
  * Resolve a candidate file path under `dir`, asserting `id` is a single safe
- * filename component AND that the joined path stays lexically confined under the
- * candidates directory. Defense in depth: a safe id (the default case) yields a
- * byte-identical path to `path.join`, so default parity is preserved; an unsafe
- * id (traversal) throws {@link UnsafeCandidateIdError} before any I/O.
+ * filename component AND REALPATH-confining the result under the project root via
+ * {@link confinedCandidateFilePath}. Defense in depth: a safe id under a NORMAL
+ * (real) candidates dir yields a byte-identical path to `path.join`, so default
+ * parity is preserved; an unsafe id throws {@link UnsafeCandidateIdError}, and a
+ * symlinked containing dir escaping root throws {@link UnsafeCandidateDirError} —
+ * both before any I/O.
  * @param root - Project root directory.
  * @param dir - Candidates subdir (pending or archive) relative to root.
  * @param id - Candidate id to embed as the filename stem.
  */
-function resolveCandidatePath(root: string, dir: string, id: string): string {
-  if (!isSafeFilenameComponent(id)) throw new UnsafeCandidateIdError("id", id);
-  const base = path.join(root, dir);
-  const filePath = path.join(base, `${id}${CANDIDATE_EXT}`);
-  const prefix = base.endsWith(path.sep) ? base : base + path.sep;
-  if (!filePath.startsWith(prefix)) throw new UnsafeCandidateIdError("id", id);
-  return filePath;
+function resolveCandidatePath(root: string, dir: string, id: string): Promise<string> {
+  return confinedCandidateFilePath(root, dir, id, unsafeCandidateId);
 }
 
-/** Absolute path to a candidate's JSON file. */
-function candidatePath(root: string, id: string): string {
+/** Absolute confined path to a candidate's JSON file. */
+function candidatePath(root: string, id: string): Promise<string> {
   return resolveCandidatePath(root, CANDIDATES_DIR, id);
 }
 
-/** Absolute path to the archived JSON file for a rejected candidate. */
-function archivePath(root: string, id: string): string {
+/** Absolute confined path to the archived JSON file for a rejected candidate. */
+function archivePath(root: string, id: string): Promise<string> {
   return resolveCandidatePath(root, CANDIDATES_ARCHIVE_DIR, id);
 }
 
@@ -205,7 +208,7 @@ export async function writeCandidate(
     ...(draft.trustDecision ? { trustDecision: draft.trustDecision } : {}),
   };
 
-  await atomicWrite(candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
+  await atomicWrite(await candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
   await deleteDuplicates(root, duplicateIds);
   return candidate;
 }
@@ -313,7 +316,7 @@ export async function readCandidate(
   root: string,
   id: string,
 ): Promise<ReviewCandidate | null> {
-  const raw = await safeReadFile(candidatePath(root, id));
+  const raw = await safeReadFile(await candidatePath(root, id));
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as ReviewCandidate;
@@ -457,7 +460,8 @@ function isValidCandidate(value: unknown): value is ReviewCandidate {
  * @returns All pending review candidates.
  */
 export async function listCandidates(root: string): Promise<ReviewCandidate[]> {
-  const dir = path.join(root, CANDIDATES_DIR);
+  const dir = await resolveConfinedCandidatesDir(root, CANDIDATES_DIR);
+  if (dir === null) return []; // absent candidates dir → nothing pending
   const ids = await listCandidateFileIds(dir);
   const candidates: ReviewCandidate[] = [];
   for (const id of ids) {
@@ -482,7 +486,7 @@ export async function countCandidates(root: string): Promise<number> {
 
 /** Remove a pending candidate from disk. Returns false when nothing existed to remove. */
 export async function deleteCandidate(root: string, id: string): Promise<boolean> {
-  const filePath = candidatePath(root, id);
+  const filePath = await candidatePath(root, id);
   if (!existsSync(filePath)) return false;
   await unlink(filePath);
   return true;
@@ -513,5 +517,5 @@ export async function deleteCandidateBySlug(root: string, slug: string): Promise
  * @returns True when the candidate was found and archived.
  */
 export async function archiveCandidate(root: string, id: string): Promise<boolean> {
-  return moveCandidateToArchive(candidatePath(root, id), archivePath(root, id));
+  return moveCandidateToArchive(await candidatePath(root, id), await archivePath(root, id));
 }

--- a/src/compiler/indexgen.ts
+++ b/src/compiler/indexgen.ts
@@ -12,9 +12,18 @@ import { atomicWrite, safeReadFile, parseFrontmatter } from "../utils/markdown.j
 import { CONCEPTS_DIR, QUERIES_DIR, INDEX_FILE } from "../utils/constants.js";
 import * as output from "../utils/output.js";
 import type { PageSummary } from "../utils/types.js";
+import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
+import type { EntityPage } from "../profile/types.js";
 
 /**
  * Generate the wiki/index.md listing all concept pages with summaries.
+ *
+ * For a NON-DEFAULT profile project this ADDITIVELY appends one section per
+ * declared entity type, enumerating each promoted typed page with a link to
+ * `<entityType>/<slug>.md`. For a DEFAULT project (no profile.json) the index is
+ * built byte-identically to before — the typed sections only ever appear when a
+ * non-default profile is active.
+ *
  * @param root - Project root directory.
  */
 export async function generateIndex(root: string): Promise<void> {
@@ -28,12 +37,27 @@ export async function generateIndex(root: string): Promise<void> {
   concepts.sort((a, b) => a.title.localeCompare(b.title));
   queries.sort((a, b) => a.title.localeCompare(b.title));
 
-  const indexContent = buildIndexContent(concepts, queries);
+  const entityPages = await collectTypedPages(root);
+  const indexContent = buildIndexContent(concepts, queries, entityPages);
   const indexPath = path.join(root, INDEX_FILE);
   await atomicWrite(indexPath, indexContent);
 
   const total = concepts.length + queries.length;
   output.status("+", output.success(`Index updated with ${total} pages.`));
+}
+
+/**
+ * Collect the promoted typed entity pages for a NON-DEFAULT profile, or an empty
+ * array for a DEFAULT project. Returns the path-confined `EntityPage`s the
+ * collector already validated — nothing here re-reads or re-resolves a path.
+ * @param root - Project root directory.
+ * @returns The non-default profile's entity pages, or `[]` for a default project.
+ */
+async function collectTypedPages(root: string): Promise<EntityPage[]> {
+  const loaded = await loadNonDefaultProfile(root);
+  if (loaded === undefined) return [];
+  const { pages } = await collectEntityPagesWithMessages(root, loaded);
+  return pages;
 }
 
 /** A scanned page paired with its parsed frontmatter. */
@@ -93,10 +117,21 @@ function stripWikilinks(text: string): string {
 
 /**
  * Build the index.md markdown content from page summaries.
- * @param pages - Sorted array of page summaries.
+ *
+ * The concepts/queries/footer rendering is UNCHANGED — when `entityPages` is
+ * empty (every DEFAULT project) the output is byte-identical to before. Typed
+ * entity sections are appended only when a non-default profile supplied pages.
+ *
+ * @param concepts - Sorted concept page summaries.
+ * @param queries - Sorted saved-query page summaries.
+ * @param entityPages - Non-default profile entity pages (empty for defaults).
  * @returns Full index.md content string.
  */
-function buildIndexContent(concepts: PageSummary[], queries: PageSummary[]): string {
+function buildIndexContent(
+  concepts: PageSummary[],
+  queries: PageSummary[],
+  entityPages: EntityPage[] = [],
+): string {
   const lines = ["# Knowledge Wiki", "", "## Concepts", ""];
 
   for (const page of concepts) {
@@ -110,10 +145,57 @@ function buildIndexContent(concepts: PageSummary[], queries: PageSummary[]): str
     }
   }
 
+  lines.push(...buildEntitySections(entityPages));
+
   const total = concepts.length + queries.length;
   lines.push("");
   lines.push(`_${total} pages | Generated ${new Date().toISOString()}_`);
   lines.push("");
 
   return lines.join("\n");
+}
+
+/**
+ * The wiki root the index lives in (`wiki`), derived from {@link INDEX_FILE}
+ * (`wiki/index.md`). Entity-page links are relativized against this so a link
+ * stays correct relative to the index regardless of the configured wiki root.
+ */
+const WIKI_ROOT = path.dirname(INDEX_FILE);
+
+/** Capitalize an entity type for a section heading (e.g. `papers` → `Papers`). */
+function entityTypeHeading(entityType: string): string {
+  return entityType.charAt(0).toUpperCase() + entityType.slice(1);
+}
+
+/**
+ * Render one additive markdown section per entity type, each listing its typed
+ * pages with a link to `<entityType>/<slug>.md` (relative to the index, which
+ * lives in `wiki/`). Pages are grouped by type and sorted by slug for stable
+ * output. Returns `[]` for a default project so the footer rendering is unchanged.
+ *
+ * The link target is derived from the page's already-confined `directory`/`slug`
+ * (relativized against `wiki/`), so this only renders what the collector validated.
+ *
+ * @param entityPages - The non-default profile's collected entity pages.
+ * @returns The markdown lines for the typed sections (empty when no pages).
+ */
+function buildEntitySections(entityPages: EntityPage[]): string[] {
+  if (entityPages.length === 0) return [];
+  const byType = new Map<string, EntityPage[]>();
+  for (const page of entityPages) {
+    const group = byType.get(page.entityType) ?? [];
+    group.push(page);
+    byType.set(page.entityType, group);
+  }
+
+  const lines: string[] = [];
+  for (const entityType of [...byType.keys()].sort()) {
+    const pages = byType.get(entityType)!.sort((a, b) => a.slug.localeCompare(b.slug));
+    lines.push("", `## ${entityTypeHeading(entityType)}`, "");
+    for (const page of pages) {
+      const link = `${path.relative(WIKI_ROOT, page.directory)}/${page.slug}.md`;
+      lines.push(`- **[${page.title ?? page.slug}](${link})** — \`${page.id}\``);
+    }
+  }
+  return lines;
 }

--- a/src/compiler/indexgen.ts
+++ b/src/compiler/indexgen.ts
@@ -42,7 +42,9 @@ export async function generateIndex(root: string): Promise<void> {
   const indexPath = path.join(root, INDEX_FILE);
   await atomicWrite(indexPath, indexContent);
 
-  const total = concepts.length + queries.length;
+  // Typed pages are rendered in the index, so the count must include them too
+  // (empty for a DEFAULT project → unchanged "concepts + queries" total).
+  const total = concepts.length + queries.length + entityPages.length;
   output.status("+", output.success(`Index updated with ${total} pages.`));
 }
 
@@ -147,7 +149,9 @@ function buildIndexContent(
 
   lines.push(...buildEntitySections(entityPages));
 
-  const total = concepts.length + queries.length;
+  // Footer count mirrors what's rendered: concepts + queries + typed pages.
+  // entityPages is empty for DEFAULT projects, keeping that footer byte-identical.
+  const total = concepts.length + queries.length + entityPages.length;
   lines.push("");
   lines.push(`_${total} pages | Generated ${new Date().toISOString()}_`);
   lines.push("");

--- a/src/compiler/rule-candidates.ts
+++ b/src/compiler/rule-candidates.ts
@@ -12,15 +12,18 @@
  * evidence, lowercase status/confidence. Do not reshape it for local use.
  */
 
-import path from "path";
 import { createHash } from "node:crypto";
 import { atomicWrite, safeReadFile, slugify } from "../utils/markdown.js";
 import {
-  CANDIDATE_JSON_EXT,
   candidateFileId,
   listCandidateFileIds,
   moveCandidateToArchive,
 } from "../utils/candidate-store.js";
+import {
+  confinedCandidateFilePath,
+  resolveConfinedCandidatesDir,
+} from "./candidate-store-paths.js";
+import { UnsafeCandidateIdError } from "./candidates.js";
 import {
   RULE_CANDIDATES_DIR,
   RULE_CANDIDATES_ARCHIVE_DIR,
@@ -42,14 +45,26 @@ const STATUS_VALUES: readonly RuleStatus[] = ["proposed", "approved", "rejected"
 /** Runtime evidence shape checker for a tagged evidence variant. */
 type EvidenceShapeChecker = (ref: Record<string, unknown>) => string | null;
 
-/** Absolute path to a rule candidate's JSON file. */
-function ruleCandidatePath(root: string, id: string): string {
-  return path.join(root, RULE_CANDIDATES_DIR, `${id}${CANDIDATE_JSON_EXT}`);
+/** Build the typed unsafe-id error for a rule-candidate file id. */
+function unsafeRuleCandidateId(id: string): Error {
+  return new UnsafeCandidateIdError("id", id);
 }
 
-/** Absolute path to the archived JSON file for a rejected rule candidate. */
-function ruleArchivePath(root: string, id: string): string {
-  return path.join(root, RULE_CANDIDATES_ARCHIVE_DIR, `${id}${CANDIDATE_JSON_EXT}`);
+/**
+ * Absolute, REALPATH-confined path to a rule candidate's JSON file. Asserts
+ * `id` is a single safe filename component and confines the result under the
+ * project root via the shared {@link confinedCandidateFilePath} — so a symlinked
+ * `.llmwiki/rule-candidates` (or `.llmwiki`) escaping root throws
+ * {@link UnsafeCandidateDirError} before any I/O. A NORMAL real dir yields the
+ * byte-identical lexical path, so default rule behavior is unchanged.
+ */
+function ruleCandidatePath(root: string, id: string): Promise<string> {
+  return confinedCandidateFilePath(root, RULE_CANDIDATES_DIR, id, unsafeRuleCandidateId);
+}
+
+/** Absolute, REALPATH-confined path to the archived JSON file for a rejected rule candidate. */
+function ruleArchivePath(root: string, id: string): Promise<string> {
+  return confinedCandidateFilePath(root, RULE_CANDIDATES_ARCHIVE_DIR, id, unsafeRuleCandidateId);
 }
 
 /** the rule importer contract caps (mirrored from the rule-import contract rule_candidate_validation.rs). */
@@ -314,7 +329,7 @@ export async function writeRuleCandidate(
   candidate: RuleCandidate,
 ): Promise<string> {
   const fileId = candidateFileId(candidate.id);
-  const target = ruleCandidatePath(root, fileId);
+  const target = await ruleCandidatePath(root, fileId);
   await atomicWrite(target, JSON.stringify(candidate, null, 2));
   return target;
 }
@@ -329,7 +344,7 @@ export async function readRuleCandidate(
   root: string,
   fileId: string,
 ): Promise<RuleCandidate | null> {
-  const raw = await safeReadFile(ruleCandidatePath(root, fileId));
+  const raw = await safeReadFile(await ruleCandidatePath(root, fileId));
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw);
@@ -345,7 +360,8 @@ export async function readRuleCandidate(
  * @param root - Project root directory.
  */
 export async function listRuleCandidates(root: string): Promise<RuleCandidate[]> {
-  const dir = path.join(root, RULE_CANDIDATES_DIR);
+  const dir = await resolveConfinedCandidatesDir(root, RULE_CANDIDATES_DIR);
+  if (dir === null) return []; // absent rule-candidates dir → nothing pending
   const fileIds = await listCandidateFileIds(dir);
   const candidates: RuleCandidate[] = [];
   for (const fileId of fileIds) {
@@ -375,7 +391,7 @@ export async function setRuleCandidateStatus(
   if (!candidate) return null;
   const updated: RuleCandidate = { ...candidate, status };
   await atomicWrite(
-    ruleCandidatePath(root, fileId),
+    await ruleCandidatePath(root, fileId),
     JSON.stringify(updated, null, 2),
   );
   return updated;
@@ -392,7 +408,7 @@ export async function archiveRuleCandidate(
   fileId: string,
 ): Promise<boolean> {
   return moveCandidateToArchive(
-    ruleCandidatePath(root, fileId),
-    ruleArchivePath(root, fileId),
+    await ruleCandidatePath(root, fileId),
+    await ruleArchivePath(root, fileId),
   );
 }

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -24,7 +24,17 @@ export function computeFreshness(page: PageFreshnessInput, snapshot: FreshnessSn
   };
 }
 
-/** Source-derived freshness status, per the spec's ordered ownership algorithm. */
+/**
+ * Source-derived freshness status, per the spec's ordered ownership algorithm.
+ *
+ * SCOPED LIMITATION (typed entity pages). Source ownership is recorded only for
+ * DEFAULT concepts (in `state.sources[file].concepts`). TYPED entity pages
+ * (non-concepts produced by a non-default profile, e.g. `papers/`, `ideas/`)
+ * have no source ownership entry, so `ownersOf` returns empty and they are
+ * INTENTIONALLY classified `unverified` — and therefore excluded from orphan
+ * pruning — in this phase. This is a known, scoped limitation: typed-page
+ * source ownership (and orphan pruning) is deferred to a later phase.
+ */
 function classify(page: PageFreshnessInput, snapshot: FreshnessSnapshot): FreshnessStatus {
   if (snapshot.stateStatus !== "ok") return "unverified";
   // Query pages are generated answers, not source projections — always unverified,

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,33 @@ export type { OkfExportReport } from "./export/okf/run.js";
 export type { OkfImportReport, OkfImportSkip, OkfImportedPage } from "./import/run.js";
 export { LockUnavailableError, QueueFullError } from "./import/run-errors.js";
 
+// @experimental — programmatic non-default entity-page staging loop. The
+// `createWiki()` facade exposes `stageEntityPage`/`promoteStagedPage`; these are
+// the input/return types consumers need. The lower-level `stageEntityPage(root,…)`
+// and `promoteCandidateUnderLock` forms stay internal. API may change.
+export type { SdkStageEntityPageInput } from "./trust/staging.js";
+export { StagingRequiresProfileError } from "./trust/staging.js";
+export type {
+  StagedChange,
+  CandidateKind,
+  HeldReasonCode,
+  RelationRef,
+  ArtifactRef,
+  WorkflowRunRef,
+} from "./trust/staged-change.js";
+// Planner sub-types named by `StagedChange.target` / `.planned` so the staged
+// surface is fully nameable by consumers (the typed `EntityRef` target especially).
+export type {
+  EntityRef,
+  RawPageRef,
+  MutationTarget,
+  MutationOperation,
+  MutationKind,
+  PlannedMutation,
+  MutationProvenance,
+} from "./trust/planner.js";
+export type { TrustDecision } from "./trust/decision.js";
+
 // Profile pack TYPES only — the loader stays internal (no `loadProfile` export).
 export type {
   ProfilePack,

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,10 @@ export { LockUnavailableError, QueueFullError } from "./import/run-errors.js";
 // `createWiki()` facade exposes `stageEntityPage`/`promoteStagedPage`; these are
 // the input/return types consumers need. The lower-level `stageEntityPage(root,…)`
 // and `promoteCandidateUnderLock` forms stay internal. API may change.
+//
+// Read-integration status: typed entity pages are a WRITE SUBSTRATE — a promoted
+// page is surfaced in `status`, the JSON export, and the wiki INDEX, but NOT YET
+// in interlinking, semantic search/embeddings, the MOC, or the viewer (planned).
 export type { SdkStageEntityPageInput } from "./trust/staging.js";
 export { StagingRequiresProfileError } from "./trust/staging.js";
 export type {

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -33,7 +33,7 @@ import {
 } from "../schema/index.js";
 import { computeFreshness } from "../freshness/index.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
-import { listPendingCandidateSlugs } from "../compiler/candidates.js";
+import { listLinkResolvablePendingSlugs } from "../compiler/candidates.js";
 
 /** Minimum body length (in characters) for a page to be considered non-empty. */
 const MIN_BODY_LENGTH = 50;
@@ -119,7 +119,7 @@ function buildPageSlugSet(
 export async function checkBrokenWikilinks(root: string): Promise<LintResult[]> {
   const pages = await collectAllPages(root);
   const existingSlugs = buildPageSlugSet(pages);
-  const pendingSlugs = await listPendingCandidateSlugs(root);
+  const pendingSlugs = await listLinkResolvablePendingSlugs(root);
   const results: LintResult[] = [];
 
   for (const page of pages) {

--- a/src/profile/collect.ts
+++ b/src/profile/collect.ts
@@ -30,13 +30,8 @@
 import { scanEntityDir, type RawEntityScan } from "../wiki/collect.js";
 import { isDefaultProfile } from "./default.js";
 import { isSlugSafe, assertSlugSafe, entityId, suggestSlugFromBasename } from "./identity.js";
-import type {
-  ProfilePack,
-  EntityPage,
-  EntityTypeDef,
-  FieldDef,
-  FieldType,
-} from "./types.js";
+import { validateEntityFields } from "./field-contract.js";
+import type { ProfilePack, EntityPage, EntityTypeDef } from "./types.js";
 
 /** Error raised only for the programming-error default-profile guard. */
 export class EntityCollectError extends Error {
@@ -87,28 +82,11 @@ function declaredSlug(frontmatter: Record<string, unknown>): string | undefined 
 }
 
 /**
- * Compute the de-duplicated set of required field names for an entity type: the
- * UNION of the entity-level `requiredFields` array and every field whose own
- * `FieldDef.required === true`. Returned as a `Set` so a field declared required
- * BOTH ways yields exactly one missing-field problem, never two.
- */
-function requiredFieldNames(def: EntityTypeDef): Set<string> {
-  const names = new Set<string>(def.requiredFields ?? []);
-  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
-    if (fieldDef.required === true) names.add(name);
-  }
-  return names;
-}
-
-/**
- * Validate a slug-safe page against its entity type's declared field contract,
- * pushing a `field-violation` problem for each missing required field and, for
- * each PRESENT field value, every declared-type / enum / min-max mismatch. A
- * field is required when it is in `def.requiredFields` OR carries
- * `FieldDef.required === true` (the union, de-duplicated). The page is NOT
+ * Validate a slug-safe page against its entity type's declared field contract via
+ * the SHARED {@link validateEntityFields} (the SAME implementation the typed write
+ * gates use), wrapping each PATH-FREE message into a `field-violation` problem
+ * tagged with the entity type and the offending `filePath`. The page is NOT
  * dropped — a contract violation is surfaced, not fatal — and this NEVER throws.
- * Messages are PATH-FREE (the offending path lives only on the structured
- * `filePath` field).
  */
 function checkFieldContract(
   entityType: string,
@@ -116,115 +94,9 @@ function checkFieldContract(
   scan: RawEntityScan,
   problems: EntityProblem[],
 ): void {
-  const fm = scan.frontmatter;
-  for (const field of requiredFieldNames(def)) {
-    if (!(field in fm)) {
-      problems.push({
-        kind: "field-violation",
-        entityType,
-        filePath: scan.filePath,
-        message: `Required field ${JSON.stringify(field)} is missing from frontmatter.`,
-      });
-    }
+  for (const message of validateEntityFields(scan.frontmatter, def)) {
+    problems.push({ kind: "field-violation", entityType, filePath: scan.filePath, message });
   }
-  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
-    checkFieldValue(entityType, name, fieldDef, scan, problems);
-  }
-}
-
-/**
- * Validate one present field value against its declared type, enum membership,
- * and numeric min/max. A missing value is not validated here (required-presence
- * is handled separately). Each mismatch becomes one PATH-FREE `field-violation`.
- */
-function checkFieldValue(
-  entityType: string,
-  name: string,
-  fieldDef: FieldDef,
-  scan: RawEntityScan,
-  problems: EntityProblem[],
-): void {
-  const value = scan.frontmatter[name];
-  if (value === undefined) return;
-  const typeError = describeTypeMismatch(name, fieldDef, value);
-  if (typeError) {
-    pushFieldViolation(entityType, scan.filePath, typeError, problems);
-    return;
-  }
-  const rangeError = describeRangeViolation(name, fieldDef, value);
-  if (rangeError) pushFieldViolation(entityType, scan.filePath, rangeError, problems);
-}
-
-/** Append a `field-violation` problem carrying a PATH-FREE message. */
-function pushFieldViolation(
-  entityType: string,
-  filePath: string,
-  message: string,
-  problems: EntityProblem[],
-): void {
-  problems.push({ kind: "field-violation", entityType, filePath, message });
-}
-
-/**
- * Return a PATH-FREE message when `value` does not match `fieldDef.type`
- * (including enum membership), or `undefined` when the type is satisfied.
- */
-function describeTypeMismatch(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
-  if (matchesDeclaredType(fieldDef, value)) return undefined;
-  if (fieldDef.type === "enum") {
-    return (
-      `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not one of ` +
-      `${JSON.stringify(fieldDef.enum ?? [])}.`
-    );
-  }
-  return `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not a valid ${fieldDef.type}.`;
-}
-
-/** True when `value` is a string parseable as a date, or a valid `Date`. */
-function isValidDate(value: unknown): boolean {
-  // YAML parses an unquoted ISO date into a JS `Date`; a quoted value stays a
-  // string. Accept either, provided it denotes a valid instant.
-  if (value instanceof Date) return !Number.isNaN(value.getTime());
-  return typeof value === "string" && !Number.isNaN(Date.parse(value));
-}
-
-/**
- * Per-field-type value predicates (enum excluded — it needs the `FieldDef`).
- * A lookup table keeps {@link matchesDeclaredType} flat instead of a wide
- * switch that would trip the complexity gate.
- */
-const TYPE_PREDICATES: Record<Exclude<FieldType, "enum">, (value: unknown) => boolean> = {
-  string: (v) => typeof v === "string",
-  slug: (v) => typeof v === "string" && isSlugSafe(v),
-  integer: (v) => Number.isInteger(v),
-  number: (v) => typeof v === "number" && Number.isFinite(v),
-  boolean: (v) => typeof v === "boolean",
-  date: isValidDate,
-  "string[]": (v) => Array.isArray(v) && v.every((item) => typeof item === "string"),
-};
-
-/** True when `value` satisfies the declared `FieldDef.type` (enum included). */
-function matchesDeclaredType(fieldDef: FieldDef, value: unknown): boolean {
-  if (fieldDef.type === "enum") {
-    return typeof value === "string" && (fieldDef.enum?.includes(value) ?? false);
-  }
-  return TYPE_PREDICATES[fieldDef.type](value);
-}
-
-/**
- * Return a PATH-FREE message when a numeric `value` falls outside the declared
- * `[min, max]`, or `undefined` when in range or when no bound applies. Only
- * meaningful after the value has passed its numeric type check.
- */
-function describeRangeViolation(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
-  if (typeof value !== "number") return undefined;
-  if (fieldDef.min !== undefined && value < fieldDef.min) {
-    return `Field ${JSON.stringify(name)} value ${value} is below min ${fieldDef.min}.`;
-  }
-  if (fieldDef.max !== undefined && value > fieldDef.max) {
-    return `Field ${JSON.stringify(name)} value ${value} exceeds max ${fieldDef.max}.`;
-  }
-  return undefined;
 }
 
 /**

--- a/src/profile/field-contract.ts
+++ b/src/profile/field-contract.ts
@@ -1,0 +1,161 @@
+/**
+ * @file src/profile/field-contract.ts
+ * @description The single, PURE per-page field-contract validator for a profile
+ * entity type — shared by the read-surface collector ({@link collectEntityPages}
+ * in `collect.ts`) and the typed WRITE gates (`stageEntityPage`,
+ * `applyTypedCandidate`), so both enforce ONE implementation (DRY).
+ *
+ * Given a page's parsed frontmatter and the resolved {@link EntityTypeDef}, it
+ * returns a list of PATH-FREE field-violation messages: one per missing required
+ * field, and one per present field value that mismatches its declared type, enum
+ * membership, or numeric min/max. It is pure (no I/O), never throws, and carries
+ * no path/entity-type context — callers attach that when they wrap each message
+ * into their own problem/error shape.
+ */
+
+import { isSlugSafe } from "./identity.js";
+import type { EntityTypeDef, FieldDef, FieldType } from "./types.js";
+
+/**
+ * Thrown by the typed WRITE gates (staging / promotion) when a candidate body's
+ * frontmatter violates its entity type's declared field contract — a missing
+ * required field, or a type/enum/range mismatch. Fails CLOSED so a contract-
+ * violating typed page is never staged or promoted (on the READ surfaces the same
+ * violations are non-fatal problems, not throws). Carries the structured list of
+ * PATH-FREE violation messages so callers can surface exactly what failed.
+ */
+export class EntityFieldContractError extends Error {
+  /** The PATH-FREE field-violation messages that caused the refusal. */
+  readonly violations: string[];
+
+  constructor(entityType: string, slug: string, violations: string[]) {
+    super(
+      `typed page ${entityType}/${slug} violates the profile field contract: ` +
+        `${violations.join(" ")}`,
+    );
+    this.name = "EntityFieldContractError";
+    this.violations = violations;
+  }
+}
+
+/**
+ * Compute the de-duplicated set of required field names for an entity type: the
+ * UNION of the entity-level `requiredFields` array and every field whose own
+ * `FieldDef.required === true`. Returned as a `Set` so a field declared required
+ * BOTH ways yields exactly one missing-field message, never two.
+ */
+function requiredFieldNames(def: EntityTypeDef): Set<string> {
+  const names = new Set<string>(def.requiredFields ?? []);
+  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
+    if (fieldDef.required === true) names.add(name);
+  }
+  return names;
+}
+
+/** True when `value` is a string parseable as a date, or a valid `Date`. */
+function isValidDate(value: unknown): boolean {
+  // YAML parses an unquoted ISO date into a JS `Date`; a quoted value stays a
+  // string. Accept either, provided it denotes a valid instant.
+  if (value instanceof Date) return !Number.isNaN(value.getTime());
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+/**
+ * Per-field-type value predicates (enum excluded — it needs the `FieldDef`).
+ * A lookup table keeps {@link matchesDeclaredType} flat instead of a wide switch.
+ */
+const TYPE_PREDICATES: Record<Exclude<FieldType, "enum">, (value: unknown) => boolean> = {
+  string: (v) => typeof v === "string",
+  slug: (v) => typeof v === "string" && isSlugSafe(v),
+  integer: (v) => Number.isInteger(v),
+  number: (v) => typeof v === "number" && Number.isFinite(v),
+  boolean: (v) => typeof v === "boolean",
+  date: isValidDate,
+  "string[]": (v) => Array.isArray(v) && v.every((item) => typeof item === "string"),
+};
+
+/** True when `value` satisfies the declared `FieldDef.type` (enum included). */
+function matchesDeclaredType(fieldDef: FieldDef, value: unknown): boolean {
+  if (fieldDef.type === "enum") {
+    return typeof value === "string" && (fieldDef.enum?.includes(value) ?? false);
+  }
+  return TYPE_PREDICATES[fieldDef.type](value);
+}
+
+/**
+ * Return a PATH-FREE message when `value` does not match `fieldDef.type`
+ * (including enum membership), or `undefined` when the type is satisfied.
+ */
+function describeTypeMismatch(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
+  if (matchesDeclaredType(fieldDef, value)) return undefined;
+  if (fieldDef.type === "enum") {
+    return (
+      `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not one of ` +
+      `${JSON.stringify(fieldDef.enum ?? [])}.`
+    );
+  }
+  return `Field ${JSON.stringify(name)} value ${JSON.stringify(value)} is not a valid ${fieldDef.type}.`;
+}
+
+/**
+ * Return a PATH-FREE message when a numeric `value` falls outside the declared
+ * `[min, max]`, or `undefined` when in range or when no bound applies. Only
+ * meaningful after the value has passed its numeric type check.
+ */
+function describeRangeViolation(name: string, fieldDef: FieldDef, value: unknown): string | undefined {
+  if (typeof value !== "number") return undefined;
+  if (fieldDef.min !== undefined && value < fieldDef.min) {
+    return `Field ${JSON.stringify(name)} value ${value} is below min ${fieldDef.min}.`;
+  }
+  if (fieldDef.max !== undefined && value > fieldDef.max) {
+    return `Field ${JSON.stringify(name)} value ${value} exceeds max ${fieldDef.max}.`;
+  }
+  return undefined;
+}
+
+/** Append every violation message for one present field value to `out`. */
+function collectFieldValueViolations(
+  name: string,
+  fieldDef: FieldDef,
+  value: unknown,
+  out: string[],
+): void {
+  if (value === undefined) return; // presence is handled by the required check
+  const typeError = describeTypeMismatch(name, fieldDef, value);
+  if (typeError) {
+    out.push(typeError);
+    return;
+  }
+  const rangeError = describeRangeViolation(name, fieldDef, value);
+  if (rangeError) out.push(rangeError);
+}
+
+/**
+ * Validate a page's parsed frontmatter against its entity type's declared field
+ * contract, returning a list of PATH-FREE violation messages (empty when the page
+ * satisfies the contract). One message per missing required field, plus one per
+ * present field value that mismatches its declared type / enum / numeric bound.
+ *
+ * A field is required when it appears in `def.requiredFields` OR carries
+ * `FieldDef.required === true` (the union, de-duplicated). Pure and total — no
+ * I/O, never throws, carries no path/entity-type context.
+ *
+ * @param frontmatter - The page's parsed frontmatter record.
+ * @param def - The resolved entity type definition to validate against.
+ * @returns Zero or more PATH-FREE field-violation messages.
+ */
+export function validateEntityFields(
+  frontmatter: Record<string, unknown>,
+  def: EntityTypeDef,
+): string[] {
+  const violations: string[] = [];
+  for (const field of requiredFieldNames(def)) {
+    if (!(field in frontmatter)) {
+      violations.push(`Required field ${JSON.stringify(field)} is missing from frontmatter.`);
+    }
+  }
+  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
+    collectFieldValueViolations(name, fieldDef, frontmatter[name], violations);
+  }
+  return violations;
+}

--- a/src/profile/identity.ts
+++ b/src/profile/identity.ts
@@ -30,6 +30,24 @@ export function isSlugSafe(s: string): s is SlugSafe {
 }
 
 /**
+ * The DEFAULT-page identity floor: is `s` a single safe path component for a
+ * default wiki page filename?
+ *
+ * Distinct from the slug-safe EntityId grammar ({@link isSlugSafe}): default
+ * pages keep their Unicode `slugify` stems (e.g. `café-society`, `机器学习`)
+ * and, per the Phase-1 invariant, NEVER become EntityIds — so this floor allows
+ * Unicode letters/digits/hyphens (whatever `slugify` produces) while still
+ * rejecting anything that could escape or hide the file: path separators
+ * (`/`, `\`), spaces, the dot-only names `.`/`..`, and a leading-dot (hidden)
+ * name. NUL and any other separator-bearing string is rejected by the same
+ * separator test (a NUL embeds no separator but a traversal/segment always
+ * does); the dot-prefix and empty-string guards cover the remainder.
+ */
+export function isSafeFilenameComponent(s: string): boolean {
+  return s.length > 0 && !/[/\\ \0]/.test(s) && s !== "." && s !== ".." && !s.startsWith(".");
+}
+
+/**
  * Assert that `s` is slug-safe, returning it branded as SlugSafe. This is the
  * ONLY way to obtain a SlugSafe value. Throws EntityIdError otherwise.
  */

--- a/src/sdk/staging-facade.ts
+++ b/src/sdk/staging-facade.ts
@@ -8,6 +8,12 @@
  * `ProfilePack`. They delegate to the trust-layer staging helpers, which fail
  * CLOSED (`StagingRequiresProfileError`) on a project with no non-default profile.
  *
+ * The facade emits NO stdout note (it runs quiet by contract); the
+ * read-integration status — typed pages are surfaced in `status`, the JSON
+ * export, and the wiki INDEX, but NOT YET in interlinking, semantic search, the
+ * MOC, or the viewer — is documented on the `stageEntityPage`/`promoteStagedPage`
+ * method docstrings instead.
+ *
  * @experimental Foundation API — the shape may change in a future minor release.
  */
 

--- a/src/sdk/staging-facade.ts
+++ b/src/sdk/staging-facade.ts
@@ -1,0 +1,35 @@
+/**
+ * @file src/sdk/staging-facade.ts
+ * @description The EXPERIMENTAL non-default staging slice of the `Wiki` facade,
+ * factored out of `src/sdk/wiki.ts` so the high-fan-in facade module stays lean.
+ *
+ * Both methods run silently under the caller-supplied quiet wrapper and load the
+ * active non-default profile INTERNALLY — the consumer never passes a
+ * `ProfilePack`. They delegate to the trust-layer staging helpers, which fail
+ * CLOSED (`StagingRequiresProfileError`) on a project with no non-default profile.
+ *
+ * @experimental Foundation API — the shape may change in a future minor release.
+ */
+
+import { stageEntityPageForProject, promoteStagedEntityPage } from "../trust/staging.js";
+import type { Wiki } from "./types.js";
+
+/** The experimental staging methods the `Wiki` facade composes in. */
+export type StagingFacadeSlice = Pick<Wiki, "stageEntityPage" | "promoteStagedPage">;
+
+/**
+ * Build the experimental staging slice of the `Wiki` facade bound to `root`.
+ *
+ * @param root - Normalized absolute project root.
+ * @param runQuiet - The facade's quiet-scoping wrapper (output suppressed).
+ * @returns The `stageEntityPage` / `promoteStagedPage` methods.
+ */
+export function buildStagingFacade(
+  root: string,
+  runQuiet: <T>(fn: () => Promise<T>) => Promise<T>,
+): StagingFacadeSlice {
+  return {
+    stageEntityPage: (input) => runQuiet(() => stageEntityPageForProject(root, input)),
+    promoteStagedPage: (candidateId) => runQuiet(() => promoteStagedEntityPage(root, candidateId)),
+  };
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -20,6 +20,8 @@ import type { JsonExportDocument, ExportJsonOptions } from "../export/json-expor
 import type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "../sources/store.js";
 import type { OkfExportReport } from "../export/okf/run.js";
 import type { OkfImportReport } from "../import/run.js";
+import type { SdkStageEntityPageInput } from "../trust/staging.js";
+import type { StagedChange } from "../trust/staged-change.js";
 
 /** Options for `createWiki`. */
 export interface CreateWikiOptions {
@@ -165,4 +167,26 @@ export interface Wiki {
    * latency/cost); `dryRun:true` writes nothing.
    */
   importOkf(dir: string, opts?: { trusted?: boolean; dryRun?: boolean }): Promise<OkfImportReport>;
+  /**
+   * @experimental
+   * Stage a NON-DEFAULT entity page for review. The SDK loads the active
+   * non-default profile internally — the caller passes no `ProfilePack`. Throws
+   * `StagingRequiresProfileError` when the project has no non-default profile
+   * (staging targets a typed `wiki/<entityType>/<slug>.md` path that only a
+   * non-default profile declares). `existingStagedCount` is the caller's
+   * per-session bookkeeping (defaults to 0). No LLM required.
+   *
+   * Foundation API — the shape may change in a future minor release.
+   */
+  stageEntityPage(input: SdkStageEntityPageInput): Promise<StagedChange>;
+  /**
+   * @experimental
+   * Promote a staged entity page candidate into the live wiki under one held
+   * lock: re-reads the candidate, re-validates its type against the active
+   * profile, re-plans + applies, and clears the candidate. The page lands at
+   * `wiki/<entityType>/<slug>.md`, or nothing does. No LLM required.
+   *
+   * Foundation API — the shape may change in a future minor release.
+   */
+  promoteStagedPage(candidateId: string): Promise<void>;
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -176,6 +176,12 @@ export interface Wiki {
    * non-default profile declares). `existingStagedCount` is the caller's
    * per-session bookkeeping (defaults to 0). No LLM required.
    *
+   * READ-INTEGRATION STATUS: typed entity pages are a WRITE SUBSTRATE. A promoted
+   * page is surfaced in `status`, the JSON export, and the wiki INDEX — but NOT
+   * YET in interlinking, semantic search / embeddings, the MOC, or the viewer
+   * (those are planned). Do not assume a staged/promoted typed page participates
+   * in retrieval or rendering yet.
+   *
    * Foundation API — the shape may change in a future minor release.
    */
   stageEntityPage(input: SdkStageEntityPageInput): Promise<StagedChange>;
@@ -185,6 +191,10 @@ export interface Wiki {
    * lock: re-reads the candidate, re-validates its type against the active
    * profile, re-plans + applies, and clears the candidate. The page lands at
    * `wiki/<entityType>/<slug>.md`, or nothing does. No LLM required.
+   *
+   * READ-INTEGRATION STATUS: the promoted page becomes visible in `status`, the
+   * JSON export, and the wiki INDEX — but NOT YET in interlinking, semantic
+   * search / embeddings, the MOC, or the viewer (those are planned).
    *
    * Foundation API — the shape may change in a future minor release.
    */

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -38,6 +38,7 @@ import { getPage, listPages } from "../pages/list.js";
 import { listSources, getSource, deleteSource } from "../sources/store.js";
 import { runOkfExport } from "../export/okf/run.js";
 import { runOkfImport } from "../import/run.js";
+import { buildStagingFacade } from "./staging-facade.js";
 import type { CreateWikiOptions, Wiki, SdkCompileOptions } from "./types.js";
 
 /**
@@ -131,5 +132,8 @@ export function createWiki(options: CreateWikiOptions): Wiki {
     exportOkf: (opts = {}) => runQuiet(() => runOkfExport(root, opts)),
 
     importOkf: (dir, opts = {}) => runQuiet(() => runOkfImport(root, dir, opts)),
+
+    // @experimental non-default staging slice — factored into staging-facade.ts.
+    ...buildStagingFacade(root, runQuiet),
   };
 }

--- a/src/state/migrate.ts
+++ b/src/state/migrate.ts
@@ -13,11 +13,14 @@
  *    migration never double-types a slug (no `concepts/concepts/rag`);
  *  - deterministic: minted id arrays are sorted lexicographically so repeated
  *    migrations of equal inputs serialise byte-for-byte identically;
- *  - fail-closed: a bare slug that violates the slug-safe grammar throws
- *    {@link EntityIdError} via {@link assertSlugSafe} rather than being dropped.
+ *  - tolerant: slug-safe slugs are typed; non-slug-safe slugs (e.g. the Unicode
+ *    stems `slugify` keeps, like `café-society` / `机器学习`) are kept in the
+ *    verbatim `concepts` / `frozenSlugs` mirror WITHOUT a typed id, so a
+ *    mixed-language wiki migrates instead of aborting. Widening the EntityId
+ *    grammar to cover Unicode is a deferred identity change, not done here.
  */
 
-import { entityId, assertSlugSafe } from "../profile/identity.js";
+import { entityId, isSlugSafe } from "../profile/identity.js";
 import type { EntityId } from "../profile/types.js";
 import type { SourceState, WikiState } from "../utils/types.js";
 
@@ -26,11 +29,15 @@ const CONCEPT_ENTITY_TYPE = "concepts";
 
 /**
  * Mint a sorted, deduplicated list of `concepts/<slug>` EntityIds from bare
- * concept slugs. Each slug is asserted slug-safe at mint time, so an invalid
- * slug throws rather than being silently skipped.
+ * concept slugs. Tolerant: only slug-safe slugs are typed; any slug that fails
+ * {@link isSlugSafe} (e.g. a Unicode stem) is SKIPPED here and survives via the
+ * verbatim `concepts` / `frozenSlugs` mirror it was drawn from. This is the
+ * single grammar/skip site, shared by migration and the writeState mirror sync.
  */
-function mintConceptEntities(slugs: string[]): EntityId[] {
-  const ids = slugs.map((slug) => entityId(CONCEPT_ENTITY_TYPE, assertSlugSafe(slug)));
+export function mintConceptEntities(slugs: string[]): EntityId[] {
+  const ids = slugs
+    .filter((slug) => isSlugSafe(slug))
+    .map((slug) => entityId(CONCEPT_ENTITY_TYPE, slug));
   return [...new Set(ids)].sort();
 }
 

--- a/src/trust/checks.ts
+++ b/src/trust/checks.ts
@@ -125,6 +125,36 @@ export const checkResourceLimit: MandatoryPageCheck = async (ctx) => {
 };
 
 /**
+ * Thrown by {@link assertBodyWithinResourceLimit} when a body exceeds
+ * {@link MAX_SOURCE_CHARS}. Lets pre-parse entry points (staging, promotion)
+ * reject an oversized body with a TYPED error BEFORE any frontmatter parse —
+ * mirroring the executor-side {@link checkResourceLimit} floor (same cap, same
+ * message wording) so the two agree. The planner's floor stays as the executor
+ * -side guarantee (defense in depth).
+ */
+export class ResourceLimitError extends Error {
+  constructor(chars: number) {
+    super(`body ${chars} chars exceeds cap of ${MAX_SOURCE_CHARS}`);
+    this.name = "ResourceLimitError";
+  }
+}
+
+/**
+ * Reject a body whose character length exceeds {@link MAX_SOURCE_CHARS} BEFORE
+ * any frontmatter parse. A pure `.length` compare — costs nothing — so a giant
+ * all-frontmatter payload can never burn parse time before the cap rejects it.
+ * A body within the cap is a no-op. Restores the "reject before parsing"
+ * guarantee at the staging/promotion entry points.
+ * @param body - The full markdown body to length-check.
+ * @throws {ResourceLimitError} When `body.length` exceeds the cap.
+ */
+export function assertBodyWithinResourceLimit(body: string): void {
+  if (body.length > MAX_SOURCE_CHARS) {
+    throw new ResourceLimitError(body.length);
+  }
+}
+
+/**
  * Block a body whose frontmatter block is present but malformed (invalid YAML
  * or a non-mapping scalar/array), reusing {@link parseFrontmatterStatus}. A body
  * with no frontmatter block or with clean frontmatter passes.

--- a/src/trust/checks.ts
+++ b/src/trust/checks.ts
@@ -14,8 +14,11 @@
  * project's existing trust primitives rather than re-deriving them:
  * - path-confinement → {@link confineUnderRoot} (rejects targets and symlinked
  *   ancestors that escape the project root);
- * - collision/no-overwrite → existence probe under the confined path (creates
- *   block on an existing target);
+ * - collision/no-overwrite → existence probe under the confined path. A target
+ *   that already exists blocks ONLY when the caller did not declare an explicit
+ *   overwrite intent (`allowOverwrite:false`); an intended upsert
+ *   (`allowOverwrite:true`) treats an existing target as a clean `update`, not a
+ *   violation;
  * - resource-limit → the per-file content cap {@link MAX_SOURCE_CHARS}, decided
  *   on raw character length BEFORE any parsing so an oversized body never gets
  *   heavy processing;
@@ -47,6 +50,13 @@ export interface PageWriteContext {
   targetPath: string;
   /** Full markdown content (frontmatter + body) to be written. */
   body: string;
+  /**
+   * Whether an existing target is an intended overwrite (`update`) rather than a
+   * collision. `false` (or omitted) keeps the strict create-only semantics:
+   * an existing target blocks. `true` lets a legitimate upsert (review-approve,
+   * compile recompile) overwrite without tripping {@link checkTargetCollision}.
+   */
+  allowOverwrite?: boolean;
 }
 
 /** A single mandatory check over a page mutation. */
@@ -73,9 +83,12 @@ export const checkPathConfinement: MandatoryPageCheck = async (ctx) => {
 };
 
 /**
- * Block when the confined target already exists: page creation is create-only
- * and never silently overwrites. A target whose own path escapes root is also
- * blocked here (a non-confinable target cannot be a safe create destination).
+ * Block when the confined target already exists AND the caller declared no
+ * overwrite intent (`allowOverwrite` falsy): a strict create never silently
+ * overwrites. When `allowOverwrite` is true, an existing target is an intended
+ * `update` and passes. A free target passes either way. A target whose own path
+ * escapes root is blocked here (a non-confinable target is not a safe write
+ * destination).
  */
 export const checkTargetCollision: MandatoryPageCheck = async (ctx) => {
   const code = "target-exists";
@@ -90,6 +103,7 @@ export const checkTargetCollision: MandatoryPageCheck = async (ctx) => {
   } catch {
     return pass(code, "target path is free");
   }
+  if (ctx.allowOverwrite) return pass(code, `target exists; intended overwrite (update): ${path.basename(abs)}`);
   return { code, verdict: "block", message: `target already exists (create-only): ${path.basename(abs)}` };
 };
 

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -48,10 +48,10 @@ import {
   replayJournal,
   type JournalBatch,
 } from "./journal.js";
-import { parseEntityId } from "../profile/identity.js";
+import { parseEntityId, isSafeFilenameComponent } from "../profile/identity.js";
 import { checkResourceLimit, checkFrontmatter, type PageWriteContext } from "./checks.js";
 import { composeTrustDecision } from "./decision.js";
-import type { PlannedMutation } from "./planner.js";
+import type { PlannedMutation, EntityRef, RawPageRef } from "./planner.js";
 
 /** Decisions under which the executor is cleared to write bytes to disk. */
 const APPLY_ALLOWED_DECISIONS = new Set(["allow", "allow-with-warning"]);
@@ -128,7 +128,24 @@ async function targetExists(abs: string): Promise<boolean> {
 }
 
 /**
- * The wiki-relative page path for a page mutation's target.
+ * The wiki-relative page path for a DEFAULT page's {@link RawPageRef} target.
+ *
+ * Defense-in-depth: the executor does not trust the caller, so it RE-ASSERTS the
+ * {@link isSafeFilenameComponent} floor on both the directory and the raw slug —
+ * a hand-built mutation carrying a `..`/separator slug is rejected with a typed
+ * {@link InvalidIdentityError} BEFORE `path.join` could collapse it into a wrong
+ * in-root location (the planner's `checkDefaultIdentitySafe` guard is not on this
+ * path).
+ */
+function rawPageRelPath(target: RawPageRef): string {
+  if (!isSafeFilenameComponent(target.directory) || !isSafeFilenameComponent(target.slug)) {
+    throw new InvalidIdentityError(`directory/slug is not a safe filename component: ${target.directory}/${target.slug}`);
+  }
+  return path.join("wiki", target.directory, `${target.slug}.md`);
+}
+
+/**
+ * The wiki-relative page path for a PROFILE entity's {@link EntityRef} target.
  *
  * Defense-in-depth: the entityType/slug are re-validated by re-parsing the
  * branded `target.id` (which throws on a non-slug-safe slug half), so a
@@ -136,15 +153,27 @@ async function targetExists(abs: string): Promise<boolean> {
  * {@link InvalidIdentityError} BEFORE `path.join` could collapse it into a wrong
  * in-root location — the planner's `checkIdentitySafe` guard is not on this path.
  */
-function pageRelPath(mutation: PlannedMutation): string {
+function entityPageRelPath(target: EntityRef): string {
   let entityType: string;
   let slug: string;
   try {
-    ({ entityType, slug } = parseEntityId(mutation.target.id));
+    ({ entityType, slug } = parseEntityId(target.id));
   } catch (err) {
     throw new InvalidIdentityError((err as Error).message);
   }
   return path.join("wiki", entityType, `${slug}.md`);
+}
+
+/**
+ * The wiki-relative page path for a page mutation's target, discriminating the
+ * union: a DEFAULT page ({@link RawPageRef}, no `id`) takes the raw-component
+ * path; a PROFILE entity ({@link EntityRef}) takes the typed-id path. Both
+ * re-assert their identity floor as defense-in-depth.
+ */
+function pageRelPath(mutation: PlannedMutation): string {
+  const target = mutation.target;
+  if ("id" in target) return entityPageRelPath(target);
+  return rawPageRelPath(target);
 }
 
 /**

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -25,6 +25,15 @@
  * SCOPE: Task 5 executes `kind:"page"` only. Any other {@link MutationKind} is
  * rejected with a typed `not-implemented` error, so an unhandled store can never
  * be silently no-op'd or half-applied.
+ *
+ * S5 — FULL-FLOOR RE-ASSERTION AT APPLY: the executor is where bytes hit disk,
+ * so it does not trust that plan-time checks still hold. Before every write it
+ * re-runs the mandatory floor (resource-limit + frontmatter; path-confinement is
+ * already enforced via {@link confineUnderRoot} and collision via the `create`
+ * re-probe) against a context whose `allowOverwrite` reflects the mutation's
+ * operation, and composes a {@link TrustDecision}. A non-allow decision throws a
+ * typed {@link MutationFloorError} and writes NOTHING — a hand-built mutation
+ * that bypassed the planner cannot smuggle an oversized or malformed body past.
  */
 
 import path from "path";
@@ -40,7 +49,12 @@ import {
   type JournalBatch,
 } from "./journal.js";
 import { parseEntityId } from "../profile/identity.js";
+import { checkResourceLimit, checkFrontmatter, type PageWriteContext } from "./checks.js";
+import { composeTrustDecision } from "./decision.js";
 import type { PlannedMutation } from "./planner.js";
+
+/** Decisions under which the executor is cleared to write bytes to disk. */
+const APPLY_ALLOWED_DECISIONS = new Set(["allow", "allow-with-warning"]);
 
 /** A single page write. Injectable so tests can fault-inject a failure. */
 export type WriteOne = (filePath: string, content: string) => Promise<void>;
@@ -89,6 +103,20 @@ class InvalidIdentityError extends Error {
   }
 }
 
+/**
+ * Thrown when a mutation fails the mandatory trust floor re-asserted at apply
+ * time (S5): an oversized body, malformed frontmatter, or any block-composing
+ * floor result. Refusing here — at the byte-writing boundary — means a
+ * hand-built mutation that never passed the planner cannot reach disk. Callers
+ * match on the typed `mutation-floor:` message prefix.
+ */
+class MutationFloorError extends Error {
+  constructor(reason: string) {
+    super(`mutation-floor: refused before write: ${reason}`);
+    this.name = "MutationFloorError";
+  }
+}
+
 /** True when something exists at `abs` (regular file, dir, or symlink). */
 async function targetExists(abs: string): Promise<boolean> {
   try {
@@ -120,9 +148,32 @@ function pageRelPath(mutation: PlannedMutation): string {
 }
 
 /**
- * Apply every page mutation in the batch under an already-open journal: record
- * each target's pre-state, then write it. Throws on the first non-page kind or
- * the first failing write, leaving the journal uncommitted for replay.
+ * Re-assert the mandatory trust floor for one mutation at apply time (S5),
+ * against a context whose `allowOverwrite` mirrors the operation (`update`
+ * overwrites; `create` does not). Runs the floor checks not already enforced on
+ * this path — resource-limit and frontmatter — and composes them; a non-allow
+ * decision throws {@link MutationFloorError} so nothing is written.
+ */
+async function assertFloorAtApply(root: string, mutation: PlannedMutation, abs: string): Promise<void> {
+  const ctx: PageWriteContext = {
+    root,
+    targetPath: abs,
+    body: mutation.body,
+    allowOverwrite: mutation.operation === "update",
+  };
+  const checks = await Promise.all([checkResourceLimit(ctx), checkFrontmatter(ctx)]);
+  const decision = composeTrustDecision(checks, { reviewRouted: false });
+  if (!APPLY_ALLOWED_DECISIONS.has(decision)) {
+    const reason = checks.find((c) => c.verdict === "block")?.message ?? decision;
+    throw new MutationFloorError(reason);
+  }
+}
+
+/**
+ * Apply every page mutation in the batch under an already-open journal:
+ * re-assert the trust floor (S5), record each target's pre-state, then write it.
+ * Throws on the first non-page kind, floor violation, or failing write, leaving
+ * the journal uncommitted for replay.
  *
  * A `create` target is RE-PROBED under the lock (the planner's collision check
  * runs before the lock): if it now exists, abort with {@link CreateCollisionError}
@@ -141,6 +192,7 @@ async function applyBatch(
     if (mutation.operation === "create" && (await targetExists(abs))) {
       throw new CreateCollisionError(abs);
     }
+    await assertFloorAtApply(root, mutation, abs);
     await recordPreState(batch, abs);
     await writeOne(abs, mutation.body);
   }

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -9,6 +9,14 @@
  * already-held review lock. The atomicity contract (and journal replay) is now
  * realized on that live path; other CLP write surfaces are still future work.
  *
+ * ATOMICITY SCOPE (honest boundary). The journal batch covers ONLY the page
+ * byte-writes in the plan. It does NOT extend to a consumer's post-write tail —
+ * e.g. `review approve`'s source-state persist, index/MOC/embeddings refresh, and
+ * candidate deletion run under the same lock but OUTSIDE this batch, and are
+ * best-effort + idempotent/re-derivable rather than journalled. "The approved
+ * batch applies atomically" means the PAGE BYTES, not the whole approve
+ * operation.
+ *
  * {@link applyApprovedMutations} runs the batch behind the project lock and a
  * single-store intent journal:
  *  1. acquire the PID-based project lock (same discipline as compile/review);

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -4,10 +4,10 @@
  * {@link PlannedMutation} plan into bytes on disk, under the CLP atomicity
  * contract ("partial application of an approved batch is a bug").
  *
- * STATUS: this planner/executor/journal seam is a Phase-2 FOUNDATION. No live
- * production write path routes through it yet (no caller invokes
- * {@link applyApprovedMutations}); the atomicity contract is realized for the
- * page store in isolation and under test, not yet across any wired surface.
+ * STATUS: the `review approve` page write is the FIRST production consumer of
+ * this seam — it routes through {@link applyApprovedMutationsLocked} under its
+ * already-held review lock. The atomicity contract (and journal replay) is now
+ * realized on that live path; other CLP write surfaces are still future work.
  *
  * {@link applyApprovedMutations} runs the batch behind the project lock and a
  * single-store intent journal:
@@ -228,16 +228,42 @@ async function applyBatch(
 }
 
 /**
- * Apply an approved plan to disk atomically. Acquires the project lock, journals
- * every target's pre-state before writing, applies each page mutation, then
- * commits the journal — releasing the lock in `finally`. A non-page kind throws
- * `not-implemented`. A mid-batch failure leaves a `pending` journal for
- * {@link replayJournal} to revert to the full pre-state.
+ * Apply an approved plan to disk atomically WHILE THE CALLER ALREADY HOLDS the
+ * project lock — the lock-free core shared with {@link applyApprovedMutations}.
  *
- * Self-recovery: BEFORE opening the new batch (but AFTER the lock is held), it
- * runs {@link replayJournal}, so a `pending` journal left dangling by a prior
- * crash is reverted under the same lock before this batch begins — the atomicity
- * guarantee no longer depends on an external caller invoking replay.
+ * The caller MUST already hold the project lock; this function acquires NOTHING,
+ * so it can run inside an outer locked region (e.g. `review approve`, which holds
+ * the review lock across its whole mutation) WITHOUT a nested-acquire deadlock.
+ *
+ * Self-recovery: BEFORE opening the new batch it runs {@link replayJournal}, so a
+ * `pending` journal left dangling by a prior crash is reverted under the SAME
+ * held lock before this batch begins. A non-page kind throws `not-implemented`; a
+ * mid-batch failure leaves a `pending` journal for replay to revert to the full
+ * pre-state.
+ *
+ * @param root - Absolute project root.
+ * @param planned - The approved mutations to apply.
+ * @param opts - Optional injectable write primitive (for fault injection).
+ */
+export async function applyApprovedMutationsLocked(
+  root: string,
+  planned: PlannedMutation[],
+  opts: ApplyOptions = {},
+): Promise<void> {
+  const writeOne = opts.writeOne ?? atomicWrite;
+  // Recover any dangling pending batch from a prior crash under the held lock.
+  await replayJournal(root);
+  const batch = await openBatch(root);
+  await applyBatch(root, planned, batch, writeOne);
+  await commitBatch(batch);
+}
+
+/**
+ * Apply an approved plan to disk atomically, acquiring the project lock itself.
+ * Acquires the PID-based project lock, delegates the journalled batch to
+ * {@link applyApprovedMutationsLocked} (replay → open → apply → commit), then
+ * releases the lock in `finally`. There is ONE batch implementation; this is the
+ * self-locking entry point for callers that do NOT already hold the lock.
  *
  * @param root - Absolute project root.
  * @param planned - The approved mutations to apply.
@@ -248,15 +274,10 @@ export async function applyApprovedMutations(
   planned: PlannedMutation[],
   opts: ApplyOptions = {},
 ): Promise<void> {
-  const writeOne = opts.writeOne ?? atomicWrite;
   const acquired = await acquireLock(root);
   if (!acquired) throw new Error("could not acquire project lock for mutation batch");
   try {
-    // Recover any dangling pending batch from a prior crash under the held lock.
-    await replayJournal(root);
-    const batch = await openBatch(root);
-    await applyBatch(root, planned, batch, writeOne);
-    await commitBatch(batch);
+    await applyApprovedMutationsLocked(root, planned, opts);
   } finally {
     await releaseLock(root);
   }

--- a/src/trust/planner.ts
+++ b/src/trust/planner.ts
@@ -23,6 +23,8 @@
  */
 
 import path from "path";
+import { lstat } from "fs/promises";
+import { confineUnderRoot } from "../utils/path-confine.js";
 import { runMandatoryPageChecks, type PageWriteContext } from "./checks.js";
 import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
 import { entityId, isSlugSafe } from "../profile/identity.js";
@@ -92,6 +94,12 @@ export interface PlanPageInput {
   origin: string;
   /** Whether the surface stages risky writes for human review. */
   reviewRouted: boolean;
+  /**
+   * Whether an existing target is an intended overwrite (`update`) rather than a
+   * collision. A legitimate upserting caller (review-approve, compile recompile)
+   * passes `true`; a strict create-only caller passes `false` (the default).
+   */
+  allowOverwrite?: boolean;
 }
 
 /** The planner's output: the plan, the composed decision, and the raw checks. */
@@ -130,18 +138,35 @@ function checkIdentitySafe(entityType: string, slug: string): TrustCheckResult {
   return { code, verdict: "block", message: `entity type/slug is not slug-safe: ${entityType}/${slug}` };
 }
 
+/** True when a confinable target already exists on disk under `root`. */
+async function targetAlreadyExists(root: string, targetPath: string): Promise<boolean> {
+  let abs: string;
+  try {
+    abs = await confineUnderRoot(targetPath, root, { mustExist: false });
+  } catch {
+    return false;
+  }
+  try {
+    await lstat(abs);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Build the single live-write mutation for an approved page. Phase 2 page
- * mutations are CREATE-ONLY: a colliding (already-existing) target is blocked
- * upstream by `checkTargetCollision`, so an approved page is always a fresh
- * `create`. In-place `update` of an existing page is a later phase.
+ * Build the single live-write mutation for an approved page. The operation is
+ * chosen by existence: a FREE target is a `create`; an already-existing target
+ * (reached here only when the caller declared `allowOverwrite`, since otherwise
+ * `checkTargetCollision` blocks) is an in-place `update`.
  */
 async function buildPageMutation(input: PlanPageInput, decision: TrustDecision): Promise<PlannedMutation> {
   const id = entityId(input.entityType, input.slug);
   const target: EntityRef = { entityType: input.entityType, slug: input.slug, id };
+  const exists = await targetAlreadyExists(input.root, pageTargetPath(input.entityType, input.slug));
   return {
     kind: "page",
-    operation: "create",
+    operation: exists ? "update" : "create",
     target,
     body: input.body,
     provenance: { origin: input.origin, decision, reviewRouted: input.reviewRouted },
@@ -158,7 +183,12 @@ async function buildPageMutation(input: PlanPageInput, decision: TrustDecision):
  */
 export async function planPageMutation(input: PlanPageInput): Promise<PlanResult> {
   const targetPath = pageTargetPath(input.entityType, input.slug);
-  const ctx: PageWriteContext = { root: input.root, targetPath, body: input.body };
+  const ctx: PageWriteContext = {
+    root: input.root,
+    targetPath,
+    body: input.body,
+    allowOverwrite: input.allowOverwrite ?? false,
+  };
   const checks = [
     checkIdentitySafe(input.entityType, input.slug),
     ...(await runMandatoryPageChecks(ctx)),

--- a/src/trust/planner.ts
+++ b/src/trust/planner.ts
@@ -27,7 +27,7 @@ import { lstat } from "fs/promises";
 import { confineUnderRoot } from "../utils/path-confine.js";
 import { runMandatoryPageChecks, type PageWriteContext } from "./checks.js";
 import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
-import { entityId, isSlugSafe } from "../profile/identity.js";
+import { entityId, isSlugSafe, isSafeFilenameComponent } from "../profile/identity.js";
 import type { EntityId } from "../profile/types.js";
 
 /** Every CLP store a mutation can target. Task 5 executes `page` only. */
@@ -49,8 +49,23 @@ export interface EntityRef {
   id: EntityId;
 }
 
-/** The store-specific target a mutation acts on. Page mutations use EntityRef. */
-export type MutationTarget = EntityRef;
+/**
+ * Reference to a DEFAULT wiki page: its directory and raw slug stem, with NO
+ * typed identity. Default pages keep their Unicode `slugify` slugs (e.g.
+ * `café-society`) and, per the Phase-1 invariant, NEVER become EntityIds — so
+ * they carry a raw stem here rather than a branded {@link EntityId}.
+ */
+export interface RawPageRef {
+  directory: string;
+  slug: string;
+}
+
+/**
+ * The store-specific target a mutation acts on. PROFILE entity pages use
+ * {@link EntityRef} (typed identity); DEFAULT pages use {@link RawPageRef} (raw
+ * stem, no typed identity).
+ */
+export type MutationTarget = EntityRef | RawPageRef;
 
 /** Where a proposed mutation came from and how it was vetted. */
 export interface MutationProvenance {
@@ -155,48 +170,119 @@ async function targetAlreadyExists(root: string, targetPath: string): Promise<bo
 }
 
 /**
- * Build the single live-write mutation for an approved page. The operation is
- * chosen by existence: a FREE target is a `create`; an already-existing target
- * (reached here only when the caller declared `allowOverwrite`, since otherwise
- * `checkTargetCollision` blocks) is an in-place `update`.
+ * Guard a DEFAULT page's raw identity: a `directory`/`slug` that is not a safe
+ * single filename component (path separator, dot-only, leading-dot, NUL, empty)
+ * yields a `block`. Like {@link checkIdentitySafe} this runs ahead of the
+ * mandatory file checks and composes via the SAME decision path — never a thrown
+ * exception — but it uses the Unicode-tolerant {@link isSafeFilenameComponent}
+ * floor (NOT the slug-safe grammar), so a non-ASCII default slug is allowed.
  */
-async function buildPageMutation(input: PlanPageInput, decision: TrustDecision): Promise<PlannedMutation> {
-  const id = entityId(input.entityType, input.slug);
-  const target: EntityRef = { entityType: input.entityType, slug: input.slug, id };
-  const exists = await targetAlreadyExists(input.root, pageTargetPath(input.entityType, input.slug));
-  return {
-    kind: "page",
-    operation: exists ? "update" : "create",
-    target,
-    body: input.body,
-    provenance: { origin: input.origin, decision, reviewRouted: input.reviewRouted },
-  };
+function checkDefaultIdentitySafe(directory: string, slug: string): TrustCheckResult {
+  const code = "invalid-identity";
+  if (isSafeFilenameComponent(directory) && isSafeFilenameComponent(slug)) {
+    return { code, verdict: "pass", message: "directory and slug are safe filename components" };
+  }
+  return { code, verdict: "block", message: `directory/slug is not a safe filename component: ${directory}/${slug}` };
+}
+
+/** The shared inputs to {@link planPageWith}, independent of target identity. */
+interface PageFloorInput {
+  root: string;
+  targetPath: string;
+  body: string;
+  origin: string;
+  reviewRouted: boolean;
+  allowOverwrite?: boolean;
 }
 
 /**
- * Plan a single page mutation: derive the target, run the mandatory checks,
- * compose the decision, and emit either one live-write mutation (on
- * allow/allow-with-warning) or none (on any block-derived decision).
+ * The shared floor→compose→build core for BOTH the typed ({@link EntityRef}) and
+ * raw ({@link RawPageRef}) page paths. Prepends the caller's identity-check
+ * result to the mandatory floor, composes the decision, and — only on a
+ * live-write decision — invokes `buildTarget` to mint the store-specific target.
+ * Factored out so the two planners never duplicate the floor/compose/existence
+ * logic (only the identity grammar and target shape differ).
+ */
+async function planPageWith(
+  input: PageFloorInput,
+  identityCheck: TrustCheckResult,
+  buildTarget: () => MutationTarget,
+): Promise<PlanResult> {
+  const ctx: PageWriteContext = {
+    root: input.root,
+    targetPath: input.targetPath,
+    body: input.body,
+    allowOverwrite: input.allowOverwrite ?? false,
+  };
+  const checks = [identityCheck, ...(await runMandatoryPageChecks(ctx))];
+  const decision = composeTrustDecision(checks, { reviewRouted: input.reviewRouted });
+  if (!LIVE_WRITE_DECISIONS.has(decision)) {
+    return { planned: [], decision, checks };
+  }
+  const exists = await targetAlreadyExists(input.root, input.targetPath);
+  const mutation: PlannedMutation = {
+    kind: "page",
+    operation: exists ? "update" : "create",
+    target: buildTarget(),
+    body: input.body,
+    provenance: { origin: input.origin, decision, reviewRouted: input.reviewRouted },
+  };
+  return { planned: [mutation], decision, checks };
+}
+
+/**
+ * Plan a single PROFILE-entity page mutation: derive the target, run the
+ * mandatory checks, compose the decision, and emit either one live-write
+ * mutation (on allow/allow-with-warning) or none (on any block-derived
+ * decision). The target is a typed {@link EntityRef} whose {@link EntityId} is
+ * minted only once the identity is known slug-safe.
  *
  * @param input - The proposed page mutation.
  * @returns The plan, composed decision, and per-check results.
  */
 export async function planPageMutation(input: PlanPageInput): Promise<PlanResult> {
   const targetPath = pageTargetPath(input.entityType, input.slug);
-  const ctx: PageWriteContext = {
-    root: input.root,
-    targetPath,
-    body: input.body,
-    allowOverwrite: input.allowOverwrite ?? false,
-  };
-  const checks = [
+  return planPageWith(
+    { ...input, targetPath },
     checkIdentitySafe(input.entityType, input.slug),
-    ...(await runMandatoryPageChecks(ctx)),
-  ];
-  const decision = composeTrustDecision(checks, { reviewRouted: input.reviewRouted });
+    () => ({ entityType: input.entityType, slug: input.slug, id: entityId(input.entityType, input.slug) }),
+  );
+}
 
-  if (!LIVE_WRITE_DECISIONS.has(decision)) {
-    return { planned: [], decision, checks };
-  }
-  return { planned: [await buildPageMutation(input, decision)], decision, checks };
+/** Inputs to {@link planDefaultPageMutation}. */
+export interface PlanDefaultPageInput {
+  /** Absolute project root the write must stay confined to. */
+  root: string;
+  /** The wiki subdirectory the page lives in (a raw filename component). */
+  directory: string;
+  /** The raw Unicode slug stem (a raw filename component; may be invalid). */
+  slug: string;
+  /** Full markdown body (frontmatter + prose). */
+  body: string;
+  /** Origin surface/actor of the proposal. */
+  origin: string;
+  /** Whether the surface stages risky writes for human review. */
+  reviewRouted: boolean;
+  /** Whether an existing target is an intended overwrite (`update`). */
+  allowOverwrite?: boolean;
+}
+
+/**
+ * Plan a single DEFAULT page mutation. Unlike {@link planPageMutation} this does
+ * NOT mint an EntityId: default pages keep their raw Unicode slug and target a
+ * {@link RawPageRef}. The identity floor is {@link isSafeFilenameComponent}
+ * (via {@link checkDefaultIdentitySafe}), the path is `wiki/<directory>/<slug>.md`,
+ * and the SAME mandatory floor + decision composition runs through
+ * {@link planPageWith}.
+ *
+ * @param input - The proposed default page mutation.
+ * @returns The plan, composed decision, and per-check results.
+ */
+export async function planDefaultPageMutation(input: PlanDefaultPageInput): Promise<PlanResult> {
+  const targetPath = pageTargetPath(input.directory, input.slug);
+  return planPageWith(
+    { ...input, targetPath },
+    checkDefaultIdentitySafe(input.directory, input.slug),
+    () => ({ directory: input.directory, slug: input.slug }),
+  );
 }

--- a/src/trust/promote.ts
+++ b/src/trust/promote.ts
@@ -1,0 +1,136 @@
+/**
+ * @file src/trust/promote.ts
+ * @description The single under-lock promotion routine for a TYPED entity-page
+ * candidate, shared by the SDK staging helper and `review approve`'s typed
+ * branch (CLP Phase-3 hardening, DRY).
+ *
+ * Promoting a typed candidate must (a) re-validate the candidate's declared
+ * `targetEntityType` against the CURRENTLY-loaded profile — the profile may have
+ * changed since the candidate was staged — and (b) re-plan + apply the write
+ * under the SAME held lock as the candidate re-read and delete, so a concurrent
+ * reject between read and apply cannot race. This module owns that contract once:
+ *
+ *  - {@link applyTypedCandidate} is the LOCK-FREE core (caller already holds the
+ *    project lock): load + validate the active profile, re-plan via the typed
+ *    {@link planPageMutation}, apply via {@link applyApprovedMutationsLocked}, and
+ *    return the wiki-relative `wiki/<entityType>/<slug>.md` path. It NEVER deletes
+ *    the candidate — the caller owns that, since `review approve` deletes only
+ *    after its source-state/index refresh tail.
+ *  - {@link promoteCandidateUnderLock} is the SELF-LOCKING SDK entry point: it
+ *    acquires the lock, RE-READS the candidate (aborting if a concurrent reject
+ *    removed it), runs {@link applyTypedCandidate}, deletes the candidate, and
+ *    releases the lock in `finally`.
+ */
+
+import { loadNonDefaultProfile } from "../profile/block.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { planPageMutation } from "./planner.js";
+import { applyApprovedMutationsLocked } from "./executor.js";
+import { readCandidate, deleteCandidate } from "../compiler/candidates.js";
+import type { ReviewCandidate } from "../utils/types.js";
+
+/**
+ * Thrown when a typed candidate cannot be promoted because the active profile no
+ * longer declares (or never declared) its `targetEntityType` — e.g. a default
+ * project with no profile, or a profile edited since staging. Promotion fails
+ * CLOSED so a typed page can never land outside the current profile schema, and
+ * the candidate is RETAINED for the caller to surface. Distinct from a blocked
+ * plan ({@link CandidatePromotionBlockedError}).
+ */
+export class CandidateProfileError extends Error {
+  constructor(entityType: string, reason: "no-profile" | "undeclared") {
+    const detail =
+      reason === "no-profile"
+        ? "the project has no non-default profile"
+        : `the active profile does not declare entity type "${entityType}"`;
+    super(`cannot promote typed candidate: ${detail}`);
+    this.name = "CandidateProfileError";
+  }
+}
+
+/**
+ * Thrown when the typed re-plan blocks at promotion time (empty plan — e.g. the
+ * mandatory floor refused an oversized body). The candidate is RETAINED; nothing
+ * partial ever lands.
+ */
+export class CandidatePromotionBlockedError extends Error {
+  constructor(entityType: string, slug: string) {
+    super(`typed candidate ${entityType}/${slug} blocked by the write planner; retained`);
+    this.name = "CandidatePromotionBlockedError";
+  }
+}
+
+/** The wiki-relative page path a typed candidate promotes to. */
+function typedPagePath(entityType: string, slug: string): string {
+  return `wiki/${entityType}/${slug}.md`;
+}
+
+/**
+ * Validate a typed candidate's `targetEntityType` against the active profile and
+ * re-plan + apply its write — the LOCK-FREE promotion core. The caller MUST
+ * already hold the project lock (so this never nests an acquire). Loads the
+ * active non-default profile, refuses if it is absent or no longer declares the
+ * type, re-plans via the typed planner (so the mandatory floor + path-confinement
+ * re-run at promotion time), and applies under the held lock. Returns the
+ * wiki-relative page path the body landed at.
+ *
+ * @param root - Absolute project root.
+ * @param candidate - The typed candidate (must carry `targetEntityType`).
+ * @returns The `wiki/<entityType>/<slug>.md` path the page was written to.
+ * @throws {CandidateProfileError} When no profile declares the type.
+ * @throws {CandidatePromotionBlockedError} When the re-plan blocks (empty plan).
+ */
+export async function applyTypedCandidate(
+  root: string,
+  candidate: ReviewCandidate,
+): Promise<string> {
+  const entityType = candidate.targetEntityType!;
+  const loaded = await loadNonDefaultProfile(root);
+  if (!loaded) throw new CandidateProfileError(entityType, "no-profile");
+  if (!(entityType in loaded.profile.entities)) {
+    throw new CandidateProfileError(entityType, "undeclared");
+  }
+  const { planned } = await planPageMutation({
+    root,
+    entityType,
+    slug: candidate.slug,
+    body: candidate.body,
+    origin: "review",
+    reviewRouted: false,
+    allowOverwrite: true,
+  });
+  if (planned.length === 0) {
+    throw new CandidatePromotionBlockedError(entityType, candidate.slug);
+  }
+  await applyApprovedMutationsLocked(root, planned);
+  return typedPagePath(entityType, candidate.slug);
+}
+
+/**
+ * Promote a typed staged candidate into the live wiki under ONE held lock:
+ * acquire → re-read (abort if a concurrent reject removed it) → validate profile
+ * + re-plan + apply via {@link applyTypedCandidate} → delete → release. The
+ * candidate read, the apply, and the delete all happen inside the same locked
+ * region so no concurrent reject/approve can race the promotion.
+ *
+ * @param root - Absolute project root.
+ * @param candidateId - The staged candidate's id.
+ * @throws {Error} When the lock cannot be acquired or the candidate is missing/untyped.
+ * @throws {CandidateProfileError} When the profile no longer declares the type.
+ * @throws {CandidatePromotionBlockedError} When the re-plan blocks.
+ */
+export async function promoteCandidateUnderLock(root: string, candidateId: string): Promise<void> {
+  const acquired = await acquireLock(root);
+  if (!acquired) throw new Error("could not acquire project lock for candidate promotion");
+  try {
+    const candidate = await readCandidate(root, candidateId);
+    if (!candidate) throw new Error(`staged candidate not found: ${candidateId}`);
+    if (!candidate.targetEntityType) {
+      throw new Error(`candidate ${candidateId} is not a typed entity page`);
+    }
+    await applyTypedCandidate(root, candidate);
+    await deleteCandidate(root, candidateId);
+  } finally {
+    await releaseLock(root);
+  }
+}

--- a/src/trust/promote.ts
+++ b/src/trust/promote.ts
@@ -27,6 +27,12 @@ import { acquireLock, releaseLock } from "../utils/lock.js";
 import { planPageMutation } from "./planner.js";
 import { applyApprovedMutationsLocked } from "./executor.js";
 import { readCandidate, deleteCandidate } from "../compiler/candidates.js";
+import {
+  validateEntityFields,
+  EntityFieldContractError,
+} from "../profile/field-contract.js";
+import { parseFrontmatter } from "../utils/markdown.js";
+import type { EntityTypeDef } from "../profile/types.js";
 import type { ReviewCandidate } from "../utils/types.js";
 
 /**
@@ -66,6 +72,31 @@ function typedPagePath(entityType: string, slug: string): string {
 }
 
 /**
+ * Validate a typed candidate's body frontmatter against its entity type's
+ * declared field contract via the SHARED {@link validateEntityFields} (the same
+ * validator staging and the read-surface collector use), throwing
+ * {@link EntityFieldContractError} BEFORE the re-plan/apply when the contract is
+ * violated. Promotion then fails CLOSED and the candidate is RETAINED (the caller
+ * deletes only after a successful apply), so a contract-violating page never lands.
+ *
+ * @param entityType - The (already type-checked) profile entity type.
+ * @param candidate - The typed candidate whose body frontmatter is validated.
+ * @param def - The resolved entity type definition supplying the contract.
+ * @throws {EntityFieldContractError} When the frontmatter violates the contract.
+ */
+function assertCandidateFieldContract(
+  entityType: string,
+  candidate: ReviewCandidate,
+  def: EntityTypeDef,
+): void {
+  const { meta } = parseFrontmatter(candidate.body);
+  const violations = validateEntityFields(meta, def);
+  if (violations.length > 0) {
+    throw new EntityFieldContractError(entityType, candidate.slug, violations);
+  }
+}
+
+/**
  * Validate a typed candidate's `targetEntityType` against the active profile and
  * re-plan + apply its write — the LOCK-FREE promotion core. The caller MUST
  * already hold the project lock (so this never nests an acquire). Loads the
@@ -78,6 +109,7 @@ function typedPagePath(entityType: string, slug: string): string {
  * @param candidate - The typed candidate (must carry `targetEntityType`).
  * @returns The `wiki/<entityType>/<slug>.md` path the page was written to.
  * @throws {CandidateProfileError} When no profile declares the type.
+ * @throws {EntityFieldContractError} When the body frontmatter violates the field contract.
  * @throws {CandidatePromotionBlockedError} When the re-plan blocks (empty plan).
  */
 export async function applyTypedCandidate(
@@ -90,6 +122,7 @@ export async function applyTypedCandidate(
   if (!(entityType in loaded.profile.entities)) {
     throw new CandidateProfileError(entityType, "undeclared");
   }
+  assertCandidateFieldContract(entityType, candidate, loaded.profile.entities[entityType]!);
   const { planned } = await planPageMutation({
     root,
     entityType,

--- a/src/trust/promote.ts
+++ b/src/trust/promote.ts
@@ -32,6 +32,7 @@ import {
   EntityFieldContractError,
 } from "../profile/field-contract.js";
 import { parseFrontmatter } from "../utils/markdown.js";
+import { assertBodyWithinResourceLimit } from "./checks.js";
 import type { EntityTypeDef } from "../profile/types.js";
 import type { ReviewCandidate } from "../utils/types.js";
 
@@ -79,9 +80,14 @@ function typedPagePath(entityType: string, slug: string): string {
  * violated. Promotion then fails CLOSED and the candidate is RETAINED (the caller
  * deletes only after a successful apply), so a contract-violating page never lands.
  *
+ * The raw body-length cap is enforced FIRST (before the frontmatter parse) so a
+ * giant all-frontmatter candidate body is rejected by `.length` alone, never
+ * burning parse time — the "reject before parsing" guarantee.
+ *
  * @param entityType - The (already type-checked) profile entity type.
  * @param candidate - The typed candidate whose body frontmatter is validated.
  * @param def - The resolved entity type definition supplying the contract.
+ * @throws {ResourceLimitError} When the candidate body exceeds the resource cap.
  * @throws {EntityFieldContractError} When the frontmatter violates the contract.
  */
 function assertCandidateFieldContract(
@@ -89,6 +95,7 @@ function assertCandidateFieldContract(
   candidate: ReviewCandidate,
   def: EntityTypeDef,
 ): void {
+  assertBodyWithinResourceLimit(candidate.body);
   const { meta } = parseFrontmatter(candidate.body);
   const violations = validateEntityFields(meta, def);
   if (violations.length > 0) {

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -31,13 +31,14 @@ import {
   type StagedChange,
 } from "./staged-change.js";
 import { promoteCandidateUnderLock } from "./promote.js";
-import { writeCandidate } from "../compiler/candidates.js";
+import { writeCandidate, countCandidates } from "../compiler/candidates.js";
 import { loadNonDefaultProfile } from "../profile/block.js";
 import {
   validateEntityFields,
   EntityFieldContractError,
 } from "../profile/field-contract.js";
 import { parseFrontmatter } from "../utils/markdown.js";
+import { assertBodyWithinResourceLimit } from "./checks.js";
 import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
 
@@ -50,10 +51,15 @@ export { EntityFieldContractError } from "../profile/field-contract.js";
  * before any planning or I/O — when the contract is violated, so a contract-
  * violating typed page never persists a candidate. A clean body is a no-op.
  *
+ * The raw body-length cap is enforced FIRST (before the frontmatter parse) so a
+ * giant all-frontmatter payload is rejected by `.length` alone, never burning
+ * parse time — the "reject before parsing" guarantee.
+ *
  * @param entityType - The (already type-checked) profile entity type.
  * @param slug - The page slug (for the error message only).
  * @param body - The full markdown body whose frontmatter is validated.
  * @param profile - The profile whose entity definition supplies the contract.
+ * @throws {ResourceLimitError} When the body exceeds the resource cap.
  * @throws {EntityFieldContractError} When the frontmatter violates the contract.
  */
 function assertFieldContract(
@@ -62,6 +68,7 @@ function assertFieldContract(
   body: string,
   profile: ProfilePack,
 ): void {
+  assertBodyWithinResourceLimit(body);
   const { meta } = parseFrontmatter(body);
   const violations = validateEntityFields(meta, profile.entities[entityType]!);
   if (violations.length > 0) {
@@ -144,10 +151,12 @@ function buildPageTarget(plan: PlanResult): EntityRef {
  * persists NOTHING, so a blocked write never lands an un-promotable candidate.
  *
  * Volume bound: the PER-CALL cap (requested vs {@link DEFAULT_STAGED_WRITE_PER_CALL})
- * is self-contained and self-enforced here. The PER-SESSION cap, however, is
- * enforced against the caller-supplied `input.existingStagedCount` — there is no
- * on-disk source of truth for a running session total, so keeping that count
- * accurate across calls is the CALLER's responsibility.
+ * is self-contained and self-enforced here. The PER-SESSION cap is enforced
+ * against the REAL number of candidates ON DISK ({@link countCandidates}), not a
+ * caller hint — so an SDK caller passing `existingStagedCount: 0` on every call
+ * can never bypass the per-session cap by under-reporting. The caller hint is
+ * still honored as a floor (`max(onDisk, hint)`) so a count the caller knows
+ * about but has not yet flushed to disk also counts against the budget.
  *
  * @param root - Absolute project root.
  * @param input - The entity page to stage (caller-provided body).
@@ -161,7 +170,9 @@ export async function stageEntityPage(
   root: string,
   input: StageEntityPageInput,
 ): Promise<StagedChange> {
-  assertStagedWriteBudget(input.existingStagedCount, 1, {
+  const onDisk = await countCandidates(root);
+  const sessionCount = Math.max(onDisk, input.existingStagedCount);
+  assertStagedWriteBudget(sessionCount, 1, {
     perCall: DEFAULT_STAGED_WRITE_PER_CALL,
     perSession: DEFAULT_STAGED_WRITE_PER_SESSION,
   });
@@ -238,9 +249,10 @@ export class StagingRequiresProfileError extends Error {
 /**
  * @experimental
  * SDK staging input: the entity page to stage WITHOUT the `ProfilePack` — the SDK
- * loads the active non-default profile itself. `existingStagedCount` is the
- * caller's per-session bookkeeping (defaults to 0); the per-session cap is the
- * caller's responsibility, consistent with {@link stageEntityPage}.
+ * loads the active non-default profile itself. `existingStagedCount` (defaults to
+ * 0) is only a FLOOR hint; the per-session cap is enforced against the real
+ * on-disk candidate count by {@link stageEntityPage}, so a caller cannot bypass
+ * it by passing 0.
  */
 export interface SdkStageEntityPageInput {
   /** Profile entity type (the wiki subdirectory), e.g. `"papers"`. */

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -33,8 +33,41 @@ import {
 import { promoteCandidateUnderLock } from "./promote.js";
 import { writeCandidate } from "../compiler/candidates.js";
 import { loadNonDefaultProfile } from "../profile/block.js";
+import {
+  validateEntityFields,
+  EntityFieldContractError,
+} from "../profile/field-contract.js";
+import { parseFrontmatter } from "../utils/markdown.js";
 import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
+
+export { EntityFieldContractError } from "../profile/field-contract.js";
+
+/**
+ * Validate a staged page body's frontmatter against its entity type's declared
+ * field contract via the SHARED {@link validateEntityFields} (the same validator
+ * the read-surface collector uses), throwing {@link EntityFieldContractError} —
+ * before any planning or I/O — when the contract is violated, so a contract-
+ * violating typed page never persists a candidate. A clean body is a no-op.
+ *
+ * @param entityType - The (already type-checked) profile entity type.
+ * @param slug - The page slug (for the error message only).
+ * @param body - The full markdown body whose frontmatter is validated.
+ * @param profile - The profile whose entity definition supplies the contract.
+ * @throws {EntityFieldContractError} When the frontmatter violates the contract.
+ */
+function assertFieldContract(
+  entityType: string,
+  slug: string,
+  body: string,
+  profile: ProfilePack,
+): void {
+  const { meta } = parseFrontmatter(body);
+  const violations = validateEntityFields(meta, profile.entities[entityType]!);
+  if (violations.length > 0) {
+    throw new EntityFieldContractError(entityType, slug, violations);
+  }
+}
 
 /**
  * Thrown when a caller tries to stage a page under an `entityType` that the
@@ -100,7 +133,10 @@ function buildPageTarget(plan: PlanResult): EntityRef {
  * Stage a NON-DEFAULT entity page for review. Fails CLOSED before any I/O: it
  * first enforces the staged-write volume bound, then verifies `input.entityType`
  * is declared by `input.profile` (throwing {@link UnknownEntityTypeError} if
- * not), so an overflow or an unknown type writes nothing. It then plans the
+ * not), then validates the body's frontmatter against the entity type's declared
+ * FIELD contract (throwing {@link EntityFieldContractError} on a missing required
+ * field / enum / range violation), so an overflow, an unknown type, or a contract
+ * violation writes nothing. It then plans the
  * write through the typed planner, captures it as a {@link StagedChange}, and
  * persists it as a typed candidate carrying `targetEntityType` + `trustDecision`.
  * If the typed plan is BLOCKED (no live-write mutation — e.g. a non-slug-safe
@@ -118,6 +154,7 @@ function buildPageTarget(plan: PlanResult): EntityRef {
  * @returns The persisted {@link StagedChange}.
  * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
  * @throws {UnknownEntityTypeError} When `entityType` is not declared by the profile.
+ * @throws {EntityFieldContractError} When the body's frontmatter violates the profile field contract.
  * @throws {BlockedStagedWriteError} When the typed plan is blocked (no live write).
  */
 export async function stageEntityPage(
@@ -131,6 +168,7 @@ export async function stageEntityPage(
   if (!(input.entityType in input.profile.entities)) {
     throw new UnknownEntityTypeError(input.entityType);
   }
+  assertFieldContract(input.entityType, input.slug, input.body, input.profile);
   const plan = await planPageMutation({
     root,
     entityType: input.entityType,

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -17,6 +17,15 @@
  *
  * The DEFAULT compile/review/import path is untouched: this is an additive,
  * programmatic slice. The staged body is caller-provided (no generation).
+ *
+ * READ-INTEGRATION STATUS (honest scope). Typed entity pages are a WRITE
+ * SUBSTRATE. A promoted page is currently surfaced in `status`, the JSON export,
+ * and the wiki INDEX (pure enumeration) — but NOT YET in interlinking, semantic
+ * search / embeddings, the MOC, or the viewer. Those read surfaces are planned
+ * (Phase 4) and have real design questions (cross-type wikilink resolution,
+ * embedding-store key qualification, viewer rendering) deliberately out of scope
+ * here. Until then, do not assume a staged/promoted typed page participates in
+ * retrieval or rendering.
  */
 
 import {

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -28,16 +28,12 @@ import {
   assertStagedWriteBudget,
   DEFAULT_STAGED_WRITE_PER_CALL,
   DEFAULT_STAGED_WRITE_PER_SESSION,
-  type HeldReasonCode,
   type StagedChange,
 } from "./staged-change.js";
-import { applyApprovedMutations } from "./executor.js";
-import { writeCandidate, readCandidate, deleteCandidate } from "../compiler/candidates.js";
-import type { EntityId, ProfilePack } from "../profile/types.js";
+import { promoteCandidateUnderLock } from "./promote.js";
+import { writeCandidate } from "../compiler/candidates.js";
+import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
-
-/** Decisions under which the planner emitted a live-write mutation. */
-const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
 
 /**
  * Thrown when a caller tries to stage a page under an `entityType` that the
@@ -49,6 +45,24 @@ export class UnknownEntityTypeError extends Error {
   constructor(entityType: string) {
     super(`entity type "${entityType}" is not declared by the profile`);
     this.name = "UnknownEntityTypeError";
+  }
+}
+
+/**
+ * Thrown when staging a page whose typed plan was BLOCKED by the Write Planner
+ * (no live-write mutation — e.g. a non-slug-safe slug like `../evil`, or an
+ * oversized body). Staging fails CLOSED so a blocked/unsafe page NEVER persists
+ * a candidate that a later `review approve` could try to promote: the decision
+ * is surfaced here and nothing is written.
+ */
+export class BlockedStagedWriteError extends Error {
+  /** The non-live-write decision the planner reached for the blocked write. */
+  readonly decision: TrustDecision;
+
+  constructor(entityType: string, slug: string, decision: TrustDecision) {
+    super(`staged page ${entityType}/${slug} blocked by the write planner (${decision}); nothing written`);
+    this.name = "BlockedStagedWriteError";
+    this.decision = decision;
   }
 }
 
@@ -69,24 +83,16 @@ export interface StageEntityPageInput {
 }
 
 /**
- * Build the StagedChange `target` for a page. When the identity is slug-safe the
- * plan minted a typed {@link EntityRef}, which we reuse. When it is NOT slug-safe
- * the plan is empty (blocked) and no id was minted — we still return a typed-shape
- * target so {@link StagedChange.target} is total, casting the raw `type/slug`
- * (this target is never promoted: a blocked plan re-blocks on promotion).
+ * Build the StagedChange `target` for a page from the live mutation the planner
+ * emitted. Staging only persists a candidate for a live-write plan (a blocked
+ * plan throws {@link BlockedStagedWriteError} before this runs), so the planned
+ * mutation always carries a minted typed {@link EntityRef}.
  */
-function buildPageTarget(entityType: string, slug: string, plan: PlanResult): EntityRef {
+function buildPageTarget(plan: PlanResult): EntityRef {
   const live = plan.planned[0]?.target;
   if (live && "id" in live) return live;
-  return { entityType, slug, id: `${entityType}/${slug}` as EntityId };
-}
-
-/**
- * Why the change was held. A non-live-write decision is a real trust block;
- * otherwise the entity write is routed for review by policy in this slice.
- */
-function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
-  return LIVE_WRITE_DECISIONS.has(decision) ? ["manual-review-requested"] : ["trust-blocked"];
+  // Unreachable: stageEntityPage throws on an empty plan before building a target.
+  throw new Error("internal: staged plan has no live mutation target");
 }
 
 /**
@@ -96,6 +102,9 @@ function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
  * not), so an overflow or an unknown type writes nothing. It then plans the
  * write through the typed planner, captures it as a {@link StagedChange}, and
  * persists it as a typed candidate carrying `targetEntityType` + `trustDecision`.
+ * If the typed plan is BLOCKED (no live-write mutation — e.g. a non-slug-safe
+ * slug or an oversized body), it throws {@link BlockedStagedWriteError} and
+ * persists NOTHING, so a blocked write never lands an un-promotable candidate.
  *
  * Volume bound: the PER-CALL cap (requested vs {@link DEFAULT_STAGED_WRITE_PER_CALL})
  * is self-contained and self-enforced here. The PER-SESSION cap, however, is
@@ -108,6 +117,7 @@ function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
  * @returns The persisted {@link StagedChange}.
  * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
  * @throws {UnknownEntityTypeError} When `entityType` is not declared by the profile.
+ * @throws {BlockedStagedWriteError} When the typed plan is blocked (no live write).
  */
 export async function stageEntityPage(
   root: string,
@@ -129,6 +139,9 @@ export async function stageEntityPage(
     reviewRouted: true,
     allowOverwrite: false,
   });
+  if (plan.planned.length === 0) {
+    throw new BlockedStagedWriteError(input.entityType, input.slug, plan.decision);
+  }
   const candidate = await writeCandidate(root, {
     title: input.slug,
     slug: input.slug,
@@ -141,45 +154,30 @@ export async function stageEntityPage(
   return {
     id: candidate.id,
     kind: "page",
-    target: buildPageTarget(input.entityType, input.slug, plan),
-    operation: plan.planned[0]?.operation ?? "create",
+    target: buildPageTarget(plan),
+    operation: plan.planned[0]!.operation,
     planned: plan.planned,
-    heldReasons: heldReasonsFor(plan.decision),
+    heldReasons: ["manual-review-requested"],
     trustDecision: plan.decision,
     createdAt: (input.now ? input.now() : new Date()).toISOString(),
   };
 }
 
 /**
- * Promote a staged entity page candidate into the live wiki. Re-reads the typed
- * candidate, RE-PLANS the write (`allowOverwrite:true`, `origin:"review"`) so the
- * mandatory floor + path confinement re-run, applies it through the executor so
- * the page lands at `wiki/<entityType>/<slug>.md`, and clears the candidate.
- *
- * If the candidate is missing/untyped, or the re-plan blocks (empty plan), it
- * throws and the candidate is RETAINED — nothing partial ever lands.
+ * Promote a staged entity page candidate into the live wiki by delegating to the
+ * shared {@link promoteCandidateUnderLock} routine — the SAME under-lock read →
+ * validate-profile → re-plan → apply → delete sequence `review approve` uses for
+ * its typed branch (DRY). Holding ONE lock across read+apply+delete closes the
+ * concurrent-reject race, and re-validating the candidate's `targetEntityType`
+ * against the freshly-loaded profile refuses a type the profile no longer
+ * declares — the page lands at `wiki/<entityType>/<slug>.md` or nothing does.
  *
  * @param root - Absolute project root.
  * @param candidateId - The staged candidate's id.
- * @throws {Error} When the candidate is missing, untyped, or its re-plan blocks.
+ * @throws {Error} When the candidate is missing or untyped.
+ * @throws {CandidateProfileError} When the profile no longer declares the type.
+ * @throws {CandidatePromotionBlockedError} When the re-plan blocks (empty plan).
  */
 export async function promoteStagedEntityPage(root: string, candidateId: string): Promise<void> {
-  const candidate = await readCandidate(root, candidateId);
-  if (!candidate) throw new Error(`staged candidate not found: ${candidateId}`);
-  const entityType = candidate.targetEntityType;
-  if (!entityType) throw new Error(`candidate ${candidateId} is not a typed entity page`);
-  const { planned } = await planPageMutation({
-    root,
-    entityType,
-    slug: candidate.slug,
-    body: candidate.body,
-    origin: "review",
-    reviewRouted: false,
-    allowOverwrite: true,
-  });
-  if (planned.length === 0) {
-    throw new Error(`staged candidate ${candidateId} blocked by the write planner; retained`);
-  }
-  await applyApprovedMutations(root, planned);
-  await deleteCandidate(root, candidateId);
+  await promoteCandidateUnderLock(root, candidateId);
 }

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -1,0 +1,161 @@
+/**
+ * @file src/trust/staging.ts
+ * @description SDK-level NON-DEFAULT entity page staging loop (CLP Phase-3 PR6).
+ *
+ * Proves the full staging round-trip through the Write Planner WITHOUT any LLM:
+ *
+ *  1. {@link stageEntityPage} plans a non-default entity write via the TYPED
+ *     {@link planPageMutation}, enforces the fail-closed staged-write volume
+ *     bound ({@link assertStagedWriteBudget}) BEFORE persisting anything, builds a
+ *     {@link StagedChange} wrapping the planned mutation, and persists it as a
+ *     typed review candidate (`targetEntityType` + `trustDecision`) — the
+ *     candidate store IS the staging mechanism per the Phase-2 spec.
+ *  2. {@link promoteStagedEntityPage} re-reads that candidate, RE-PLANS the write
+ *     (so the mandatory floor + path-confinement re-run at promotion time), and
+ *     applies it through the executor so the page lands at
+ *     `wiki/<entityType>/<slug>.md`, then clears the candidate.
+ *
+ * The DEFAULT compile/review/import path is untouched: this is an additive,
+ * programmatic slice. The staged body is caller-provided (no generation).
+ */
+
+import {
+  planPageMutation,
+  type EntityRef,
+  type PlanResult,
+} from "./planner.js";
+import {
+  assertStagedWriteBudget,
+  DEFAULT_STAGED_WRITE_PER_CALL,
+  DEFAULT_STAGED_WRITE_PER_SESSION,
+  type HeldReasonCode,
+  type StagedChange,
+} from "./staged-change.js";
+import { applyApprovedMutations } from "./executor.js";
+import { isSlugSafe } from "../profile/identity.js";
+import { writeCandidate, readCandidate, deleteCandidate } from "../compiler/candidates.js";
+import type { EntityId, ProfilePack } from "../profile/types.js";
+import type { TrustDecision } from "./decision.js";
+
+/** Decisions under which the planner emitted a live-write mutation. */
+const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
+
+/** Inputs to {@link stageEntityPage}; the body is caller-provided (no LLM). */
+export interface StageEntityPageInput {
+  /** Profile entity type (the wiki subdirectory), e.g. `"papers"`. */
+  entityType: string;
+  /** Page slug (the filename stem); may be invalid — the planner decides. */
+  slug: string;
+  /** Full markdown body (frontmatter + prose) to stage verbatim. */
+  body: string;
+  /** The loaded non-default profile this page belongs to. */
+  profile: ProfilePack;
+  /** Staged writes already held this session (for the volume bound). */
+  existingStagedCount: number;
+  /** Injectable clock for deterministic `createdAt` (defaults to now). */
+  now?: () => Date;
+}
+
+/**
+ * Build the StagedChange `target` for a page. When the identity is slug-safe the
+ * plan minted a typed {@link EntityRef}, which we reuse. When it is NOT slug-safe
+ * the plan is empty (blocked) and no id was minted — we still return a typed-shape
+ * target so {@link StagedChange.target} is total, casting the raw `type/slug`
+ * (this target is never promoted: a blocked plan re-blocks on promotion).
+ */
+function buildPageTarget(entityType: string, slug: string, plan: PlanResult): EntityRef {
+  const live = plan.planned[0]?.target;
+  if (live && "id" in live) return live;
+  return { entityType, slug, id: `${entityType}/${slug}` as EntityId };
+}
+
+/**
+ * Why the change was held. A non-live-write decision is a real trust block;
+ * otherwise the entity write is routed for review by policy in this slice.
+ */
+function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
+  return LIVE_WRITE_DECISIONS.has(decision) ? ["manual-review-requested"] : ["trust-blocked"];
+}
+
+/**
+ * Stage a NON-DEFAULT entity page for review. Enforces the fail-closed staged
+ * write budget FIRST (so an overflow writes nothing), plans the write through the
+ * typed planner, captures it as a {@link StagedChange}, and persists it as a
+ * typed candidate carrying `targetEntityType` + `trustDecision`.
+ *
+ * @param root - Absolute project root.
+ * @param input - The entity page to stage (caller-provided body).
+ * @returns The persisted {@link StagedChange}.
+ * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
+ */
+export async function stageEntityPage(
+  root: string,
+  input: StageEntityPageInput,
+): Promise<StagedChange> {
+  assertStagedWriteBudget(input.existingStagedCount, 1, {
+    perCall: DEFAULT_STAGED_WRITE_PER_CALL,
+    perSession: DEFAULT_STAGED_WRITE_PER_SESSION,
+  });
+  const plan = await planPageMutation({
+    root,
+    entityType: input.entityType,
+    slug: input.slug,
+    body: input.body,
+    origin: "sdk",
+    reviewRouted: true,
+    allowOverwrite: false,
+  });
+  const candidate = await writeCandidate(root, {
+    title: input.slug,
+    slug: input.slug,
+    summary: "",
+    sources: [],
+    body: input.body,
+    targetEntityType: input.entityType,
+    trustDecision: plan.decision,
+  });
+  return {
+    id: candidate.id,
+    kind: "page",
+    target: buildPageTarget(input.entityType, input.slug, plan),
+    operation: plan.planned[0]?.operation ?? "create",
+    planned: plan.planned,
+    heldReasons: heldReasonsFor(plan.decision),
+    trustDecision: plan.decision,
+    createdAt: (input.now ? input.now() : new Date()).toISOString(),
+  };
+}
+
+/**
+ * Promote a staged entity page candidate into the live wiki. Re-reads the typed
+ * candidate, RE-PLANS the write (`allowOverwrite:true`, `origin:"review"`) so the
+ * mandatory floor + path confinement re-run, applies it through the executor so
+ * the page lands at `wiki/<entityType>/<slug>.md`, and clears the candidate.
+ *
+ * If the candidate is missing/untyped, or the re-plan blocks (empty plan), it
+ * throws and the candidate is RETAINED — nothing partial ever lands.
+ *
+ * @param root - Absolute project root.
+ * @param candidateId - The staged candidate's id.
+ * @throws {Error} When the candidate is missing, untyped, or its re-plan blocks.
+ */
+export async function promoteStagedEntityPage(root: string, candidateId: string): Promise<void> {
+  const candidate = await readCandidate(root, candidateId);
+  if (!candidate) throw new Error(`staged candidate not found: ${candidateId}`);
+  const entityType = candidate.targetEntityType;
+  if (!entityType) throw new Error(`candidate ${candidateId} is not a typed entity page`);
+  const { planned } = await planPageMutation({
+    root,
+    entityType,
+    slug: candidate.slug,
+    body: candidate.body,
+    origin: "review",
+    reviewRouted: false,
+    allowOverwrite: true,
+  });
+  if (planned.length === 0) {
+    throw new Error(`staged candidate ${candidateId} blocked by the write planner; retained`);
+  }
+  await applyApprovedMutations(root, planned);
+  await deleteCandidate(root, candidateId);
+}

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -32,6 +32,7 @@ import {
 } from "./staged-change.js";
 import { promoteCandidateUnderLock } from "./promote.js";
 import { writeCandidate } from "../compiler/candidates.js";
+import { loadNonDefaultProfile } from "../profile/block.js";
 import type { ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
 
@@ -180,4 +181,63 @@ export async function stageEntityPage(
  */
 export async function promoteStagedEntityPage(root: string, candidateId: string): Promise<void> {
   await promoteCandidateUnderLock(root, candidateId);
+}
+
+/**
+ * @experimental
+ * Thrown when the SDK staging entry point is called on a project that has NO
+ * non-default profile. Staging targets a typed `wiki/<entityType>/<slug>.md`
+ * path, which only a non-default profile declares — so a default project cannot
+ * stage. Fails CLOSED before any planning or I/O.
+ */
+export class StagingRequiresProfileError extends Error {
+  constructor() {
+    super("staging requires a non-default profile; this project has none");
+    this.name = "StagingRequiresProfileError";
+  }
+}
+
+/**
+ * @experimental
+ * SDK staging input: the entity page to stage WITHOUT the `ProfilePack` — the SDK
+ * loads the active non-default profile itself. `existingStagedCount` is the
+ * caller's per-session bookkeeping (defaults to 0); the per-session cap is the
+ * caller's responsibility, consistent with {@link stageEntityPage}.
+ */
+export interface SdkStageEntityPageInput {
+  /** Profile entity type (the wiki subdirectory), e.g. `"papers"`. */
+  entityType: string;
+  /** Page slug (the filename stem); may be invalid — the planner decides. */
+  slug: string;
+  /** Full markdown body (frontmatter + prose) to stage verbatim. */
+  body: string;
+  /** Staged writes already held this session (for the volume bound). Defaults to 0. */
+  existingStagedCount?: number;
+}
+
+/**
+ * @experimental
+ * SDK entry point for staging a non-default entity page: loads the active
+ * non-default profile INTERNALLY (throwing {@link StagingRequiresProfileError}
+ * when the project has none) and delegates to {@link stageEntityPage}. The caller
+ * never passes a {@link ProfilePack} — the SDK owns it.
+ *
+ * @param root - Absolute project root.
+ * @param input - The entity page to stage (no profile; body caller-provided).
+ * @returns The persisted {@link StagedChange}.
+ * @throws {StagingRequiresProfileError} When the project has no non-default profile.
+ */
+export async function stageEntityPageForProject(
+  root: string,
+  input: SdkStageEntityPageInput,
+): Promise<StagedChange> {
+  const loaded = await loadNonDefaultProfile(root);
+  if (!loaded) throw new StagingRequiresProfileError();
+  return stageEntityPage(root, {
+    entityType: input.entityType,
+    slug: input.slug,
+    body: input.body,
+    profile: loaded.profile,
+    existingStagedCount: input.existingStagedCount ?? 0,
+  });
 }

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -32,13 +32,25 @@ import {
   type StagedChange,
 } from "./staged-change.js";
 import { applyApprovedMutations } from "./executor.js";
-import { isSlugSafe } from "../profile/identity.js";
 import { writeCandidate, readCandidate, deleteCandidate } from "../compiler/candidates.js";
 import type { EntityId, ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
 
 /** Decisions under which the planner emitted a live-write mutation. */
 const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
+
+/**
+ * Thrown when a caller tries to stage a page under an `entityType` that the
+ * supplied {@link ProfilePack} does not declare. Staging fails CLOSED before any
+ * planning or I/O so an unknown type can never land `wiki/<type>/<slug>.md`
+ * outside the profile schema.
+ */
+export class UnknownEntityTypeError extends Error {
+  constructor(entityType: string) {
+    super(`entity type "${entityType}" is not declared by the profile`);
+    this.name = "UnknownEntityTypeError";
+  }
+}
 
 /** Inputs to {@link stageEntityPage}; the body is caller-provided (no LLM). */
 export interface StageEntityPageInput {
@@ -78,15 +90,24 @@ function heldReasonsFor(decision: TrustDecision): HeldReasonCode[] {
 }
 
 /**
- * Stage a NON-DEFAULT entity page for review. Enforces the fail-closed staged
- * write budget FIRST (so an overflow writes nothing), plans the write through the
- * typed planner, captures it as a {@link StagedChange}, and persists it as a
- * typed candidate carrying `targetEntityType` + `trustDecision`.
+ * Stage a NON-DEFAULT entity page for review. Fails CLOSED before any I/O: it
+ * first enforces the staged-write volume bound, then verifies `input.entityType`
+ * is declared by `input.profile` (throwing {@link UnknownEntityTypeError} if
+ * not), so an overflow or an unknown type writes nothing. It then plans the
+ * write through the typed planner, captures it as a {@link StagedChange}, and
+ * persists it as a typed candidate carrying `targetEntityType` + `trustDecision`.
+ *
+ * Volume bound: the PER-CALL cap (requested vs {@link DEFAULT_STAGED_WRITE_PER_CALL})
+ * is self-contained and self-enforced here. The PER-SESSION cap, however, is
+ * enforced against the caller-supplied `input.existingStagedCount` — there is no
+ * on-disk source of truth for a running session total, so keeping that count
+ * accurate across calls is the CALLER's responsibility.
  *
  * @param root - Absolute project root.
  * @param input - The entity page to stage (caller-provided body).
  * @returns The persisted {@link StagedChange}.
  * @throws {StagedWriteOverflowError} When the staged-write volume bound is hit.
+ * @throws {UnknownEntityTypeError} When `entityType` is not declared by the profile.
  */
 export async function stageEntityPage(
   root: string,
@@ -96,6 +117,9 @@ export async function stageEntityPage(
     perCall: DEFAULT_STAGED_WRITE_PER_CALL,
     perSession: DEFAULT_STAGED_WRITE_PER_SESSION,
   });
+  if (!(input.entityType in input.profile.entities)) {
+    throw new UnknownEntityTypeError(input.entityType);
+  }
   const plan = await planPageMutation({
     root,
     entityType: input.entityType,

--- a/src/utils/candidate-store.ts
+++ b/src/utils/candidate-store.ts
@@ -15,7 +15,7 @@ import path from "path";
 import { safeReadFile } from "./markdown.js";
 
 /** Extension used for all candidate JSON files. */
-export const CANDIDATE_JSON_EXT = ".json";
+const CANDIDATE_JSON_EXT = ".json";
 
 /**
  * Turn a dotted candidate id into a single filesystem-safe path segment.

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,7 +4,7 @@
  * for wiki pages.
  */
 
-import { writeFile, rename, readFile, mkdir } from "fs/promises";
+import { writeFile, rename, readFile, mkdir, lstat } from "fs/promises";
 import path from "path";
 import yaml from "js-yaml";
 import type {
@@ -128,9 +128,30 @@ export function parseFrontmatterStatus(content: string): {
   return { meta, body: match[2], hasFrontmatterBlock: true, malformedFrontmatter };
 }
 
-/** Atomically write a file (write to .tmp, then rename). */
+/**
+ * Atomically write a file (write to .tmp, then rename).
+ *
+ * Defense against the confine→write race (S3): callers resolve `filePath` with
+ * `confineUnderRoot(..., {mustExist:false})`, which returns a LEXICAL path after
+ * checking the nearest EXISTING ancestor. Between that check and this write, the
+ * final directory can be swapped for a symlink that escapes the project root, so
+ * the rename would land outside root. `atomicWrite` lacks root context, so it
+ * fails CLOSED on the actual escape vector: immediately before writing, it
+ * `lstat`s the parent directory and refuses if it is a SYMLINK. Project writes
+ * always target real directories, so this never rejects a legitimate write; it
+ * matches the wider trust model (a symlinked dir is never trusted).
+ *
+ * @param filePath - Absolute destination path (its parent must be a real dir).
+ * @param content - File contents to write.
+ * @throws If the resolved parent directory is a symlink (confine→write escape).
+ */
 export async function atomicWrite(filePath: string, content: string): Promise<void> {
-  await mkdir(path.dirname(filePath), { recursive: true });
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const dirStat = await lstat(dir);
+  if (dirStat.isSymbolicLink()) {
+    throw new Error(`refusing to write through a symlinked directory: ${dir}`);
+  }
   const tmpPath = filePath + ".tmp";
   await writeFile(tmpPath, content, "utf-8");
   await rename(tmpPath, filePath);

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -24,7 +24,39 @@ import { existsSync } from "fs";
 import path from "path";
 import { LLMWIKI_DIR, STATE_FILE } from "./constants.js";
 import { note } from "./output.js";
+import { mintConceptEntities } from "../state/migrate.js";
 import type { WikiState, SourceState } from "./types.js";
+
+/** The schema version that carries the typed-ownership mirror. */
+const TYPED_MIRROR_VERSION = 2;
+
+/**
+ * Re-derive the v2 typed-ownership mirror from the v1 string lists so the two
+ * never desync, regardless of which writer produced the state. For a v2 state
+ * each source's `entities` is re-derived from its `concepts` and the top-level
+ * `frozenEntities` from `frozenSlugs`, using the SAME tolerant minting as the
+ * migration ({@link mintConceptEntities}) so non-slug-safe (e.g. Unicode) slugs
+ * are simply absent from the typed mirror rather than aborting the write.
+ *
+ * For a v1 state this is a STRICT no-op — the input is returned unchanged so the
+ * default-profile (v1) on-disk bytes are byte-identical to before.
+ *
+ * NOTE: this re-derives the CONCEPTS mirror only. A later phase that introduces
+ * non-concept typed entities must extend this to preserve those, since blindly
+ * re-deriving from `concepts` would drop them.
+ */
+export function syncEntityMirror(state: WikiState): WikiState {
+  if (state.version !== TYPED_MIRROR_VERSION) return state;
+  const sources: Record<string, SourceState> = {};
+  for (const [file, source] of Object.entries(state.sources)) {
+    sources[file] = { ...source, entities: mintConceptEntities(source.concepts) };
+  }
+  return {
+    ...state,
+    sources,
+    frozenEntities: mintConceptEntities(state.frozenSlugs ?? []),
+  };
+}
 
 function emptyState(): WikiState {
   return { version: 1, indexHash: "", sources: {} };
@@ -174,7 +206,10 @@ export async function writeState(root: string, state: WikiState): Promise<void> 
   const filePath = path.join(root, STATE_FILE);
   const tmpPath = filePath + ".tmp";
 
-  await writeFile(tmpPath, JSON.stringify(state, null, 2), "utf-8");
+  // Re-derive the v2 typed mirror at the single write choke point so no writer
+  // can persist a desynced `entities` / `frozenEntities`. No-op for v1 states.
+  const synced = syncEntityMirror(state);
+  await writeFile(tmpPath, JSON.stringify(synced, null, 2), "utf-8");
   await rename(tmpPath, filePath);
 }
 

--- a/test/atomic-write-confine-race.test.ts
+++ b/test/atomic-write-confine-race.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @file test/atomic-write-confine-race.test.ts
+ * @description FIX S3 — close the confine→write TOCTOU window in `atomicWrite`.
+ *
+ * Callers resolve a write target with `confineUnderRoot(..., {mustExist:false})`,
+ * which returns a LEXICAL path after checking the nearest EXISTING ancestor.
+ * Between that check and the rename, the final directory can be swapped for a
+ * symlink that escapes the project root, so the write would land outside.
+ *
+ * `atomicWrite` lacks root context, so it fails CLOSED on the actual escape
+ * vector: it refuses to write when its parent directory is a SYMLINK. This test
+ * mirrors the confirmed exploit — confine a path under a real dir, replace that
+ * dir with a symlink to an out-of-tree location, then attempt the write — and
+ * asserts nothing is written outside the project.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, rename, symlink, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { confineUnderRoot } from "../src/utils/path-confine.js";
+import { atomicWrite } from "../src/utils/markdown.js";
+
+let root = "";
+let outside = "";
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  if (outside) await rm(outside, { recursive: true, force: true });
+  root = outside = "";
+});
+
+describe("atomicWrite confine→write race (S3)", () => {
+  it("refuses to write through a final dir swapped to an escaping symlink", async () => {
+    root = await mkdtemp(path.join(tmpdir(), "s3-root-"));
+    outside = await mkdtemp(path.join(tmpdir(), "s3-out-"));
+    await mkdir(path.join(root, "concepts"), { recursive: true });
+
+    // Confinement passes against the REAL dir (the legitimate pre-write state).
+    const target = await confineUnderRoot("concepts/leak.md", root, { mustExist: false });
+
+    // Race: swap the confined parent dir for a symlink that escapes root.
+    await rename(path.join(root, "concepts"), path.join(root, "concepts.real"));
+    await symlink(outside, path.join(root, "concepts"), "dir");
+
+    await expect(atomicWrite(target, "secret")).rejects.toThrow(/symlink/i);
+    expect(existsSync(path.join(outside, "leak.md"))).toBe(false); // nothing escaped
+    expect(await readdir(outside)).toHaveLength(0);
+  });
+
+  it("still writes normally into a real directory", async () => {
+    root = await mkdtemp(path.join(tmpdir(), "s3-ok-"));
+    await mkdir(path.join(root, "concepts"), { recursive: true });
+    const target = path.join(root, "concepts", "page.md");
+    await atomicWrite(target, "body");
+    expect(existsSync(target)).toBe(true);
+  });
+});

--- a/test/candidate-id-safety.test.ts
+++ b/test/candidate-id-safety.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @file test/candidate-id-safety.test.ts
+ * @description Path-traversal hardening for candidate ids/slugs (FIX #2).
+ *
+ * `writeCandidate` builds a candidate id as `${slug}-${hex}` and the path
+ * helpers join that id straight into `.llmwiki/candidates/`. A traversal-bearing
+ * slug (`../evil`) would make the id a path-escape string. These tests pin that:
+ *  - `writeCandidate` REFUSES an unsafe slug (typed error, nothing written);
+ *  - a normal safe candidate still round-trips identically (byte-for-byte body);
+ *  - no file is ever written outside the candidates dir.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdir, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import {
+  writeCandidate,
+  readCandidate,
+  UnsafeCandidateIdError,
+} from "../src/compiler/candidates.js";
+import { CANDIDATES_DIR } from "../src/utils/constants.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+const BODY = "---\ntitle: Safe\n---\n\nBody.\n";
+
+/** A safe candidate draft for `slug` with a fixed body. */
+function draftFor(slug: string) {
+  return { title: slug, slug, summary: "", sources: [], body: BODY };
+}
+
+describe("candidate id/slug path-traversal safety", () => {
+  it("refuses an unsafe traversal slug and writes nothing", async () => {
+    await expect(writeCandidate(root.dir, draftFor("../evil"))).rejects.toBeInstanceOf(
+      UnsafeCandidateIdError,
+    );
+    const dir = path.join(root.dir, CANDIDATES_DIR);
+    const files = existsSync(dir) ? await readdir(dir) : [];
+    expect(files.filter((f) => f.endsWith(".json"))).toHaveLength(0);
+  });
+
+  it("refuses a slug containing a path separator and writes nothing", async () => {
+    await expect(writeCandidate(root.dir, draftFor("nested/evil"))).rejects.toBeInstanceOf(
+      UnsafeCandidateIdError,
+    );
+    expect(existsSync(path.join(root.dir, "nested"))).toBe(false);
+  });
+
+  it("does not escape the candidates dir for a deep traversal slug", async () => {
+    await expect(
+      writeCandidate(root.dir, draftFor("../../outside")),
+    ).rejects.toBeInstanceOf(UnsafeCandidateIdError);
+    expect(existsSync(path.join(path.dirname(root.dir), "outside.json"))).toBe(false);
+  });
+
+  it("round-trips a normal safe candidate identically", async () => {
+    const created = await writeCandidate(root.dir, draftFor("attention-rag"));
+    expect(created.id).toMatch(/^attention-rag-[0-9a-f]{8}$/);
+    const loaded = await readCandidate(root.dir, created.id);
+    expect(loaded?.body).toBe(BODY);
+    const file = path.join(root.dir, CANDIDATES_DIR, `${created.id}.json`);
+    expect(JSON.parse(await readFile(file, "utf8")).slug).toBe("attention-rag");
+  });
+});

--- a/test/candidate-identity-dedup.test.ts
+++ b/test/candidate-identity-dedup.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @file test/candidate-identity-dedup.test.ts
+ * @description Cross-entity-type candidate dedup (FIX #2 — data loss).
+ *
+ * Candidate duplicate detection must key on the FULL target identity
+ * (target-type + slug), not slug alone. Staging `papers/foo` then `ideas/foo`
+ * must persist TWO candidate files — neither silently dropped — while writing
+ * the SAME `papers/foo` twice canonicalizes to one (same-type same-slug IS a
+ * duplicate). A DEFAULT concepts candidate (no typed target) dedups EXACTLY as
+ * before: two concepts candidates for one slug collapse to a single file.
+ */
+
+import { describe, it, expect } from "vitest";
+import { listCandidates, writeCandidate } from "../src/compiler/candidates.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+/** Build a typed candidate draft for an entity type + slug. */
+function typedDraft(entityType: string, slug: string, body: string) {
+  return { title: slug, slug, summary: "", sources: [], body, targetEntityType: entityType };
+}
+
+/** Build a DEFAULT concepts candidate draft (no typed target). */
+function conceptsDraft(slug: string, body: string) {
+  return { title: slug, slug, summary: "", sources: [], body };
+}
+
+/** Write two candidate drafts in order and return every persisted candidate. */
+async function writeBothThenList(
+  firstDraft: Parameters<typeof writeCandidate>[1],
+  secondDraft: Parameters<typeof writeCandidate>[1],
+) {
+  const first = await writeCandidate(root.dir, firstDraft);
+  await writeCandidate(root.dir, secondDraft);
+  return { first, all: await listCandidates(root.dir) };
+}
+
+/**
+ * Write two drafts that share one target identity, then assert they collapse to
+ * a SINGLE canonical file (same id, latest body wins).
+ */
+async function expectCollapsesToOne(
+  firstDraft: Parameters<typeof writeCandidate>[1],
+  secondDraft: Parameters<typeof writeCandidate>[1],
+): Promise<void> {
+  const { first, all } = await writeBothThenList(firstDraft, secondDraft);
+  expect(all).toHaveLength(1);
+  expect(all[0]?.id).toBe(first.id);
+  expect(all[0]?.body).toBe(secondDraft.body);
+}
+
+describe("candidate dedup keys on full target identity (FIX #2)", () => {
+  it("keeps papers/foo and ideas/foo as TWO distinct candidates", async () => {
+    const { all } = await writeBothThenList(
+      typedDraft("papers", "foo", "paper body"),
+      typedDraft("ideas", "foo", "idea body"),
+    );
+    expect(all).toHaveLength(2);
+    const byType = Object.fromEntries(all.map((c) => [c.targetEntityType, c.body]));
+    expect(byType).toEqual({ papers: "paper body", ideas: "idea body" });
+  });
+
+  it("canonicalizes the SAME papers/foo written twice to one file (same identity)", async () => {
+    await expectCollapsesToOne(typedDraft("papers", "foo", "v1"), typedDraft("papers", "foo", "v2"));
+  });
+
+  it("dedups two DEFAULT concepts candidates for one slug to one file (unchanged)", async () => {
+    await expectCollapsesToOne(conceptsDraft("topic", "first"), conceptsDraft("topic", "second"));
+  });
+
+  it("keeps a typed papers/foo and a default concepts foo as distinct", async () => {
+    const { all } = await writeBothThenList(
+      conceptsDraft("foo", "concept body"),
+      typedDraft("papers", "foo", "paper body"),
+    );
+    expect(all).toHaveLength(2);
+  });
+});

--- a/test/candidate-store-confinement.test.ts
+++ b/test/candidate-store-confinement.test.ts
@@ -18,10 +18,9 @@
  * while a NORMAL candidates dir still round-trips a candidate identically.
  */
 
-import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, readdir, symlink, writeFile } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
+import { mkdir, readdir, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import {
   writeCandidate,
   readCandidate,
@@ -31,9 +30,9 @@ import {
 } from "../src/compiler/candidates.js";
 import { UnsafeCandidateDirError } from "../src/compiler/candidate-store-paths.js";
 import { LLMWIKI_DIR } from "../src/utils/constants.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
 
-let root = "";
-let outside = "";
+const ctx = useConfinementRoots("candidate");
 
 const BODY = "---\ntitle: Safe\n---\n\nBody.\n";
 
@@ -44,68 +43,57 @@ function draftFor(slug: string) {
 
 /** Make `.llmwiki/candidates` a SYMLINK to the out-of-tree `outside` dir. */
 async function symlinkCandidatesOutside(): Promise<void> {
-  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
-  await symlink(outside, path.join(root, LLMWIKI_DIR, "candidates"), "dir");
+  await mkdir(path.join(ctx.root, LLMWIKI_DIR), { recursive: true });
+  await symlink(ctx.outside, path.join(ctx.root, LLMWIKI_DIR, "candidates"), "dir");
 }
 
 /** Names of entries currently in the out-of-tree dir. */
 async function outsideEntries(): Promise<string[]> {
-  return readdir(outside);
+  return readdir(ctx.outside);
 }
-
-beforeEach(async () => {
-  root = await mkdtemp(path.join(os.tmpdir(), "candidate-confine-"));
-  outside = await mkdtemp(path.join(os.tmpdir(), "candidate-outside-"));
-});
-
-afterEach(async () => {
-  if (root) await rm(root, { recursive: true, force: true });
-  if (outside) await rm(outside, { recursive: true, force: true });
-  root = outside = "";
-});
 
 describe("candidate store — symlinked candidates dir (filesystem tampering)", () => {
   it("writeCandidate REFUSES and creates nothing outside root", async () => {
     await symlinkCandidatesOutside();
-    await expect(writeCandidate(root, draftFor("safe"))).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(writeCandidate(ctx.root, draftFor("safe"))).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toHaveLength(0);
   });
 
   it("readCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
-    await writeFile(path.join(outside, "planted.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "planted.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(readCandidate(root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(readCandidate(ctx.root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["planted.json"]);
   });
 
   it("deleteCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
-    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "victim.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(deleteCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(deleteCandidate(ctx.root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["victim.json"]);
   });
 
   it("archiveCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
-    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "victim.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(archiveCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(archiveCandidate(ctx.root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["victim.json"]);
   });
 
   it("listCandidates over the symlinked dir fails closed, never reading through it", async () => {
-    await writeFile(path.join(outside, "leak.json"), "{}", "utf8");
+    await writeFile(path.join(ctx.outside, "leak.json"), "{}", "utf8");
     await symlinkCandidatesOutside();
-    await expect(listCandidates(root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    await expect(listCandidates(ctx.root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
     expect(await outsideEntries()).toEqual(["leak.json"]);
   });
 });
 
 describe("candidate store — normal dir regression", () => {
   it("round-trips a candidate identically through a REAL candidates dir", async () => {
-    const created = await writeCandidate(root, draftFor("attention-rag"));
+    const created = await writeCandidate(ctx.root, draftFor("attention-rag"));
     expect(created.id).toMatch(/^attention-rag-[0-9a-f]{8}$/);
-    const loaded = await readCandidate(root, created.id);
+    const loaded = await readCandidate(ctx.root, created.id);
     expect(loaded?.body).toBe(BODY);
-    expect(await listCandidates(root)).toHaveLength(1);
+    expect(await listCandidates(ctx.root)).toHaveLength(1);
   });
 });

--- a/test/candidate-store-confinement.test.ts
+++ b/test/candidate-store-confinement.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @file test/candidate-store-confinement.test.ts
+ * @description Fail-closed coverage for candidate-store directory confinement
+ * (Phase-3 hardening, FIX #1).
+ *
+ * Before this guard, `resolveCandidatePath` validated only the candidate id and a
+ * LEXICAL prefix — it never REALPATH-confined the candidates directory. So a
+ * symlinked `.llmwiki/candidates -> /tmp/outside` made `writeCandidate` (and
+ * read/delete/archive/list) operate OUTSIDE the project root.
+ *
+ * The store now resolves every candidate path through `confineUnderRoot`, which
+ * realpath-confines the nearest existing ancestor under root, and lists/scans the
+ * candidates directory only after a realpath dir check that fails CLOSED on an
+ * existing-but-escaping symlink (absent dir → empty, never a write through it).
+ *
+ * These tests mirror `test/trust-journal-confinement.test.ts`: a symlinked
+ * candidates dir refuses every operation and leaves the out-of-tree dir empty,
+ * while a NORMAL candidates dir still round-trips a candidate identically.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, readdir, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  writeCandidate,
+  readCandidate,
+  deleteCandidate,
+  archiveCandidate,
+  listCandidates,
+} from "../src/compiler/candidates.js";
+import { UnsafeCandidateDirError } from "../src/compiler/candidate-store-paths.js";
+import { LLMWIKI_DIR } from "../src/utils/constants.js";
+
+let root = "";
+let outside = "";
+
+const BODY = "---\ntitle: Safe\n---\n\nBody.\n";
+
+/** A safe candidate draft for `slug` with a fixed body. */
+function draftFor(slug: string) {
+  return { title: slug, slug, summary: "", sources: [], body: BODY };
+}
+
+/** Make `.llmwiki/candidates` a SYMLINK to the out-of-tree `outside` dir. */
+async function symlinkCandidatesOutside(): Promise<void> {
+  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+  await symlink(outside, path.join(root, LLMWIKI_DIR, "candidates"), "dir");
+}
+
+/** Names of entries currently in the out-of-tree dir. */
+async function outsideEntries(): Promise<string[]> {
+  return readdir(outside);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "candidate-confine-"));
+  outside = await mkdtemp(path.join(os.tmpdir(), "candidate-outside-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  if (outside) await rm(outside, { recursive: true, force: true });
+  root = outside = "";
+});
+
+describe("candidate store — symlinked candidates dir (filesystem tampering)", () => {
+  it("writeCandidate REFUSES and creates nothing outside root", async () => {
+    await symlinkCandidatesOutside();
+    await expect(writeCandidate(root, draftFor("safe"))).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toHaveLength(0);
+  });
+
+  it("readCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(outside, "planted.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(readCandidate(root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["planted.json"]);
+  });
+
+  it("deleteCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(deleteCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["victim.json"]);
+  });
+
+  it("archiveCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(outside, "victim.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(archiveCandidate(root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["victim.json"]);
+  });
+
+  it("listCandidates over the symlinked dir fails closed, never reading through it", async () => {
+    await writeFile(path.join(outside, "leak.json"), "{}", "utf8");
+    await symlinkCandidatesOutside();
+    await expect(listCandidates(root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["leak.json"]);
+  });
+});
+
+describe("candidate store — normal dir regression", () => {
+  it("round-trips a candidate identically through a REAL candidates dir", async () => {
+    const created = await writeCandidate(root, draftFor("attention-rag"));
+    expect(created.id).toMatch(/^attention-rag-[0-9a-f]{8}$/);
+    const loaded = await readCandidate(root, created.id);
+    expect(loaded?.body).toBe(BODY);
+    expect(await listCandidates(root)).toHaveLength(1);
+  });
+});

--- a/test/fixtures/confinement-roots.ts
+++ b/test/fixtures/confinement-roots.ts
@@ -1,0 +1,50 @@
+/**
+ * @file test/fixtures/confinement-roots.ts
+ * @description Shared tmp-root lifecycle for candidate-store confinement tests.
+ *
+ * Both the concept-store and rule-store confinement suites need the same pair
+ * of out-of-tree temp directories — an in-project `root` and an `outside`
+ * directory a symlink can be pointed at — created in `beforeEach` and removed in
+ * `afterEach`. Extracting the lifecycle here removes the duplicated boilerplate
+ * (flagged by fallow) while keeping each suite's symlink/assertion logic local.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { beforeEach, afterEach } from "vitest";
+
+/**
+ * Mutable context populated by {@link useConfinementRoots}. `root` is the
+ * in-project root; `outside` is an out-of-tree dir a symlink can target.
+ */
+export interface ConfinementRoots {
+  /** Absolute path of the current test's in-project temp root. */
+  root: string;
+  /** Absolute path of the current test's out-of-tree (escape-target) dir. */
+  outside: string;
+}
+
+/**
+ * Register beforeEach/afterEach hooks that create and tear down the `root` and
+ * `outside` temp directories for a confinement suite.
+ *
+ * @param label - Short prefix used to name both temp directories.
+ * @returns Mutable context whose fields are set fresh for each test.
+ */
+export function useConfinementRoots(label: string): ConfinementRoots {
+  const ctx: ConfinementRoots = { root: "", outside: "" };
+
+  beforeEach(async () => {
+    ctx.root = await mkdtemp(path.join(os.tmpdir(), `${label}-confine-`));
+    ctx.outside = await mkdtemp(path.join(os.tmpdir(), `${label}-outside-`));
+  });
+
+  afterEach(async () => {
+    if (ctx.root) await rm(ctx.root, { recursive: true, force: true });
+    if (ctx.outside) await rm(ctx.outside, { recursive: true, force: true });
+    ctx.root = ctx.outside = "";
+  });
+
+  return ctx;
+}

--- a/test/indexgen.test.ts
+++ b/test/indexgen.test.ts
@@ -5,6 +5,7 @@ import { buildFrontmatter } from "../src/utils/markdown.js";
 import { makeTempRoot } from "./fixtures/temp-root.js";
 import { writePage } from "./fixtures/write-page.js";
 import { generateAndReadIndex } from "./fixtures/generate-and-read-index.js";
+import { buildResearchLiteProject } from "./fixtures/profile-fixtures.js";
 
 describe("generateIndex", () => {
   let root: string;
@@ -68,5 +69,52 @@ describe("generateIndex", () => {
     expect(index).toContain("[[alive|Alive]]");
     expect(index).not.toContain("[[dead|Dead]]");
     expect(index).toContain("1 pages");
+  });
+
+  it("omits typed entity sections for a DEFAULT project (byte-identical)", async () => {
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha", summary: "A concept" }, "Body of Alpha.");
+    const index = await generateAndReadIndex(root);
+
+    // A default project (no profile.json) renders exactly the legacy sections.
+    expect(index).toContain("# Knowledge Wiki");
+    expect(index).toContain("## Concepts");
+    expect(index).not.toContain("## Papers");
+    expect(index).not.toContain("## Entity Pages");
+  });
+});
+
+describe("generateIndex (non-default profile)", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot("idx-profile");
+    await buildResearchLiteProject(root);
+  });
+
+  it("lists a promoted typed page under its entity-type section", async () => {
+    const index = await generateAndReadIndex(root);
+
+    expect(index).toContain("## Papers");
+    expect(index).toContain("attention-is-all-you-need");
+    expect(index).toContain("papers/attention-is-all-you-need.md");
+  });
+
+  it("groups pages under one section per entity type", async () => {
+    const index = await generateAndReadIndex(root);
+
+    expect(index).toContain("## Papers");
+    expect(index).toContain("## Ideas");
+    expect(index).toContain("## Experiments");
+    expect(index).toContain("ideas/sparse-routing.md");
+    expect(index).toContain("experiments/ablation-batch-size.md");
+  });
+
+  it("still renders the default Concepts section alongside typed sections", async () => {
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha", summary: "A concept" }, "Body of Alpha.");
+    const index = await generateAndReadIndex(root);
+
+    expect(index).toContain("## Concepts");
+    expect(index).toContain("[[alpha|Alpha]]");
+    expect(index).toContain("## Papers");
   });
 });

--- a/test/indexgen.test.ts
+++ b/test/indexgen.test.ts
@@ -117,4 +117,18 @@ describe("generateIndex (non-default profile)", () => {
     expect(index).toContain("[[alpha|Alpha]]");
     expect(index).toContain("## Papers");
   });
+
+  it("counts typed pages in the footer total", async () => {
+    // research-lite seeds 5 typed pages (2 papers + 2 ideas + 1 experiment).
+    const index = await generateAndReadIndex(root);
+
+    expect(index).toContain("5 pages");
+  });
+
+  it("counts typed pages alongside concepts in the total", async () => {
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha", summary: "A concept" }, "Body of Alpha.");
+    const index = await generateAndReadIndex(root);
+
+    expect(index).toContain("6 pages"); // 5 typed + 1 concept
+  });
 });

--- a/test/pending-target-lint.test.ts
+++ b/test/pending-target-lint.test.ts
@@ -27,6 +27,20 @@ const LIVE_PAGE = [
   "Extra body text keeps the empty-page lint rule quiet.",
 ].join("\n");
 
+/** Concept page linking to [[foo]] — used to probe typed-candidate suppression. */
+const FOO_LINK_PAGE = [
+  "---",
+  "title: Foo Linker",
+  "summary: Links to foo.",
+  "sources: []",
+  'createdAt: "2026-01-01T00:00:00.000Z"',
+  'updatedAt: "2026-01-01T00:00:00.000Z"',
+  "---",
+  "",
+  "This live page links to [[foo]] which has no resolvable page.",
+  "Extra body text keeps the empty-page lint rule quiet.",
+].join("\n");
+
 describe("pending-target lint", () => {
   it("reports pending-target instead of broken-wikilink and does not penalize health", async () => {
     await env.writeConcept("live-page", LIVE_PAGE);
@@ -49,6 +63,37 @@ describe("pending-target lint", () => {
     const pending = health.rules.find((r) => r.rule === "pending-target");
     expect(pending?.deduction).toBe(0);
     expect(health.score).toBe(100);
+  });
+
+  it("does NOT suppress a broken wikilink for a TYPED pending candidate", async () => {
+    await env.writeConcept("foo-linker", FOO_LINK_PAGE);
+    await writeCandidate(env.dir, {
+      title: "Foo",
+      slug: "foo",
+      summary: "Typed foo.",
+      sources: [],
+      body: "typed body",
+      targetEntityType: "papers",
+    });
+
+    const summary = await lint(env.dir);
+    expect(summary.results.map((r) => r.rule)).toContain("broken-wikilink");
+    expect(summary.results.map((r) => r.rule)).not.toContain("pending-target");
+  });
+
+  it("still demotes a broken wikilink for a DEFAULT pending candidate", async () => {
+    await env.writeConcept("foo-linker", FOO_LINK_PAGE);
+    await writeCandidate(env.dir, {
+      title: "Foo",
+      slug: "foo",
+      summary: "Default foo.",
+      sources: [],
+      body: "default body",
+    });
+
+    const summary = await lint(env.dir);
+    expect(summary.results.map((r) => r.rule)).toContain("pending-target");
+    expect(summary.results.map((r) => r.rule)).not.toContain("broken-wikilink");
   });
 });
 

--- a/test/query-save-profile-gate.test.ts
+++ b/test/query-save-profile-gate.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @file test/query-save-profile-gate.test.ts
+ * @description FIX #6 — `query --save` must be DISABLED in profile-enabled
+ * (non-default-profile) projects, where the saved-query write path is not yet
+ * Trust-Guard-routed (CLP plan D7 / spec-07). In a default project it still
+ * saves exactly as before.
+ *
+ * These tests drive `maybeSaveQueryPage` directly (the gate that wraps
+ * `saveQueryPage`) so they exercise the real save/disable decision without the
+ * full LLM answer pipeline.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync } from "fs";
+import { readdir } from "fs/promises";
+import path from "path";
+import { maybeSaveQueryPage } from "../src/commands/query.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { buildResearchLiteProject } from "./fixtures/profile-fixtures.js";
+
+const QUESTION = "What is attention?";
+const ANSWER = "Attention is a weighting mechanism over a sequence.";
+
+describe("query --save profile gate", () => {
+  let root: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot("qsave-gate");
+    originalCwd = process.cwd();
+    process.chdir(root);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+  });
+
+  it("DEFAULT project: --save writes a queries page (unchanged)", async () => {
+    const slug = await maybeSaveQueryPage(root, QUESTION, ANSWER, true);
+    expect(slug).toBeDefined();
+    expect(existsSync(path.join(root, "wiki/queries", `${slug}.md`))).toBe(true);
+  });
+
+  it("profile-enabled project: --save does NOT write a queries page", async () => {
+    await buildResearchLiteProject(root);
+    const slug = await maybeSaveQueryPage(root, QUESTION, ANSWER, true);
+    expect(slug).toBeUndefined();
+    const queries = await readdir(path.join(root, "wiki/queries"));
+    expect(queries).toHaveLength(0);
+  });
+
+  it("save=false never writes regardless of profile", async () => {
+    const slug = await maybeSaveQueryPage(root, QUESTION, ANSWER, false);
+    expect(slug).toBeUndefined();
+    const queries = await readdir(path.join(root, "wiki/queries"));
+    expect(queries).toHaveLength(0);
+  });
+});

--- a/test/review-approve-planner.test.ts
+++ b/test/review-approve-planner.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @file test/review-approve-planner.test.ts
+ * @description Reroute-specific coverage for `review approve` once its page
+ * write goes through the write planner/executor (CLP Invariant 4) instead of a
+ * direct `atomicWrite`. The byte/stdout PARITY of the happy path is pinned by
+ * the existing `test/review.test.ts` "review approve command" suite (which must
+ * still pass unchanged); this file pins the behaviours the reroute newly
+ * activates: Unicode slugs (only possible because PR2's typed planner is
+ * bypassed for default pages), upsert-on-overwrite, loud failure when the
+ * mandatory resource-limit floor blocks the body, and crashed-batch journal
+ * replay under the already-held review lock.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { writeFile, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { writeCandidate } from "../src/compiler/candidates.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import { openBatch, recordPreState, type JournalBatch } from "../src/trust/journal.js";
+import { CANDIDATES_DIR, CONCEPTS_DIR, MAX_SOURCE_CHARS } from "../src/utils/constants.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+
+const root = useTempRoot();
+
+/** A frontmatter+body page string that passes validateWikiPage, for `slug`. */
+function validBody(slug: string): string {
+  return [
+    "---",
+    `title: ${slug}`,
+    'summary: "A summary"',
+    "sources:",
+    '  - "source.md"',
+    'createdAt: "2026-01-01T00:00:00.000Z"',
+    'updatedAt: "2026-01-01T00:00:00.000Z"',
+    "tags: []",
+    "aliases: []",
+    "---",
+    "",
+    `Body for ${slug}.`,
+    "",
+  ].join("\n");
+}
+
+/** Write a pending candidate whose body is the valid page for its slug. */
+function draftFor(slug: string, body = validBody(slug)) {
+  return { title: slug, slug, summary: "A summary", sources: ["source.md"], body };
+}
+
+/** Absolute wiki page / candidate-record paths for a slug under the temp root. */
+const pageFor = (slug: string) => path.join(root.dir, CONCEPTS_DIR, `${slug}.md`);
+const recordFor = (id: string) => path.join(root.dir, CANDIDATES_DIR, `${id}.json`);
+
+/**
+ * Seed a candidate for `slug` (body defaults to its valid page), silence both
+ * console streams, run approve, and return the candidate id — the shared arrange
+ * step so each reroute test asserts only its own outcome.
+ */
+async function approveDraft(slug: string, body?: string): Promise<string> {
+  const candidate = await writeCandidate(root.dir, draftFor(slug, body ?? validBody(slug)));
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  await reviewApproveCommand(candidate.id);
+  return candidate.id;
+}
+
+describe("review approve — planner reroute", () => {
+  it("approves a Unicode-slug candidate and writes wiki/concepts/café-society.md", async () => {
+    const slug = "café-society";
+    const id = await approveDraft(slug);
+    expect(await readFile(pageFor(slug), "utf-8")).toBe(validBody(slug));
+    expect(existsSync(recordFor(id))).toBe(false);
+  });
+
+  it("re-approves an existing page via update without a create collision", async () => {
+    const slug = "reapprove";
+    await writeFile(pageFor(slug), "stale prior bytes\n");
+    await approveDraft(slug);
+    expect(await readFile(pageFor(slug), "utf-8")).toBe(validBody(slug));
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("fails loudly and retains the candidate when the body exceeds the resource-limit floor", async () => {
+    const slug = "oversized";
+    const filler = "\n" + "x".repeat(MAX_SOURCE_CHARS); // valid frontmatter, oversized total
+    const id = await approveDraft(slug, validBody(slug) + filler);
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(pageFor(slug))).toBe(false);
+    expect(existsSync(recordFor(id))).toBe(true);
+    process.exitCode = 0;
+  });
+
+  it("replays a dangling pending journal on the next approve (crashed-batch recovery)", async () => {
+    // Plant the journal under the SAME root form the command uses (process.cwd,
+    // the realpath of root.dir) so the crashed batch is the one approve replays.
+    const cmdRoot = process.cwd();
+    const orphan = path.join(cmdRoot, CONCEPTS_DIR, "orphan.md");
+    await writeFile(orphan, "pre-batch bytes\n");
+    const batch: JournalBatch = await openBatch(cmdRoot);
+    await recordPreState(batch, orphan); // pending, never committed → a crashed batch
+    await writeFile(orphan, "torn post-crash bytes\n"); // simulate a half-applied write
+
+    await approveDraft("trigger");
+
+    // The approve ran replayJournal under the review lock → orphan reverted to pre-batch bytes.
+    expect(await readFile(orphan, "utf-8")).toBe("pre-batch bytes\n");
+  });
+});

--- a/test/review-approve-typed.test.ts
+++ b/test/review-approve-typed.test.ts
@@ -151,6 +151,40 @@ describe("review approve — typed candidates skip the default title validator",
   });
 });
 
+describe("review approve — typed read-integration note (loud + honest)", () => {
+  /** Capture every console.log argument as one joined string for substring asserts. */
+  function captureLog(): () => string {
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.join(" "));
+    });
+    return () => lines.join("\n");
+  }
+
+  it("prints the integration-pending note after a typed approval", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidate();
+    const readLog = captureLog();
+
+    await reviewApproveCommand(id);
+
+    const out = readLog();
+    expect(out).toContain("not yet included in interlinking");
+    expect(out).toContain("wiki/papers/linear-attention.md");
+  });
+
+  it("does NOT print the note for a DEFAULT (concepts) approval", async () => {
+    const candidate = await writeCandidate(root, {
+      title: SLUG, slug: SLUG, summary: "", sources: [], body: BODY,
+    });
+    const readLog = captureLog();
+
+    await reviewApproveCommand(candidate.id);
+
+    expect(readLog()).not.toContain("not yet included in interlinking");
+  });
+});
+
 /** A sourceStates map carrying one source entry for `src.md`. */
 const SOURCE_STATES = {
   "src.md": { hash: "h1", concepts: [], compiledAt: "2026-01-01T00:00:00.000Z" },

--- a/test/review-approve-typed.test.ts
+++ b/test/review-approve-typed.test.ts
@@ -45,15 +45,40 @@ afterEach(async () => {
 
 /** Write a typed `papers` candidate for SLUG and return its id. */
 async function stageTypedCandidate(entityType = "papers"): Promise<string> {
+  return stageTypedCandidateBody(BODY, entityType);
+}
+
+/** Write a typed candidate with an explicit body + type, returning its id. */
+async function stageTypedCandidateBody(body: string, entityType: string): Promise<string> {
   const candidate = await writeCandidate(root, {
     title: SLUG,
     slug: SLUG,
     summary: "",
     sources: [],
-    body: BODY,
+    body,
     targetEntityType: entityType,
   });
   return candidate.id;
+}
+
+/**
+ * Assert a candidate was REFUSED: the page at `pageRelDir/<slug>.md` was not
+ * written, the candidate `id` is retained, and the process exit code is 1.
+ */
+function expectRefused(pageRelDir: string, id: string): void {
+  expect(existsSync(path.join(root, pageRelDir, `${SLUG}.md`))).toBe(false);
+  expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
+  expect(process.exitCode).toBe(1);
+}
+
+/**
+ * Assert a candidate was APPROVED: the page at `pageRelDir/<slug>.md` holds
+ * exactly `body`, the candidate `id` is cleared, and the exit code is 0.
+ */
+async function expectApproved(pageRelDir: string, id: string, body: string): Promise<void> {
+  expect(await readFile(path.join(root, pageRelDir, `${SLUG}.md`), "utf8")).toBe(body);
+  expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(false);
+  expect(process.exitCode ?? 0).toBe(0);
 }
 
 describe("review approve — typed entity routing", () => {
@@ -63,10 +88,8 @@ describe("review approve — typed entity routing", () => {
 
     await reviewApproveCommand(id);
 
-    expect(await readFile(path.join(root, "wiki/papers", `${SLUG}.md`), "utf8")).toBe(BODY);
+    await expectApproved("wiki/papers", id, BODY);
     expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
-    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(false);
-    expect(process.exitCode ?? 0).toBe(0);
   });
 
   it("refuses a typed candidate in a DEFAULT project (no profile) and retains it", async () => {
@@ -74,10 +97,8 @@ describe("review approve — typed entity routing", () => {
 
     await reviewApproveCommand(id);
 
-    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+    expectRefused("wiki/papers", id);
     expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
-    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
-    expect(process.exitCode).toBe(1);
   });
 
   it("refuses a typed candidate whose type is undeclared by the profile and retains it", async () => {
@@ -86,8 +107,45 @@ describe("review approve — typed entity routing", () => {
 
     await reviewApproveCommand(id);
 
-    expect(existsSync(path.join(root, "wiki/bogus", `${SLUG}.md`))).toBe(false);
-    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
-    expect(process.exitCode).toBe(1);
+    expectRefused("wiki/bogus", id);
+  });
+});
+
+/** A valid `experiments` body: required `runtime` field, NO `title`. */
+const NO_TITLE_EXPERIMENT_BODY = "---\nruntime: cpu\n---\n\n# Ablation\n\nBody.\n";
+/** A `papers` body missing its required `title` field. */
+const NO_TITLE_PAPER_BODY = "---\nvenue: NeurIPS\n---\n\n# Paper\n\nBody.\n";
+
+describe("review approve — typed candidates skip the default title validator", () => {
+  it("approves a typed experiments candidate with valid fields but no title", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidateBody(NO_TITLE_EXPERIMENT_BODY, "experiments");
+
+    await reviewApproveCommand(id);
+
+    await expectApproved("wiki/experiments", id, NO_TITLE_EXPERIMENT_BODY);
+  });
+
+  it("still refuses a typed candidate that violates its field contract", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidateBody(NO_TITLE_PAPER_BODY, "papers");
+
+    await reviewApproveCommand(id);
+
+    expectRefused("wiki/papers", id);
+  });
+
+  it("still rejects a DEFAULT candidate missing its title via validateWikiPage", async () => {
+    const candidate = await writeCandidate(root, {
+      title: SLUG,
+      slug: SLUG,
+      summary: "",
+      sources: [],
+      body: NO_TITLE_PAPER_BODY,
+    });
+
+    await reviewApproveCommand(candidate.id);
+
+    expectRefused("wiki/concepts", candidate.id);
   });
 });

--- a/test/review-approve-typed.test.ts
+++ b/test/review-approve-typed.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @file test/review-approve-typed.test.ts
+ * @description Typed-target routing for `review approve <id>` (FIX #1).
+ *
+ * A candidate carrying `targetEntityType` (staged via the typed planner) must be
+ * routed by `review approve` through the TYPED planner — landing at
+ * `wiki/<entityType>/<slug>.md`, NOT silently in `wiki/concepts/`. A typed
+ * candidate in a DEFAULT project (no profile) or with an undeclared type is
+ * REFUSED (exit 1, candidate retained). A default candidate (no typed target)
+ * keeps the existing concepts path; that parity is pinned by review.test.ts and
+ * review-approve-planner.test.ts, which must still pass unchanged.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import os from "os";
+import { writeCandidate } from "../src/compiler/candidates.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import { CANDIDATES_DIR } from "../src/utils/constants.js";
+import { buildResearchLiteProject } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+let originalCwd = "";
+
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\n# Linear Attention\n\nBody.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "review-typed-"));
+  originalCwd = process.cwd();
+  process.chdir(root);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = 0;
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  process.exitCode = 0;
+});
+
+/** Write a typed `papers` candidate for SLUG and return its id. */
+async function stageTypedCandidate(entityType = "papers"): Promise<string> {
+  const candidate = await writeCandidate(root, {
+    title: SLUG,
+    slug: SLUG,
+    summary: "",
+    sources: [],
+    body: BODY,
+    targetEntityType: entityType,
+  });
+  return candidate.id;
+}
+
+describe("review approve — typed entity routing", () => {
+  it("routes a typed papers candidate to wiki/papers/<slug>.md and clears it", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidate();
+
+    await reviewApproveCommand(id);
+
+    expect(await readFile(path.join(root, "wiki/papers", `${SLUG}.md`), "utf8")).toBe(BODY);
+    expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(false);
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("refuses a typed candidate in a DEFAULT project (no profile) and retains it", async () => {
+    const id = await stageTypedCandidate();
+
+    await reviewApproveCommand(id);
+
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, "wiki/concepts", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses a typed candidate whose type is undeclared by the profile and retains it", async () => {
+    await buildResearchLiteProject(root);
+    const id = await stageTypedCandidate("bogus");
+
+    await reviewApproveCommand(id);
+
+    expect(existsSync(path.join(root, "wiki/bogus", `${SLUG}.md`))).toBe(false);
+    expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/test/review-approve-typed.test.ts
+++ b/test/review-approve-typed.test.ts
@@ -18,6 +18,7 @@ import path from "path";
 import os from "os";
 import { writeCandidate } from "../src/compiler/candidates.js";
 import reviewApproveCommand from "../src/commands/review-approve.js";
+import { readState } from "../src/utils/state.js";
 import { CANDIDATES_DIR } from "../src/utils/constants.js";
 import { buildResearchLiteProject } from "./fixtures/profile-fixtures.js";
 
@@ -147,5 +148,38 @@ describe("review approve — typed candidates skip the default title validator",
     await reviewApproveCommand(candidate.id);
 
     expectRefused("wiki/concepts", candidate.id);
+  });
+});
+
+/** A sourceStates map carrying one source entry for `src.md`. */
+const SOURCE_STATES = {
+  "src.md": { hash: "h1", concepts: [], compiledAt: "2026-01-01T00:00:00.000Z" },
+};
+
+describe("review approve — state tail skipped for typed candidates (F4)", () => {
+  it("does NOT write a typed candidate's slug into any source's concepts list", async () => {
+    await buildResearchLiteProject(root);
+    const candidate = await writeCandidate(root, {
+      title: SLUG, slug: SLUG, summary: "", sources: ["src.md"], body: BODY,
+      targetEntityType: "papers", sourceStates: SOURCE_STATES,
+    });
+
+    await reviewApproveCommand(candidate.id);
+
+    await expectApproved("wiki/papers", candidate.id, BODY);
+    const state = await readState(root);
+    expect(state.sources).toEqual({}); // no concepts pollution from the typed slug
+  });
+
+  it("still persists source states for a DEFAULT candidate (unchanged)", async () => {
+    const candidate = await writeCandidate(root, {
+      title: SLUG, slug: SLUG, summary: "", sources: ["src.md"], body: BODY,
+      sourceStates: SOURCE_STATES,
+    });
+
+    await reviewApproveCommand(candidate.id);
+
+    const state = await readState(root);
+    expect(state.sources["src.md"]?.concepts).toEqual([SLUG]);
   });
 });

--- a/test/review-candidate-lifecycle.test.ts
+++ b/test/review-candidate-lifecycle.test.ts
@@ -14,7 +14,7 @@ import path from "path";
 import {
   deleteCandidateBySlug,
   listCandidates,
-  listPendingCandidateSlugs,
+  listLinkResolvablePendingSlugs,
   readCandidateBySlug,
   writeCandidate,
 } from "../src/compiler/candidates.js";
@@ -49,7 +49,7 @@ describe("pending candidate lifecycle", () => {
   it("lists and deletes pending candidates by slug", async () => {
     const candidate = await writeCandidate(root.dir, draft("topic", "body"));
     expect(await readCandidateBySlug(root.dir, "topic")).toMatchObject({ id: candidate.id });
-    expect(await listPendingCandidateSlugs(root.dir)).toEqual(new Set(["topic"]));
+    expect(await listLinkResolvablePendingSlugs(root.dir)).toEqual(new Set(["topic"]));
 
     expect(await deleteCandidateBySlug(root.dir, "topic")).toBe(true);
     expect(await readCandidateBySlug(root.dir, "topic")).toBeNull();

--- a/test/review-candidate-metadata.test.ts
+++ b/test/review-candidate-metadata.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { writeCandidate, readCandidate } from "../src/compiler/candidates.js";
+import type { CandidateDraft } from "../src/compiler/candidates.js";
 import reviewListCommand from "../src/commands/review-list.js";
 import reviewShowCommand from "../src/commands/review-show.js";
 import { useTempRoot } from "./fixtures/temp-root.js";
@@ -30,6 +31,34 @@ function collectLogOutput(spy: ReturnType<typeof vi.spyOn>): string {
   return spy.mock.calls.map((args) => args.join(" ")).join("\n");
 }
 
+/**
+ * Write a candidate from `draft`, then run `review list` + `review show <id>`
+ * with console captured, returning the combined stdout. Shared by the display
+ * tests so the seed → spy → render → collect boilerplate lives in one place.
+ */
+async function renderListAndShow(rootDir: string, draft: CandidateDraft): Promise<string> {
+  const candidate = await writeCandidate(rootDir, draft);
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  await reviewListCommand();
+  await reviewShowCommand(candidate.id);
+  return collectLogOutput(logSpy);
+}
+
+/** A `policy`-held candidate draft body shared by the metadata + display tests. */
+function policyDraft(): CandidateDraft {
+  return {
+    title: "Policy Held",
+    slug: "policy-held",
+    summary: "Held by policy.",
+    sources: [],
+    body: BODY,
+    reviewMode: "policy",
+    heldReasons: [{ code: "low-confidence", detail: "confidence 0.2 < 0.5" }],
+    confidence: 0.2,
+    contradicted: false,
+  };
+}
+
 describe("review candidate metadata", () => {
   it("defaults writeCandidate metadata to forced manual review", async () => {
     const candidate = await writeCandidate(root.dir, {
@@ -45,27 +74,36 @@ describe("review candidate metadata", () => {
   });
 
   it("round-trips policy metadata and displays it in list/show", async () => {
-    const candidate = await writeCandidate(root.dir, {
-      title: "Policy Held",
-      slug: "policy-held",
-      summary: "Held by policy.",
-      sources: [],
-      body: BODY,
-      reviewMode: "policy",
-      heldReasons: [{ code: "low-confidence", detail: "confidence 0.2 < 0.5" }],
-      confidence: 0.2,
-      contradicted: false,
-    });
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    await reviewListCommand();
-    await reviewShowCommand(candidate.id);
-
-    const output = collectLogOutput(logSpy);
+    const output = await renderListAndShow(root.dir, policyDraft());
     expect(output).toContain("policy: low-confidence");
     expect(output).toContain("confidence 0.2 < 0.5");
     expect(output).toContain("confidence: 0.2");
     expect(output).toContain("contradicted: false");
+  });
+
+  it("surfaces the typed target in list/show for a typed candidate (FIX #4)", async () => {
+    const output = await renderListAndShow(root.dir, {
+      title: "Transformer",
+      slug: "transformer",
+      summary: "A paper.",
+      sources: [],
+      body: BODY,
+      targetEntityType: "papers",
+    });
+    expect(output).toContain("→ papers/transformer");
+    expect(output).toContain("Target:    wiki/papers/transformer.md");
+  });
+
+  it("default candidate list/show output omits the typed target line (FIX #4)", async () => {
+    const output = await renderListAndShow(root.dir, {
+      title: "Default Concept",
+      slug: "default-concept",
+      summary: "A concept.",
+      sources: [],
+      body: BODY,
+    });
+    expect(output).not.toContain("Target:");
+    expect(output).toContain("→ default-concept ");
   });
 });
 

--- a/test/rule-candidate-store-confinement.test.ts
+++ b/test/rule-candidate-store-confinement.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @file test/rule-candidate-store-confinement.test.ts
+ * @description Fail-closed coverage for RULE-candidate-store directory
+ * confinement (Phase-3 hardening), mirroring
+ * `test/candidate-store-confinement.test.ts` for the sibling concept store.
+ *
+ * Before this guard, `ruleCandidatePath`/`ruleArchivePath` did a bare
+ * `path.join(root, RULE_CANDIDATES_DIR, …)` with NO realpath confinement, then
+ * wrote via `atomicWrite` and `readdir`-ed the directory. So a symlinked
+ * `.llmwiki/rule-candidates -> /tmp/outside` redirected every
+ * write/read/list/archive OUTSIDE the project root — the identical
+ * containing-directory escape already closed for the concept store.
+ *
+ * The rule store now routes every path through the SAME shared confinement
+ * helpers (`candidate-store-paths.ts`): a symlinked rule-candidates dir refuses
+ * every operation and leaves the out-of-tree dir untouched, while a NORMAL dir
+ * still round-trips a candidate identically.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, readdir, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  buildRuleCandidate,
+  buildRuleSlug,
+  writeRuleCandidate,
+  readRuleCandidate,
+  listRuleCandidates,
+  archiveRuleCandidate,
+} from "../src/compiler/rule-candidates.js";
+import { candidateFileId } from "../src/utils/candidate-store.js";
+import { UnsafeCandidateDirError } from "../src/compiler/candidate-store-paths.js";
+import { LLMWIKI_DIR } from "../src/utils/constants.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+import type { RuleCandidate } from "../src/utils/rule-types.js";
+
+const ctx = useConfinementRoots("rule-cand");
+
+const FIXED_NOW = "2026-05-31T00:00:00.000Z";
+
+/** A valid RuleCandidate for `title` in the `process` category. */
+function candidateFor(title: string): RuleCandidate {
+  const slug = buildRuleSlug(title, `${title}|when|then`);
+  return buildRuleCandidate(
+    {
+      category: "process",
+      slug,
+      title,
+      description: "desc",
+      when: "a thing happens",
+      then: "warn",
+      evidence: [{ kind: "file", path: "guide.md" }],
+      provenance: { source: "llm-wiki-compiler" },
+      confidence: "high",
+    },
+    FIXED_NOW,
+  );
+}
+
+/** Make `.llmwiki/rule-candidates` a SYMLINK to the out-of-tree `outside` dir. */
+async function symlinkRuleDirOutside(): Promise<void> {
+  await mkdir(path.join(ctx.root, LLMWIKI_DIR), { recursive: true });
+  await symlink(ctx.outside, path.join(ctx.root, LLMWIKI_DIR, "rule-candidates"), "dir");
+}
+
+/** Names of entries currently in the out-of-tree dir. */
+async function outsideEntries(): Promise<string[]> {
+  return readdir(ctx.outside);
+}
+
+describe("rule-candidate store — symlinked rule-candidates dir (tampering)", () => {
+  it("writeRuleCandidate REFUSES and creates nothing outside root", async () => {
+    await symlinkRuleDirOutside();
+    await expect(writeRuleCandidate(ctx.root, candidateFor("Require tests"))).rejects.toBeInstanceOf(
+      UnsafeCandidateDirError,
+    );
+    expect(await outsideEntries()).toHaveLength(0);
+  });
+
+  it("readRuleCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(ctx.outside, "planted.json"), "{}", "utf8");
+    await symlinkRuleDirOutside();
+    await expect(readRuleCandidate(ctx.root, "planted")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["planted.json"]);
+  });
+
+  it("archiveRuleCandidate over the symlinked dir fails closed, leaving outside untouched", async () => {
+    await writeFile(path.join(ctx.outside, "victim.json"), "{}", "utf8");
+    await symlinkRuleDirOutside();
+    await expect(archiveRuleCandidate(ctx.root, "victim")).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["victim.json"]);
+  });
+
+  it("listRuleCandidates over the symlinked dir fails closed, never reading through it", async () => {
+    await writeFile(path.join(ctx.outside, "leak.json"), "{}", "utf8");
+    await symlinkRuleDirOutside();
+    await expect(listRuleCandidates(ctx.root)).rejects.toBeInstanceOf(UnsafeCandidateDirError);
+    expect(await outsideEntries()).toEqual(["leak.json"]);
+  });
+});
+
+describe("rule-candidate store — normal dir regression", () => {
+  it("round-trips a rule candidate identically through a REAL dir", async () => {
+    const candidate = candidateFor("Require tests");
+    const written = await writeRuleCandidate(ctx.root, candidate);
+    expect(written).toContain(
+      path.join(".llmwiki/rule-candidates", `${candidateFileId(candidate.id)}.json`),
+    );
+    const loaded = await readRuleCandidate(ctx.root, candidateFileId(candidate.id));
+    expect(loaded).toEqual(candidate);
+    expect(await listRuleCandidates(ctx.root)).toHaveLength(1);
+  });
+});

--- a/test/sdk/staging.test.ts
+++ b/test/sdk/staging.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @file test/sdk/staging.test.ts
+ * @description Tests the EXPERIMENTAL `createWiki()` staging methods, which load
+ * the active non-default profile INTERNALLY (the caller passes no ProfilePack).
+ *
+ * Over a project WITH a non-default profile, `stageEntityPage` creates a typed
+ * candidate and `promoteStagedPage` lands the body at `wiki/<entityType>/<slug>.md`.
+ * Over a DEFAULT project (no profile), `stageEntityPage` throws the clear
+ * "requires a non-default profile" error.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { createWiki } from "../../src/sdk/wiki.js";
+import { StagingRequiresProfileError } from "../../src/trust/staging.js";
+import { buildResearchLiteProject } from "../fixtures/profile-fixtures.js";
+
+let root = "";
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\nStaged body.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "sdk-staging-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("createWiki staging (experimental)", () => {
+  it("stages then promotes a typed page through the SDK facade", async () => {
+    await buildResearchLiteProject(root);
+    const wiki = createWiki({ root });
+
+    const staged = await wiki.stageEntityPage({ entityType: "papers", slug: SLUG, body: BODY });
+    expect(staged.target).toMatchObject({ entityType: "papers", slug: SLUG, id: `papers/${SLUG}` });
+
+    await wiki.promoteStagedPage(staged.id);
+    expect(await readFile(path.join(root, "wiki/papers", `${SLUG}.md`), "utf8")).toBe(BODY);
+  });
+
+  it("throws the requires-a-non-default-profile error on a default project", async () => {
+    const wiki = createWiki({ root });
+    await expect(
+      wiki.stageEntityPage({ entityType: "papers", slug: SLUG, body: BODY }),
+    ).rejects.toBeInstanceOf(StagingRequiresProfileError);
+  });
+});

--- a/test/state-migrate.test.ts
+++ b/test/state-migrate.test.ts
@@ -9,12 +9,13 @@
  *  - lossless upgrade (v1 fields retained, typed mirror added),
  *  - idempotency (re-migrating a v2 state is a no-op, never double-typed),
  *  - determinism (sorted output, byte-stable across repeated runs), and
- *  - fail-closed behaviour (a non-slug-safe bare slug throws, never dropped).
+ *  - tolerant behaviour (a non-slug-safe bare slug — e.g. a Unicode stem — is
+ *    kept verbatim in `concepts` / `frozenSlugs` but gets no typed id, so a
+ *    mixed-language wiki migrates instead of aborting).
  */
 
 import { describe, it, expect } from "vitest";
 import { migrateStateToV2 } from "../src/state/migrate.js";
-import { EntityIdError } from "../src/profile/identity.js";
 import type { WikiState } from "../src/utils/types.js";
 
 /** A minimal, valid v1 state used as the base fixture for the suite. */
@@ -100,16 +101,28 @@ describe("migrateStateToV2 — idempotency gate >= 2", () => {
   });
 });
 
-describe("migrateStateToV2 — fail-closed", () => {
-  it("throws on a bare slug with spaces rather than silently dropping it", () => {
+describe("migrateStateToV2 — tolerant of non-slug-safe slugs", () => {
+  it("does not throw and skips typing a non-ASCII (Unicode) source slug", () => {
     const v1 = v1Fixture();
-    v1.sources["a.md"].concepts = ["Bad Slug"];
-    expect(() => migrateStateToV2(v1)).toThrow(EntityIdError);
+    v1.sources["a.md"].concepts = ["café-society", "机器学习", "rag"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.sources["a.md"].entities).toEqual(["concepts/rag"]);
+    expect(v2.sources["a.md"].concepts).toEqual(["café-society", "机器学习", "rag"]);
   });
 
-  it("throws on an uppercase frozen slug rather than silently dropping it", () => {
+  it("keeps a non-slug-safe frozen slug verbatim but mints no typed id for it", () => {
     const v1 = v1Fixture();
-    v1.frozenSlugs = ["UPPER"];
-    expect(() => migrateStateToV2(v1)).toThrow(EntityIdError);
+    v1.frozenSlugs = ["café-society", "机器学习", "rag"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.frozenEntities).toEqual(["concepts/rag"]);
+    expect(v2.frozenSlugs).toEqual(["café-society", "机器学习", "rag"]);
+  });
+
+  it("skips a slug with spaces / uppercase rather than throwing", () => {
+    const v1 = v1Fixture();
+    v1.sources["a.md"].concepts = ["Bad Slug", "UPPER", "ok"];
+    const v2 = migrateStateToV2(v1);
+    expect(v2.sources["a.md"].entities).toEqual(["concepts/ok"]);
+    expect(v2.sources["a.md"].concepts).toEqual(["Bad Slug", "UPPER", "ok"]);
   });
 });

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -101,6 +101,18 @@ describe("state reset", () => {
     await rm(outside, { recursive: true, force: true });
   });
 
+  it("refuses cleanly when state.json.bak is a directory (no raw EISDIR)", async () => {
+    await seedState(OK_STATE);
+    await mkdir(BAK_PATH(), { recursive: true }); // .bak is a DIRECTORY
+
+    const result = await runCLI(["state", "reset", "--yes"], root);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout + result.stderr).not.toMatch(/EISDIR/);
+    expect(result.stdout + result.stderr).toMatch(/not a regular file/i);
+    expect(existsSync(STATE_PATH())).toBe(true); // state untouched
+  });
+
   it("refuses cleanly when the project lock is held by a live holder", async () => {
     await seedState(OK_STATE);
     // A lock naming THIS (live) process PID is not stale, so acquireLock fails.

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -94,6 +94,7 @@ describe("state reset", () => {
 
     const result = await runCLI(["state", "reset", "--yes"], root);
 
+    expect(result.code).not.toBe(0); // a confinement refusal is a FAILURE, not a no-op
     expect(result.stdout + result.stderr).toMatch(/escapes the project root/);
     expect(existsSync(outsideState)).toBe(true); // not moved
     expect(existsSync(`${outsideState}.bak`)).toBe(false); // not clobbered

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @file test/state-reset-cli.test.ts
+ * @description Subprocess tests for the `llmwiki state reset` recovery command.
+ *
+ * Covers the four contract paths: a dry refusal without `--yes` (no mutation),
+ * a confirmed reset that backs up and removes the state file, the recovery case
+ * where the on-disk state was written by a NEWER llmwiki version (`{"version":3}`,
+ * which `readState` would reject) yet `--yes` still backs it up without throwing,
+ * and the no-op when there is no state file to reset.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { runCLI } from "./fixtures/run-cli.js";
+import { STATE_FILE } from "../src/utils/constants.js";
+
+let root = "";
+
+/** Write a state.json with the given JSON content under `.llmwiki/`. */
+async function seedState(content: unknown): Promise<void> {
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(path.join(root, STATE_FILE), JSON.stringify(content), "utf8");
+}
+
+const STATE_PATH = (): string => path.join(root, STATE_FILE);
+const BAK_PATH = (): string => `${STATE_PATH()}.bak`;
+
+const OK_STATE = { version: 1, indexHash: "abc", sources: {} };
+
+/**
+ * Seed `content` as state.json, run a confirmed `state reset --yes`, and assert
+ * the file was backed up and removed. Returns the parsed `.bak` contents so each
+ * caller can assert its specific backed-up payload.
+ */
+async function resetAndReadBackup(content: unknown): Promise<unknown> {
+  await seedState(content);
+  const result = await runCLI(["state", "reset", "--yes"], root);
+  expect(result.code).toBe(0);
+  expect(existsSync(STATE_PATH())).toBe(false);
+  expect(existsSync(BAK_PATH())).toBe(true);
+  return JSON.parse(await readFile(BAK_PATH(), "utf8"));
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "state-reset-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  root = "";
+});
+
+describe("state reset", () => {
+  it("without --yes prints the plan and makes no change", async () => {
+    await seedState(OK_STATE);
+    const before = await readFile(STATE_PATH(), "utf8");
+
+    const result = await runCLI(["state", "reset"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("--yes");
+    expect(await readFile(STATE_PATH(), "utf8")).toBe(before);
+    expect(existsSync(BAK_PATH())).toBe(false);
+  });
+
+  it("with --yes backs up and removes the state file", async () => {
+    expect(await resetAndReadBackup(OK_STATE)).toEqual(OK_STATE);
+  });
+
+  it("with --yes recovers a state written by a newer llmwiki version", async () => {
+    expect(await resetAndReadBackup({ version: 3 })).toEqual({ version: 3 });
+  });
+
+  it("with no state file reports nothing to reset and exits 0", async () => {
+    const result = await runCLI(["state", "reset"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("No state file to reset.");
+    expect(existsSync(BAK_PATH())).toBe(false);
+  });
+});

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -48,6 +48,19 @@ async function resetAndReadBackup(content: unknown): Promise<unknown> {
   return JSON.parse(await readFile(BAK_PATH(), "utf8"));
 }
 
+/**
+ * Run a confirmed `state reset --yes` expected to REFUSE, and assert the
+ * refusal is a non-zero exit whose output matches `messagePattern` and that the
+ * seeded state file is left untouched. Shared by the refusal paths (lock held,
+ * `.bak` is a directory) so each only declares its own message + seed.
+ */
+async function expectRefusedReset(messagePattern: RegExp): Promise<void> {
+  const result = await runCLI(["state", "reset", "--yes"], root);
+  expect(result.code).not.toBe(0); // a refusal is a FAILURE, not a silent no-op
+  expect(result.stdout + result.stderr).toMatch(messagePattern);
+  expect(existsSync(STATE_PATH())).toBe(true); // state untouched
+}
+
 beforeEach(async () => {
   root = await mkdtemp(path.join(os.tmpdir(), "state-reset-"));
 });
@@ -105,12 +118,9 @@ describe("state reset", () => {
     await seedState(OK_STATE);
     await mkdir(BAK_PATH(), { recursive: true }); // .bak is a DIRECTORY
 
-    const result = await runCLI(["state", "reset", "--yes"], root);
-
-    expect(result.code).not.toBe(0);
-    expect(result.stdout + result.stderr).not.toMatch(/EISDIR/);
-    expect(result.stdout + result.stderr).toMatch(/not a regular file/i);
-    expect(existsSync(STATE_PATH())).toBe(true); // state untouched
+    await expectRefusedReset(/not a regular file/i);
+    const out = await runCLI(["state", "reset", "--yes"], root);
+    expect(out.stdout + out.stderr).not.toMatch(/EISDIR/); // actionable, not a raw errno
   });
 
   it("refuses cleanly when the project lock is held by a live holder", async () => {
@@ -118,11 +128,7 @@ describe("state reset", () => {
     // A lock naming THIS (live) process PID is not stale, so acquireLock fails.
     await writeFile(path.join(root, LOCK_FILE), String(process.pid), "utf8");
 
-    const result = await runCLI(["state", "reset", "--yes"], root);
-
-    expect(result.code).toBe(0);
-    expect(result.stdout + result.stderr).toMatch(/another llmwiki process|using this project/i);
-    expect(existsSync(STATE_PATH())).toBe(true); // untouched
-    expect(existsSync(BAK_PATH())).toBe(false);
+    await expectRefusedReset(/another llmwiki process|using this project/i);
+    expect(existsSync(BAK_PATH())).toBe(false); // no backup created on refusal
   });
 });

--- a/test/state-reset-cli.test.ts
+++ b/test/state-reset-cli.test.ts
@@ -7,15 +7,19 @@
  * where the on-disk state was written by a NEWER llmwiki version (`{"version":3}`,
  * which `readState` would reject) yet `--yes` still backs it up without throwing,
  * and the no-op when there is no state file to reset.
+ *
+ * Plus two hardening paths: a `.llmwiki` that is a SYMLINK to an out-of-tree dir
+ * fails CLOSED (the outside state file is never moved/clobbered), and a reset
+ * while the project LOCK is held by a live holder refuses cleanly.
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, writeFile, readFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { runCLI } from "./fixtures/run-cli.js";
-import { STATE_FILE } from "../src/utils/constants.js";
+import { STATE_FILE, LLMWIKI_DIR, LOCK_FILE } from "../src/utils/constants.js";
 
 let root = "";
 
@@ -79,6 +83,33 @@ describe("state reset", () => {
 
     expect(result.code).toBe(0);
     expect(result.stdout + result.stderr).toContain("No state file to reset.");
+    expect(existsSync(BAK_PATH())).toBe(false);
+  });
+
+  it("fails closed when .llmwiki is a symlink to an out-of-tree dir", async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), "state-reset-outside-"));
+    const outsideState = path.join(outside, "state.json");
+    await writeFile(outsideState, JSON.stringify({ version: 3 }), "utf8");
+    await symlink(outside, path.join(root, LLMWIKI_DIR), "dir");
+
+    const result = await runCLI(["state", "reset", "--yes"], root);
+
+    expect(result.stdout + result.stderr).toMatch(/escapes the project root/);
+    expect(existsSync(outsideState)).toBe(true); // not moved
+    expect(existsSync(`${outsideState}.bak`)).toBe(false); // not clobbered
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  it("refuses cleanly when the project lock is held by a live holder", async () => {
+    await seedState(OK_STATE);
+    // A lock naming THIS (live) process PID is not stale, so acquireLock fails.
+    await writeFile(path.join(root, LOCK_FILE), String(process.pid), "utf8");
+
+    const result = await runCLI(["state", "reset", "--yes"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/another llmwiki process|using this project/i);
+    expect(existsSync(STATE_PATH())).toBe(true); // untouched
     expect(existsSync(BAK_PATH())).toBe(false);
   });
 });

--- a/test/state-sync-mirror.test.ts
+++ b/test/state-sync-mirror.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the v2 typed-mirror re-derivation at the writeState choke point.
+ *
+ * Phase 3 wires {@link syncEntityMirror} into {@link writeState} so that every
+ * persisted v2 state has `entities` / `frozenEntities` re-derived from the v1
+ * `concepts` / `frozenSlugs` lists — no writer can leave the mirror stale. The
+ * key parity guarantee is pinned here too: writing a v1 (default-profile) state
+ * is BYTE-IDENTICAL to before, with no typed-mirror keys added.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { writeState, syncEntityMirror } from "../src/utils/state.js";
+import { STATE_FILE } from "../src/utils/constants.js";
+import type { WikiState } from "../src/utils/types.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "state-sync-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Read and parse the persisted state.json. */
+async function readPersisted(): Promise<WikiState> {
+  return JSON.parse(await readFile(path.join(root, STATE_FILE), "utf-8"));
+}
+
+/** A v2 state whose typed mirror is intentionally stale/missing. */
+function staleV2(): WikiState {
+  return {
+    version: 2,
+    indexHash: "i",
+    sources: { "a.md": { hash: "h", concepts: ["rag", "x"], compiledAt: "T" } },
+    frozenSlugs: ["rag", "old"],
+    frozenEntities: ["concepts/rag", "concepts/old", "concepts/stale"],
+  };
+}
+
+describe("syncEntityMirror — v2 re-derivation", () => {
+  it("re-derives source entities from the current concepts", () => {
+    const synced = syncEntityMirror(staleV2());
+    expect(synced.sources["a.md"].entities).toEqual(["concepts/rag", "concepts/x"]);
+  });
+
+  it("shrinks frozenEntities to match a smaller frozenSlugs (no stale entry)", () => {
+    const state = staleV2();
+    state.frozenSlugs = ["rag"];
+    const synced = syncEntityMirror(state);
+    expect(synced.frozenEntities).toEqual(["concepts/rag"]);
+  });
+
+  it("skips non-slug-safe (Unicode) concepts when re-deriving the mirror", () => {
+    const state = staleV2();
+    state.sources["a.md"].concepts = ["café-society", "rag"];
+    const synced = syncEntityMirror(state);
+    expect(synced.sources["a.md"].entities).toEqual(["concepts/rag"]);
+  });
+
+  it("returns a v1 state unchanged (strict no-op)", () => {
+    const v1: WikiState = { version: 1, indexHash: "i", sources: {}, frozenSlugs: ["rag"] };
+    expect(syncEntityMirror(v1)).toBe(v1);
+  });
+});
+
+describe("writeState — persists a consistent v2 mirror", () => {
+  it("writes entities matching the changed concepts", async () => {
+    await writeState(root, staleV2());
+    const persisted = await readPersisted();
+    expect(persisted.sources["a.md"].entities).toEqual(["concepts/rag", "concepts/x"]);
+  });
+
+  it("writes a frozenEntities with no stale entry after unfreezing", async () => {
+    const state = staleV2();
+    state.frozenSlugs = ["rag"];
+    await writeState(root, state);
+    expect((await readPersisted()).frozenEntities).toEqual(["concepts/rag"]);
+  });
+});
+
+describe("writeState — v1 is byte-identical (parity)", () => {
+  it("adds no entities / frozenEntities keys to a persisted v1 state", async () => {
+    const v1: WikiState = {
+      version: 1,
+      indexHash: "i",
+      sources: { "a.md": { hash: "h", concepts: ["rag"], compiledAt: "T" } },
+      frozenSlugs: ["rag"],
+    };
+    await writeState(root, v1);
+    const raw = await readFile(path.join(root, STATE_FILE), "utf-8");
+    expect(raw).toBe(JSON.stringify(v1, null, 2));
+    expect(raw).not.toContain("entities");
+    expect(raw).not.toContain("frozenEntities");
+  });
+});

--- a/test/trust-checks.test.ts
+++ b/test/trust-checks.test.ts
@@ -78,6 +78,12 @@ describe("checkTargetCollision", () => {
     const res = await checkTargetCollision(ctx(`${WIKI}/free.md`));
     expect(res.verdict).toBe("pass");
   });
+
+  it("passes an existing target when allowOverwrite is true (intended update)", async () => {
+    await writeFile(path.join(root, WIKI, "dup.md"), GOOD_BODY);
+    const res = await checkTargetCollision({ ...ctx(`${WIKI}/dup.md`), allowOverwrite: true });
+    expect(res.verdict).toBe("pass");
+  });
 });
 
 describe("checkResourceLimit", () => {

--- a/test/trust-planner-default.test.ts
+++ b/test/trust-planner-default.test.ts
@@ -22,7 +22,8 @@ import {
   type PlannedMutation,
   type RawPageRef,
 } from "../src/trust/planner.js";
-import { applyApprovedMutations } from "../src/trust/executor.js";
+import { applyApprovedMutations, applyApprovedMutationsLocked } from "../src/trust/executor.js";
+import { acquireLock, releaseLock } from "../src/utils/lock.js";
 import { makeTrustRoot, cleanupTrustRoot, existsUnder } from "./trust/fixture.js";
 
 let root: string;
@@ -102,6 +103,20 @@ describe("planDefaultPageMutation — unsafe filename components are blocked", (
   it("blocks an unsafe directory component", async () => {
     const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { directory: "../evil" }));
     expect(out.planned).toEqual([]);
+  });
+});
+
+describe("applyApprovedMutationsLocked — lock-free core for an outer locked region", () => {
+  it("writes the page when the CALLER already holds the lock (no nested acquire)", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG));
+    expect(await acquireLock(root)).toBe(true); // simulate the held review lock
+    try {
+      await applyApprovedMutationsLocked(root, out.planned);
+    } finally {
+      await releaseLock(root);
+    }
+    const target = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    expect(await readFile(target, "utf-8")).toBe(GOOD_BODY);
   });
 });
 

--- a/test/trust-planner-default.test.ts
+++ b/test/trust-planner-default.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @file test/trust-planner-default.test.ts
+ * @description Coverage for the DEFAULT raw-page mutation path
+ * (`planDefaultPageMutation` in `src/trust/planner.ts`) plus its executor
+ * round-trip. Default wiki pages carry Unicode `slugify` slugs (e.g.
+ * `café-society`, `机器学习`) and, per the Phase-1 invariant, NEVER become
+ * EntityIds — so this path uses a {@link RawPageRef} (raw stem, no typed id)
+ * and the {@link isSafeFilenameComponent} identity floor rather than the
+ * slug-safe EntityId grammar.
+ *
+ * The suite pins: a Unicode slug on a free target plans+writes a `create`
+ * with a RawPageRef; an existing target upserts (`update`) or blocks by
+ * `allowOverwrite`; a traversal/separator/dot/leading-dot slug is blocked at
+ * plan time AND re-rejected by the executor for a hand-built RawPageRef.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, readFile } from "fs/promises";
+import path from "path";
+import {
+  planDefaultPageMutation,
+  type PlannedMutation,
+  type RawPageRef,
+} from "../src/trust/planner.js";
+import { applyApprovedMutations } from "../src/trust/executor.js";
+import { makeTrustRoot, cleanupTrustRoot, existsUnder } from "./trust/fixture.js";
+
+let root: string;
+const GOOD_BODY = "---\ntitle: Ok\n---\n\nbody\n";
+const UNICODE_SLUG = "café-society";
+
+beforeEach(async () => {
+  root = await makeTrustRoot("trust-planner-default-");
+});
+
+afterEach(async () => {
+  await cleanupTrustRoot(root);
+});
+
+function defaultArgs(slug: string, overrides: Record<string, unknown> = {}) {
+  return {
+    root,
+    directory: "concepts",
+    slug,
+    body: GOOD_BODY,
+    origin: "agent",
+    reviewRouted: false,
+    ...overrides,
+  };
+}
+
+describe("planDefaultPageMutation — Unicode slug, free target", () => {
+  it("allows and plans one create with a RawPageRef (no id)", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG));
+    expect(out.decision).toBe("allow");
+    expect(out.planned).toHaveLength(1);
+    const target = out.planned[0].target as RawPageRef;
+    expect(target).toEqual({ directory: "concepts", slug: UNICODE_SLUG });
+    expect("id" in target).toBe(false);
+    expect(out.planned[0].operation).toBe("create");
+  });
+
+  it("executor writes wiki/concepts/<unicode>.md with the body", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG));
+    await applyApprovedMutations(root, out.planned);
+    const written = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    expect(await readFile(written, "utf-8")).toBe(GOOD_BODY);
+  });
+});
+
+describe("planDefaultPageMutation — existing target", () => {
+  it("plans an update overwriting when allowOverwrite is true", async () => {
+    const target = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    await writeFile(target, "OLD");
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { allowOverwrite: true }));
+    expect(out.decision).toBe("allow");
+    expect(out.planned[0].operation).toBe("update");
+    await applyApprovedMutations(root, out.planned);
+    expect(await readFile(target, "utf-8")).toBe(GOOD_BODY);
+  });
+
+  it("blocks (no live mutation) when allowOverwrite is false", async () => {
+    const target = path.join(root, "wiki", "concepts", `${UNICODE_SLUG}.md`);
+    await writeFile(target, "OLD");
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { allowOverwrite: false }));
+    expect(out.decision).toBe("deny");
+    expect(out.planned).toEqual([]);
+    expect(await readFile(target, "utf-8")).toBe("OLD");
+  });
+});
+
+describe("planDefaultPageMutation — unsafe filename components are blocked", () => {
+  const unsafe = ["../escape", "a/b", "a\\b", "with\0nul", ".", "..", ".hidden", ""];
+  for (const slug of unsafe) {
+    it(`blocks slug ${JSON.stringify(slug)} with no live mutation`, async () => {
+      const out = await planDefaultPageMutation(defaultArgs(slug));
+      expect(out.planned).toEqual([]);
+      expect(out.decision).not.toBe("allow");
+    });
+  }
+
+  it("blocks an unsafe directory component", async () => {
+    const out = await planDefaultPageMutation(defaultArgs(UNICODE_SLUG, { directory: "../evil" }));
+    expect(out.planned).toEqual([]);
+  });
+});
+
+describe("executor re-asserts the default-page identity floor", () => {
+  it("throws invalid-identity for a hand-built RawPageRef with a `..` slug", async () => {
+    const evil: PlannedMutation = {
+      kind: "page",
+      operation: "create",
+      target: { directory: "concepts", slug: "../escape" } as RawPageRef,
+      body: GOOD_BODY,
+      provenance: { origin: "agent", decision: "allow", reviewRouted: false },
+    };
+    await expect(applyApprovedMutations(root, [evil])).rejects.toThrow(/invalid-identity/);
+    expect(await existsUnder(root, "wiki/escape.md")).toBe(false);
+  });
+});

--- a/test/trust-planner.test.ts
+++ b/test/trust-planner.test.ts
@@ -19,7 +19,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { writeFile, readFile } from "fs/promises";
 import path from "path";
-import { planPageMutation, type PlannedMutation } from "../src/trust/planner.js";
+import {
+  planPageMutation,
+  planDefaultPageMutation,
+  type PlannedMutation,
+  type RawPageRef,
+} from "../src/trust/planner.js";
 import { applyApprovedMutations } from "../src/trust/executor.js";
 import { replayJournal, openBatch, recordPreState } from "../src/trust/journal.js";
 import { entityId } from "../src/profile/identity.js";

--- a/test/trust-planner.test.ts
+++ b/test/trust-planner.test.ts
@@ -23,6 +23,7 @@ import { planPageMutation, type PlannedMutation } from "../src/trust/planner.js"
 import { applyApprovedMutations } from "../src/trust/executor.js";
 import { replayJournal, openBatch, recordPreState } from "../src/trust/journal.js";
 import { entityId } from "../src/profile/identity.js";
+import { MAX_SOURCE_CHARS } from "../src/utils/constants.js";
 import {
   WIKI,
   makeTrustRoot,
@@ -76,6 +77,30 @@ describe("planPageMutation — decision→plan mapping", () => {
   });
 });
 
+describe("planPageMutation — create vs update intent", () => {
+  it("plans a create for a free target regardless of allowOverwrite", async () => {
+    const out = await planPageMutation(planArgs("free", { allowOverwrite: true }));
+    expect(out.decision).toBe("allow");
+    expect(out.planned).toHaveLength(1);
+    expect(out.planned[0].operation).toBe("create");
+  });
+
+  it("plans an update (decision allow) for an existing target when allowOverwrite", async () => {
+    await writeFile(path.join(root, WIKI, "exists.md"), GOOD_BODY);
+    const out = await planPageMutation(planArgs("exists", { allowOverwrite: true }));
+    expect(out.decision).toBe("allow");
+    expect(out.planned).toHaveLength(1);
+    expect(out.planned[0].operation).toBe("update");
+  });
+
+  it("blocks (no live mutation) for an existing target when allowOverwrite is false", async () => {
+    await writeFile(path.join(root, WIKI, "exists.md"), GOOD_BODY);
+    const out = await planPageMutation(planArgs("exists", { allowOverwrite: false }));
+    expect(out.decision).toBe("deny");
+    expect(out.planned).toEqual([]);
+  });
+});
+
 /** Build a page-create PlannedMutation targeting `<WIKI>/<slug>.md`. */
 async function plannedFor(slug: string): Promise<PlannedMutation> {
   const out = await planPageMutation(planArgs(slug));
@@ -110,6 +135,47 @@ describe("applyApprovedMutations — create-collision re-probe under lock", () =
 
     // The pre-existing file is untouched — never overwritten by the create.
     expect(await readFile(target, "utf-8")).toBe("CONCURRENT");
+  });
+});
+
+/** Hand-build an `update` mutation targeting `<WIKI>/<slug>.md` with `body`. */
+function updateMutation(slug: string, body: string): PlannedMutation {
+  return {
+    kind: "page",
+    operation: "update",
+    target: { entityType: "concepts", slug, id: entityId("concepts", slug) },
+    body,
+    provenance: {
+      origin: "agent",
+      decision: "allow",
+      reviewRouted: false,
+    },
+  };
+}
+
+describe("applyApprovedMutations — update overwrites an existing target", () => {
+  it("overwrites without a create-collision error", async () => {
+    const target = path.join(root, WIKI, "exists.md");
+    await writeFile(target, "OLD");
+    const update = updateMutation("exists", GOOD_BODY);
+    await applyApprovedMutations(root, [update]);
+    expect(await readFile(target, "utf-8")).toBe(GOOD_BODY);
+  });
+});
+
+describe("applyApprovedMutations — S5 full-floor re-assertion", () => {
+  it("refuses an OVERSIZED body with MutationFloorError and writes nothing", async () => {
+    const huge = "x".repeat(MAX_SOURCE_CHARS + 1);
+    const update = updateMutation("big", huge);
+    await expect(applyApprovedMutations(root, [update])).rejects.toThrow(/mutation-floor/);
+    expect(await existsUnder(root, `${WIKI}/big.md`)).toBe(false);
+  });
+
+  it("refuses MALFORMED frontmatter with MutationFloorError and writes nothing", async () => {
+    const bad = "---\ntitle: : : bad\n  nope\n---\n\nbody\n";
+    const update = updateMutation("malformed", bad);
+    await expect(applyApprovedMutations(root, [update])).rejects.toThrow(/mutation-floor/);
+    expect(await existsUnder(root, `${WIKI}/malformed.md`)).toBe(false);
   });
 });
 

--- a/test/trust-promote.test.ts
+++ b/test/trust-promote.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @file test/trust-promote.test.ts
+ * @description Lock-safe typed promotion guards (FIX #3).
+ *
+ * `promoteCandidateUnderLock` (the shared routine behind both the SDK staging
+ * helper and `review approve`'s typed branch) re-reads the candidate, loads +
+ * validates the active profile, re-plans, applies, and deletes — ALL under one
+ * held lock. These tests pin the two race/staleness guards:
+ *  - concurrent-reject: the candidate vanishes between stage and promote →
+ *    promote aborts cleanly, no page written;
+ *  - profile-staleness: the active profile no longer declares the staged type →
+ *    promote refuses (CandidateProfileError), candidate retained;
+ * and the happy path: the page lands at `wiki/<entityType>/<slug>.md` and the
+ * candidate is cleared.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  stageEntityPage,
+  promoteStagedEntityPage,
+} from "../src/trust/staging.js";
+import { CandidateProfileError } from "../src/trust/promote.js";
+import { deleteCandidate } from "../src/compiler/candidates.js";
+import { PROFILE_FILE } from "../src/utils/constants.js";
+import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\nBody.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "trust-promote-"));
+  await buildResearchLiteProject(root);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Stage a fresh (non-colliding) typed `papers` candidate and return its id. */
+async function stage(): Promise<string> {
+  const staged = await stageEntityPage(root, {
+    entityType: "papers",
+    slug: SLUG,
+    body: BODY,
+    profile: RESEARCH_LITE_PROFILE,
+    existingStagedCount: 0,
+  });
+  return staged.id;
+}
+
+describe("lock-safe typed promotion", () => {
+  it("promotes the happy path to wiki/papers/<slug>.md and clears the candidate", async () => {
+    const id = await stage();
+    await promoteStagedEntityPage(root, id);
+    const page = path.join(root, "wiki/papers", `${SLUG}.md`);
+    expect(existsSync(page)).toBe(true);
+  });
+
+  it("aborts cleanly when the candidate was rejected between stage and promote", async () => {
+    const id = await stage();
+    await deleteCandidate(root, id); // concurrent reject
+
+    await expect(promoteStagedEntityPage(root, id)).rejects.toThrow(/not found/);
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+  });
+
+  it("refuses promotion when the profile no longer declares the staged type", async () => {
+    const id = await stage();
+    // Rewrite the profile so `papers` is no longer a declared entity type.
+    const trimmed = { ...RESEARCH_LITE_PROFILE, entities: { experiments: RESEARCH_LITE_PROFILE.entities.experiments } };
+    await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(trimmed), "utf8");
+
+    await expect(promoteStagedEntityPage(root, id)).rejects.toBeInstanceOf(CandidateProfileError);
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+  });
+});

--- a/test/trust-promote.test.ts
+++ b/test/trust-promote.test.ts
@@ -24,8 +24,9 @@ import {
   promoteStagedEntityPage,
 } from "../src/trust/staging.js";
 import { CandidateProfileError } from "../src/trust/promote.js";
-import { deleteCandidate } from "../src/compiler/candidates.js";
-import { PROFILE_FILE } from "../src/utils/constants.js";
+import { ResourceLimitError } from "../src/trust/checks.js";
+import { writeCandidate, deleteCandidate } from "../src/compiler/candidates.js";
+import { MAX_SOURCE_CHARS, PROFILE_FILE } from "../src/utils/constants.js";
 import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
 
 let root = "";
@@ -76,6 +77,21 @@ describe("lock-safe typed promotion", () => {
     await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(trimmed), "utf8");
 
     await expect(promoteStagedEntityPage(root, id)).rejects.toBeInstanceOf(CandidateProfileError);
+    expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
+  });
+});
+
+describe("promotion length-guard runs before frontmatter parse (FIX #5)", () => {
+  it("rejects an oversized all-frontmatter body with ResourceLimitError, not a field-contract error", async () => {
+    // All-frontmatter body > the cap: a yaml.load would burn ~1s; the length
+    // guard must fire FIRST, so the error is ResourceLimitError (not parse-driven).
+    const huge = `---\ntitle: ${"x".repeat(MAX_SOURCE_CHARS + 1)}\n---\n`;
+    const candidate = await writeCandidate(root, {
+      title: SLUG, slug: SLUG, summary: "", sources: [], body: huge,
+      targetEntityType: "papers",
+    });
+
+    await expect(promoteStagedEntityPage(root, candidate.id)).rejects.toBeInstanceOf(ResourceLimitError);
     expect(existsSync(path.join(root, "wiki/papers", `${SLUG}.md`))).toBe(false);
   });
 });

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @file test/trust-staging.test.ts
+ * @description End-to-end SDK-level test for the CLP Phase-3 NON-DEFAULT entity
+ * page staging loop (PR6 capstone).
+ *
+ * Drives `stageEntityPage` → `promoteStagedEntityPage` against the research-lite
+ * non-default profile fixture and asserts the full loop:
+ *  - staging a non-default entity page persists a typed candidate carrying
+ *    `targetEntityType` + `trustDecision`, and returns a `StagedChange` whose
+ *    target is a typed `EntityRef` (`papers/attention-is-all-you-need`);
+ *  - promotion lands the body at `wiki/papers/<slug>.md` and clears the candidate;
+ *  - the per-session volume bound fails CLOSED (no candidate written);
+ *  - a non-slug-safe identity blocks the live mutation without escaping the root;
+ *  - the DEFAULT candidate JSON shape stays clean (no typed keys) — a parity
+ *    guard complementing the frozen goldens.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, readFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  stageEntityPage,
+  promoteStagedEntityPage,
+} from "../src/trust/staging.js";
+import {
+  DEFAULT_STAGED_WRITE_PER_SESSION,
+  StagedWriteOverflowError,
+} from "../src/trust/staged-change.js";
+import { writeCandidate, listCandidates } from "../src/compiler/candidates.js";
+import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+const SLUG = "attention-is-all-you-need";
+const BODY = "---\ntitle: Attention Is All You Need\n---\n\n# Attention\n\nStaged body.\n";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "trust-staging-"));
+  await buildResearchLiteProject(root);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Read the single candidate JSON file in the candidates dir, parsed. */
+async function readOnlyCandidate(): Promise<Record<string, unknown>> {
+  const dir = path.join(root, ".llmwiki/candidates");
+  const files = (await readdir(dir)).filter((f) => f.endsWith(".json"));
+  expect(files).toHaveLength(1);
+  return JSON.parse(await readFile(path.join(dir, files[0]!), "utf8"));
+}
+
+describe("non-default entity page staging", () => {
+  it("stages a typed candidate carrying the entity type + a typed EntityRef target", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "papers",
+      slug: SLUG,
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount: 0,
+    });
+
+    expect(staged.kind).toBe("page");
+    expect(staged.target).toMatchObject({ entityType: "papers", slug: SLUG, id: `papers/${SLUG}` });
+    const candidate = await readOnlyCandidate();
+    expect(candidate.targetEntityType).toBe("papers");
+    expect(candidate.trustDecision).toBe(staged.trustDecision);
+    expect(candidate.body).toBe(BODY);
+  });
+
+  it("promotes the staged page into wiki/<entityType>/<slug>.md and clears the candidate", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "papers",
+      slug: SLUG,
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount: 0,
+    });
+
+    await promoteStagedEntityPage(root, staged.id);
+
+    const page = path.join(root, "wiki/papers", `${SLUG}.md`);
+    expect(await readFile(page, "utf8")).toBe(BODY);
+    expect(await listCandidates(root)).toHaveLength(0);
+  });
+
+  it("fails CLOSED on the per-session volume bound, writing no candidate", async () => {
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: SLUG,
+        body: BODY,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: DEFAULT_STAGED_WRITE_PER_SESSION,
+      }),
+    ).rejects.toBeInstanceOf(StagedWriteOverflowError);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
+  });
+
+  it("blocks a non-slug-safe identity without writing an escaping path", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "papers",
+      slug: "../evil",
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount: 0,
+    });
+
+    expect(staged.planned).toHaveLength(0);
+    expect(staged.heldReasons).toContain("trust-blocked");
+    expect(existsSync(path.join(root, "wiki/evil.md"))).toBe(false);
+  });
+
+  it("keeps the DEFAULT candidate JSON clean of typed keys (parity guard)", async () => {
+    await writeCandidate(root, {
+      title: "Plain",
+      slug: "plain",
+      summary: "",
+      sources: [],
+      body: "---\ntitle: Plain\n---\nBody.",
+    });
+
+    const candidate = await readOnlyCandidate();
+    expect("targetEntityType" in candidate).toBe(false);
+    expect("trustDecision" in candidate).toBe(false);
+  });
+});

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -25,6 +25,7 @@ import {
   promoteStagedEntityPage,
   UnknownEntityTypeError,
   BlockedStagedWriteError,
+  EntityFieldContractError,
 } from "../src/trust/staging.js";
 import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
@@ -129,6 +130,20 @@ describe("non-default entity page staging", () => {
     ).rejects.toBeInstanceOf(BlockedStagedWriteError);
 
     expect(existsSync(path.join(root, "wiki/evil.md"))).toBe(false);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
+  });
+
+  it("refuses a typed page missing a required field, writing NO candidate", async () => {
+    const noTitle = "---\nvenue: NeurIPS\n---\n\n# Body\n\nNo title field.\n";
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: SLUG,
+        body: noTitle,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(EntityFieldContractError);
     expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -24,6 +24,7 @@ import {
   stageEntityPage,
   promoteStagedEntityPage,
   UnknownEntityTypeError,
+  BlockedStagedWriteError,
 } from "../src/trust/staging.js";
 import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
@@ -33,8 +34,11 @@ import { writeCandidate, listCandidates } from "../src/compiler/candidates.js";
 import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
 
 let root = "";
-const SLUG = "attention-is-all-you-need";
-const BODY = "---\ntitle: Attention Is All You Need\n---\n\n# Attention\n\nStaged body.\n";
+// A FRESH slug not pre-seeded by buildResearchLiteProject, so the typed plan is
+// a live `create` (a seeded slug would collide under allowOverwrite:false and
+// route to stage-for-review — a blocked plan that now writes no candidate).
+const SLUG = "linear-attention";
+const BODY = "---\ntitle: Linear Attention\n---\n\n# Attention\n\nStaged body.\n";
 
 beforeEach(async () => {
   root = await mkdtemp(path.join(os.tmpdir(), "trust-staging-"));
@@ -113,18 +117,19 @@ describe("non-default entity page staging", () => {
     expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 
-  it("blocks a non-slug-safe identity without writing an escaping path", async () => {
-    const staged = await stageEntityPage(root, {
-      entityType: "papers",
-      slug: "../evil",
-      body: BODY,
-      profile: RESEARCH_LITE_PROFILE,
-      existingStagedCount: 0,
-    });
+  it("blocks a non-slug-safe identity, writing NO candidate and no escaping path", async () => {
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: "../evil",
+        body: BODY,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(BlockedStagedWriteError);
 
-    expect(staged.planned).toHaveLength(0);
-    expect(staged.heldReasons).toContain("trust-blocked");
     expect(existsSync(path.join(root, "wiki/evil.md"))).toBe(false);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 
   it("keeps the DEFAULT candidate JSON clean of typed keys (parity guard)", async () => {

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -23,6 +23,7 @@ import os from "node:os";
 import {
   stageEntityPage,
   promoteStagedEntityPage,
+  UnknownEntityTypeError,
 } from "../src/trust/staging.js";
 import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
@@ -96,6 +97,19 @@ describe("non-default entity page staging", () => {
         existingStagedCount: DEFAULT_STAGED_WRITE_PER_SESSION,
       }),
     ).rejects.toBeInstanceOf(StagedWriteOverflowError);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
+  });
+
+  it("rejects an entityType not declared by the profile, writing no candidate", async () => {
+    await expect(
+      stageEntityPage(root, {
+        entityType: "bogus",
+        slug: SLUG,
+        body: BODY,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(UnknownEntityTypeError);
     expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 

--- a/test/trust-staging.test.ts
+++ b/test/trust-staging.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, readFile, readdir } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, readFile, readdir, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -31,7 +31,9 @@ import {
   DEFAULT_STAGED_WRITE_PER_SESSION,
   StagedWriteOverflowError,
 } from "../src/trust/staged-change.js";
-import { writeCandidate, listCandidates } from "../src/compiler/candidates.js";
+import { ResourceLimitError } from "../src/trust/checks.js";
+import { MAX_SOURCE_CHARS } from "../src/utils/constants.js";
+import { writeCandidate, listCandidates, countCandidates } from "../src/compiler/candidates.js";
 import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
 
 let root = "";
@@ -49,6 +51,26 @@ beforeEach(async () => {
 afterEach(async () => {
   await rm(root, { recursive: true, force: true });
 });
+
+/**
+ * Seed `count` minimal valid candidate JSON files directly to disk (each a
+ * distinct slug), so {@link countCandidates} reports exactly `count` without
+ * routing through the staging budget. Models a session that has already landed
+ * candidates on disk.
+ */
+async function seedCandidatesOnDisk(count: number): Promise<void> {
+  const dir = path.join(root, ".llmwiki/candidates");
+  await mkdir(dir, { recursive: true });
+  for (let i = 0; i < count; i++) {
+    const id = `seed-${i}-abcd0000`;
+    const record = {
+      id, title: `t${i}`, slug: `seed-${i}`, summary: "", sources: [], body: "b",
+      generatedAt: "2026-01-01T00:00:00.000Z", reviewMode: "forced",
+      heldReasons: [{ code: "manual-review-requested" }],
+    };
+    await writeFile(path.join(dir, `${id}.json`), JSON.stringify(record), "utf8");
+  }
+}
 
 /** Read the single candidate JSON file in the candidates dir, parsed. */
 async function readOnlyCandidate(): Promise<Record<string, unknown>> {
@@ -159,5 +181,52 @@ describe("non-default entity page staging", () => {
     const candidate = await readOnlyCandidate();
     expect("targetEntityType" in candidate).toBe(false);
     expect("trustDecision" in candidate).toBe(false);
+  });
+});
+
+describe("per-session flood bound is derived from disk (FIX #3)", () => {
+  /** Stage one papers page, returning the rejection promise (no await). */
+  function stageOne(existingStagedCount: number): Promise<unknown> {
+    return stageEntityPage(root, {
+      entityType: "papers",
+      slug: SLUG,
+      body: BODY,
+      profile: RESEARCH_LITE_PROFILE,
+      existingStagedCount,
+    });
+  }
+
+  it("rejects when the on-disk count is at the cap EVEN IF the caller passes 0", async () => {
+    await seedCandidatesOnDisk(DEFAULT_STAGED_WRITE_PER_SESSION);
+
+    await expect(stageOne(0)).rejects.toBeInstanceOf(StagedWriteOverflowError);
+    // The exploit count is unchanged: no new candidate landed.
+    expect(await countCandidates(root)).toBe(DEFAULT_STAGED_WRITE_PER_SESSION);
+  });
+
+  it("still stages normally when the on-disk count is under the cap", async () => {
+    await seedCandidatesOnDisk(1);
+
+    const staged = await stageOne(0);
+    expect(staged).toMatchObject({ kind: "page" });
+    expect(await countCandidates(root)).toBe(2);
+  });
+});
+
+describe("staging length-guard runs before frontmatter parse (FIX #5)", () => {
+  it("rejects an oversized all-frontmatter body with ResourceLimitError, writing no candidate", async () => {
+    // All-frontmatter body > cap: the length guard must fire BEFORE yaml.load,
+    // so the thrown error is ResourceLimitError, not EntityFieldContractError.
+    const huge = `---\ntitle: ${"x".repeat(MAX_SOURCE_CHARS + 1)}\n---\n`;
+    await expect(
+      stageEntityPage(root, {
+        entityType: "papers",
+        slug: SLUG,
+        body: huge,
+        profile: RESEARCH_LITE_PROFILE,
+        existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(ResourceLimitError);
+    expect(existsSync(path.join(root, ".llmwiki/candidates"))).toBe(false);
   });
 });


### PR DESCRIPTION
Stacked on PR #128 (do not merge yet). Addresses the audit's headline finding — typed entity pages were written but invisible to every read surface — with the safe, design-question-free slice, and makes the rest explicit instead of silent.

- **Index findability:** the wiki index (`wiki/index.md`) now lists typed entity pages grouped by entity type, with links to `wiki/<entityType>/<slug>.md`. Additive and non-default only — a default project's index is byte-identical.
- **Loud, not silent:** approving a typed candidate now prints a one-line note that typed pages aren't yet in interlinking, semantic search, or the viewer; the SDK staging docstrings say the same. The half-integration is visible and documented rather than a silent trap on a public API.
- **Deferred design questions captured:** a Phase 4 read-integration plan records why the remaining surfaces (interlinking, embeddings, MOC, viewer) are deferred — each has a genuine design decision (cross-type wikilink resolution, embedding-store key collision, viewer graph routes) that interacts with the Phase 4 relation/lifecycle model.

Typed pages are now surfaced in status, JSON export, and the index; search/links/graph/viewer are explicitly Phase 4. Default profile byte-identical; full suite green (2026).