### PR TITLE
feat(relations): Phase 4 PR4 — append-only JSONL relation store + RelationRef

### DIFF
--- a/src/relations/digest.ts
+++ b/src/relations/digest.ts
@@ -1,0 +1,68 @@
+/**
+ * @file src/relations/digest.ts
+ * @description Canonical content hashing for relations. Mirrors
+ * `src/profile/digest.ts`: a SHA-256 over the RFC 8785 (JCS) canonicalization
+ * of the content fields, so equal content yields an equal hash regardless of
+ * key order or whitespace. The hash is the dedup key and the `preconditionHash`
+ * a staged edit checks against.
+ *
+ * Symmetric-edge canonicalization: for a `symmetric` relation type, the edge
+ * (a→b) and (b→a) are the SAME edge, so the endpoints are ordered
+ * lexicographically BEFORE hashing — both directions then produce one hash.
+ * For a `directed` type the endpoints keep their declared order.
+ */
+
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+import type { EntityId } from "../profile/types.js";
+import type { RelationContentInput } from "./types.js";
+
+/** The endpoint direction semantics that govern canonicalization. */
+export type RelationDirection = "directed" | "symmetric";
+
+/**
+ * Order a relation's endpoints for hashing. A `symmetric` edge orders its
+ * endpoints lexicographically so (a→b) and (b→a) hash identically; a `directed`
+ * edge keeps them as given.
+ *
+ * @param from - The `from` endpoint id.
+ * @param to - The `to` endpoint id.
+ * @param direction - The relation type's direction.
+ * @returns The endpoints in canonical (hash) order.
+ */
+export function canonicalEndpoints(
+  from: EntityId,
+  to: EntityId,
+  direction: RelationDirection,
+): { from: EntityId; to: EntityId } {
+  if (direction === "symmetric" && to < from) {
+    return { from: to, to: from };
+  }
+  return { from, to };
+}
+
+/**
+ * Compute the canonical content hash of a relation.
+ *
+ * Returns the lowercase-hex SHA-256 of the RFC 8785 canonicalization of
+ * `{type, from, to, attributes, evidence}`. The caller is responsible for
+ * passing endpoints already in canonical order (see {@link canonicalEndpoints})
+ * so symmetric duplicates collapse to one hash.
+ *
+ * @param input - The relation content fields.
+ * @returns Lowercase hex SHA-256 of the canonical JSON form.
+ */
+export function relationContentHash(input: RelationContentInput): string {
+  const content = {
+    type: input.type,
+    from: input.from,
+    to: input.to,
+    attributes: input.attributes,
+    evidence: input.evidence,
+  };
+  const canonical = canonicalize(content);
+  if (canonical === undefined) {
+    throw new Error("relation canonicalization produced no output");
+  }
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}

