### PR TITLE
feat(profile): Phase 4 PR3 — typed relation type definitions + fail-closed load validation

### DIFF
--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -41,6 +41,21 @@ export async function profileShow(): Promise<void> {
   console.log(`profileId:  ${loaded.profile.profileId}`);
   console.log(`digest:     ${loaded.digest}`);
   console.log(`loadedFrom: ${loadedFrom}`);
+  printRelations(loaded.profile.relations);
+}
+
+/**
+ * Print the declared relation types, one line each, ONLY when the profile
+ * declares any. A relation-less profile (including the built-in default) prints
+ * nothing extra, so its `profile show` output stays unchanged.
+ */
+function printRelations(relations: ProfilePack["relations"]): void {
+  const entries = Object.entries(relations ?? {});
+  if (entries.length === 0) return;
+  console.log(`relations:  ${entries.length}`);
+  for (const [name, def] of entries) {
+    console.log(`  ${name}: ${def.from.join(",")} -> ${def.to.join(",")} (${def.direction})`);
+  }
 }
 
 /**

--- a/src/profile/schema/profile.v1.schema.json
+++ b/src/profile/schema/profile.v1.schema.json
@@ -28,6 +28,11 @@
       "type": "object",
       "minProperties": 1,
       "additionalProperties": { "$ref": "#/$defs/entityTypeDef" }
+    },
+    "relations": {
+      "type": "object",
+      "description": "Optional typed relation type declarations, keyed by slug-safe id. Endpoint entity-type references and requiredAttributes membership are enforced by validateProfile().",
+      "additionalProperties": { "$ref": "#/$defs/relationTypeDef" }
     }
   },
   "$defs": {
@@ -72,6 +77,21 @@
           "type": "object",
           "additionalProperties": { "type": "array", "items": { "type": "string" } }
         }
+      }
+    },
+    "relationTypeDef": {
+      "type": "object",
+      "required": ["from", "to", "direction"],
+      "additionalProperties": false,
+      "properties": {
+        "from": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "to": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "direction": { "enum": ["directed", "symmetric"] },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/fieldDef" }
+        },
+        "requiredAttributes": { "type": "array", "items": { "type": "string" } }
       }
     },
     "entityTypeDef": {

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -65,6 +65,34 @@ export interface LifecycleDef {
   transitionRequirements?: Record<string, string[]>;
 }
 
+/**
+ * Declarative definition of one typed relation type within a profile pack.
+ *
+ * A relation type declares its endpoints by entity-type id (`from`/`to`, each a
+ * non-empty list of DECLARED entity types), a `direction` (`directed` keeps the
+ * endpoint roles distinct; `symmetric` treats them as an unordered pair —
+ * canonicalization of symmetric pairs is enforced at STORE time in a later
+ * slice, not here), and optionally a set of typed `attributes` (reusing the same
+ * {@link FieldDef} contract as entity fields) with a `requiredAttributes`
+ * subset that must reference declared attribute keys.
+ *
+ * This is SCHEMA + VALIDATION only: there is no relation store or write path in
+ * this slice. The DEFAULT profile declares no relations, so the whole block is
+ * omitted-for-default and never appears in default output or digest.
+ */
+export interface RelationTypeDef {
+  /** Endpoint entity-type ids on the `from` side; each must be a declared entity. */
+  from: string[];
+  /** Endpoint entity-type ids on the `to` side; each must be a declared entity. */
+  to: string[];
+  /** `directed` keeps endpoint roles distinct; `symmetric` treats them as unordered. */
+  direction: "directed" | "symmetric";
+  /** Typed relation attributes, validated with the same {@link FieldDef} contract as fields. */
+  attributes?: Record<string, FieldDef>;
+  /** Attribute keys (subset of `attributes`) that must be present on a relation instance. */
+  requiredAttributes?: string[];
+}
+
 /** Declarative definition of one entity type within a profile pack. */
 export interface EntityTypeDef {
   directory: string;
@@ -84,6 +112,13 @@ export interface ProfilePack {
   displayName?: string;
   extends?: string[];
   entities: Record<string, EntityTypeDef>;
+  /**
+   * Typed relation type declarations, keyed by slug-safe relation-type id.
+   * OPTIONAL and omitted-for-default: a relation-less profile (including the
+   * built-in default) carries no `relations` key, so its digest and output are
+   * unchanged. See {@link RelationTypeDef}.
+   */
+  relations?: Record<string, RelationTypeDef>;
 }
 
 /** A profile resolved from disk (or built-in), with its source and digest. */

--- a/src/profile/validate.ts
+++ b/src/profile/validate.ts
@@ -16,7 +16,9 @@
  *     canonicalization + uniqueness + reserved-root confinement, requiredFields
  *     references, lifecycle FSM well-formedness, slug-safe entity-type keys,
  *     defensive non-finite-number rejection, the unsupported `extends`
- *     inheritance, and (in `validateProfile` only) reserved profile ids.
+ *     inheritance, relation-type well-formedness (slug-safe keys, declared
+ *     endpoints, requiredAttributes membership), and (in `validateProfile`
+ *     only) reserved profile ids.
  *
  * Validation NEVER mutates the caller's input: the raw object is cloned up
  * front and only the clone is canonicalized and returned. `validateProfileShape`
@@ -26,7 +28,7 @@
  * Unreachable lifecycle states are collected as warnings, not errors.
  */
 
-import type { ProfilePack, EntityTypeDef, FieldDef, LifecycleDef } from "./types.js";
+import type { ProfilePack, EntityTypeDef, FieldDef, LifecycleDef, RelationTypeDef } from "./types.js";
 import { isSlugSafe } from "./identity.js";
 import { validateEntityDirectory } from "./paths.js";
 import { assertStructurallyValid } from "./schema-validator.js";
@@ -88,15 +90,20 @@ function rejectInheritance(raw: ProfilePack): void {
   );
 }
 
