### PR TITLE
feat(profile): Phase 4 PR2 — runtime lifecycle transition enforcement + invalid-state lint

### DIFF
--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -33,6 +33,7 @@ import {
   CandidatePromotionBlockedError,
 } from "../trust/promote.js";
 import { EntityFieldContractError } from "../profile/field-contract.js";
+import { LifecycleTransitionError } from "../profile/lifecycle.js";
 import { deleteCandidate } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
@@ -108,8 +109,9 @@ async function routeApprovedPageWrite(
 /**
  * Route a TYPED candidate through the profile-validated typed planner. Refuses
  * (exit 1, candidate retained) when the project has no profile, the type is no
- * longer declared, the body violates the declared field contract, or the re-plan
- * blocks — never a silent fall back to concepts. Returns the absolute
+ * longer declared, the body violates the declared field contract, the body
+ * performs an illegal lifecycle transition, or the re-plan blocks — never a
+ * silent fall back to concepts. Returns the absolute
  * `wiki/<entityType>/<slug>.md` path on success.
  */
 async function routeTypedPageWrite(
@@ -125,7 +127,8 @@ async function routeTypedPageWrite(
     if (
       err instanceof CandidateProfileError ||
       err instanceof CandidatePromotionBlockedError ||
-      err instanceof EntityFieldContractError
+      err instanceof EntityFieldContractError ||
+      err instanceof LifecycleTransitionError
     ) {
       output.status("!", output.error(`Candidate ${id} not approved: ${err.message}`));
       process.exitCode = 1;

--- a/src/profile/lifecycle-read.ts
+++ b/src/profile/lifecycle-read.ts
@@ -1,0 +1,50 @@
+/**
+ * @file src/profile/lifecycle-read.ts
+ * @description Path-confined reader for an entity page's PREVIOUS lifecycle-field
+ * value — the `prev` state the runtime transition validator
+ * ({@link validateLifecycleTransition}) checks a write against.
+ *
+ * A lifecycle transition is "from the value already on disk to the value in the
+ * incoming body". This module supplies that prior value: it resolves the existing
+ * `wiki/<entityType>/<slug>.md` through the SAME confined-regular-file primitive
+ * the source/wiki readers use ({@link confinedRegularFile}), so a symlinked or
+ * escaping page is treated as absent rather than followed. When the page does not
+ * yet exist (a create) it returns `undefined`, which the validator treats as "not
+ * a transition".
+ */
+
+import path from "path";
+import { confinedRegularFile, safeRealpath } from "../utils/path-confine.js";
+import { parseFrontmatter, safeReadFile } from "../utils/markdown.js";
+import type { EntityTypeDef } from "./types.js";
+
+/**
+ * Read the previous lifecycle-field value of an entity page from disk, or
+ * `undefined` when the page does not exist (a create) or carries no value for the
+ * lifecycle field. The page is resolved under `<root>/<def.directory>` via
+ * {@link confinedRegularFile}, so a symlinked / out-of-tree page is treated as
+ * absent (returns `undefined`) — never followed.
+ *
+ * @param root - Absolute project root.
+ * @param def - The resolved entity type definition (supplies the directory).
+ * @param slug - The page slug (the filename stem).
+ * @param field - The lifecycle field name whose prior value is read.
+ * @returns The prior lifecycle-field value as a string, or `undefined`.
+ */
+export async function readPrevLifecycleState(
+  root: string,
+  def: EntityTypeDef,
+  slug: string,
+  field: string,
+): Promise<string | undefined> {
+  // Canonicalize the root first so the directory base matches the file's
+  // realpath (on macOS the temp/symlinked root would otherwise fail confinement
+  // and spuriously report "no prev page").
+  const canonicalRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  const dir = path.join(canonicalRoot, def.directory);
+  const real = await confinedRegularFile(dir, `${slug}.md`);
+  if (real === null) return undefined;
+  const { meta } = parseFrontmatter(await safeReadFile(real));
+  const value = meta[field];
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/profile/lifecycle.ts
+++ b/src/profile/lifecycle.ts
@@ -1,0 +1,160 @@
+/**
+ * @file src/profile/lifecycle.ts
+ * @description The single, PURE per-page lifecycle-TRANSITION validator — the
+ * RUNTIME counterpart to the load-time {@link validateLifecycle} in `validate.ts`.
+ *
+ * Where `validateLifecycle` proves a {@link LifecycleDef} is itself well-formed
+ * when a profile loads, this module enforces that a CONCRETE page write obeys
+ * that FSM: a page's lifecycle-field value must be a declared state, a change of
+ * that value from its previous on-disk value must follow a legal out-edge, and
+ * any evidence a target state requires must be present in the frontmatter.
+ *
+ * Given a page's `prev` state (the value on disk, or `undefined` when the page is
+ * being created), its parsed `frontmatter`, and the resolved {@link LifecycleDef},
+ * {@link validateLifecycleTransition} returns a list of PATH-FREE problem
+ * messages. It is pure (no I/O), never throws, and carries no path/entity-type
+ * context — callers attach that when they wrap each message into their own
+ * error/problem shape (mirroring `field-contract.ts`).
+ */
+
+import type { LifecycleDef } from "./types.js";
+
+/**
+ * Thrown by the typed WRITE gates (staging / promotion) when a candidate body's
+ * lifecycle-field value performs an illegal transition, names an undeclared
+ * state, or omits required transition evidence. Fails CLOSED so a lifecycle-
+ * violating typed page is never staged or promoted (on the READ surfaces the
+ * same violations are non-fatal lint findings, not throws). Carries the
+ * structured list of PATH-FREE problem messages so callers can surface exactly
+ * what failed.
+ */
+export class LifecycleTransitionError extends Error {
+  /** The PATH-FREE lifecycle problem messages that caused the refusal. */
+  readonly problems: string[];
+
+  constructor(entityType: string, slug: string, problems: string[]) {
+    super(
+      `typed page ${entityType}/${slug} violates the profile lifecycle: ` +
+        `${problems.join(" ")}`,
+    );
+    this.name = "LifecycleTransitionError";
+    this.problems = problems;
+  }
+}
+
+/**
+ * Derive the declared state set for a lifecycle: the UNION of `initial`, every
+ * `terminal` state, and every transition key and endpoint. This is the SAME
+ * derivation `validateLifecycle` uses at load time, so the runtime state set a
+ * page is checked against can never disagree with the validated definition.
+ * Exported so the lint surface checks against the IDENTICAL state set (DRY).
+ */
+export function lifecycleStateSet(lifecycle: LifecycleDef): Set<string> {
+  const states = new Set<string>([lifecycle.initial, ...lifecycle.terminal]);
+  for (const [from, tos] of Object.entries(lifecycle.transitions)) {
+    states.add(from);
+    for (const to of tos) states.add(to);
+  }
+  return states;
+}
+
+/**
+ * Append the state-validity problem for `next` when it is present but not a
+ * string, or is a string outside the declared state set. An absent `next`
+ * (undefined) is a no-op — the lifecycle field is OPTIONAL on a page and is only
+ * validated when present. Returns true when `next` is a usable declared state
+ * (so the caller may proceed to transition/evidence checks).
+ */
+function checkStateDeclared(
+  next: unknown,
+  states: Set<string>,
+  out: string[],
+): next is string {
+  if (next === undefined) return false;
+  if (typeof next !== "string" || !states.has(next)) {
+    out.push(`lifecycle state ${JSON.stringify(next)} is not a declared state`);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Append the transition-edge problem when `prev` is defined and `next` differs
+ * from it but is NOT a legal out-edge in `transitions[prev]`. A terminal `prev`
+ * has no out-edges, so any change away from it is illegal. A create (`prev`
+ * undefined) is not a transition and is exempt — its floor is state-validity +
+ * evidence, checked separately.
+ */
+function checkTransitionEdge(
+  lifecycle: LifecycleDef,
+  prev: string | undefined,
+  next: string,
+  out: string[],
+): void {
+  if (prev === undefined || prev === next) return;
+  const legal = lifecycle.transitions[prev] ?? [];
+  if (!legal.includes(next)) {
+    out.push(`illegal lifecycle transition ${JSON.stringify(prev)} → ${JSON.stringify(next)}`);
+  }
+}
+
+/**
+ * Append one problem per required evidence field that `transitionRequirements`
+ * lists for the target state `next` but the frontmatter does not supply
+ * (non-empty). Applies on BOTH a create-into-`next` and a transition-to-`next`,
+ * so a state that requires evidence can never be entered without it.
+ */
+function checkRequiredEvidence(
+  lifecycle: LifecycleDef,
+  next: string,
+  frontmatter: Record<string, unknown>,
+  out: string[],
+): void {
+  for (const field of lifecycle.transitionRequirements?.[next] ?? []) {
+    if (!isEvidencePresent(frontmatter[field])) {
+      out.push(`lifecycle transition to ${JSON.stringify(next)} requires evidence field ${JSON.stringify(field)}`);
+    }
+  }
+}
+
+/** True when an evidence value is present and non-empty (not "", not []). */
+function isEvidencePresent(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+/**
+ * Validate a page's lifecycle-field transition against its entity type's
+ * declared {@link LifecycleDef}, returning a list of PATH-FREE problem messages
+ * (empty when the write obeys the FSM). The runtime counterpart to load-time
+ * {@link validateLifecycle}.
+ *
+ * The `next` state is read from `frontmatter[lifecycle.field]`. When absent the
+ * write is exempt (the lifecycle field is optional). When present it must be a
+ * declared state; a change from a defined `prev` must follow a legal out-edge (a
+ * create is not a transition); and any evidence the target state requires must be
+ * present. Pure and total — no I/O, never throws, carries no path/entity-type
+ * context.
+ *
+ * @param lifecycle - The resolved lifecycle definition to validate against.
+ * @param prev - The page's previous on-disk lifecycle-field value, or `undefined`
+ *   when the page is being created.
+ * @param next - The candidate lifecycle-field value (read from `frontmatter`).
+ * @param frontmatter - The page's parsed frontmatter (the evidence source).
+ * @returns Zero or more PATH-FREE lifecycle problem messages.
+ */
+export function validateLifecycleTransition(
+  lifecycle: LifecycleDef,
+  prev: string | undefined,
+  next: unknown,
+  frontmatter: Record<string, unknown>,
+): string[] {
+  const problems: string[] = [];
+  const states = lifecycleStateSet(lifecycle);
+  if (!checkStateDeclared(next, states, problems)) return problems;
+  checkTransitionEdge(lifecycle, prev, next, problems);
+  checkRequiredEvidence(lifecycle, next, frontmatter, problems);
+  return problems;
+}

--- a/src/profile/lint.ts
+++ b/src/profile/lint.ts
@@ -23,8 +23,12 @@
 
 import { collectEntityPages, type EntityProblem, type EntityProblemKind } from "./collect.js";
 import { checkPageEmpty, checkPageMalformedCitations } from "../linter/rules.js";
-import type { ProfilePack, EntityPage } from "./types.js";
+import { lifecycleStateSet } from "./lifecycle.js";
+import type { ProfilePack, EntityPage, LifecycleDef } from "./types.js";
 import type { LintResult } from "../linter/types.js";
+
+/** Rule id for a typed entity page whose lifecycle-field value is off the FSM. */
+const INVALID_LIFECYCLE_STATE_RULE = "invalid-lifecycle-state";
 
 /** Severity for each problem kind: identity/structure errors, contract warnings. */
 const PROBLEM_SEVERITY: Record<EntityProblemKind, LintResult["severity"]> = {
@@ -77,10 +81,36 @@ function lintEntityPageContent(page: EntityPage): LintResult[] {
 }
 
 /**
+ * Flag a typed entity page whose lifecycle-field value is NOT a declared state of
+ * its entity type's lifecycle as an `invalid-lifecycle-state` warning. An entity
+ * type with no `lifecycle`, or a page whose lifecycle field is absent (the field
+ * is optional), yields no finding — so the default/concepts path (no lifecycle)
+ * stays byte-identical.
+ *
+ * @param page - The collected entity page to check.
+ * @param lifecycle - The entity type's lifecycle, or `undefined` when it has none.
+ * @returns A single-element finding array, or an empty array when on-FSM.
+ */
+function checkLifecycleStates(page: EntityPage, lifecycle?: LifecycleDef): LintResult[] {
+  if (!lifecycle) return [];
+  const value = page.frontmatter[lifecycle.field];
+  if (value === undefined) return [];
+  if (typeof value === "string" && lifecycleStateSet(lifecycle).has(value)) return [];
+  return [{
+    rule: INVALID_LIFECYCLE_STATE_RULE,
+    severity: "warning",
+    file: page.filePath,
+    message: `lifecycle field ${JSON.stringify(lifecycle.field)} value ${JSON.stringify(value)} is not a declared state`,
+    entityType: page.entityType,
+  }];
+}
+
+/**
  * Surface a non-default profile's entity-page issues as `LintResult`s,
  * additively. Collects the profile's entity pages, maps every structured
  * problem to a finding (correct severity per {@link PROBLEM_SEVERITY}), then
- * runs the profile-safe content rules over each collected page.
+ * runs the profile-safe content rules and the lifecycle-state check over each
+ * collected page.
  *
  * @param root - Absolute project root directory.
  * @param profile - A NON-default profile pack (the default profile has no
@@ -95,6 +125,7 @@ export async function lintProfileEntities(
   const results: LintResult[] = problems.map(problemToResult);
   for (const page of pages) {
     results.push(...lintEntityPageContent(page));
+    results.push(...checkLifecycleStates(page, profile.entities[page.entityType]?.lifecycle));
   }
   return results;
 }

--- a/src/trust/promote.ts
+++ b/src/trust/promote.ts
@@ -31,6 +31,11 @@ import {
   validateEntityFields,
   EntityFieldContractError,
 } from "../profile/field-contract.js";
+import {
+  validateLifecycleTransition,
+  LifecycleTransitionError,
+} from "../profile/lifecycle.js";
+import { readPrevLifecycleState } from "../profile/lifecycle-read.js";
 import { parseFrontmatter } from "../utils/markdown.js";
 import { assertBodyWithinResourceLimit } from "./checks.js";
 import type { EntityTypeDef } from "../profile/types.js";
@@ -104,6 +109,38 @@ function assertCandidateFieldContract(
 }
 
 /**
+ * Validate a typed candidate's lifecycle transition via the SHARED
+ * {@link validateLifecycleTransition} (the runtime counterpart to load-time
+ * `validateLifecycle`), throwing {@link LifecycleTransitionError} BEFORE the
+ * re-plan/apply when the candidate body's lifecycle-field value names an
+ * undeclared state, performs an illegal transition from the on-disk page's
+ * current state, or omits required evidence. An entity type with NO declared
+ * `lifecycle` is a no-op. Promotion then fails CLOSED and the candidate is
+ * RETAINED, so a lifecycle-violating page never lands.
+ *
+ * @param root - Absolute project root (to read the existing page's prev state).
+ * @param entityType - The (already type-checked) profile entity type.
+ * @param candidate - The typed candidate whose body lifecycle is validated.
+ * @param def - The resolved entity type definition supplying the lifecycle.
+ * @throws {LifecycleTransitionError} When the lifecycle transition is illegal.
+ */
+async function assertCandidateLifecycle(
+  root: string,
+  entityType: string,
+  candidate: ReviewCandidate,
+  def: EntityTypeDef,
+): Promise<void> {
+  const lifecycle = def.lifecycle;
+  if (!lifecycle) return;
+  const { meta } = parseFrontmatter(candidate.body);
+  const prev = await readPrevLifecycleState(root, def, candidate.slug, lifecycle.field);
+  const problems = validateLifecycleTransition(lifecycle, prev, meta[lifecycle.field], meta);
+  if (problems.length > 0) {
+    throw new LifecycleTransitionError(entityType, candidate.slug, problems);
+  }
+}
+
+/**
  * Validate a typed candidate's `targetEntityType` against the active profile and
  * re-plan + apply its write — the LOCK-FREE promotion core. The caller MUST
  * already hold the project lock (so this never nests an acquire). Loads the
@@ -117,6 +154,7 @@ function assertCandidateFieldContract(
  * @returns The `wiki/<entityType>/<slug>.md` path the page was written to.
  * @throws {CandidateProfileError} When no profile declares the type.
  * @throws {EntityFieldContractError} When the body frontmatter violates the field contract.
+ * @throws {LifecycleTransitionError} When the body performs an illegal lifecycle transition.
  * @throws {CandidatePromotionBlockedError} When the re-plan blocks (empty plan).
  */
 export async function applyTypedCandidate(
@@ -129,7 +167,9 @@ export async function applyTypedCandidate(
   if (!(entityType in loaded.profile.entities)) {
     throw new CandidateProfileError(entityType, "undeclared");
   }
-  assertCandidateFieldContract(entityType, candidate, loaded.profile.entities[entityType]!);
+  const def = loaded.profile.entities[entityType]!;
+  assertCandidateFieldContract(entityType, candidate, def);
+  await assertCandidateLifecycle(root, entityType, candidate, def);
   const { planned } = await planPageMutation({
     root,
     entityType,

--- a/src/trust/staging.ts
+++ b/src/trust/staging.ts
@@ -46,12 +46,18 @@ import {
   validateEntityFields,
   EntityFieldContractError,
 } from "../profile/field-contract.js";
+import {
+  validateLifecycleTransition,
+  LifecycleTransitionError,
+} from "../profile/lifecycle.js";
+import { readPrevLifecycleState } from "../profile/lifecycle-read.js";
 import { parseFrontmatter } from "../utils/markdown.js";
 import { assertBodyWithinResourceLimit } from "./checks.js";
-import type { ProfilePack } from "../profile/types.js";
+import type { EntityTypeDef, ProfilePack } from "../profile/types.js";
 import type { TrustDecision } from "./decision.js";
 
 export { EntityFieldContractError } from "../profile/field-contract.js";
+export { LifecycleTransitionError } from "../profile/lifecycle.js";
 
 /**
  * Validate a staged page body's frontmatter against its entity type's declared
@@ -82,6 +88,40 @@ function assertFieldContract(
   const violations = validateEntityFields(meta, profile.entities[entityType]!);
   if (violations.length > 0) {
     throw new EntityFieldContractError(entityType, slug, violations);
+  }
+}
+
+/**
+ * Validate a staged page body's lifecycle transition via the SHARED
+ * {@link validateLifecycleTransition} (the runtime counterpart to load-time
+ * `validateLifecycle`), throwing {@link LifecycleTransitionError} — before any
+ * planning or I/O — when the lifecycle field's value names an undeclared state,
+ * performs an illegal transition from the page's existing on-disk state, or omits
+ * required transition evidence. An entity type with NO declared `lifecycle` is a
+ * no-op (skipped). The `prev` state is read from the existing
+ * `wiki/<entityType>/<slug>.md` (path-confined) when one exists, else `undefined`
+ * (a create).
+ *
+ * @param root - Absolute project root (to read the existing page's prev state).
+ * @param entityType - The (already type-checked) profile entity type.
+ * @param slug - The page slug (filename stem + error message).
+ * @param frontmatter - The staged body's parsed frontmatter (next state + evidence).
+ * @param def - The resolved entity type definition supplying the lifecycle.
+ * @throws {LifecycleTransitionError} When the lifecycle transition is illegal.
+ */
+async function assertLifecycleTransition(
+  root: string,
+  entityType: string,
+  slug: string,
+  frontmatter: Record<string, unknown>,
+  def: EntityTypeDef,
+): Promise<void> {
+  const lifecycle = def.lifecycle;
+  if (!lifecycle) return;
+  const prev = await readPrevLifecycleState(root, def, slug, lifecycle.field);
+  const problems = validateLifecycleTransition(lifecycle, prev, frontmatter[lifecycle.field], frontmatter);
+  if (problems.length > 0) {
+    throw new LifecycleTransitionError(entityType, slug, problems);
   }
 }
 
@@ -189,6 +229,14 @@ export async function stageEntityPage(
     throw new UnknownEntityTypeError(input.entityType);
   }
   assertFieldContract(input.entityType, input.slug, input.body, input.profile);
+  const { meta } = parseFrontmatter(input.body);
+  await assertLifecycleTransition(
+    root,
+    input.entityType,
+    input.slug,
+    meta,
+    input.profile.entities[input.entityType]!,
+  );
   const plan = await planPageMutation({
     root,
     entityType: input.entityType,

--- a/test/profile-lifecycle-enforce.test.ts
+++ b/test/profile-lifecycle-enforce.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @file test/profile-lifecycle-enforce.test.ts
+ * @description RUNTIME lifecycle-transition enforcement on the typed write path
+ * (Phase 4 PR2), plus the `invalid-lifecycle-state` lint.
+ *
+ * Transitions FROM an existing page are exercised through the promotion path
+ * (`review approve` on a typed candidate, which overwrites), since staging is for
+ * NEW pages (it refuses to overwrite). Creation-into-a-state is exercised through
+ * `stageEntityPage`. The lifecycle FSM under test is research-lite `ideas`
+ * (`proposed → testing → tested → {validated,failed}`):
+ *  - a legal transition (proposed → testing) promotes the page;
+ *  - an illegal transition (proposed → validated) is REFUSED (exit 1, candidate
+ *    retained, nothing written);
+ *  - entering `failed` with unmet required evidence (`failureReason`) is refused;
+ *  - a NEW page created directly at a declared non-initial state is allowed;
+ *  - a typed page whose `status` is off the FSM surfaces an
+ *    `invalid-lifecycle-state` lint finding;
+ *  - a DEFAULT concepts candidate (no lifecycle) approves unchanged.
+ */
+
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { stageEntityPage, LifecycleTransitionError } from "../src/trust/staging.js";
+import { applyTypedCandidate } from "../src/trust/promote.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import { writeCandidate } from "../src/compiler/candidates.js";
+import { lint } from "../src/linter/index.js";
+import { PROFILE_FILE, CANDIDATES_DIR } from "../src/utils/constants.js";
+import {
+  buildResearchLiteProject,
+  RESEARCH_LITE_PROFILE,
+  writeMarkdownPage,
+} from "./fixtures/profile-fixtures.js";
+
+let root = "";
+const IDEA = "sparse-routing"; // pre-seeded by buildResearchLiteProject at status: proposed
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "lifecycle-enforce-"));
+  await buildResearchLiteProject(root);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Write a typed `ideas` candidate carrying `body` and return its id. */
+async function stageIdeaCandidate(body: string): Promise<string> {
+  const candidate = await writeCandidate(root, {
+    title: IDEA, slug: IDEA, summary: "", sources: [], body, targetEntityType: "ideas",
+  });
+  return candidate.id;
+}
+
+/**
+ * Run a CLI command `fn` with `dir` as the cwd, console silenced, and
+ * `process.exitCode` reset before/after — restoring everything in `finally`.
+ * Shared so the chdir+mock boilerplate is not duplicated across tests.
+ */
+async function runCliInDir(dir: string, fn: () => Promise<void>): Promise<void> {
+  const cwd = process.cwd();
+  process.chdir(dir);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = 0;
+  try {
+    await fn();
+  } finally {
+    process.chdir(cwd);
+    vi.restoreAllMocks();
+    process.exitCode = 0;
+  }
+}
+
+describe("runtime lifecycle enforcement — transition on promote", () => {
+  it("promotes a legal transition proposed → testing", async () => {
+    const candidate = { slug: IDEA, body: "---\nstatus: testing\n---\n\nTesting.\n", targetEntityType: "ideas" };
+    const rel = await applyTypedCandidate(root, candidate as never);
+    expect(await readFile(path.join(root, rel), "utf8")).toContain("status: testing");
+  });
+
+  it("refuses an illegal transition proposed → validated, leaving the page unchanged", async () => {
+    await expect(
+      applyTypedCandidate(root, { slug: IDEA, body: "---\nstatus: validated\n---\n\nSkip.\n", targetEntityType: "ideas" } as never),
+    ).rejects.toBeInstanceOf(LifecycleTransitionError);
+    expect(await readFile(path.join(root, "wiki/ideas", `${IDEA}.md`), "utf8")).toContain("status: proposed");
+  });
+
+  it("review approve refuses an illegal transition (exit 1, candidate retained)", async () => {
+    await runCliInDir(root, async () => {
+      const id = await stageIdeaCandidate("---\nstatus: validated\n---\n\nSkip.\n");
+      await reviewApproveCommand(id);
+      expect(process.exitCode).toBe(1);
+      expect(existsSync(path.join(root, CANDIDATES_DIR, `${id}.json`))).toBe(true);
+    });
+  });
+});
+
+describe("runtime lifecycle enforcement — creation via staging", () => {
+  it("allows creating a NEW page directly at a declared non-initial state", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "ideas", slug: "fresh-idea", body: "---\nstatus: tested\n---\n\nImported.\n",
+      profile: RESEARCH_LITE_PROFILE, existingStagedCount: 0,
+    });
+    expect(staged).toMatchObject({ kind: "page" });
+  });
+
+  it("refuses creating a NEW page at an off-FSM lifecycle value", async () => {
+    // A profile whose lifecycle field is NOT enum-constrained, so the off-FSM
+    // value reaches the lifecycle gate rather than the field-contract gate.
+    const profile = {
+      ...RESEARCH_LITE_PROFILE,
+      entities: {
+        ...RESEARCH_LITE_PROFILE.entities,
+        ideas: { directory: "wiki/ideas", lifecycle: RESEARCH_LITE_PROFILE.entities.ideas.lifecycle },
+      },
+    };
+    await expect(
+      stageEntityPage(root, {
+        entityType: "ideas", slug: "off-fsm", body: "---\nstatus: shipped\n---\n\nNope.\n",
+        profile, existingStagedCount: 0,
+      }),
+    ).rejects.toBeInstanceOf(LifecycleTransitionError);
+  });
+});
+
+/** A research-lite profile whose `ideas.failed` state requires `failureReason`. */
+const REQUIREMENTS_PROFILE = {
+  ...RESEARCH_LITE_PROFILE,
+  entities: {
+    ...RESEARCH_LITE_PROFILE.entities,
+    ideas: {
+      ...RESEARCH_LITE_PROFILE.entities.ideas,
+      lifecycle: {
+        ...RESEARCH_LITE_PROFILE.entities.ideas.lifecycle,
+        transitionRequirements: { failed: ["failureReason"] },
+      },
+    },
+  },
+};
+
+describe("runtime lifecycle enforcement — required evidence", () => {
+  beforeEach(async () => {
+    await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(REQUIREMENTS_PROFILE), "utf8");
+    await writeMarkdownPage(root, "wiki/ideas", IDEA, "---\nstatus: tested\n---\n\nReady.\n");
+  });
+
+  it("refuses entering `failed` without the required `failureReason` evidence", async () => {
+    await expect(
+      applyTypedCandidate(root, { slug: IDEA, body: "---\nstatus: failed\n---\n\nNo reason.\n", targetEntityType: "ideas" } as never),
+    ).rejects.toBeInstanceOf(LifecycleTransitionError);
+    expect(await readFile(path.join(root, "wiki/ideas", `${IDEA}.md`), "utf8")).toContain("status: tested");
+  });
+
+  it("allows entering `failed` when the required evidence is present", async () => {
+    const body = "---\nstatus: failed\nfailureReason: out of compute\n---\n\nDone.\n";
+    const rel = await applyTypedCandidate(root, { slug: IDEA, body, targetEntityType: "ideas" } as never);
+    expect(await readFile(path.join(root, rel), "utf8")).toContain("status: failed");
+  });
+});
+
+describe("invalid-lifecycle-state lint", () => {
+  it("flags an entity page whose lifecycle field value is off the FSM", async () => {
+    await writeMarkdownPage(root, "wiki/ideas", "broken-state", "---\nstatus: shipped\n---\n\nOff the FSM.\n");
+    const { results } = await lint(root);
+    const found = results.filter((r) => r.rule === "invalid-lifecycle-state");
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ severity: "warning", entityType: "ideas" });
+  });
+
+  it("emits no lifecycle finding for on-FSM pages", async () => {
+    const { results } = await lint(root);
+    expect(results.some((r) => r.rule === "invalid-lifecycle-state")).toBe(false);
+  });
+});
+
+describe("default concepts candidate (no lifecycle) is unaffected", () => {
+  it("approves a DEFAULT concepts candidate unchanged", async () => {
+    const defaultRoot = await mkdtemp(path.join(os.tmpdir(), "lifecycle-default-"));
+    try {
+      await runCliInDir(defaultRoot, async () => {
+        const candidate = await writeCandidate(defaultRoot, {
+          title: "Topic", slug: "topic", summary: "", sources: [],
+          body: "---\ntitle: Topic\n---\n\nConcept body.\n",
+        });
+        await reviewApproveCommand(candidate.id);
+        expect(existsSync(path.join(defaultRoot, "wiki/concepts", "topic.md"))).toBe(true);
+        expect(process.exitCode ?? 0).toBe(0);
+      });
+    } finally {
+      await rm(defaultRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Stacked on PR #130 (do not merge yet). The lifecycle FSM *definition* was already validated at profile-load; this adds the *runtime* enforcement the spec requires ("direct writes / review approval / MCP / SDK cannot perform illegal transitions; required evidence enforced by core").

- New `validateLifecycleTransition` (sibling of the field-contract validator): rejects an undeclared state, an illegal transition (next not in the legal out-edges of prev; a terminal prev has none), and a transition to a state missing its declared `transitionRequirements` evidence. New-page creates are exempt from the edge check but still gated on state-validity + evidence.
- Wired as a mandatory, fail-closed gate into every typed write — staging, promotion, and `review approve` — so an illegal transition is refused (candidate retained), sharing one implementation across CLI/SDK.
- An `invalid-lifecycle-state` lint flags a typed page whose lifecycle field isn't a declared state.

Default/concepts declare no lifecycle, so the gate is a no-op there — default profile byte-identical; full suite green (2155).