--- a/src/relations/store-read.ts
+++ b/src/relations/store-read.ts
@@ -1,0 +1,144 @@
+/**
+ * @file src/relations/store-read.ts
+ * @description The READ half of the relation store: parse the append-only
+ * JSONL at `wiki/graph/relations.jsonl` into the live set of relations.
+ *
+ * Durability contract (07 §JSONL Durability And Concurrency):
+ *  - The FIRST line is a header carrying `schemaVersion`. A `schemaVersion`
+ *    greater than {@link RELATION_STORE_SCHEMA_VERSION} → FAIL CLOSED
+ *    ({@link RelationStoreTooNewError}); we do not guess at a future format.
+ *  - Every record carries a CHECKSUM, recomputed and compared on read. A bad
+ *    checksum or a malformed record BEFORE the final line is interior
+ *    corruption → FAIL CLOSED ({@link RelationStoreCorruptError}).
+ *  - A torn TRAILING line (an incomplete final append) is TOLERATED and
+ *    REPORTED as a `problem` — never silently dropped, never failed on.
+ *  - The graph directory's realpath is confined under root before reading; a
+ *    symlinked `wiki/graph` fails closed.
+ *  - Absent file → empty result.
+ *
+ * UPDATE SEMANTICS: the store is append-only and an update appends a NEW record
+ * with the same `id`. This reader returns the LATEST record per `id` (last wins
+ * by file order), so a superseded record is dropped from the live set while
+ * remaining on disk for audit.
+ */
+
+import { readFile } from "fs/promises";
+import path from "path";
+import { RELATIONS_FILE } from "../utils/constants.js";
+import type { RelationRef, RelationRecord } from "./types.js";
+import {
+  RELATION_STORE_SCHEMA_VERSION,
+  RelationStoreTooNewError,
+  RelationStoreCorruptError,
+} from "./types.js";
+import { recordChecksum, resolveGraphDir } from "./store-record.js";
+
+/** The outcome of reading the store: live relations plus any tolerated problems. */
+export interface ReadRelationsResult {
+  /** Latest record per id, in first-seen id order. */
+  relations: RelationRef[];
+  /** Human-readable notes about tolerated issues (e.g. a torn trailing line). */
+  problems: string[];
+}
+
+/** Read the raw store file bytes, or null when the file is absent. */
+async function readStoreFile(root: string): Promise<string | null> {
+  const { dir, exists } = await resolveGraphDir(root); // throws on symlink escape
+  if (!exists) return null;
+  const file = path.join(dir, path.basename(RELATIONS_FILE));
+  try {
+    return await readFile(file, "utf-8");
+  } catch {
+    return null; // dir exists but file does not → no relations yet
+  }
+}
+
+/** Parse and validate the header line, failing closed on an unknown future version. */
+function parseHeader(line: string): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new RelationStoreCorruptError("header line is not valid JSON");
+  }
+  const header = parsed as { kind?: unknown; schemaVersion?: unknown };
+  if (header.kind !== "relation-store-header" || typeof header.schemaVersion !== "number") {
+    throw new RelationStoreCorruptError("first line is not a valid store header");
+  }
+  if (header.schemaVersion > RELATION_STORE_SCHEMA_VERSION) {
+    throw new RelationStoreTooNewError(header.schemaVersion, RELATION_STORE_SCHEMA_VERSION);
+  }
+}
+
+/** Split a record line into its {@link RelationRef} and stored checksum, validating shape. */
+function parseRecord(line: string): RelationRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new RelationStoreCorruptError("record line is not valid JSON");
+  }
+  const rec = parsed as Partial<RelationRecord>;
+  const idOk = typeof rec.id === "string" && rec.id.startsWith("rel_");
+  if (!idOk || typeof rec.checksum !== "string" || typeof rec.type !== "string") {
+    throw new RelationStoreCorruptError("record line is missing required fields");
+  }
+  return rec as RelationRecord;
+}
+
+/** Verify a parsed record's stored checksum against a recomputation; throw on mismatch. */
+function verifyChecksum(record: RelationRecord): RelationRef {
+  const { checksum, ...ref } = record;
+  if (recordChecksum(ref) !== checksum) {
+    throw new RelationStoreCorruptError(`checksum mismatch for relation ${ref.id}`);
+  }
+  return ref;
+}
+
+/** Collapse records to the latest per id (last wins), preserving first-seen order. */
+function latestPerId(records: RelationRef[]): RelationRef[] {
+  const byId = new Map<string, RelationRef>();
+  for (const ref of records) {
+    byId.set(ref.id, ref);
+  }
+  return [...byId.values()];
+}
+
+/**
+ * Parse every record line AFTER the header. A failure on any line except the
+ * LAST is interior corruption (fail closed); a failure on the last line is a
+ * torn trailing append — tolerated, reported via `problems`.
+ */
+function parseRecords(lines: string[], problems: string[]): RelationRef[] {
+  const refs: RelationRef[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const isLast = i === lines.length - 1;
+    try {
+      refs.push(verifyChecksum(parseRecord(lines[i])));
+    } catch (err) {
+      if (isLast) {
+        problems.push(`tolerated torn trailing line: ${(err as Error).message}`);
+        break;
+      }
+      throw err; // interior corruption → fail closed
+    }
+  }
+  return refs;
+}
+
+/**
+ * Read the relation store into the live set of relations plus any tolerated
+ * problems. See the file overview for the full durability contract.
+ *
+ * @param root - Absolute project root.
+ * @returns The latest relation per id and a list of tolerated problems.
+ */
+export async function readRelations(root: string): Promise<ReadRelationsResult> {
+  const raw = await readStoreFile(root); // throws on symlink escape
+  if (raw === null || raw.trim() === "") return { relations: [], problems: [] };
+  const lines = raw.split("\n").filter((line) => line.length > 0);
+  parseHeader(lines[0]);
+  const problems: string[] = [];
+  const refs = parseRecords(lines.slice(1), problems);
+  return { relations: latestPerId(refs), problems };
+}

