### PR TITLE
refactor(lint,candidates): Phase 4 groundwork — split rules.ts and candidates.ts under the size limit

### DIFF
--- a/src/compiler/candidate-paths.ts
+++ b/src/compiler/candidate-paths.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared candidate-store path resolution for the review pipeline.
+ *
+ * Both the WRITE side ({@link file://./candidates.ts}) and the READ side
+ * ({@link file://./candidate-read.ts}) of the candidate store need to turn a
+ * candidate id into a confined absolute JSON path. Hosting those resolvers here
+ * — rather than in either of the two larger modules — lets the read and write
+ * modules import the same primitives WITHOUT forming an import cycle (the read
+ * module re-exported back through `candidates.ts` would otherwise close a loop).
+ *
+ * The resolvers delegate to {@link confinedCandidateFilePath}, so a safe id under
+ * a NORMAL (real) candidates dir yields a byte-identical path to `path.join`
+ * (default parity preserved); an unsafe id throws {@link UnsafeCandidateIdError},
+ * and a symlinked containing dir escaping root throws — both before any I/O.
+ */
+
+import { confinedCandidateFilePath } from "./candidate-store-paths.js";
+import {
+  CANDIDATES_DIR,
+  CANDIDATES_ARCHIVE_DIR,
+} from "../utils/constants.js";
+
+/**
+ * Thrown when a candidate id or slug is not a single safe path component, so a
+ * traversal-bearing value (e.g. `../evil`) can never be joined into a candidate
+ * file path that escapes `.llmwiki/candidates/`. Default slugs from `slugify`
+ * are already filename-safe, so this never fires on the default path.
+ */
+export class UnsafeCandidateIdError extends Error {
+  constructor(kind: "id" | "slug", value: string) {
+    super(`unsafe candidate ${kind}: ${JSON.stringify(value)} is not a single safe path component`);
+    this.name = "UnsafeCandidateIdError";
+  }
+}
+
+/** Build the typed unsafe-id error for a candidate file id. */
+function unsafeCandidateId(id: string): Error {
+  return new UnsafeCandidateIdError("id", id);
+}
+
+/**
+ * Resolve a candidate file path under `dir`, asserting `id` is a single safe
+ * filename component AND REALPATH-confining the result under the project root via
+ * {@link confinedCandidateFilePath}. Defense in depth: a safe id under a NORMAL
+ * (real) candidates dir yields a byte-identical path to `path.join`, so default
+ * parity is preserved; an unsafe id throws {@link UnsafeCandidateIdError}, and a
+ * symlinked containing dir escaping root throws {@link UnsafeCandidateDirError} —
+ * both before any I/O.
+ * @param root - Project root directory.
+ * @param dir - Candidates subdir (pending or archive) relative to root.
+ * @param id - Candidate id to embed as the filename stem.
+ */
+function resolveCandidatePath(root: string, dir: string, id: string): Promise<string> {
+  return confinedCandidateFilePath(root, dir, id, unsafeCandidateId);
+}
+
+/** Absolute confined path to a candidate's JSON file. */
+export function candidatePath(root: string, id: string): Promise<string> {
+  return resolveCandidatePath(root, CANDIDATES_DIR, id);
+}
+
+/** Absolute confined path to the archived JSON file for a rejected candidate. */
+export function archivePath(root: string, id: string): Promise<string> {
+  return resolveCandidatePath(root, CANDIDATES_ARCHIVE_DIR, id);
+}

--- a/src/compiler/candidate-read.ts
+++ b/src/compiler/candidate-read.ts
@@ -1,0 +1,308 @@
+/**
+ * Review candidate READ, list, and sanitize/validate path.
+ *
+ * This is the load half of the candidate store (the write/dedup/identity half
+ * lives in {@link file://./candidates.ts}). It parses one candidate JSON file at
+ * a time, defends every consumed field at the IO boundary so a hand-edited or
+ * legacy file can never crash downstream consumers (`review list`, `review
+ * show`, `listCandidates`), and exposes the load helpers the review subcommands
+ * share (`loadCandidateOrFail`, `loadCandidateUnderLockOrFail`).
+ *
+ * It imports only the shared path resolvers ({@link file://./candidate-paths.ts})
+ * and never imports the write module, so `candidates.ts` can re-export these
+ * symbols without forming an import cycle.
+ */
+
+import {
+  listCandidateFileIds,
+} from "../utils/candidate-store.js";
+import {
+  resolveConfinedCandidatesDir,
+} from "./candidate-store-paths.js";
+import { candidatePath } from "./candidate-paths.js";
+import { safeReadFile } from "../utils/markdown.js";
+import * as output from "../utils/output.js";
+import { CANDIDATES_DIR } from "../utils/constants.js";
+import type { ReviewCandidate, SourceState } from "../utils/types.js";
+import type { HeldReason, PolicyHeldReasonCode, ReviewMode } from "../review/policy.js";
+import type { TrustDecision } from "../trust/decision.js";
+
+/** Default metadata for legacy `compile --review` callers. */
+export const DEFAULT_HELD_REASONS: HeldReason[] = [{ code: "manual-review-requested" }];
+
+/** All valid ReviewMode values. */
+const VALID_REVIEW_MODES: ReviewMode[] = ["policy", "forced", "imported"];
+
+/** All valid PolicyHeldReasonCode values — mirrors the closed union in policy.ts. */
+const VALID_HELD_REASON_CODES: PolicyHeldReasonCode[] = [
+  "low-confidence",
+  "contradicted",
+  "schema-violating",
+  "provenance-violating",
+  "all",
+  "manual-review-requested",
+  "imported-okf",
+];
+
+/** All valid TrustDecision values — mirrors the closed union in trust/decision.ts. */
+const VALID_TRUST_DECISIONS: TrustDecision[] = [
+  "allow",
+  "allow-with-warning",
+  "stage-for-review",
+  "quarantine",
+  "deny",
+];
+
+/** Find the pending candidate for a slug, if one exists. */
+export async function readCandidateBySlug(
+  root: string,
+  slug: string,
+): Promise<ReviewCandidate | null> {
+  const candidates = await listCandidates(root);
+  return candidates.find((candidate) => candidate.slug === slug) ?? null;
+}
+
+/**
+ * Collect the slugs of pending candidates whose approval lands in a
+ * link-resolvable directory (default concepts/queries). Typed candidates
+ * (those carrying `targetEntityType`) are EXCLUDED: typed pages are not part
+ * of the concepts/queries wikilink interlinking system (see
+ * {@link file://./../sdk/types.ts}), so approving one would NOT make a
+ * `[[link]]` resolve. Including their slugs here would wrongly demote a real
+ * broken wikilink to an info-level "awaiting review" — hiding a link that
+ * stays broken after approval.
+ */
+export async function listLinkResolvablePendingSlugs(root: string): Promise<Set<string>> {
+  const candidates = await listCandidates(root);
+  return new Set(
+    candidates.filter((candidate) => !candidate.targetEntityType).map((candidate) => candidate.slug),
+  );
+}
+
+/**
+ * Emit a CLI error, set exit code 1, and return null. Used by candidate load
+ * helpers to avoid duplicating the error-path boilerplate.
+ * @param message - Error message to display.
+ */
+function failWithError(message: string): null {
+  output.status("!", output.error(message));
+  process.exitCode = 1;
+  return null;
+}
+
+/**
+ * Load a candidate by id and, if missing, emit the standard "not found" CLI
+ * error and set process.exitCode = 1. Returns null when the candidate is
+ * missing so callers can early-return without re-implementing the same
+ * error block in every review subcommand.
+ * @param root - Project root directory.
+ * @param id - Candidate id to look up.
+ */
+export async function loadCandidateOrFail(
+  root: string,
+  id: string,
+): Promise<ReviewCandidate | null> {
+  const candidate = await readCandidate(root, id);
+  if (!candidate) return failWithError(`Candidate not found: ${id}`);
+  return candidate;
+}
+
+/**
+ * Re-read a candidate under the lock and abort if it has disappeared.
+ *
+ * This is the authoritative TOCTOU guard: a concurrent approve or reject may
+ * have removed the candidate after the pre-lock fast-fail but before the lock
+ * was acquired. Returning `null` signals the caller to abort without writing
+ * any output artefact.
+ * @param root - Project root directory.
+ * @param id - Candidate id to load.
+ * @returns The candidate if still present, or `null` after setting exit code 1.
+ */
+export async function loadCandidateUnderLockOrFail(
+  root: string,
+  id: string,
+): Promise<ReviewCandidate | null> {
+  const candidate = await readCandidate(root, id);
+  if (!candidate) {
+    return failWithError(`Candidate ${id} was removed by another process during review.`);
+  }
+  return candidate;
+}
+
+/**
+ * Parse a single candidate JSON file. Returns null when the file is missing.
+ * Structurally invalid files (unparseable JSON or missing required fields) are
+ * skipped with a warning rather than throwing, so `review list`/`show` never
+ * crash due to a hand-edited or truncated candidate file.
+ */
+export async function readCandidate(
+  root: string,
+  id: string,
+): Promise<ReviewCandidate | null> {
+  const raw = await safeReadFile(await candidatePath(root, id));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as ReviewCandidate;
+    if (!isValidCandidate(parsed)) {
+      output.note(`[llmwiki] Skipping malformed candidate file: ${id}.json (missing required fields)`);
+      return null;
+    }
+    return sanitizeCandidate(parsed);
+  } catch {
+    output.note(`[llmwiki] Skipping unparseable candidate file: ${id}.json`);
+    return null;
+  }
+}
+
+/**
+ * Sanitize and default every consumed field at the IO boundary. Ensures that
+ * user-edited or legacy candidate files can never crash downstream consumers
+ * (review list, review show, listCandidates).
+ *
+ * Fields that can be safely defaulted are corrected in place:
+ * - `generatedAt`: non-string values are replaced with a sentinel ISO string.
+ * - `reviewMode`: unknown values default to `"forced"` (safe legacy assumption).
+ * - `heldReasons`: non-array, missing, or entries with invalid codes are cleaned;
+ *   if the result is empty after filtering, defaults to `DEFAULT_HELD_REASONS`.
+ * - `sourceStates`: non-object values are treated as absent; entries with unsafe
+ *   keys (path separators, `..` traversal) or invalid field types are dropped so
+ *   approval can never write malformed state from a bad candidate file.
+ */
+function sanitizeCandidate(candidate: ReviewCandidate): ReviewCandidate {
+  const generatedAt =
+    typeof candidate.generatedAt === "string"
+      ? candidate.generatedAt
+      : new Date(0).toISOString();
+
+  const reviewMode: ReviewMode = VALID_REVIEW_MODES.includes(candidate.reviewMode)
+    ? candidate.reviewMode
+    : "forced";
+
+  const heldReasons = sanitizeHeldReasons(candidate.heldReasons);
+  const sourceStates = sanitizeSourceStates(candidate.sourceStates);
+
+  const result: ReviewCandidate = { ...candidate, generatedAt, reviewMode, heldReasons };
+  if (sourceStates !== undefined) result.sourceStates = sourceStates;
+  else delete result.sourceStates;
+  sanitizeTypedTarget(result);
+  return result;
+}
+
+/**
+ * Validate the Phase-2 typed-staging fields in place. Drops `targetEntityType`
+ * unless it's a string and `trustDecision` unless it's a valid TrustDecision,
+ * so a hand-edited or malformed candidate file can never carry junk metadata.
+ * @param candidate - The candidate to sanitize (mutated in place).
+ */
+function sanitizeTypedTarget(candidate: ReviewCandidate): void {
+  if (typeof candidate.targetEntityType !== "string") {
+    delete candidate.targetEntityType;
+  }
+  if (!VALID_TRUST_DECISIONS.includes(candidate.trustDecision as TrustDecision)) {
+    delete candidate.trustDecision;
+  }
+}
+
+/** Filter `heldReasons` to only entries with a valid code shape; default when empty. */
+function sanitizeHeldReasons(raw: unknown): HeldReason[] {
+  if (!Array.isArray(raw)) return DEFAULT_HELD_REASONS;
+  const valid = raw.filter(
+    (r): r is HeldReason =>
+      r !== null &&
+      typeof r === "object" &&
+      typeof (r as Record<string, unknown>).code === "string" &&
+      VALID_HELD_REASON_CODES.includes((r as HeldReason).code),
+  );
+  return valid.length > 0 ? valid : DEFAULT_HELD_REASONS;
+}
+
+/**
+ * Return true when a source-state key is a safe plain basename.
+ * Rejects any key containing `/`, `\`, or the sequence `..` to prevent
+ * path-traversal attacks when the key is later used as a state.json entry.
+ */
+function isSourceKeysafe(key: string): boolean {
+  return !key.includes("/") && !key.includes("\\") && !key.includes("..");
+}
+
+/**
+ * Validate and filter a raw `sourceStates` value from disk.
+ *
+ * Rules enforced per entry:
+ * - Key must be a safe plain basename (no path separators, no `..`).
+ * - `hash` must be a non-empty string.
+ * - `concepts` must be a `string[]`.
+ * - `compiledAt` must be a string.
+ *
+ * If `raw` is not a plain object, returns `undefined` (treated as absent).
+ * Valid entries are kept; invalid ones are silently dropped.
+ */
+function sanitizeSourceStates(
+  raw: unknown,
+): Record<string, SourceState> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const result: Record<string, SourceState> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!isSourceKeyValid(key, value)) continue;
+    result[key] = value as SourceState;
+  }
+  return result;
+}
+
+/** Return true when both the key is path-safe and the entry fields are valid. */
+function isSourceKeyValid(key: string, value: unknown): boolean {
+  if (!isSourceKeysafe(key)) return false;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.hash === "string" &&
+    entry.hash.length > 0 &&
+    Array.isArray(entry.concepts) &&
+    (entry.concepts as unknown[]).every((c) => typeof c === "string") &&
+    typeof entry.compiledAt === "string"
+  );
+}
+
+/** Defensive type-guard so corrupted candidate files don't blow up the CLI. */
+function isValidCandidate(value: unknown): value is ReviewCandidate {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.slug === "string" &&
+    typeof candidate.body === "string" &&
+    Array.isArray(candidate.sources)
+  );
+}
+
+/**
+ * List every candidate currently pending review, sorted by generation time.
+ * Skips files that aren't candidate JSON (e.g. the archive subdirectory).
+ * @param root - Project root directory.
+ * @returns All pending review candidates.
+ */
+export async function listCandidates(root: string): Promise<ReviewCandidate[]> {
+  const dir = await resolveConfinedCandidatesDir(root, CANDIDATES_DIR);
+  if (dir === null) return []; // absent candidates dir → nothing pending
+  const ids = await listCandidateFileIds(dir);
+  const candidates: ReviewCandidate[] = [];
+  for (const id of ids) {
+    const candidate = await readCandidate(root, id);
+    if (candidate) candidates.push(candidate);
+  }
+
+  candidates.sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
+  return candidates;
+}
+
+/**
+ * Count pending candidates using the same validity filter as listCandidates,
+ * so consumers (e.g. `wiki_status.pendingCandidates`) never report counts
+ * that disagree with what `review list` actually shows. Malformed JSON files
+ * are skipped here exactly as they are by listCandidates.
+ */
+export async function countCandidates(root: string): Promise<number> {
+  const candidates = await listCandidates(root);
+  return candidates.length;
+}

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -10,31 +10,42 @@
  * compile runs and can be inspected manually without the CLI. Each record
  * stores the full page body so approval is a pure copy — the LLM is never
  * called again at approval time.
