### PR TITLE
feat(trust): Phase 4 PR5 — trust-gated relation writes + lifecycle transition API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,14 +63,29 @@ export { LockUnavailableError, QueueFullError } from "./import/run-errors.js";
 // in interlinking, semantic search/embeddings, the MOC, or the viewer (planned).
 export type { SdkStageEntityPageInput } from "./trust/staging.js";
 export { StagingRequiresProfileError } from "./trust/staging.js";
+// The staged-change RELATION/ARTIFACT targets are Phase-4 STUB shapes named
+// `Staged…` so the canonical relation `RelationRef` (from `relations/types.ts`,
+// below) owns the unprefixed name.
 export type {
   StagedChange,
   CandidateKind,
   HeldReasonCode,
-  RelationRef,
-  ArtifactRef,
   WorkflowRunRef,
+  StagedRelationRef,
+  StagedArtifactRef,
 } from "./trust/staged-change.js";
+
+// @experimental — trust-gated relation writes + lifecycle transitions
+// (planner-routed, shared SDK/CLI). `createWiki().createRelation` /
+// `.transitionLifecycle` expose these; these are the input/return + typed-error
+// types consumers need.
+export type { AppendRelationInput } from "./relations/store.js";
+export type { RelationRef, RelationId, CitationRef } from "./relations/types.js";
+export { RelationEndpointError } from "./relations/types.js";
+export { RelationWriteDeniedError, RelationsRequireProfileError } from "./trust/relation-write.js";
+export type { SdkTransitionLifecycleInput } from "./sdk/types.js";
+export { LifecycleTransitionUnavailableError } from "./trust/lifecycle-transition.js";
+export { LifecycleTransitionError } from "./profile/lifecycle.js";
 // Planner sub-types named by `StagedChange.target` / `.planned` so the staged
 // surface is fully nameable by consumers (the typed `EntityRef` target especially).
 export type {

--- a/src/profile/lifecycle-read.ts
+++ b/src/profile/lifecycle-read.ts
@@ -37,14 +37,33 @@ export async function readPrevLifecycleState(
   slug: string,
   field: string,
 ): Promise<string | undefined> {
-  // Canonicalize the root first so the directory base matches the file's
-  // realpath (on macOS the temp/symlinked root would otherwise fail confinement
-  // and spuriously report "no prev page").
-  const canonicalRoot = (await safeRealpath(root)) ?? path.resolve(root);
-  const dir = path.join(canonicalRoot, def.directory);
-  const real = await confinedRegularFile(dir, `${slug}.md`);
+  const real = await resolveConfinedEntityPage(root, def, slug);
   if (real === null) return undefined;
   const { meta } = parseFrontmatter(await safeReadFile(real));
   const value = meta[field];
   return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Resolve an entity page's confined real path: `<realpath(root)>/<def.directory>/<slug>.md`
+ * via {@link confinedRegularFile}, or `null` when the page is absent or escapes
+ * the project root (a symlinked / out-of-tree page is treated as absent — never
+ * followed). The root is canonicalized FIRST so the directory base matches the
+ * file's realpath (on macOS a temp/symlinked root would otherwise fail
+ * confinement and spuriously report "no page"). Shared by the prev-state read and
+ * the lifecycle-transition read so both confine identically.
+ *
+ * @param root - Absolute project root.
+ * @param def - The resolved entity type definition (supplies the directory).
+ * @param slug - The page slug (the filename stem).
+ * @returns The confined real path, or `null` when the page is absent/escaping.
+ */
+export async function resolveConfinedEntityPage(
+  root: string,
+  def: EntityTypeDef,
+  slug: string,
+): Promise<string | null> {
+  const canonicalRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  const dir = path.join(canonicalRoot, def.directory);
+  return confinedRegularFile(dir, `${slug}.md`);
 }

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -125,8 +125,36 @@ async function underLock<T>(root: string, fn: () => Promise<T>): Promise<T> {
 }
 
 /**
+ * Validate and APPEND a new relation WHILE THE CALLER ALREADY HOLDS the project
+ * lock — the lock-free core shared with {@link appendRelation}, mirroring the
+ * {@link applyApprovedMutationsLocked} split on the page path.
+ *
+ * The caller MUST already hold the project lock; this function acquires NOTHING,
+ * so a planner-routed write path ({@link createRelation}) can take ONE lock and
+ * run validation + append inside it without a nested-acquire deadlock. Validation
+ * (endpoint entity types, required attributes) still runs BEFORE any write, so a
+ * violation throws {@link RelationEndpointError} and writes nothing.
+ *
+ * @param root - Absolute project root.
+ * @param profile - The governing profile pack (its `relations` block is the schema).
+ * @param input - The new relation's content.
+ * @returns The persisted relation reference.
+ */
+export async function appendRelationLocked(
+  root: string,
+  profile: ProfilePack,
+  input: AppendRelationInput,
+): Promise<RelationRef> {
+  const ref = buildRelationRef(profile, input); // throws before any write
+  await appendLine(root, ref);
+  return ref;
+}
+
+/**
  * Validate and APPEND a new relation, returning its {@link RelationRef}.
  *
+ * The self-locking entry point for callers that do NOT already hold the lock:
+ * acquires the project lock and delegates to {@link appendRelationLocked}.
  * Validation (endpoint entity types, required attributes) runs BEFORE any
  * write, so a violation throws {@link RelationEndpointError} and writes nothing.
  * The id is minted once; symmetric endpoints are canonicalized so (a→b) and
@@ -142,9 +170,7 @@ export async function appendRelation(
   profile: ProfilePack,
   input: AppendRelationInput,
 ): Promise<RelationRef> {
-  const ref = buildRelationRef(profile, input); // throws before any write
-  await underLock(root, () => appendLine(root, ref));
-  return ref;
+  return underLock(root, () => appendRelationLocked(root, profile, input));
 }
 
 /**

--- a/src/sdk/staging-facade.ts
+++ b/src/sdk/staging-facade.ts
@@ -18,17 +18,25 @@
  */
 
 import { stageEntityPageForProject, promoteStagedEntityPage } from "../trust/staging.js";
+import { createRelationForProject } from "../trust/relation-write.js";
+import { transitionLifecycle } from "../trust/lifecycle-transition.js";
 import type { Wiki } from "./types.js";
 
-/** The experimental staging methods the `Wiki` facade composes in. */
-export type StagingFacadeSlice = Pick<Wiki, "stageEntityPage" | "promoteStagedPage">;
+/** The experimental non-default methods the `Wiki` facade composes in. */
+export type StagingFacadeSlice = Pick<
+  Wiki,
+  "stageEntityPage" | "promoteStagedPage" | "createRelation" | "transitionLifecycle"
+>;
 
 /**
- * Build the experimental staging slice of the `Wiki` facade bound to `root`.
+ * Build the experimental non-default slice of the `Wiki` facade bound to `root`:
+ * page staging/promotion plus the trust-gated relation-write and lifecycle-
+ * transition APIs. Each loads the active non-default profile INTERNALLY (the
+ * consumer passes no `ProfilePack`) and fails CLOSED on a default project.
  *
  * @param root - Normalized absolute project root.
  * @param runQuiet - The facade's quiet-scoping wrapper (output suppressed).
- * @returns The `stageEntityPage` / `promoteStagedPage` methods.
+ * @returns The experimental non-default Wiki methods.
  */
 export function buildStagingFacade(
   root: string,
@@ -37,5 +45,8 @@ export function buildStagingFacade(
   return {
     stageEntityPage: (input) => runQuiet(() => stageEntityPageForProject(root, input)),
     promoteStagedPage: (candidateId) => runQuiet(() => promoteStagedEntityPage(root, candidateId)),
+    createRelation: (input) => runQuiet(() => createRelationForProject(root, input)),
+    transitionLifecycle: (input) =>
+      runQuiet(() => transitionLifecycle(root, input.entityType, input.slug, input.toState, input.evidence)),
   };
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -22,6 +22,24 @@ import type { OkfExportReport } from "../export/okf/run.js";
 import type { OkfImportReport } from "../import/run.js";
 import type { SdkStageEntityPageInput } from "../trust/staging.js";
 import type { StagedChange } from "../trust/staged-change.js";
+import type { AppendRelationInput } from "../relations/store.js";
+import type { RelationRef } from "../relations/types.js";
+
+/**
+ * @experimental
+ * SDK input for {@link Wiki.transitionLifecycle}: the entity page to transition
+ * and its target state, plus any frontmatter `evidence` a target state requires.
+ */
+export interface SdkTransitionLifecycleInput {
+  /** Profile entity type whose page is transitioned (must declare a lifecycle). */
+  entityType: string;
+  /** Page slug (the filename stem) of the page to transition. */
+  slug: string;
+  /** The lifecycle state to transition the page into. */
+  toState: string;
+  /** Optional frontmatter fields a target state requires, merged into the page. */
+  evidence?: Record<string, unknown>;
+}
 
 /** Options for `createWiki`. */
 export interface CreateWikiOptions {
@@ -205,4 +223,32 @@ export interface Wiki {
    * Foundation API — the shape may change in a future minor release.
    */
   promoteStagedPage(candidateId: string): Promise<void>;
+  /**
+   * @experimental
+   * Create a typed RELATION through the trust planner. The SDK loads the active
+   * non-default profile internally — the caller passes no `ProfilePack`. The
+   * write routes through ONE planner decision (endpoint validity + required
+   * attributes) and, only when allowed, appends to the relation store under one
+   * lock. Throws `RelationsRequireProfileError` on a default project (no
+   * `relations` block) and `RelationWriteDeniedError` when the planner denies the
+   * write (undeclared type, disallowed endpoint, missing required attribute) —
+   * nothing is written in either case. No LLM required.
+   *
+   * Foundation API — the shape may change in a future minor release.
+   */
+  createRelation(input: AppendRelationInput): Promise<RelationRef>;
+  /**
+   * @experimental
+   * Transition a typed entity page's lifecycle field to `input.toState` as a
+   * validated page update. The SDK loads the active non-default profile
+   * internally. The write rides the EXISTING typed page path, which re-runs the
+   * lifecycle gate — an illegal transition (or one missing required `evidence`)
+   * is REFUSED (`LifecycleTransitionError`) and the page is left unchanged.
+   * Throws `LifecycleTransitionUnavailableError` when the project has no profile,
+   * the type is unknown, the type has no lifecycle, or the page does not exist.
+   * No LLM required.
+   *
+   * Foundation API — the shape may change in a future minor release.
+   */
+  transitionLifecycle(input: SdkTransitionLifecycleInput): Promise<void>;
 }

--- a/src/trust/executor.ts
+++ b/src/trust/executor.ts
@@ -224,6 +224,10 @@ async function applyBatch(
   writeOne: WriteOne,
 ): Promise<void> {
   for (const mutation of planned) {
+    // Only `page` mutations ride this executor + journal. `relation` writes have
+    // their own append-only durability (src/trust/relation-write.ts) and a
+    // `lifecycle-transition` is itself a validated PAGE update, so neither kind
+    // is ever planned into this batch — the throw stays a hard invariant guard.
     if (mutation.kind !== "page") throw new NotImplementedMutationError(mutation.kind);
     const abs = await confineUnderRoot(pageRelPath(mutation), root, { mustExist: false });
     if (mutation.operation === "create" && (await targetExists(abs))) {

--- a/src/trust/lifecycle-transition.ts
+++ b/src/trust/lifecycle-transition.ts
@@ -1,0 +1,111 @@
+/**
+ * @file src/trust/lifecycle-transition.ts
+ * @description The trust-gated LIFECYCLE TRANSITION entry point, shared by the
+ * SDK and CLI.
+ *
+ * A lifecycle transition is NOT a new executor kind — it is a validated PAGE
+ * UPDATE. PR2 already enforces the lifecycle gate ({@link validateLifecycleTransition})
+ * on any typed page write, so {@link transitionLifecycle} is a thin, correctly
+ * gated READ-MODIFY-WRITE: it reads the existing `wiki/<entityType>/<slug>.md`,
+ * sets its lifecycle field to `toState` (merging any required `evidence` into the
+ * frontmatter), and re-writes the page through the EXISTING typed promotion path
+ * ({@link applyTypedCandidate}). That path re-runs the PR2 lifecycle gate, so an
+ * illegal transition (or one missing required evidence) is REFUSED there and the
+ * page is left unchanged — no separate validation is duplicated here.
+ *
+ * Because the write rides the existing page executor + journal, this destabilizes
+ * NOTHING: the page bytes land atomically exactly as a typed promotion does.
+ */
+
+import { loadNonDefaultProfile } from "../profile/block.js";
+import { resolveConfinedEntityPage } from "../profile/lifecycle-read.js";
+import { parseFrontmatter, buildFrontmatter, safeReadFile } from "../utils/markdown.js";
+import { applyTypedCandidate } from "./promote.js";
+import type { EntityTypeDef } from "../profile/types.js";
+import type { ReviewCandidate } from "../utils/types.js";
+
+/** Optional evidence fields merged into the page frontmatter for the transition. */
+export type LifecycleEvidence = Record<string, unknown>;
+
+/**
+ * Thrown when a lifecycle transition is requested for an entity type that has NO
+ * declared lifecycle, or whose page does not exist. Fails CLOSED before any write
+ * so a transition is only ever attempted against a real, lifecycle-bearing page.
+ */
+export class LifecycleTransitionUnavailableError extends Error {
+  constructor(reason: "no-profile" | "unknown-type" | "no-lifecycle" | "no-page", detail: string) {
+    super(`cannot transition lifecycle: ${detail}`);
+    this.name = "LifecycleTransitionUnavailableError";
+    void reason;
+  }
+}
+
+/** Resolve the entity def, failing closed when the profile/type/lifecycle is absent. */
+async function resolveLifecycleDef(root: string, entityType: string): Promise<EntityTypeDef> {
+  const loaded = await loadNonDefaultProfile(root);
+  if (!loaded) throw new LifecycleTransitionUnavailableError("no-profile", "the project has no non-default profile");
+  const def = loaded.profile.entities[entityType];
+  if (!def) {
+    throw new LifecycleTransitionUnavailableError("unknown-type", `the profile does not declare entity type "${entityType}"`);
+  }
+  if (!def.lifecycle) {
+    throw new LifecycleTransitionUnavailableError("no-lifecycle", `entity type "${entityType}" has no declared lifecycle`);
+  }
+  return def;
+}
+
+/** Read the existing page body (path-confined), failing closed when it is absent. */
+async function readExistingPage(root: string, def: EntityTypeDef, slug: string): Promise<string> {
+  const real = await resolveConfinedEntityPage(root, def, slug);
+  if (real === null) {
+    throw new LifecycleTransitionUnavailableError("no-page", `no page at ${def.directory}/${slug}.md to transition`);
+  }
+  return safeReadFile(real);
+}
+
+/**
+ * Build the new page body for the transition: parse the existing body, set the
+ * lifecycle field to `toState`, merge any `evidence` fields into the frontmatter,
+ * and re-assemble `${buildFrontmatter(meta)}\n${body}` (the project's standard
+ * page assembly). The prose body is preserved verbatim.
+ */
+function buildTransitionedBody(existing: string, field: string, toState: string, evidence?: LifecycleEvidence): string {
+  const { meta, body } = parseFrontmatter(existing);
+  const nextMeta = { ...meta, ...(evidence ?? {}), [field]: toState };
+  return `${buildFrontmatter(nextMeta)}\n${body}`;
+}
+
+/**
+ * Transition a typed entity page's lifecycle field to `toState` as a validated
+ * page update. Loads the entity def (throwing {@link LifecycleTransitionUnavailableError}
+ * when the type has no lifecycle), reads the existing page (throwing when it is
+ * missing), rewrites its lifecycle field (+ any `evidence`), and applies the new
+ * body through {@link applyTypedCandidate} — which RE-RUNS the PR2 lifecycle gate,
+ * so an illegal transition or one missing required evidence is REFUSED there
+ * (`LifecycleTransitionError` propagates) and the page is left unchanged.
+ *
+ * @param root - Absolute project root.
+ * @param entityType - The profile entity type whose page is transitioned.
+ * @param slug - The page slug (the filename stem).
+ * @param toState - The lifecycle state to transition the page into.
+ * @param evidence - Optional frontmatter fields a target state requires (merged in).
+ * @throws {LifecycleTransitionUnavailableError} When no profile/type/lifecycle/page.
+ * @throws {LifecycleTransitionError} When the PR2 gate refuses the transition.
+ */
+export async function transitionLifecycle(
+  root: string,
+  entityType: string,
+  slug: string,
+  toState: string,
+  evidence?: LifecycleEvidence,
+): Promise<void> {
+  const def = await resolveLifecycleDef(root, entityType);
+  const existing = await readExistingPage(root, def, slug);
+  const body = buildTransitionedBody(existing, def.lifecycle!.field, toState, evidence);
+  const candidate: Pick<ReviewCandidate, "slug" | "body" | "targetEntityType"> = {
+    slug,
+    body,
+    targetEntityType: entityType,
+  };
+  await applyTypedCandidate(root, candidate as ReviewCandidate);
+}

--- a/src/trust/relation-plan.ts
+++ b/src/trust/relation-plan.ts
@@ -1,0 +1,124 @@
+/**
+ * @file src/trust/relation-plan.ts
+ * @description The RELATION write planner — the relation-store analogue of the
+ * page {@link planPageMutation}. It routes a proposed relation write through ONE
+ * planner decision (CLP Invariant 4): it runs the mandatory relation checks
+ * (endpoint validity against the profile relation-type def + required attributes)
+ * and composes a {@link TrustDecision} via the SAME {@link composeTrustDecision}
+ * the page path uses.
+ *
+ * This DOES NOT touch disk and mints no id — it is a pure decision over the
+ * proposed relation. It RE-VALIDATES exactly what the store
+ * ({@link appendRelationLocked}) also enforces, so it is defense in depth plus a
+ * uniform decision shared by every surface: a relation write that the planner
+ * would deny never reaches the store, and the store stays the final fail-closed
+ * floor for a hand-built append that bypassed the planner.
+ *
+ * The relation surface is NOT review-routed, so a `block` composes to `deny`
+ * (never `stage-for-review`): relation staging is out of scope for this slice.
+ */
+
+import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
+import { parseEntityId, EntityIdError } from "../profile/identity.js";
+import type { ProfilePack, RelationTypeDef } from "../profile/types.js";
+import type { AppendRelationInput } from "../relations/store.js";
+
+/** The planner's output for a relation write: the composed decision + raw checks. */
+export interface RelationPlanResult {
+  decision: TrustDecision;
+  checks: TrustCheckResult[];
+}
+
+/** Build a passing check result for a named relation check. */
+function pass(code: string, message: string): TrustCheckResult {
+  return { code, verdict: "pass", message };
+}
+
+/** Build a blocking check result for a named relation check. */
+function block(code: string, message: string): TrustCheckResult {
+  return { code, verdict: "block", message };
+}
+
+/**
+ * Check the relation type is declared by the profile. A relation write against a
+ * type that `profile.relations` does not declare yields a `block` (no def to
+ * validate endpoints/attributes against), mirroring the store's `relationDef`
+ * fail-closed throw — but as a uniform decision rather than an exception.
+ */
+function checkRelationTypeDeclared(profile: ProfilePack, type: string): TrustCheckResult {
+  const code = "unknown-relation-type";
+  if (profile.relations?.[type]) return pass(code, `relation type '${type}' is declared`);
+  return block(code, `unknown relation type '${type}'`);
+}
+
+/**
+ * Check one endpoint's entity type is allowed on its side of the relation. A
+ * non-`<type>/<slug>` id, or an endpoint whose entity type is outside the def's
+ * declared `from`/`to` set, yields a `block` — the planner counterpart to the
+ * store's `assertEndpoint`.
+ */
+function checkEndpoint(
+  id: string,
+  allowed: string[],
+  side: "from" | "to",
+  type: string,
+): TrustCheckResult {
+  const code = `relation-endpoint-${side}`;
+  let entityType: string;
+  try {
+    ({ entityType } = parseEntityId(id as never));
+  } catch (err) {
+    if (err instanceof EntityIdError) return block(code, `relation '${type}' ${side} endpoint id is invalid: ${id}`);
+    throw err;
+  }
+  if (allowed.includes(entityType)) return pass(code, `relation '${type}' ${side} endpoint type '${entityType}' is allowed`);
+  return block(code, `relation '${type}' ${side} endpoint type '${entityType}' is not allowed`);
+}
+
+/**
+ * Check every required attribute of the relation type is present in the proposed
+ * relation's attributes — the planner counterpart to the store's
+ * `assertRequiredAttributes`. A missing required attribute yields a `block`.
+ */
+function checkRequiredAttributes(def: RelationTypeDef, input: AppendRelationInput): TrustCheckResult {
+  const code = "relation-required-attribute";
+  const attributes = input.attributes ?? {};
+  const missing = (def.requiredAttributes ?? []).filter((name) => !(name in attributes));
+  if (missing.length === 0) return pass(code, "all required relation attributes are present");
+  return block(code, `relation '${input.type}' is missing required attribute(s): ${missing.join(", ")}`);
+}
+
+/**
+ * Run every mandatory relation check, in evaluation order. When the relation type
+ * is undeclared the endpoint/attribute checks have no def to run against, so only
+ * the type check is returned (it already blocks).
+ */
+function runMandatoryRelationChecks(profile: ProfilePack, input: AppendRelationInput): TrustCheckResult[] {
+  const typeCheck = checkRelationTypeDeclared(profile, input.type);
+  const def = profile.relations?.[input.type];
+  if (!def) return [typeCheck];
+  return [
+    typeCheck,
+    checkEndpoint(input.from, def.from, "from", input.type),
+    checkEndpoint(input.to, def.to, "to", input.type),
+    checkRequiredAttributes(def, input),
+  ];
+}
+
+/**
+ * Plan a single relation write: run the mandatory relation checks (type declared,
+ * endpoint entity types allowed, required attributes present) and compose them
+ * into one {@link TrustDecision}. NOTHING is written and no id is minted — the
+ * caller ({@link createRelation}) only proceeds to the store on a live-write
+ * decision. The relation surface is not review-routed, so a `block` composes to
+ * `deny`.
+ *
+ * @param profile - The governing profile pack (its `relations` block is the schema).
+ * @param input - The proposed relation write.
+ * @returns The composed decision and the per-check results.
+ */
+export function planRelationMutation(profile: ProfilePack, input: AppendRelationInput): RelationPlanResult {
+  const checks = runMandatoryRelationChecks(profile, input);
+  const decision = composeTrustDecision(checks, { reviewRouted: false });
+  return { decision, checks };
+}

--- a/src/trust/relation-write.ts
+++ b/src/trust/relation-write.ts
@@ -1,0 +1,114 @@
+/**
+ * @file src/trust/relation-write.ts
+ * @description The trust-gated RELATION WRITE entry point — the relation analogue
+ * of the page executor's planner→apply seam (CLP Invariant 4: a mutation routes
+ * through ONE planner decision, then applies under ONE lock).
+ *
+ * {@link createRelation} is shared by the SDK and CLI. It plans the relation via
+ * {@link planRelationMutation}; on any non-live-write decision it throws a typed
+ * {@link RelationWriteDeniedError} and writes NOTHING. Only on
+ * `allow`/`allow-with-warning` does it acquire the project lock ONCE and append
+ * through the lock-free {@link appendRelationLocked}, releasing in `finally`.
+ *
+ * Relations have their OWN append-only durability (PR4) under the lock — they are
+ * deliberately NOT routed through the page temp-rename journal, so this path
+ * leaves the page executor untouched.
+ */
+
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import { appendRelationLocked, type AppendRelationInput } from "../relations/store.js";
+import { planRelationMutation } from "./relation-plan.js";
+import { loadNonDefaultProfile } from "../profile/block.js";
+import type { TrustDecision } from "./decision.js";
+import type { ProfilePack } from "../profile/types.js";
+import type { RelationRef } from "../relations/types.js";
+
+/** Decisions under which a relation write is cleared to append. */
+const LIVE_WRITE_DECISIONS: ReadonlySet<TrustDecision> = new Set(["allow", "allow-with-warning"]);
+
+/**
+ * Thrown when the relation planner reaches a non-live-write decision (an
+ * undeclared relation type, a disallowed endpoint entity type, or a missing
+ * required attribute). The write fails CLOSED: nothing is appended. Carries the
+ * composed `decision` so callers can report exactly how the write was routed.
+ */
+export class RelationWriteDeniedError extends Error {
+  /** The non-live-write decision the planner reached. */
+  readonly decision: TrustDecision;
+
+  constructor(type: string, decision: TrustDecision) {
+    super(`relation write of type '${type}' denied by the write planner (${decision}); nothing written`);
+    this.name = "RelationWriteDeniedError";
+    this.decision = decision;
+  }
+}
+
+/**
+ * Create a relation through the trust planner: plan the write, and — only on a
+ * live-write decision — acquire the project lock ONCE and append via the
+ * lock-free {@link appendRelationLocked}. A non-live-write decision throws
+ * {@link RelationWriteDeniedError} BEFORE any lock or write, so a denied relation
+ * leaves the store untouched.
+ *
+ * @param root - Absolute project root.
+ * @param profile - The governing profile pack (its `relations` block is the schema).
+ * @param input - The relation to create.
+ * @returns The persisted {@link RelationRef}.
+ * @throws {RelationWriteDeniedError} When the planner denies the write.
+ */
+export async function createRelation(
+  root: string,
+  profile: ProfilePack,
+  input: AppendRelationInput,
+): Promise<RelationRef> {
+  const { decision } = planRelationMutation(profile, input);
+  if (!LIVE_WRITE_DECISIONS.has(decision)) {
+    throw new RelationWriteDeniedError(input.type, decision);
+  }
+  if (!(await acquireLock(root))) {
+    throw new Error("could not acquire project lock for relation write");
+  }
+  try {
+    return await appendRelationLocked(root, profile, input);
+  } finally {
+    await releaseLock(root);
+  }
+}
+
+/**
+ * @experimental
+ * Thrown when the SDK relation-write entry point is called on a project that has
+ * NO non-default profile. Relations are declared only by a non-default profile's
+ * `relations` block, so a default project cannot write one. Fails CLOSED before
+ * any planning or I/O.
+ */
+export class RelationsRequireProfileError extends Error {
+  constructor() {
+    super("relation writes require a non-default profile; this project has none");
+    this.name = "RelationsRequireProfileError";
+  }
+}
+
+/**
+ * @experimental
+ * SDK entry point for creating a relation: loads the active non-default profile
+ * INTERNALLY (throwing {@link RelationsRequireProfileError} when the project has
+ * none) and delegates to {@link createRelation}. The caller never passes a
+ * {@link ProfilePack} — the SDK owns it. A default project (no `relations`) cannot
+ * call this meaningfully: with no non-default profile it throws here, and any
+ * declared-but-absent relation type is denied by {@link createRelation}.
+ *
+ * @param root - Absolute project root.
+ * @param input - The relation to create (no profile; the SDK loads it).
+ * @returns The persisted {@link RelationRef}.
+ * @throws {RelationsRequireProfileError} When the project has no non-default profile.
+ * @throws {RelationWriteDeniedError} When the planner denies the write.
+ */
+export async function createRelationForProject(
+  root: string,
+  input: AppendRelationInput,
+): Promise<RelationRef> {
+  const loaded = await loadNonDefaultProfile(root);
+  if (!loaded) throw new RelationsRequireProfileError();
+  return createRelation(root, loaded.profile, input);
+}

--- a/src/trust/staged-change.ts
+++ b/src/trust/staged-change.ts
@@ -27,9 +27,11 @@
  * not be able to consume the whole session budget in one shot, but the limit is
  * generous enough for realistic batch proposals. Per-session ≥ per-call always.
  *
- * `RelationRef` / `ArtifactRef` are Phase-4 STUBS declared here purely so the
- * {@link StagedChange.target} union is total across all {@link CandidateKind}s;
- * relation/artifact staging logic lands later and may replace these shapes.
+ * `StagedRelationRef` / `StagedArtifactRef` are Phase-4 STUBS declared here purely
+ * so the {@link StagedChange.target} union is total across all {@link CandidateKind}s;
+ * relation/artifact staging logic lands later and may replace these shapes. They
+ * are deliberately distinct from the canonical relation `RelationRef`
+ * (`src/relations/types.ts`), which is the real persisted-edge type.
  */
 
 import type { TrustDecision } from "./decision.js";
@@ -61,15 +63,15 @@ export type HeldReasonCode =
   | "human-gate"
   | (string & {});
 
-/** Phase-4 STUB: a staged relation target. Replaced when relations land. */
-export interface RelationRef {
+/** Phase-4 STUB: a staged relation target. Distinct from the canonical `RelationRef`. */
+export interface StagedRelationRef {
   fromId: string;
   toId: string;
   relationType: string;
 }
 
 /** Phase-4 STUB: a staged artifact target. Replaced when artifacts land. */
-export interface ArtifactRef {
+export interface StagedArtifactRef {
   artifactId: string;
   artifactType: string;
 }
@@ -88,7 +90,7 @@ export interface WorkflowRunRef {
 export interface StagedChange {
   id: string;
   kind: CandidateKind;
-  target: EntityRef | RelationRef | ArtifactRef | WorkflowRunRef;
+  target: EntityRef | StagedRelationRef | StagedArtifactRef | WorkflowRunRef;
   operation: MutationOperation;
   planned: PlannedMutation[];
   heldReasons: HeldReasonCode[];

--- a/test/sdk-relation-lifecycle.test.ts
+++ b/test/sdk-relation-lifecycle.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @file test/sdk-relation-lifecycle.test.ts
+ * @description SDK-facade round-trip for the experimental trust-gated relation
+ * write + lifecycle transition (Phase 4 PR5): `createWiki().createRelation` and
+ * `.transitionLifecycle` on a profile project, the required-evidence refusal,
+ * and the default-project guard.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { EntityId, ProfilePack } from "../src/profile/types.js";
+import { createWiki } from "../src/index.js";
+import { RelationsRequireProfileError } from "../src/trust/relation-write.js";
+import { LifecycleTransitionError } from "../src/profile/lifecycle.js";
+import { readRelations } from "../src/relations/store-read.js";
+import { PROFILE_FILE } from "../src/utils/constants.js";
+import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
+
+const EXP = "experiments/ablation-batch-size" as EntityId;
+const IDEA = "ideas/sparse-routing" as EntityId;
+
+/** A research-lite profile with a `tests` relation + a `failed` evidence requirement. */
+function profile(): ProfilePack {
+  const ideas = RESEARCH_LITE_PROFILE.entities.ideas;
+  return {
+    ...RESEARCH_LITE_PROFILE,
+    entities: {
+      ...RESEARCH_LITE_PROFILE.entities,
+      ideas: { ...ideas, lifecycle: { ...ideas.lifecycle, transitionRequirements: { failed: ["failureReason"] } } },
+    },
+    relations: { tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } },
+  } as ProfilePack;
+}
+
+let root = "";
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "sdk-rel-lc-"));
+  await buildResearchLiteProject(root);
+  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(profile()), "utf8");
+});
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+describe("createWiki() relation + lifecycle round-trip", () => {
+  it("createRelation appends a relation visible via the store", async () => {
+    const wiki = createWiki({ root });
+    const ref = await wiki.createRelation({ type: "tests", from: EXP, to: IDEA });
+    const { relations } = await readRelations(root);
+    expect(relations).toMatchObject([{ id: ref.id, type: "tests", from: EXP, to: IDEA }]);
+  });
+
+  it("transitionLifecycle updates the page, then refuses missing required evidence", async () => {
+    const wiki = createWiki({ root });
+    await wiki.transitionLifecycle({ entityType: "ideas", slug: "sparse-routing", toState: "testing" });
+    await wiki.transitionLifecycle({ entityType: "ideas", slug: "sparse-routing", toState: "tested" });
+    expect(await readFile(path.join(root, "wiki/ideas/sparse-routing.md"), "utf8")).toContain("status: tested");
+    const bad = wiki.transitionLifecycle({ entityType: "ideas", slug: "sparse-routing", toState: "failed" });
+    await expect(bad).rejects.toBeInstanceOf(LifecycleTransitionError);
+  });
+
+  it("admits the transition once required evidence is supplied", async () => {
+    const wiki = createWiki({ root });
+    await wiki.transitionLifecycle({ entityType: "ideas", slug: "sparse-routing", toState: "testing" });
+    await wiki.transitionLifecycle({ entityType: "ideas", slug: "sparse-routing", toState: "tested" });
+    await wiki.transitionLifecycle({
+      entityType: "ideas", slug: "sparse-routing", toState: "failed", evidence: { failureReason: "out of compute" },
+    });
+    const page = await readFile(path.join(root, "wiki/ideas/sparse-routing.md"), "utf8");
+    expect(page).toContain("status: failed");
+    expect(page).toContain("failureReason: out of compute");
+  });
+});
+
+describe("default project guard", () => {
+  it("createRelation throws RelationsRequireProfileError on a default project", async () => {
+    const defaultRoot = await mkdtemp(path.join(os.tmpdir(), "sdk-rel-default-"));
+    try {
+      const wiki = createWiki({ root: defaultRoot });
+      await expect(
+        wiki.createRelation({ type: "tests", from: EXP, to: IDEA }),
+      ).rejects.toBeInstanceOf(RelationsRequireProfileError);
+    } finally {
+      await rm(defaultRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/trust-relation-write.test.ts
+++ b/test/trust-relation-write.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @file test/trust-relation-write.test.ts
+ * @description Tests for the trust-gated relation-write + lifecycle-transition
+ * APIs (Phase 4 PR5) at the trust layer (no SDK facade).
+ *
+ * Relation writes route through the planner ({@link planRelationMutation}) and,
+ * only when allowed, append to the PR4 store under one lock; lifecycle
+ * transitions are a validated read-modify-write through the existing typed page
+ * path, which re-runs the PR2 lifecycle gate. The fixture profile carries a
+ * `tests` relation (experiments→ideas) and the research-lite `ideas` lifecycle.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { EntityId, ProfilePack } from "../src/profile/types.js";
+import { createRelation, RelationWriteDeniedError } from "../src/trust/relation-write.js";
+import { transitionLifecycle, LifecycleTransitionUnavailableError } from "../src/trust/lifecycle-transition.js";
+import { LifecycleTransitionError } from "../src/profile/lifecycle.js";
+import { readRelations } from "../src/relations/store-read.js";
+import { PROFILE_FILE } from "../src/utils/constants.js";
+import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
+
+const EXP = "experiments/ablation-batch-size" as EntityId;
+const IDEA = "ideas/sparse-routing" as EntityId;
+
+/** A research-lite profile carrying a `tests` relation experiments→ideas. */
+function relationProfile(): ProfilePack {
+  return {
+    ...RESEARCH_LITE_PROFILE,
+    relations: { tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } },
+  } as ProfilePack;
+}
+
+let root = "";
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "trust-relation-"));
+  await buildResearchLiteProject(root);
+  await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(relationProfile()), "utf8");
+});
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+describe("createRelation (planner-gated)", () => {
+  it("appends a valid relation and returns a readable RelationRef", async () => {
+    const ref = await createRelation(root, relationProfile(), { type: "tests", from: EXP, to: IDEA });
+    expect(ref.id).toMatch(/^rel_/);
+    const store = await readRelations(root);
+    expect(store.problems).toEqual([]);
+    expect(store.relations).toMatchObject([{ id: ref.id, type: "tests", from: EXP, to: IDEA }]);
+  });
+
+  it("denies an undeclared relation type, writing nothing", async () => {
+    const bad = createRelation(root, relationProfile(), { type: "nope", from: EXP, to: IDEA });
+    await expect(bad).rejects.toBeInstanceOf(RelationWriteDeniedError);
+    await expect(readRelations(root)).resolves.toMatchObject({ relations: [] });
+  });
+
+  it("denies a wrong endpoint entity type, writing nothing", async () => {
+    const bad = createRelation(root, relationProfile(), { type: "tests", from: IDEA, to: IDEA });
+    await expect(bad).rejects.toBeInstanceOf(RelationWriteDeniedError);
+    await expect(readRelations(root)).resolves.toMatchObject({ relations: [] });
+  });
+});
+
+describe("transitionLifecycle (validated page update)", () => {
+  it("updates the page frontmatter on disk for a legal transition", async () => {
+    await transitionLifecycle(root, "ideas", "sparse-routing", "testing");
+    const page = await readFile(path.join(root, "wiki/ideas/sparse-routing.md"), "utf8");
+    expect(page).toContain("status: testing");
+  });
+
+  it("refuses an illegal transition via the PR2 gate, leaving the page unchanged", async () => {
+    const bad = transitionLifecycle(root, "ideas", "sparse-routing", "validated");
+    await expect(bad).rejects.toBeInstanceOf(LifecycleTransitionError);
+    const page = await readFile(path.join(root, "wiki/ideas/sparse-routing.md"), "utf8");
+    expect(page).toContain("status: proposed");
+  });
+
+  it("throws for an entity type with no lifecycle", async () => {
+    const bad = transitionLifecycle(root, "experiments", "ablation-batch-size", "anything");
+    await expect(bad).rejects.toBeInstanceOf(LifecycleTransitionUnavailableError);
+  });
+});


### PR DESCRIPTION
Stacked on PR #133 (do not merge yet). Gives relations and lifecycle transitions a trust-gated write API (Invariant 4: writes route through one planner decision), shared by SDK/CLI.

- `createRelation` plans through `planRelationMutation` (endpoint + required-attribute checks → a composed deny on violation) then appends via the relation store's own append-only durability under the lock — never the page journal. A denied write throws and writes nothing.
- `transitionLifecycle` is a thin, correctly-gated read-modify-write: it sets the page's lifecycle field + evidence and writes through the existing typed page path, which re-runs the PR2 transition gate, so an illegal transition or missing evidence is refused and the page is unchanged.
- Both exposed as `@experimental` `createWiki()` methods that load the profile internally; the page executor/journal is untouched (the relation/lifecycle-transition MutationKinds never reach the page `applyBatch`).

Default projects (no relations/lifecycle) can't call these meaningfully and are unaffected — default byte-identical; full suite green (2192).