--- a/src/relations/store-record.ts
+++ b/src/relations/store-record.ts
@@ -1,0 +1,77 @@
+/**
+ * @file src/relations/store-record.ts
+ * @description Shared record (de)serialization for the relation store: the
+ * per-record checksum, the header line, and the graph-directory confinement
+ * helper. Kept separate so the append (write) and read paths compute the
+ * checksum and resolve the directory through ONE definition — a write and a
+ * read can never disagree on what a valid line is.
+ *
+ * The checksum is a SHA-256 over the RFC 8785 canonicalization of the record's
+ * content fields (the {@link RelationRef}, i.e. everything except `checksum`),
+ * recomputed on read and compared. It detects a flipped byte anywhere in the
+ * line independently of the content hash (which a writer could, in principle,
+ * have written wrong).
+ */
+
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+import path from "path";
+import { lstat } from "fs/promises";
+import { WIKI_GRAPH_DIR } from "../utils/constants.js";
+import { safeRealpath, isInsideDir } from "../utils/path-confine.js";
+import type { RelationRef, RelationRecord, RelationStoreHeader } from "./types.js";
+import { RELATION_STORE_SCHEMA_VERSION } from "./types.js";
+
+/** Compute the per-record checksum over a relation's content (excludes `checksum`). */
+export function recordChecksum(ref: RelationRef): string {
+  const canonical = canonicalize(ref);
+  if (canonical === undefined) {
+    throw new Error("relation record canonicalization produced no output");
+  }
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+/** Serialize a {@link RelationRef} to its on-disk JSONL line (with trailing newline). */
+export function serializeRecord(ref: RelationRef): string {
+  const record: RelationRecord = { ...ref, checksum: recordChecksum(ref) };
+  return JSON.stringify(record) + "\n";
+}
+
+/** The header line (with trailing newline) written when a store is created. */
+export function headerLine(): string {
+  const header: RelationStoreHeader = {
+    kind: "relation-store-header",
+    schemaVersion: RELATION_STORE_SCHEMA_VERSION,
+  };
+  return JSON.stringify(header) + "\n";
+}
+
+/**
+ * Resolve the trusted on-disk graph directory for `root`: `<realpath(root)>/wiki/graph`,
+ * requiring it (if it exists) to be a REAL directory at that literal path. A
+ * symlinked `wiki/graph` (which would redirect every read/write outside the
+ * project) FAILS CLOSED here by throwing. Returns `{ dir, exists }`: `exists`
+ * is false when the directory is simply absent (the "no relations" state).
+ *
+ * @param root - Absolute project root.
+ * @returns The confined graph dir and whether it currently exists on disk.
+ */
+export async function resolveGraphDir(root: string): Promise<{ dir: string; exists: boolean }> {
+  const canonicalRoot = await safeRealpath(root);
+  const base = canonicalRoot ?? path.resolve(root);
+  const dir = path.join(base, WIKI_GRAPH_DIR);
+  let st;
+  try {
+    st = await lstat(dir);
+  } catch {
+    return { dir, exists: false }; // absent → no relations yet
+  }
+  if (!st.isDirectory()) {
+    throw new Error(`relation graph path is not a directory (symlink?): ${WIKI_GRAPH_DIR}`);
+  }
+  const real = await safeRealpath(dir);
+  if (real === null || !isInsideDir(real, base)) {
+    throw new Error(`relation graph directory escapes project root: ${WIKI_GRAPH_DIR}`);
+  }
+  return { dir: real, exists: true };
+}

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -1,0 +1,183 @@
+/**
+ * @file src/relations/store.ts
+ * @description The WRITE half of the append-only relation store. Validates a
+ * relation against its profile relation-type def, mints a stable `rel_<ULID>`
+ * id, canonicalizes symmetric endpoints, and APPENDS the record (record +
+ * checksum) under the project lock as a single writer. A new store gets a
+ * header line first. The read half lives in `store-read.ts`.
+ *
+ * DURABILITY: appends use O_APPEND under {@link acquireLock}/{@link releaseLock}
+ * so a single writer extends the file atomically (each line either lands whole
+ * or, at worst, leaves a torn TRAILING line the reader tolerates and reports).
+ * CONFINEMENT: the graph dir is resolved through {@link resolveGraphDir}, which
+ * fails closed if `wiki/graph` is a symlink escaping root.
+ *
+ * UPDATE: because the store is append-only, {@link updateRelation} appends a
+ * NEW record carrying the SAME `id` with a recomputed `contentHash`. The reader
+ * returns the latest record per id, so the prior record is superseded while
+ * staying on disk for audit. Changing `type`/`from`/`to` is a delete+create
+ * (a different edge) and is NOT an update — callers pass only attributes/evidence.
+ */
+
+import { open, mkdir } from "fs/promises";
+import path from "path";
+import { RELATIONS_FILE } from "../utils/constants.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { parseEntityId } from "../profile/identity.js";
+import type { EntityId, ProfilePack, RelationTypeDef } from "../profile/types.js";
+import type { CitationRef, RelationRef } from "./types.js";
+import { RelationEndpointError } from "./types.js";
+import { mintRelationId } from "./ulid.js";
+import { canonicalEndpoints, relationContentHash } from "./digest.js";
+import { headerLine, serializeRecord, resolveGraphDir } from "./store-record.js";
+import { readRelations } from "./store-read.js";
+
+/** The caller-supplied content of a new relation (id + hash are derived). */
+export interface AppendRelationInput {
+  type: string;
+  from: EntityId;
+  to: EntityId;
+  attributes?: Record<string, unknown>;
+  evidence?: CitationRef[];
+}
+
+/** An in-place attribute/evidence patch applied under an existing relation id. */
+export interface UpdateRelationPatch {
+  attributes?: Record<string, unknown>;
+  evidence?: CitationRef[];
+}
+
+/** Look up a relation-type def, failing closed if the type is undeclared. */
+function relationDef(profile: ProfilePack, type: string): RelationTypeDef {
+  const def = profile.relations?.[type];
+  if (!def) {
+    throw new RelationEndpointError(`unknown relation type '${type}'`);
+  }
+  return def;
+}
+
+/** Assert one endpoint's entity type is allowed on its side of the relation. */
+function assertEndpoint(id: EntityId, allowed: string[], side: "from" | "to", type: string): void {
+  const { entityType } = parseEntityId(id);
+  if (!allowed.includes(entityType)) {
+    throw new RelationEndpointError(
+      `relation '${type}' ${side} endpoint type '${entityType}' is not allowed (expected one of ${allowed.join(", ")})`,
+    );
+  }
+}
+
+/** Assert every required attribute of the relation type is present in `attributes`. */
+function assertRequiredAttributes(def: RelationTypeDef, attributes: Record<string, unknown>, type: string): void {
+  for (const name of def.requiredAttributes ?? []) {
+    if (!(name in attributes)) {
+      throw new RelationEndpointError(`relation '${type}' is missing required attribute '${name}'`);
+    }
+  }
+}
+
+/**
+ * Validate endpoints + required attributes against the relation-type def, then
+ * build the {@link RelationRef}: canonicalize symmetric endpoints, mint the id
+ * (or reuse `existingId` for an update), and compute the content hash. NOTHING
+ * is written here — validation throwing leaves the store untouched.
+ */
+function buildRelationRef(
+  profile: ProfilePack,
+  input: AppendRelationInput,
+  existingId?: RelationRef["id"],
+): RelationRef {
+  const def = relationDef(profile, input.type);
+  assertEndpoint(input.from, def.from, "from", input.type);
+  assertEndpoint(input.to, def.to, "to", input.type);
+  const attributes = input.attributes ?? {};
+  assertRequiredAttributes(def, attributes, input.type);
+  const { from, to } = canonicalEndpoints(input.from, input.to, def.direction);
+  const content = { type: input.type, from, to, attributes, evidence: input.evidence };
+  return { id: existingId ?? mintRelationId(), ...content, contentHash: relationContentHash(content) };
+}
+
+/** Append one serialized record line to the store under O_APPEND, creating the dir/header. */
+async function appendLine(root: string, ref: RelationRef): Promise<void> {
+  const { dir } = await resolveGraphDir(root); // throws on symlink escape
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, path.basename(RELATIONS_FILE));
+  const handle = await open(file, "a");
+  try {
+    if ((await handle.stat()).size === 0) {
+      await handle.write(headerLine());
+    }
+    await handle.write(serializeRecord(ref));
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Run `fn` while holding the project lock; release in a finally. */
+async function underLock<T>(root: string, fn: () => Promise<T>): Promise<T> {
+  if (!(await acquireLock(root))) {
+    throw new Error("could not acquire project lock for relation store write");
+  }
+  try {
+    return await fn();
+  } finally {
+    await releaseLock(root);
+  }
+}
+
+/**
+ * Validate and APPEND a new relation, returning its {@link RelationRef}.
+ *
+ * Validation (endpoint entity types, required attributes) runs BEFORE any
+ * write, so a violation throws {@link RelationEndpointError} and writes nothing.
+ * The id is minted once; symmetric endpoints are canonicalized so (a→b) and
+ * (b→a) share a content hash. The append occurs under the project lock.
+ *
+ * @param root - Absolute project root.
+ * @param profile - The governing profile pack (its `relations` block is the schema).
+ * @param input - The new relation's content.
+ * @returns The persisted relation reference.
+ */
+export async function appendRelation(
+  root: string,
+  profile: ProfilePack,
+  input: AppendRelationInput,
+): Promise<RelationRef> {
+  const ref = buildRelationRef(profile, input); // throws before any write
+  await underLock(root, () => appendLine(root, ref));
+  return ref;
+}
+
+/**
+ * Apply an in-place attribute/evidence update to an existing relation. Appends
+ * a new record carrying the SAME `id` with a recomputed `contentHash`; the
+ * reader returns the latest record per id, so this supersedes the prior one.
+ * The relation's `type`/`from`/`to` are preserved from the existing record.
+ *
+ * @param root - Absolute project root.
+ * @param profile - The governing profile pack.
+ * @param id - The id of the relation to update.
+ * @param patch - The attribute/evidence patch to apply.
+ * @returns The updated relation reference (same id, new content hash).
+ */
+export async function updateRelation(
+  root: string,
+  profile: ProfilePack,
+  id: RelationRef["id"],
+  patch: UpdateRelationPatch,
+): Promise<RelationRef> {
+  const { relations } = await readRelations(root);
+  const existing = relations.find((rel) => rel.id === id);
+  if (!existing) {
+    throw new RelationEndpointError(`no relation with id '${id}' to update`);
+  }
+  const input: AppendRelationInput = {
+    type: existing.type,
+    from: existing.from,
+    to: existing.to,
+    attributes: patch.attributes ?? existing.attributes,
+    evidence: patch.evidence ?? existing.evidence,
+  };
+  const ref = buildRelationRef(profile, input, id);
+  await underLock(root, () => appendLine(root, ref));
+  return ref;
+}

--- a/src/relations/types.ts
+++ b/src/relations/types.ts
@@ -1,0 +1,118 @@
+/**
+ * @file src/relations/types.ts
+ * @description Type surface for the typed RELATION STORE (Phase 4) — the
+ * append-only JSONL graph at `wiki/graph/relations.jsonl`.
+ *
+ * A {@link RelationRef} is one typed edge between two entity pages. Its `id`
+ * (`rel_<ULID>`) is allocated ONCE at creation and is NEVER derived from or
+ * recomputed against content — it is the stable handle a staged edit or a
+ * later update references. Its `contentHash` is the canonical RFC 8785 digest
+ * over `{type, from, to, attributes, evidence}` and IS recomputed whenever
+ * `attributes`/`evidence` change; it serves both as the dedup key and as the
+ * `preconditionHash` a staged edit checks against before applying. Changing
+ * `type`/`from`/`to` is a delete+create (a different edge), not an in-place
+ * update.
+ *
+ * On disk each line is a {@link RelationRecord}: the `RelationRef` plus a
+ * per-record `checksum` (sha256 of the canonical record-without-checksum form).
+ * The first line of a non-empty store is a {@link RelationStoreHeader} carrying
+ * the store `schemaVersion`. Readers FAIL CLOSED when that version exceeds
+ * {@link RELATION_STORE_SCHEMA_VERSION}; a torn trailing line is tolerated and
+ * reported; interior corruption fails closed for the whole store.
+ */
+
+import type { EntityId } from "../profile/types.js";
+
+/** The relation-store JSONL schema version readers understand. */
+export const RELATION_STORE_SCHEMA_VERSION = 1;
+
+/**
+ * A minimal citation backing a relation: the source file the claim came from
+ * and an optional span within it (line range / char offset, free-form). The
+ * exact span grammar is deferred; the contract here is only that it is a
+ * stable string so it participates deterministically in the content hash.
+ */
+export interface CitationRef {
+  /** Project-relative path of the source the relation is evidenced by. */
+  sourcePath: string;
+  /** Optional span within the source (free-form, e.g. `"L10-L14"`). */
+  sourceSpan?: string;
+}
+
+/** A relation id, always of the form `rel_<ULID>`. */
+export type RelationId = `rel_${string}`;
+
+/**
+ * One typed edge between two entity pages.
+ *
+ * `id` is minted once and never recomputed; `contentHash` is the canonical
+ * digest of the content fields and is recomputed on every attribute/evidence
+ * update. See the file overview for the full lifecycle contract.
+ */
+export interface RelationRef {
+  /** Stable handle, allocated once at creation. */
+  id: RelationId;
+  /** Relation-type id, a key of `profile.relations`. */
+  type: string;
+  /** The `from` endpoint entity page id (`<entityType>/<slug>`). */
+  from: EntityId;
+  /** The `to` endpoint entity page id. */
+  to: EntityId;
+  /** Typed relation attributes (validated against the relation-type def). */
+  attributes: Record<string, unknown>;
+  /** Optional citations backing the relation. */
+  evidence?: CitationRef[];
+  /** Canonical digest over `{type, from, to, attributes, evidence}`. */
+  contentHash: string;
+}
+
+/**
+ * The on-disk JSONL line shape: a {@link RelationRef} plus the per-record
+ * `checksum` recomputed and compared on read. The checksum covers the record's
+ * content (the `RelationRef` fields) so a flipped byte anywhere is detected.
+ */
+export interface RelationRecord extends RelationRef {
+  /** sha256 of the canonical record (all fields except `checksum`). */
+  checksum: string;
+}
+
+/** The first line of a non-empty store, carrying its schema version. */
+export interface RelationStoreHeader {
+  /** Discriminator marking this line as the header, not a record. */
+  kind: "relation-store-header";
+  /** The store schema version; readers fail closed when it exceeds known. */
+  schemaVersion: number;
+}
+
+/** The content fields a {@link RelationRef}'s `contentHash` is computed over. */
+export interface RelationContentInput {
+  type: string;
+  from: EntityId;
+  to: EntityId;
+  attributes: Record<string, unknown>;
+  evidence?: CitationRef[];
+}
+
+/** Raised when a store's `schemaVersion` exceeds the known version (fail closed). */
+export class RelationStoreTooNewError extends Error {
+  constructor(found: number, known: number) {
+    super(`relation store schemaVersion ${found} exceeds supported ${known}`);
+    this.name = "RelationStoreTooNewError";
+  }
+}
+
+/** Raised when interior store content is corrupt (bad checksum / malformed line). */
+export class RelationStoreCorruptError extends Error {
+  constructor(message: string) {
+    super(`relation store corrupt: ${message}`);
+    this.name = "RelationStoreCorruptError";
+  }
+}
+
+/** Raised when a relation's endpoints/attributes violate the relation-type def. */
+export class RelationEndpointError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RelationEndpointError";
+  }
+}