+ *
+ * This module owns the WRITE/dedup/identity/delete/archive half of the store.
+ * The READ/list/sanitize/validate half lives in {@link file://./candidate-read.ts}
+ * and the shared path resolvers in {@link file://./candidate-paths.ts}; both are
+ * RE-EXPORTED below so existing importers of `candidates.ts` are unchanged.
  */
 
 import { unlink } from "fs/promises";
 import { existsSync } from "fs";
-import path from "path";
 import { randomBytes } from "crypto";
 import { isSafeFilenameComponent } from "../profile/identity.js";
-import { atomicWrite, safeReadFile } from "../utils/markdown.js";
+import { atomicWrite } from "../utils/markdown.js";
+import { moveCandidateToArchive } from "../utils/candidate-store.js";
+import { candidatePath, archivePath, UnsafeCandidateIdError } from "./candidate-paths.js";
 import {
-  listCandidateFileIds,
-  moveCandidateToArchive,
-} from "../utils/candidate-store.js";
-import {
-  confinedCandidateFilePath,
-  resolveConfinedCandidatesDir,
-} from "./candidate-store-paths.js";
-import * as output from "../utils/output.js";
-import {
-  CANDIDATES_DIR,
-  CANDIDATES_ARCHIVE_DIR,
-} from "../utils/constants.js";
+  listCandidates,
+  countCandidates,
+  DEFAULT_HELD_REASONS,
+} from "./candidate-read.js";
 import type { ReviewCandidate, SourceState } from "../utils/types.js";
-import type { HeldReason, PolicyHeldReasonCode, ReviewMode } from "../review/policy.js";
+import type { HeldReason, ReviewMode } from "../review/policy.js";
 import type { LintResult } from "../linter/types.js";
 import type { TrustDecision } from "../trust/decision.js";
+
+// Re-export the read/list/sanitize half and shared path symbols so every
+// existing importer of `candidates.ts` keeps working without churn.
+export {
+  readCandidate,
+  readCandidateBySlug,
+  listCandidates,
+  countCandidates,
+  listLinkResolvablePendingSlugs,
+  loadCandidateOrFail,
+  loadCandidateUnderLockOrFail,
+} from "./candidate-read.js";
+export { UnsafeCandidateIdError } from "./candidate-paths.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
 const ID_SUFFIX_BYTES = 4;
@@ -94,45 +105,6 @@ export interface CandidateDraft {
   trustDecision?: TrustDecision;
 }
 
-/** Default metadata for legacy `compile --review` callers. */
-const DEFAULT_HELD_REASONS: HeldReason[] = [{ code: "manual-review-requested" }];
-
-/** All valid ReviewMode values. */
-const VALID_REVIEW_MODES: ReviewMode[] = ["policy", "forced", "imported"];
-
-/** All valid PolicyHeldReasonCode values — mirrors the closed union in policy.ts. */
-const VALID_HELD_REASON_CODES: PolicyHeldReasonCode[] = [
-  "low-confidence",
-  "contradicted",
-  "schema-violating",
-  "provenance-violating",
-  "all",
-  "manual-review-requested",
-  "imported-okf",
-];
-
-/** All valid TrustDecision values — mirrors the closed union in trust/decision.ts. */
-const VALID_TRUST_DECISIONS: TrustDecision[] = [
-  "allow",
-  "allow-with-warning",
-  "stage-for-review",
-  "quarantine",
-  "deny",
-];
-
-/**
- * Thrown when a candidate id or slug is not a single safe path component, so a
- * traversal-bearing value (e.g. `../evil`) can never be joined into a candidate
- * file path that escapes `.llmwiki/candidates/`. Default slugs from `slugify`
- * are already filename-safe, so this never fires on the default path.
- */
-export class UnsafeCandidateIdError extends Error {
-  constructor(kind: "id" | "slug", value: string) {
-    super(`unsafe candidate ${kind}: ${JSON.stringify(value)} is not a single safe path component`);
-    this.name = "UnsafeCandidateIdError";
-  }
-}
-
 /** Build a deterministic-but-unique id from a slug and a short random suffix. */
 function buildCandidateId(slug: string): string {
   const suffix = randomBytes(ID_SUFFIX_BYTES).toString("hex");
@@ -156,37 +128,6 @@ function candidateTargetKey(candidate: {
 }): string {
   const target = candidate.targetEntityType ?? candidate.targetDirectory ?? "concepts";
   return `${target}/${candidate.slug}`;
-}
-
-/** Build the typed unsafe-id error for a candidate file id. */
-function unsafeCandidateId(id: string): Error {
-  return new UnsafeCandidateIdError("id", id);
-}
-
-/**
- * Resolve a candidate file path under `dir`, asserting `id` is a single safe
- * filename component AND REALPATH-confining the result under the project root via
- * {@link confinedCandidateFilePath}. Defense in depth: a safe id under a NORMAL
- * (real) candidates dir yields a byte-identical path to `path.join`, so default
- * parity is preserved; an unsafe id throws {@link UnsafeCandidateIdError}, and a
- * symlinked containing dir escaping root throws {@link UnsafeCandidateDirError} —
- * both before any I/O.
- * @param root - Project root directory.
- * @param dir - Candidates subdir (pending or archive) relative to root.
- * @param id - Candidate id to embed as the filename stem.
- */
-function resolveCandidatePath(root: string, dir: string, id: string): Promise<string> {
-  return confinedCandidateFilePath(root, dir, id, unsafeCandidateId);
-}
-
-/** Absolute confined path to a candidate's JSON file. */
-function candidatePath(root: string, id: string): Promise<string> {
-  return resolveCandidatePath(root, CANDIDATES_DIR, id);
-}
-
-/** Absolute confined path to the archived JSON file for a rejected candidate. */
-function archivePath(root: string, id: string): Promise<string> {
-  return resolveCandidatePath(root, CANDIDATES_ARCHIVE_DIR, id);
 }
 
 /**
@@ -263,260 +204,6 @@ async function deleteDuplicates(root: string, ids: string[]): Promise<void> {
   for (const id of ids) {
     await deleteCandidate(root, id);
   }
-}
-
-/** Find the pending candidate for a slug, if one exists. */
-export async function readCandidateBySlug(
-  root: string,
-  slug: string,
-): Promise<ReviewCandidate | null> {
-  const candidates = await listCandidates(root);
-  return candidates.find((candidate) => candidate.slug === slug) ?? null;
-}
-
-/**
- * Collect the slugs of pending candidates whose approval lands in a
- * link-resolvable directory (default concepts/queries). Typed candidates
- * (those carrying `targetEntityType`) are EXCLUDED: typed pages are not part
- * of the concepts/queries wikilink interlinking system (see
- * {@link file://./../sdk/types.ts}), so approving one would NOT make a
- * `[[link]]` resolve. Including their slugs here would wrongly demote a real
- * broken wikilink to an info-level "awaiting review" — hiding a link that
- * stays broken after approval.
- */
-export async function listLinkResolvablePendingSlugs(root: string): Promise<Set<string>> {
-  const candidates = await listCandidates(root);
-  return new Set(
-    candidates.filter((candidate) => !candidate.targetEntityType).map((candidate) => candidate.slug),
-  );
-}
-
-/**
- * Emit a CLI error, set exit code 1, and return null. Used by candidate load
- * helpers to avoid duplicating the error-path boilerplate.
- * @param message - Error message to display.
- */
-function failWithError(message: string): null {
-  output.status("!", output.error(message));
-  process.exitCode = 1;
-  return null;
-}
-
-/**
- * Load a candidate by id and, if missing, emit the standard "not found" CLI
- * error and set process.exitCode = 1. Returns null when the candidate is
- * missing so callers can early-return without re-implementing the same
- * error block in every review subcommand.
- * @param root - Project root directory.
- * @param id - Candidate id to look up.
- */
-export async function loadCandidateOrFail(
-  root: string,
-  id: string,
-): Promise<ReviewCandidate | null> {
-  const candidate = await readCandidate(root, id);
-  if (!candidate) return failWithError(`Candidate not found: ${id}`);
-  return candidate;
-}
-
-/**
- * Re-read a candidate under the lock and abort if it has disappeared.
- *
- * This is the authoritative TOCTOU guard: a concurrent approve or reject may
- * have removed the candidate after the pre-lock fast-fail but before the lock
- * was acquired. Returning `null` signals the caller to abort without writing
- * any output artefact.
- * @param root - Project root directory.
- * @param id - Candidate id to load.
- * @returns The candidate if still present, or `null` after setting exit code 1.
- */
-export async function loadCandidateUnderLockOrFail(
-  root: string,
-  id: string,
-): Promise<ReviewCandidate | null> {
-  const candidate = await readCandidate(root, id);
-  if (!candidate) {
-    return failWithError(`Candidate ${id} was removed by another process during review.`);
-  }
-  return candidate;
-}
-
-/**
- * Parse a single candidate JSON file. Returns null when the file is missing.
- * Structurally invalid files (unparseable JSON or missing required fields) are
- * skipped with a warning rather than throwing, so `review list`/`show` never
- * crash due to a hand-edited or truncated candidate file.
- */
-export async function readCandidate(
-  root: string,
-  id: string,
-): Promise<ReviewCandidate | null> {
-  const raw = await safeReadFile(await candidatePath(root, id));
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as ReviewCandidate;
-    if (!isValidCandidate(parsed)) {
-      output.note(`[llmwiki] Skipping malformed candidate file: ${id}.json (missing required fields)`);
-      return null;
-    }
-    return sanitizeCandidate(parsed);
-  } catch {
-    output.note(`[llmwiki] Skipping unparseable candidate file: ${id}.json`);
-    return null;
-  }
-}
-
-/**
- * Sanitize and default every consumed field at the IO boundary. Ensures that
- * user-edited or legacy candidate files can never crash downstream consumers
- * (review list, review show, listCandidates).
- *
- * Fields that can be safely defaulted are corrected in place:
- * - `generatedAt`: non-string values are replaced with a sentinel ISO string.
- * - `reviewMode`: unknown values default to `"forced"` (safe legacy assumption).
- * - `heldReasons`: non-array, missing, or entries with invalid codes are cleaned;
- *   if the result is empty after filtering, defaults to `DEFAULT_HELD_REASONS`.
- * - `sourceStates`: non-object values are treated as absent; entries with unsafe
- *   keys (path separators, `..` traversal) or invalid field types are dropped so
- *   approval can never write malformed state from a bad candidate file.
- */
-function sanitizeCandidate(candidate: ReviewCandidate): ReviewCandidate {
-  const generatedAt =
-    typeof candidate.generatedAt === "string"
-      ? candidate.generatedAt
-      : new Date(0).toISOString();
-
-  const reviewMode: ReviewMode = VALID_REVIEW_MODES.includes(candidate.reviewMode)
-    ? candidate.reviewMode
-    : "forced";
-
-  const heldReasons = sanitizeHeldReasons(candidate.heldReasons);
-  const sourceStates = sanitizeSourceStates(candidate.sourceStates);
-
-  const result: ReviewCandidate = { ...candidate, generatedAt, reviewMode, heldReasons };
-  if (sourceStates !== undefined) result.sourceStates = sourceStates;
-  else delete result.sourceStates;
-  sanitizeTypedTarget(result);
-  return result;
-}
-
-/**
- * Validate the Phase-2 typed-staging fields in place. Drops `targetEntityType`
- * unless it's a string and `trustDecision` unless it's a valid TrustDecision,
- * so a hand-edited or malformed candidate file can never carry junk metadata.
- * @param candidate - The candidate to sanitize (mutated in place).
- */
-function sanitizeTypedTarget(candidate: ReviewCandidate): void {
-  if (typeof candidate.targetEntityType !== "string") {
-    delete candidate.targetEntityType;
-  }
-  if (!VALID_TRUST_DECISIONS.includes(candidate.trustDecision as TrustDecision)) {
-    delete candidate.trustDecision;
-  }
-}
-
-/** Filter `heldReasons` to only entries with a valid code shape; default when empty. */
-function sanitizeHeldReasons(raw: unknown): HeldReason[] {
-  if (!Array.isArray(raw)) return DEFAULT_HELD_REASONS;
-  const valid = raw.filter(
-    (r): r is HeldReason =>
-      r !== null &&
-      typeof r === "object" &&
-      typeof (r as Record<string, unknown>).code === "string" &&
-      VALID_HELD_REASON_CODES.includes((r as HeldReason).code),
-  );
-  return valid.length > 0 ? valid : DEFAULT_HELD_REASONS;
-}
-
-/**
- * Return true when a source-state key is a safe plain basename.
- * Rejects any key containing `/`, `\`, or the sequence `..` to prevent
- * path-traversal attacks when the key is later used as a state.json entry.
- */
-function isSourceKeysafe(key: string): boolean {
-  return !key.includes("/") && !key.includes("\\") && !key.includes("..");
-}
-
-/**
- * Validate and filter a raw `sourceStates` value from disk.
- *
- * Rules enforced per entry:
- * - Key must be a safe plain basename (no path separators, no `..`).
- * - `hash` must be a non-empty string.
- * - `concepts` must be a `string[]`.
- * - `compiledAt` must be a string.
- *
- * If `raw` is not a plain object, returns `undefined` (treated as absent).
- * Valid entries are kept; invalid ones are silently dropped.
- */
-function sanitizeSourceStates(
-  raw: unknown,
-): Record<string, SourceState> | undefined {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
-  const result: Record<string, SourceState> = {};
-  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
-    if (!isSourceKeyValid(key, value)) continue;
-    result[key] = value as SourceState;
-  }
-  return result;
-}
-
-/** Return true when both the key is path-safe and the entry fields are valid. */
-function isSourceKeyValid(key: string, value: unknown): boolean {
-  if (!isSourceKeysafe(key)) return false;
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const entry = value as Record<string, unknown>;
-  return (
-    typeof entry.hash === "string" &&
-    entry.hash.length > 0 &&
-    Array.isArray(entry.concepts) &&
-    (entry.concepts as unknown[]).every((c) => typeof c === "string") &&
-    typeof entry.compiledAt === "string"
-  );
-}
-
-/** Defensive type-guard so corrupted candidate files don't blow up the CLI. */
-function isValidCandidate(value: unknown): value is ReviewCandidate {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as Record<string, unknown>;
-  return (
-    typeof candidate.id === "string" &&
-    typeof candidate.title === "string" &&
-    typeof candidate.slug === "string" &&
-    typeof candidate.body === "string" &&
-    Array.isArray(candidate.sources)
-  );
-}
-
-/**
- * List every candidate currently pending review, sorted by generation time.
- * Skips files that aren't candidate JSON (e.g. the archive subdirectory).
- * @param root - Project root directory.
- * @returns All pending review candidates.
- */
-export async function listCandidates(root: string): Promise<ReviewCandidate[]> {
-  const dir = await resolveConfinedCandidatesDir(root, CANDIDATES_DIR);
-  if (dir === null) return []; // absent candidates dir → nothing pending
-  const ids = await listCandidateFileIds(dir);
-  const candidates: ReviewCandidate[] = [];
-  for (const id of ids) {
-    const candidate = await readCandidate(root, id);
-    if (candidate) candidates.push(candidate);
-  }
-
-  candidates.sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
-  return candidates;
-}
-
-/**
- * Count pending candidates using the same validity filter as listCandidates,
- * so consumers (e.g. `wiki_status.pendingCandidates`) never report counts
- * that disagree with what `review list` actually shows. Malformed JSON files
- * are skipped here exactly as they are by listCandidates.
- */
-export async function countCandidates(root: string): Promise<number> {
-  const candidates = await listCandidates(root);
-  return candidates.length;
 }
 
 /** Remove a pending candidate from disk. Returns false when nothing existed to remove. */