+/** Reject any non-finite numeric value on one FieldDef (default/min/max). */
+function assertFieldDefFinite(where: string, field: FieldDef): void {
+  for (const key of ["default", "min", "max"] as const) {
+    const value = field[key];
+    if (typeof value === "number") {
+      assert(Number.isFinite(value), `${where} has a non-finite ${key}`);
+    }
+  }
+}
+
 /** Reject any non-finite numeric field-def or retrieval value defensively. */
 function assertFiniteNumbers(entityType: string, def: EntityTypeDef): void {
   for (const [name, field] of Object.entries(def.fields ?? {})) {
-    for (const key of ["default", "min", "max"] as const) {
-      const value = field[key];
-      if (typeof value === "number") {
-        assert(Number.isFinite(value), `entity '${entityType}' field '${name}' has a non-finite ${key}`);
-      }
-    }
+    assertFieldDefFinite(`entity '${entityType}' field '${name}'`, field);
   }
   const weight = def.retrieval?.defaultWeight;
   if (typeof weight === "number") {
@@ -206,6 +213,47 @@ function validateEntities(entities: Record<string, EntityTypeDef>): string[] {
   return warnings;
 }
 
+/** Every from/to endpoint must reference a DECLARED entity type. */
+function validateRelationEndpoints(rel: string, def: RelationTypeDef, entities: Set<string>): void {
+  assert(def.from.length > 0, `relation '${rel}' has an empty 'from' endpoint list`);
+  assert(def.to.length > 0, `relation '${rel}' has an empty 'to' endpoint list`);
+  for (const endpoint of [...def.from, ...def.to]) {
+    assert(entities.has(endpoint), `relation '${rel}' endpoint '${endpoint}' is not a declared entity type`);
+  }
+}
+
+/** requiredAttributes entries must be declared keys in `attributes`; attrs finite. */
+function validateRelationAttributes(rel: string, def: RelationTypeDef): void {
+  const attributes = def.attributes ?? {};
+  for (const [name, field] of Object.entries(attributes)) {
+    assertFieldDefFinite(`relation '${rel}' attribute '${name}'`, field);
+  }
+  for (const name of def.requiredAttributes ?? []) {
+    assert(name in attributes, `relation '${rel}' requiredAttributes references undeclared attribute '${name}'`);
+  }
+}
+
+/**
+ * Validate the optional `relations` block (fail-closed). Each relation-type key
+ * must be slug-safe; `from`/`to` must be non-empty and reference declared entity
+ * types; `direction` is schema-enforced to `directed`/`symmetric`; attribute
+ * FieldDefs must be finite and every `requiredAttributes` entry must name a
+ * declared attribute. Symmetric-pair canonicalization is a STORE-time concern
+ * (a later slice), so only the def shape is validated here.
+ */
+function validateRelations(
+  relations: Record<string, RelationTypeDef> | undefined,
+  entities: Record<string, EntityTypeDef>,
+): void {
+  if (!relations) return;
+  const declared = new Set(Object.keys(entities));
+  for (const [rel, def] of Object.entries(relations)) {
+    assert(isSlugSafe(rel), `relation type key '${rel}' must be slug-safe`);
+    validateRelationEndpoints(rel, def, declared);
+    validateRelationAttributes(rel, def);
+  }
+}
+
 /**
  * Validate a raw profile's SHAPE: the ajv structural gate plus every semantic
  * check, EXCEPT the reserved profileId rejection. The built-in default profile
@@ -218,6 +266,7 @@ export function validateProfileShape(raw: unknown): ProfileValidationResult {
   const profile = structuredClone(raw) as ProfilePack;
   rejectInheritance(profile);
   const warnings = validateEntities(profile.entities);
+  validateRelations(profile.relations, profile.entities);
   return { profile, warnings };
 }
 

--- a/test/profile-cli.test.ts
+++ b/test/profile-cli.test.ts
@@ -83,6 +83,21 @@ describe("profile show / validate", () => {
     expect(result.stdout).toContain("valid");
   });
 
+  it("show displays declared relation types", async () => {
+    const profile = {
+      schemaVersion: 1,
+      profileId: "research-rel",
+      entities: { experiments: { directory: "wiki/experiments" }, ideas: { directory: "wiki/ideas" } },
+      relations: { tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } },
+    };
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(profile), "utf8");
+    const result = await runCLI(["profile", "show"], root);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toMatch(/relations:\s+1/);
+    expect(result.stdout).toMatch(/tests: experiments -> ideas \(directed\)/);
+  });
+
   it("validate exits non-zero with a message for an invalid profile", async () => {
     await mkdir(path.join(root, ".llmwiki"), { recursive: true });
     await writeFile(path.join(root, PROFILE_FILE), JSON.stringify({ schemaVersion: 2, profileId: "x", entities: {} }), "utf8");

--- a/test/profile-relations.test.ts
+++ b/test/profile-relations.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @file test/profile-relations.test.ts
+ * @description Tests for typed relation-type definitions (Phase 4) — the
+ * optional `relations` block on a profile pack and its fail-closed load
+ * validation.
+ *
+ * A relation type declares `from`/`to` endpoint entity-type lists, a direction,
+ * and typed attributes. These tests pin: a valid block loads; endpoints must
+ * reference DECLARED entity types; `requiredAttributes` must name declared
+ * attributes; an invalid `direction` is rejected structurally; relation keys
+ * must be slug-safe; and a relation-less / default profile is unaffected (its
+ * digest stays stable). The DEFAULT profile declares NO relations, so all of
+ * this is omitted-for-default and parity is intact.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateProfile, ProfileValidationError } from "../src/profile/validate.js";
+import { profileDigest } from "../src/profile/digest.js";
+import type { ProfilePack, RelationTypeDef } from "../src/profile/types.js";
+
+/** A minimal valid profile with two entity types and one relation type. */
+function relationProfile(rel?: Partial<RelationTypeDef>): ProfilePack {
+  return {
+    schemaVersion: 1,
+    profileId: "research",
+    entities: {
+      experiments: { directory: "wiki/experiments" },
+      ideas: { directory: "wiki/ideas" },
+      methods: { directory: "wiki/methods" },
+    },
+    relations: {
+      tests: {
+        from: ["experiments"],
+        to: ["ideas", "methods"],
+        direction: "directed",
+        attributes: { evidence: { type: "string" }, metricValue: { type: "string" } },
+        requiredAttributes: ["evidence"],
+        ...rel,
+      },
+    },
+  };
+}
+
+describe("validateProfile — relation types (happy path)", () => {
+  it("accepts a valid relations block and returns it", () => {
+    const result = validateProfile(relationProfile());
+    expect(result.profile.relations?.tests.direction).toBe("directed");
+    expect(result.profile.relations?.tests.from).toEqual(["experiments"]);
+  });
+
+  it("accepts a symmetric relation with no attributes", () => {
+    const raw = relationProfile({ direction: "symmetric", attributes: undefined, requiredAttributes: undefined });
+    expect(() => validateProfile(raw)).not.toThrow();
+  });
+});
+
+describe("validateProfile — relation types (fail closed)", () => {
+  it("rejects a from-endpoint that is not a declared entity type", () => {
+    const raw = relationProfile({ from: ["ghosts"] });
+    expect(() => validateProfile(raw)).toThrow(ProfileValidationError);
+    expect(() => validateProfile(raw)).toThrow(/endpoint 'ghosts' is not a declared entity/);
+  });
+
+  it("rejects a to-endpoint that is not a declared entity type", () => {
+    const raw = relationProfile({ to: ["ideas", "phantom"] });
+    expect(() => validateProfile(raw)).toThrow(/endpoint 'phantom' is not a declared entity/);
+  });
+
+  it("rejects requiredAttributes referencing an undeclared attribute", () => {
+    const raw = relationProfile({ requiredAttributes: ["evidence", "nope"] });
+    expect(() => validateProfile(raw)).toThrow(/requiredAttributes references undeclared attribute 'nope'/);
+  });
+
+  it("rejects an invalid direction via the schema gate", () => {
+    const raw = relationProfile({ direction: "bidirectional" as never });
+    expect(() => validateProfile(raw)).toThrow(ProfileValidationError);
+  });
+
+  it("rejects a slug-unsafe relation type key", () => {
+    const raw = relationProfile();
+    raw.relations = { "Tests Of": raw.relations!.tests };
+    expect(() => validateProfile(raw)).toThrow(/slug-safe/);
+  });
+
+  it("rejects an empty from list via the schema minItems gate", () => {
+    const raw = relationProfile({ from: [] });
+    expect(() => validateProfile(raw)).toThrow(ProfileValidationError);
+  });
+
+  it("rejects an unknown relation-def key (additionalProperties:false)", () => {
+    const raw = relationProfile();
+    (raw.relations!.tests as Record<string, unknown>).bogus = 1;
+    expect(() => validateProfile(raw)).toThrow(/unknown|unexpected/i);
+  });
+});
+
+describe("profileDigest — relations parity", () => {
+  it("produces a stable digest for a profile with relations", () => {
+    expect(profileDigest(relationProfile())).toBe(profileDigest(relationProfile()));
+    expect(profileDigest(relationProfile())).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("a relation-less profile digest is unchanged by the new key being absent", () => {
+    const relationless: ProfilePack = {
+      schemaVersion: 1,
+      profileId: "research",
+      entities: { experiments: { directory: "wiki/experiments" } },
+    };
+    const withEmptyKeyOmitted = { ...relationless };
+    expect(profileDigest(relationless)).toBe(profileDigest(withEmptyKeyOmitted));
+  });
+});


### PR DESCRIPTION
Stacked on PR #131 (do not merge yet). Lets a non-default profile DECLARE typed relation types (the `relations` block) — schema + validation only; the relation store and writes come in PR4/PR5.

- New `RelationTypeDef` (`from`/`to` endpoint entity-type lists, `direction` directed|symmetric, typed `attributes`, `requiredAttributes`) + an optional `relations` block on the profile, in the type, the JSON schema, and the digest.
- Fail-closed load validation: a relation whose `from`/`to` references an undeclared entity type, a `requiredAttributes` entry not in `attributes`, a slug-unsafe relation key, or an invalid `direction` all reject the profile. `profile show` surfaces declared relations.

The default profile declares no relations, so the block is omitted everywhere — default byte-identical; full suite green (2167).