--- a/src/relations/ulid.ts
+++ b/src/relations/ulid.ts
@@ -1,0 +1,77 @@
+/**
+ * @file src/relations/ulid.ts
+ * @description A small, dependency-free ULID generator used to mint relation
+ * ids. A ULID is 26 Crockford base32 characters: a 48-bit millisecond
+ * timestamp (10 chars) followed by 80 bits of randomness (16 chars). The
+ * timestamp prefix makes ids roughly sortable by creation time; the random
+ * suffix makes collisions within a millisecond astronomically unlikely.
+ *
+ * `Date.now()` and `crypto.randomBytes` are appropriate here: this is
+ * PRODUCTION code, not a workflow script. (The Date.now ban applies only to
+ * the workflow scripts.) We implement the encoding ourselves rather than add a
+ * dependency.
+ */
+
+import { randomBytes } from "node:crypto";
+import type { RelationId } from "./types.js";
+
+/** Crockford base32 alphabet (no I, L, O, U to avoid visual ambiguity). */
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/** Base32 chars encoding the 48-bit timestamp portion. */
+const TIME_CHARS = 10;
+/** Base32 chars encoding the 80-bit random portion. */
+const RANDOM_CHARS = 16;
+/** Bits consumed per Crockford base32 character. */
+const BITS_PER_CHAR = 5;
+
+/** Encode a 48-bit millisecond timestamp as 10 Crockford base32 chars. */
+function encodeTime(ms: number): string {
+  let remaining = ms;
+  const out: string[] = new Array(TIME_CHARS);
+  for (let i = TIME_CHARS - 1; i >= 0; i--) {
+    out[i] = CROCKFORD[remaining % 32];
+    remaining = Math.floor(remaining / 32);
+  }
+  return out.join("");
+}
+
+/**
+ * Encode 80 random bits as 16 Crockford base32 chars. We draw the 80 bits as
+ * 10 bytes and walk them as a bit stream, emitting one base32 char per 5 bits.
+ */
+function encodeRandom(): string {
+  const bytes = randomBytes(10);
+  let bitBuffer = 0;
+  let bitCount = 0;
+  const out: string[] = [];
+  for (const byte of bytes) {
+    bitBuffer = (bitBuffer << 8) | byte;
+    bitCount += 8;
+    while (bitCount >= BITS_PER_CHAR) {
+      bitCount -= BITS_PER_CHAR;
+      out.push(CROCKFORD[(bitBuffer >>> bitCount) & 0x1f]);
+    }
+  }
+  return out.join("").slice(0, RANDOM_CHARS);
+}
+
+/**
+ * Generate a 26-character Crockford base32 ULID: 48-bit `Date.now()` time
+ * prefix + 80 random bits.
+ *
+ * @returns A 26-char uppercase ULID string.
+ */
+export function ulid(): string {
+  return encodeTime(Date.now()) + encodeRandom();
+}
+
+/**
+ * Mint a fresh relation id of the form `rel_<ULID>`. Allocated once at relation
+ * creation and never recomputed from content.
+ *
+ * @returns A new `rel_<ULID>` id.
+ */
+export function mintRelationId(): RelationId {
+  return `rel_${ulid()}`;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -93,6 +93,15 @@ export const INDEX_FILE = "wiki/index.md";
 export const MOC_FILE = "wiki/MOC.md";
 
 /**
+ * The typed relation graph directory and its append-only store. Lives under
+ * `wiki/` alongside the compiled pages. A DEFAULT profile declares no relations
+ * and never creates `wiki/graph/`, so its absence is the "no relations" state —
+ * keeping default output and parity unchanged.
+ */
+export const WIKI_GRAPH_DIR = "wiki/graph";
+export const RELATIONS_FILE = "wiki/graph/relations.jsonl";
+
+/**
  * Append-only activity journal at the project root, per Karpathy's llm-wiki
  * gist: a chronological record of what happened and when (ingests, compiles,
  * queries, lint passes). Lives at the root rather than under wiki/ because it

--- a/test/relation-digest.test.ts
+++ b/test/relation-digest.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @file test/relation-digest.test.ts
+ * @description Tests for relation content hashing and ULID minting (Phase 4).
+ *
+ * Pins: the content hash is a stable lowercase-hex SHA-256 invariant to
+ * attribute key order; a symmetric edge canonicalizes its endpoints so (a→b)
+ * and (b→a) hash identically while a directed edge does not; and a minted
+ * relation id is a 26-char ULID-bearing `rel_` handle.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { EntityId } from "../src/profile/types.js";
+import { relationContentHash, canonicalEndpoints } from "../src/relations/digest.js";
+import { ulid, mintRelationId } from "../src/relations/ulid.js";
+
+const A = "experiments/a" as EntityId;
+const B = "ideas/b" as EntityId;
+
+describe("relationContentHash", () => {
+  it("is a stable lowercase-hex sha256 invariant to attribute key order", () => {
+    const h1 = relationContentHash({ type: "tests", from: A, to: B, attributes: { x: 1, y: 2 } });
+    const h2 = relationContentHash({ type: "tests", from: A, to: B, attributes: { y: 2, x: 1 } });
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("differs when content changes", () => {
+    const base = relationContentHash({ type: "tests", from: A, to: B, attributes: {} });
+    const changed = relationContentHash({ type: "tests", from: A, to: B, attributes: { z: 1 } });
+    expect(base).not.toBe(changed);
+  });
+});
+
+describe("symmetric endpoint canonicalization", () => {
+  it("makes (a→b) and (b→a) hash identically for a symmetric type", () => {
+    const ab = canonicalEndpoints(A, B, "symmetric");
+    const ba = canonicalEndpoints(B, A, "symmetric");
+    const h1 = relationContentHash({ type: "rel", ...ab, attributes: {} });
+    const h2 = relationContentHash({ type: "rel", ...ba, attributes: {} });
+    expect(h1).toBe(h2);
+  });
+
+  it("keeps directed (a→b) and (b→a) distinct", () => {
+    const h1 = relationContentHash({ type: "rel", ...canonicalEndpoints(A, B, "directed"), attributes: {} });
+    const h2 = relationContentHash({ type: "rel", ...canonicalEndpoints(B, A, "directed"), attributes: {} });
+    expect(h1).not.toBe(h2);
+  });
+});
+
+describe("ulid / mintRelationId", () => {
+  it("mints a 26-char crockford ulid and a rel_ handle", () => {
+    expect(ulid()).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(mintRelationId()).toMatch(/^rel_[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(mintRelationId()).not.toBe(mintRelationId());
+  });
+});

--- a/test/relation-store.test.ts
+++ b/test/relation-store.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @file test/relation-store.test.ts
+ * @description Tests for the append-only JSONL relation store (Phase 4 PR4).
+ *
+ * Covers: append→readback round-trip with a `rel_` id + stable contentHash;
+ * endpoint/required-attribute violations fail closed writing nothing; symmetric
+ * canonicalization; a torn trailing line is tolerated+reported; interior
+ * corruption + a too-new schemaVersion fail closed; a symlinked `wiki/graph`
+ * fails closed; update appends under the same id; and a DEFAULT project (no
+ * `wiki/graph`) reads empty.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, readFile, writeFile, appendFile, symlink } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { EntityId, ProfilePack } from "../src/profile/types.js";
+import { RELATIONS_FILE } from "../src/utils/constants.js";
+import { appendRelation, updateRelation } from "../src/relations/store.js";
+import { readRelations } from "../src/relations/store-read.js";
+import {
+  RelationEndpointError,
+  RelationStoreCorruptError,
+  RelationStoreTooNewError,
+} from "../src/relations/types.js";
+
+const EXP_A = "experiments/a" as EntityId;
+const IDEA_B = "ideas/b" as EntityId;
+
+/** A non-default profile with a directed `tests` and a symmetric `related` relation. */
+function profile(): ProfilePack {
+  return {
+    schemaVersion: 1,
+    profileId: "research",
+    entities: { experiments: { directory: "wiki/experiments" }, ideas: { directory: "wiki/ideas" } },
+    relations: {
+      tests: { from: ["experiments"], to: ["ideas"], direction: "directed", attributes: { note: { type: "string" } }, requiredAttributes: ["note"] },
+      related: { from: ["experiments", "ideas"], to: ["experiments", "ideas"], direction: "symmetric" },
+    },
+  };
+}
+
+let root = "";
+beforeEach(async () => { root = await mkdtemp(path.join(os.tmpdir(), "rel-store-")); });
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+/** Append-mode test profile + the on-disk store path. */
+const storePath = (): string => path.join(root, RELATIONS_FILE);
+
+describe("appendRelation / readRelations round-trip", () => {
+  it("persists a relation with a rel_ id and stable contentHash", async () => {
+    const ref = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    expect(ref.id).toMatch(/^rel_/);
+    const { relations, problems } = await readRelations(root);
+    expect(problems).toEqual([]);
+    expect(relations).toHaveLength(1);
+    expect(relations[0]).toMatchObject({ id: ref.id, contentHash: ref.contentHash, from: EXP_A });
+  });
+});
+
+describe("endpoint + attribute validation (fail closed)", () => {
+  it("rejects a wrong from-endpoint entity type and writes nothing", async () => {
+    const bad = appendRelation(root, profile(), { type: "tests", from: IDEA_B, to: IDEA_B, attributes: { note: "x" } });
+    await expect(bad).rejects.toThrow(RelationEndpointError);
+    await expect(readRelations(root)).resolves.toMatchObject({ relations: [] });
+  });
+
+  it("rejects a missing required attribute", async () => {
+    const bad = appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: {} });
+    await expect(bad).rejects.toThrow(/missing required attribute 'note'/);
+  });
+});
+
+describe("symmetric canonicalization", () => {
+  it("(a→b) and (b→a) share a contentHash", async () => {
+    const ab = await appendRelation(root, profile(), { type: "related", from: EXP_A, to: IDEA_B, attributes: {} });
+    const ba = await appendRelation(root, profile(), { type: "related", from: IDEA_B, to: EXP_A, attributes: {} });
+    expect(ab.contentHash).toBe(ba.contentHash);
+  });
+});
+
+describe("durability: torn / corrupt / too-new", () => {
+  it("tolerates and reports a torn trailing line", async () => {
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    await appendFile(storePath(), '{"id":"rel_torn","type":"tes');
+    const { relations, problems } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(problems[0]).toMatch(/torn trailing line/);
+  });
+
+  it("fails closed on an interior bad-checksum line", async () => {
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    const raw = await readFile(storePath(), "utf-8");
+    const tampered = raw.replace(/"note":"x"/, '"note":"TAMPERED"');
+    await writeFile(storePath(), tampered + '{"id":"rel_z","type":"tests","checksum":"_"}\n');
+    await expect(readRelations(root)).rejects.toThrow(RelationStoreCorruptError);
+  });
+
+  it("fails closed when schemaVersion exceeds the known version", async () => {
+    await mkdir(path.dirname(storePath()), { recursive: true });
+    await writeFile(storePath(), '{"kind":"relation-store-header","schemaVersion":99}\n');
+    await expect(readRelations(root)).rejects.toThrow(RelationStoreTooNewError);
+  });
+});
+
+describe("confinement + default + update", () => {
+  it("fails closed when wiki/graph is a symlinked escape", async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), "rel-escape-"));
+    await mkdir(path.join(root, "wiki"), { recursive: true });
+    await symlink(outside, path.join(root, "wiki", "graph"));
+    await expect(readRelations(root)).rejects.toThrow(/escapes project root|not a directory/);
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  it("reads empty for a DEFAULT project with no wiki/graph", async () => {
+    await expect(readRelations(root)).resolves.toEqual({ relations: [], problems: [] });
+  });
+
+  it("update appends under the same id with a new contentHash", async () => {
+    const ref = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    const updated = await updateRelation(root, profile(), ref.id, { attributes: { note: "y" } });
+    expect(updated.id).toBe(ref.id);
+    expect(updated.contentHash).not.toBe(ref.contentHash);
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].attributes).toEqual({ note: "y" });
+  });
+});


### PR DESCRIPTION
Stacked on PR #132 (do not merge yet). The durable typed-relation store; not yet wired through the planner (PR5).

- `RelationRef` (`rel_<ULID>` id allocated once, never recomputed; `contentHash` = canonical RFC8785 digest over {type,from,to,attributes,evidence}; symmetric edges canonicalized so a↔b hashes identically).
- `wiki/graph/relations.jsonl` with the JSONL durability contract: header `schemaVersion` (reader fails closed when newer), per-record checksum (interior corruption fails closed), torn trailing line tolerated + reported (never silently dropped), appends under the project lock. The graph dir is realpath-confined (fails closed on a symlink escape, mirroring the journal).
- Endpoint validation against the profile relation def (from/to entity types + required attributes) before any write. Dependency-free ULID via node:crypto.

A default project has no `wiki/graph/` → empty relations, parity intact; full suite green (2182).