--- a/src/linter/rules-citations.ts
+++ b/src/linter/rules-citations.ts
@@ -1,0 +1,216 @@
+/**
+ * Citation / provenance lint rules.
+ *
+ * This family validates the `^[file.md]` citation markers that anchor wiki
+ * prose to its sources: broken citations (source file missing or claim-level
+ * line span out of bounds) and malformed claim citations (entries that don't
+ * parse against the documented `file.md` / `file.md:N-N` / `file.md#LN-LN`
+ * grammar). Each on-disk walker has a pure per-page variant so the in-memory
+ * candidate-lint path (`compile --review`) surfaces the same findings before a
+ * reviewer approves a candidate. Re-exported through {@link file://./rules.ts}.
+ */
+
+import { existsSync } from "fs";
+import path from "path";
+import {
+  isMalformedCitationEntry,
+  parseFrontmatter,
+  safeReadFile,
+  splitCitationMarker,
+} from "../utils/markdown.js";
+import { SOURCES_DIR } from "../utils/constants.js";
+import type { LintResult } from "./types.js";
+import {
+  CITATION_PATTERN,
+  collectAllPages,
+  findMatchesInContent,
+} from "./rules-shared.js";
+
+/** Regex matching the `:start-end` span suffix on a citation entry. */
+const COLON_SPAN_PATTERN = /^[^:#]+:(\d+)(?:[,-]\s*(\d+))?$/;
+
+/** Regex matching the `#Lstart-Lend` span suffix on a citation entry. */
+const HASH_SPAN_PATTERN = /^[^:#]+#L(\d+)(?:-L(\d+))?$/;
+
+/** Parsed line range from a citation entry, or null if no range is present. */
+interface ParsedLineRange {
+  start: number;
+  end: number;
+}
+
+/** Strip an optional `:start-end` or `#Lstart-Lend` span suffix from a citation entry. */
+function stripSpanSuffix(entry: string): string {
+  const colonIdx = entry.indexOf(":");
+  const hashIdx = entry.indexOf("#");
+  const cuts = [colonIdx, hashIdx].filter((i) => i >= 0);
+  if (cuts.length === 0) return entry;
+  return entry.slice(0, Math.min(...cuts));
+}
+
+/** Extract the line range from a citation entry string, or return null if there is none. */
+function parseLineRange(entry: string): ParsedLineRange | null {
+  const colonMatch = COLON_SPAN_PATTERN.exec(entry);
+  if (colonMatch) {
+    const start = Number(colonMatch[1]);
+    const end = colonMatch[2] !== undefined ? Number(colonMatch[2]) : start;
+    return { start, end };
+  }
+  const hashMatch = HASH_SPAN_PATTERN.exec(entry);
+  if (hashMatch) {
+    const start = Number(hashMatch[1]);
+    const end = hashMatch[2] !== undefined ? Number(hashMatch[2]) : start;
+    return { start, end };
+  }
+  return null;
+}
+
+/** Count the number of lines in a file's text content. */
+function countLines(content: string): number {
+  if (content.length === 0) return 0;
+  return content.split("\n").length;
+}
+
+/**
+ * Find ^[filename.md] citations referencing source files that don't exist, and
+ * flag claim-level spans whose line ranges exceed the source file's actual length.
+ * Handles both single-source ^[file.md] and multi-source ^[a.md, b.md] forms,
+ * plus the claim-level extension `^[file.md:42-58]` / `^[file.md#L42-L58]`.
+ * Line counts are cached per source file to avoid redundant reads.
+ */
+export async function checkBrokenCitations(root: string): Promise<LintResult[]> {
+  const pages = await collectAllPages(root);
+  const sourcesDir = path.join(root, SOURCES_DIR);
+  const results: LintResult[] = [];
+  const lineCountCache = new Map<string, number>();
+
+  for (const page of pages) {
+    const { meta } = parseFrontmatter(page.content);
+    // Imported pages cite EXTERNAL bundle sources (not copied into sources/), so
+    // local source-existence does not apply — exempt them from broken-citation.
+    if (meta.provenanceState === "imported") continue;
+    const pageFindings = await checkPageBrokenCitations(
+      page.content,
+      page.filePath,
+      sourcesDir,
+      lineCountCache,
+    );
+    results.push(...pageFindings);
+  }
+
+  return results;
+}
+
+/**
+ * Pure-body variant of {@link checkBrokenCitations} that inspects a single
+ * page's content against an in-memory or on-disk sources directory. Used
+ * by the on-disk lint walker above, and by the in-memory candidate-lint
+ * path so `compile --review` surfaces broken-source-file and out-of-bounds
+ * span findings before a reviewer approves the candidate.
+ *
+ * @param content - Full page markdown including frontmatter.
+ * @param filePath - Logical path embedded in diagnostics (may be virtual).
+ * @param sourcesDir - Absolute path to the project's sources/ directory.
+ * @param lineCountCache - Optional cross-page cache; provide one when
+ *   linting many pages so source file line counts aren't re-read.
+ */
+export async function checkPageBrokenCitations(
+  content: string,
+  filePath: string,
+  sourcesDir: string,
+  lineCountCache: Map<string, number> = new Map(),
+): Promise<LintResult[]> {
+  const results: LintResult[] = [];
+  for (const { captured, line } of findMatchesInContent(content, CITATION_PATTERN)) {
+    await collectBrokenForMarker(captured, line, filePath, sourcesDir, lineCountCache, results);
+  }
+  return results;
+}
+
+/** Append broken-citation diagnostics for every entry inside a single ^[...] marker. */
+async function collectBrokenForMarker(
+  captured: string,
+  line: number,
+  pageFile: string,
+  sourcesDir: string,
+  lineCountCache: Map<string, number>,
+  out: LintResult[],
+): Promise<void> {
+  for (const part of splitCitationMarker(captured)) {
+    const trimmed = part.trim();
+    if (trimmed.length === 0) continue;
+    const filename = stripSpanSuffix(trimmed);
+    const citedPath = path.join(sourcesDir, filename);
+    if (!existsSync(citedPath)) {
+      out.push({
+        rule: "broken-citation",
+        severity: "error",
+        file: pageFile,
+        message: `Broken citation ^[${filename}] — source file not found`,
+        line,
+      });
+      continue;
+    }
+    const range = parseLineRange(trimmed);
+    if (range === null) continue;
+    const lineCount = await resolveLineCount(citedPath, filename, lineCountCache);
+    if (range.end <= lineCount) continue;
+    out.push({
+      rule: "broken-citation",
+      severity: "error",
+      file: pageFile,
+      message: `Claim-level span ^[${trimmed}] is out of bounds (source has only ${lineCount} lines)`,
+      line,
+    });
+  }
+}
+
+/** Return the line count for a source file, reading and caching if necessary. */
+async function resolveLineCount(
+  citedPath: string,
+  filename: string,
+  cache: Map<string, number>,
+): Promise<number> {
+  const cached = cache.get(filename);
+  if (cached !== undefined) return cached;
+  const content = await safeReadFile(citedPath);
+  const lineCount = countLines(content);
+  cache.set(filename, lineCount);
+  return lineCount;
+}
+
+/**
+ * Find ^[...] markers whose entries do not parse against the documented
+ * paragraph or claim-level grammar (e.g. `^[file.md:abc]` or `^[file.md#X]`).
+ * Detects malformed claim-level citations without breaking the paragraph form.
+ */
+export async function checkMalformedClaimCitations(root: string): Promise<LintResult[]> {
+  const pages = await collectAllPages(root);
+  const results: LintResult[] = [];
+  for (const page of pages) {
+    results.push(...checkPageMalformedCitations(page.content, page.filePath));
+  }
+  return results;
+}
+
+/**
+ * Pure-body variant of {@link checkMalformedClaimCitations} that inspects
+ * a single page's content. Used by both the on-disk lint walker above and
+ * the in-memory candidate-lint path so `compile --review` surfaces
+ * malformed claim citations before a reviewer approves the candidate.
+ */
+export function checkPageMalformedCitations(content: string, filePath: string): LintResult[] {
+  const results: LintResult[] = [];
+  for (const { captured, line } of findMatchesInContent(content, CITATION_PATTERN)) {
+    for (const part of splitCitationMarker(captured)) {
+      if (!isMalformedCitationEntry(part)) continue;
+      results.push({
+        rule: "malformed-claim-citation",
+        severity: "error",
+        file: filePath,
+        message: `Malformed claim citation ^[${captured}] — expected file.md, file.md:N-N, or file.md#LN-LN`,
+        line,
+      });
+    }
+  }
+  return results;
+}

--- a/src/linter/rules-crosslinks.ts
+++ b/src/linter/rules-crosslinks.ts
@@ -1,0 +1,86 @@
+/**
+ * Schema cross-link lint rules.
+ *
+ * Enforces the per-kind `minWikilinks` minimums declared in the project schema:
+ * each page resolves to a kind, and a page whose body carries fewer
+ * `[[wikilinks]]` than its kind requires warns. The on-disk walker
+ * ({@link checkSchemaCrossLinks}) fans the pure per-page helper
+ * ({@link checkPageCrossLinks}) across every page, and that same per-page helper
+ * is reused by the review pipeline to attach schema violations to a candidate at
+ * write time. Re-exported through {@link file://./rules.ts}.
+ */
+
+import { parseFrontmatter } from "../utils/markdown.js";
+import type { LintResult } from "./types.js";
+import {
+  countWikilinks,
+  resolvePageKind,
+  type SchemaConfig,
+} from "../schema/index.js";
+import { collectAllPages } from "./rules-shared.js";
+
+/**
+ * Enforce per-kind cross-link minimums declared in the schema.
+ * For each page, resolve its kind, look up the rule, and warn when the page
+ * body has fewer wikilinks than the rule requires. Pages with kind `concept`
+ * and a minimum of 0 (the default) generate no diagnostics, so existing
+ * projects without a schema file see no behaviour change.
+ *
+ * Implementation delegates to {@link checkPageCrossLinks} per page so the
+ * actual rule logic lives in exactly one place — the on-disk walker just
+ * fans the per-page helper across `collectAllPages`.
+ * @param root - Project root directory.
+ * @param schema - Resolved schema config.
+ */
+export async function checkSchemaCrossLinks(
+  root: string,
+  schema: SchemaConfig,
+): Promise<LintResult[]> {
+  const pages = await collectAllPages(root);
+  const results: LintResult[] = [];
+  for (const page of pages) {
+    results.push(...checkPageCrossLinks(page.content, page.filePath, schema));
+  }
+  return results;
+}
+
+/**
+ * Check cross-link minimums for a single page given as a raw content string.
+ *
+ * Unlike `checkSchemaCrossLinks`, this function operates on content already in
+ * memory without reading from disk. Used by the review pipeline to attach
+ * schema violations to a candidate at write time so `review show` can surface
+ * them before the reviewer approves the page.
+ *
+ * The `filePath` parameter is embedded verbatim in each `LintResult.file` so
+ * callers control how the candidate is identified in diagnostic output.
+ *
+ * @param content - Full page content including frontmatter.
+ * @param filePath - Logical file path to embed in diagnostics (may be virtual).
+ * @param schema - Resolved schema config.
+ * @returns Lint results for this single page, empty when no violations found.
+ */
+export function checkPageCrossLinks(
+  content: string,
+  filePath: string,
+  schema: SchemaConfig,
+): LintResult[] {
+  const { meta, body } = parseFrontmatter(content);
+  const kind = resolvePageKind(meta.kind, schema);
+  const rule = schema.kinds[kind];
+  if (rule.minWikilinks <= 0) return [];
+
+  const linkCount = countWikilinks(body);
+  if (linkCount >= rule.minWikilinks) return [];
+
+  return [
+    {
+      rule: "schema-cross-link-minimum",
+      severity: "warning",
+      file: filePath,
+      message:
+        `Page kind "${kind}" requires at least ${rule.minWikilinks} ` +
+        `[[wikilinks]] but only ${linkCount} found.`,
+    },
+  ];
+}

--- a/src/linter/rules-shared.ts
+++ b/src/linter/rules-shared.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared primitives for the wiki lint rule families.
+ *
+ * The lint rules are split across sibling modules by family — wikilink/orphan/
+ * freshness/quality in {@link file://./rules.ts}, citation/provenance in
+ * {@link file://./rules-citations.ts}, and schema cross-links in
+ * {@link file://./rules-crosslinks.ts}. The helpers every family needs to walk
+ * the wiki (`collectAllPages`, `readMarkdownFiles`, `findMatchesInContent`) live
+ * here so the family modules can import them WITHOUT importing `rules.ts` — which
+ * re-exports the families and would otherwise close an import cycle.
+ */
+
+import { readdir, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+
+/** Pattern matching ^[filename.md] citation markers in markdown content. */
+export const CITATION_PATTERN = /\^\[([^\]]+)\]/g;
+
+/** Match result with its line number and captured group. */
+export interface LineMatch {
+  captured: string;
+  line: number;
+}
+
+/**
+ * Scan all lines of a page's content and return regex matches with line numbers.
+ * Shared by rules that need to locate patterns within page bodies.
+ */
+export function findMatchesInContent(content: string, pattern: RegExp): LineMatch[] {
+  const results: LineMatch[] = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const matches = lines[i].matchAll(pattern);
+    for (const match of matches) {
+      results.push({ captured: match[1], line: i + 1 });
+    }
+  }
+  return results;
+}
+
+/**
+ * Read all .md files from a directory, returning their paths and parsed content.
+ * Returns an empty array if the directory does not exist.
+ */
+async function readMarkdownFiles(
+  dirPath: string,
+): Promise<Array<{ filePath: string; content: string }>> {
+  if (!existsSync(dirPath)) return [];
+
+  const entries = await readdir(dirPath);
+  const mdFiles = entries.filter((f) => f.endsWith(".md"));
+
+  const results = await Promise.all(
+    mdFiles.map(async (fileName) => {
+      const filePath = path.join(dirPath, fileName);
+      const content = await readFile(filePath, "utf-8");
+      return { filePath, content };
+    }),
+  );
+
+  return results;
+}
+
+/**
+ * Collect all wiki pages from both concepts/ and queries/ directories.
+ */
+export async function collectAllPages(
+  root: string,
+): Promise<Array<{ filePath: string; content: string }>> {
+  const conceptPages = await readMarkdownFiles(path.join(root, CONCEPTS_DIR));
+  const queryPages = await readMarkdownFiles(path.join(root, QUERIES_DIR));
+  return [...conceptPages, ...queryPages];
+}

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -5,100 +5,54 @@
  * an array of LintResult diagnostics. Rules perform pure static analysis
  * with no LLM calls — they inspect frontmatter, wikilinks, citations,
  * and file structure to find potential issues.
+ *
+ * This module hosts the wikilink/orphan/freshness/quality family directly and
+ * RE-EXPORTS the citation/provenance family ({@link file://./rules-citations.ts})
+ * and the schema cross-link family ({@link file://./rules-crosslinks.ts}) so
+ * `src/linter/index.ts` and every other importer see a single `rules.js`
+ * surface unchanged. Shared walk helpers live in
+ * {@link file://./rules-shared.ts} to keep the families cycle-free.
  */
 
-import { readdir, readFile } from "fs/promises";
-import { existsSync } from "fs";
 import path from "path";
 import {
-  isMalformedCitationEntry,
   parseFrontmatter,
   parseProvenanceMetadata,
-  safeReadFile,
   slugify,
-  splitCitationMarker,
 } from "../utils/markdown.js";
 import {
-  CONCEPTS_DIR,
   LOW_CONFIDENCE_THRESHOLD,
   MAX_INFERRED_PARAGRAPHS_WITHOUT_CITATIONS,
-  QUERIES_DIR,
-  SOURCES_DIR,
 } from "../utils/constants.js";
 import type { LintResult } from "./types.js";
-import {
-  countWikilinks,
-  resolvePageKind,
-  type SchemaConfig,
-} from "../schema/index.js";
 import { computeFreshness } from "../freshness/index.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
 import { listLinkResolvablePendingSlugs } from "../compiler/candidates.js";
+import {
+  CITATION_PATTERN,
+  collectAllPages,
+  findMatchesInContent,
+} from "./rules-shared.js";
+
+// Re-export the shared walk helpers and the citation + cross-link families so
+// every importer of `rules.js` keeps a single, unchanged surface.
+export { collectAllPages } from "./rules-shared.js";
+export {
+  checkBrokenCitations,
+  checkPageBrokenCitations,
+  checkMalformedClaimCitations,
+  checkPageMalformedCitations,
+} from "./rules-citations.js";
+export {
+  checkSchemaCrossLinks,
+  checkPageCrossLinks,
+} from "./rules-crosslinks.js";
 
 /** Minimum body length (in characters) for a page to be considered non-empty. */
 const MIN_BODY_LENGTH = 50;
 
 /** Pattern matching [[Wikilink Title]] references in markdown content. */
 const WIKILINK_PATTERN = /\[\[([^\]]+)\]\]/g;
-
-/** Pattern matching ^[filename.md] citation markers in markdown content. */
-const CITATION_PATTERN = /\^\[([^\]]+)\]/g;
-
-/** Match result with its line number and captured group. */
-interface LineMatch {
-  captured: string;
-  line: number;
-}
-
-/**
- * Scan all lines of a page's content and return regex matches with line numbers.
- * Shared by rules that need to locate patterns within page bodies.
- */
-function findMatchesInContent(content: string, pattern: RegExp): LineMatch[] {
-  const results: LineMatch[] = [];
-  const lines = content.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const matches = lines[i].matchAll(pattern);
-    for (const match of matches) {
-      results.push({ captured: match[1], line: i + 1 });
-    }
-  }
-  return results;
-}
-
-/**
- * Read all .md files from a directory, returning their paths and parsed content.
- * Returns an empty array if the directory does not exist.
- */
-async function readMarkdownFiles(
-  dirPath: string,
-): Promise<Array<{ filePath: string; content: string }>> {
-  if (!existsSync(dirPath)) return [];
-
-  const entries = await readdir(dirPath);
-  const mdFiles = entries.filter((f) => f.endsWith(".md"));
-
-  const results = await Promise.all(
-    mdFiles.map(async (fileName) => {
-      const filePath = path.join(dirPath, fileName);
-      const content = await readFile(filePath, "utf-8");
-      return { filePath, content };
-    }),
-  );
-
-  return results;
-}
-
-/**
- * Collect all wiki pages from both concepts/ and queries/ directories.
- */
-export async function collectAllPages(
-  root: string,
-): Promise<Array<{ filePath: string; content: string }>> {
-  const conceptPages = await readMarkdownFiles(path.join(root, CONCEPTS_DIR));
-  const queryPages = await readMarkdownFiles(path.join(root, QUERIES_DIR));
-  return [...conceptPages, ...queryPages];
-}
 
 /**
  * Build a set of slugs for all existing wiki pages.
@@ -304,15 +258,6 @@ export function checkPageEmpty(page: {
   ];
 }
 
-/** Strip an optional `:start-end` or `#Lstart-Lend` span suffix from a citation entry. */
-function stripSpanSuffix(entry: string): string {
-  const colonIdx = entry.indexOf(":");
-  const hashIdx = entry.indexOf("#");
-  const cuts = [colonIdx, hashIdx].filter((i) => i >= 0);
-  if (cuts.length === 0) return entry;
-  return entry.slice(0, Math.min(...cuts));
-}
-
 /**
  * Flag pages whose frontmatter declares confidence below the threshold.
  * Pages without a confidence field are silently skipped to preserve
@@ -413,250 +358,4 @@ function countUncitedProseParagraphs(body: string): number {
     count += 1;
   }
   return count;
-}
-
-/** Regex matching the `:start-end` span suffix on a citation entry. */
-const COLON_SPAN_PATTERN = /^[^:#]+:(\d+)(?:[,-]\s*(\d+))?$/;
-
-/** Regex matching the `#Lstart-Lend` span suffix on a citation entry. */
-const HASH_SPAN_PATTERN = /^[^:#]+#L(\d+)(?:-L(\d+))?$/;
-
-/** Parsed line range from a citation entry, or null if no range is present. */
-interface ParsedLineRange {
-  start: number;
-  end: number;
-}
-
-/**
- * Enforce per-kind cross-link minimums declared in the schema.
- * For each page, resolve its kind, look up the rule, and warn when the page
- * body has fewer wikilinks than the rule requires. Pages with kind `concept`
- * and a minimum of 0 (the default) generate no diagnostics, so existing
- * projects without a schema file see no behaviour change.
- *
- * Implementation delegates to {@link checkPageCrossLinks} per page so the
- * actual rule logic lives in exactly one place — the on-disk walker just
- * fans the per-page helper across `collectAllPages`.
- * @param root - Project root directory.
- * @param schema - Resolved schema config.
- */
-export async function checkSchemaCrossLinks(
-  root: string,
-  schema: SchemaConfig,
-): Promise<LintResult[]> {
-  const pages = await collectAllPages(root);
-  const results: LintResult[] = [];
-  for (const page of pages) {
-    results.push(...checkPageCrossLinks(page.content, page.filePath, schema));
-  }
-  return results;
-}
-
-/**
- * Check cross-link minimums for a single page given as a raw content string.
- *
- * Unlike `checkSchemaCrossLinks`, this function operates on content already in
- * memory without reading from disk. Used by the review pipeline to attach
- * schema violations to a candidate at write time so `review show` can surface
- * them before the reviewer approves the page.
- *
- * The `filePath` parameter is embedded verbatim in each `LintResult.file` so
- * callers control how the candidate is identified in diagnostic output.
- *
- * @param content - Full page content including frontmatter.
- * @param filePath - Logical file path to embed in diagnostics (may be virtual).
- * @param schema - Resolved schema config.
- * @returns Lint results for this single page, empty when no violations found.
- */
-export function checkPageCrossLinks(
-  content: string,
-  filePath: string,
-  schema: SchemaConfig,
-): LintResult[] {
-  const { meta, body } = parseFrontmatter(content);
-  const kind = resolvePageKind(meta.kind, schema);
-  const rule = schema.kinds[kind];
-  if (rule.minWikilinks <= 0) return [];
-
-  const linkCount = countWikilinks(body);
-  if (linkCount >= rule.minWikilinks) return [];
-
-  return [
-    {
-      rule: "schema-cross-link-minimum",
-      severity: "warning",
-      file: filePath,
-      message:
-        `Page kind "${kind}" requires at least ${rule.minWikilinks} ` +
-        `[[wikilinks]] but only ${linkCount} found.`,
-    },
-  ];
-}
-
-/** Extract the line range from a citation entry string, or return null if there is none. */
-function parseLineRange(entry: string): ParsedLineRange | null {
-  const colonMatch = COLON_SPAN_PATTERN.exec(entry);
-  if (colonMatch) {
-    const start = Number(colonMatch[1]);
-    const end = colonMatch[2] !== undefined ? Number(colonMatch[2]) : start;
-    return { start, end };
-  }
-  const hashMatch = HASH_SPAN_PATTERN.exec(entry);
-  if (hashMatch) {
-    const start = Number(hashMatch[1]);
-    const end = hashMatch[2] !== undefined ? Number(hashMatch[2]) : start;
-    return { start, end };
-  }
-  return null;
-}
-
-/** Count the number of lines in a file's text content. */
-function countLines(content: string): number {
-  if (content.length === 0) return 0;
-  return content.split("\n").length;
-}
-
-/**
- * Find ^[filename.md] citations referencing source files that don't exist, and
- * flag claim-level spans whose line ranges exceed the source file's actual length.
- * Handles both single-source ^[file.md] and multi-source ^[a.md, b.md] forms,
- * plus the claim-level extension `^[file.md:42-58]` / `^[file.md#L42-L58]`.
- * Line counts are cached per source file to avoid redundant reads.
- */
-export async function checkBrokenCitations(root: string): Promise<LintResult[]> {
-  const pages = await collectAllPages(root);
-  const sourcesDir = path.join(root, SOURCES_DIR);
-  const results: LintResult[] = [];
-  const lineCountCache = new Map<string, number>();
-
-  for (const page of pages) {
-    const { meta } = parseFrontmatter(page.content);
-    // Imported pages cite EXTERNAL bundle sources (not copied into sources/), so
-    // local source-existence does not apply — exempt them from broken-citation.
-    if (meta.provenanceState === "imported") continue;
-    const pageFindings = await checkPageBrokenCitations(
-      page.content,
-      page.filePath,
-      sourcesDir,
-      lineCountCache,
-    );
-    results.push(...pageFindings);
-  }
-
-  return results;
-}
-
-/**
- * Pure-body variant of {@link checkBrokenCitations} that inspects a single
- * page's content against an in-memory or on-disk sources directory. Used
- * by the on-disk lint walker above, and by the in-memory candidate-lint
- * path so `compile --review` surfaces broken-source-file and out-of-bounds
- * span findings before a reviewer approves the candidate.
- *
- * @param content - Full page markdown including frontmatter.
- * @param filePath - Logical path embedded in diagnostics (may be virtual).
- * @param sourcesDir - Absolute path to the project's sources/ directory.
- * @param lineCountCache - Optional cross-page cache; provide one when
- *   linting many pages so source file line counts aren't re-read.
- */
-export async function checkPageBrokenCitations(
-  content: string,
-  filePath: string,
-  sourcesDir: string,
-  lineCountCache: Map<string, number> = new Map(),
-): Promise<LintResult[]> {
-  const results: LintResult[] = [];
-  for (const { captured, line } of findMatchesInContent(content, CITATION_PATTERN)) {
-    await collectBrokenForMarker(captured, line, filePath, sourcesDir, lineCountCache, results);
-  }
-  return results;
-}
-
-/** Append broken-citation diagnostics for every entry inside a single ^[...] marker. */
-async function collectBrokenForMarker(
-  captured: string,
-  line: number,
-  pageFile: string,
-  sourcesDir: string,
-  lineCountCache: Map<string, number>,
-  out: LintResult[],
-): Promise<void> {
-  for (const part of splitCitationMarker(captured)) {
-    const trimmed = part.trim();
-    if (trimmed.length === 0) continue;
-    const filename = stripSpanSuffix(trimmed);
-    const citedPath = path.join(sourcesDir, filename);
-    if (!existsSync(citedPath)) {
-      out.push({
-        rule: "broken-citation",
-        severity: "error",
-        file: pageFile,
-        message: `Broken citation ^[${filename}] — source file not found`,
-        line,
-      });
-      continue;
-    }
-    const range = parseLineRange(trimmed);
-    if (range === null) continue;
-    const lineCount = await resolveLineCount(citedPath, filename, lineCountCache);
-    if (range.end <= lineCount) continue;
-    out.push({
-      rule: "broken-citation",
-      severity: "error",
-      file: pageFile,
-      message: `Claim-level span ^[${trimmed}] is out of bounds (source has only ${lineCount} lines)`,
-      line,
-    });
-  }
-}
-
-/** Return the line count for a source file, reading and caching if necessary. */
-async function resolveLineCount(
-  citedPath: string,
-  filename: string,
-  cache: Map<string, number>,
-): Promise<number> {
-  const cached = cache.get(filename);
-  if (cached !== undefined) return cached;
-  const content = await safeReadFile(citedPath);
-  const lineCount = countLines(content);
-  cache.set(filename, lineCount);
-  return lineCount;
-}
-
-/**
- * Find ^[...] markers whose entries do not parse against the documented
- * paragraph or claim-level grammar (e.g. `^[file.md:abc]` or `^[file.md#X]`).
- * Detects malformed claim-level citations without breaking the paragraph form.
- */
-export async function checkMalformedClaimCitations(root: string): Promise<LintResult[]> {
-  const pages = await collectAllPages(root);
-  const results: LintResult[] = [];
-  for (const page of pages) {
-    results.push(...checkPageMalformedCitations(page.content, page.filePath));
-  }
-  return results;
-}
-
-/**
- * Pure-body variant of {@link checkMalformedClaimCitations} that inspects
- * a single page's content. Used by both the on-disk lint walker above and
- * the in-memory candidate-lint path so `compile --review` surfaces
- * malformed claim citations before a reviewer approves the candidate.
- */
-export function checkPageMalformedCitations(content: string, filePath: string): LintResult[] {
-  const results: LintResult[] = [];
-  for (const { captured, line } of findMatchesInContent(content, CITATION_PATTERN)) {
-    for (const part of splitCitationMarker(captured)) {
-      if (!isMalformedCitationEntry(part)) continue;
-      results.push({
-        rule: "malformed-claim-citation",
-        severity: "error",
-        file: filePath,
-        message: `Malformed claim citation ^[${captured}] — expected file.md, file.md:N-N, or file.md#LN-LN`,
-        line,
-      });
-    }
-  }
-  return results;
 }


### PR DESCRIPTION
First of the stacked Phase 4 PRs (do not merge yet). Pure mechanical groundwork: both `src/linter/rules.ts` (~643) and `src/compiler/candidates.ts` (~442) were over the 400-line code limit and are exactly where Phase 4's relation/lifecycle lint and candidate logic will land. Split now, before adding logic.

- `candidates.ts` → `candidate-read.ts` (read/list/sanitize/validate) + `candidate-paths.ts` (shared path resolvers), with `candidates.ts` keeping the write/dedup side and re-exporting the rest so all import sites are unchanged.
- `rules.ts` → `rules-citations.ts` + `rules-crosslinks.ts` + `rules-shared.ts`, with `rules.ts` keeping the wikilink/quality rules and re-exporting the families.

Leaf shared-modules break the re-export/import cycles. Zero behavior change: lint codes/messages and candidate output identical, default goldens byte-identical, full suite unchanged (2145).