### PR TITLE
feat(relations): Phase 4 PR6 — dangling/corrupt relation lint + relation counts/views in status & export

### DIFF
--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -31,6 +31,33 @@ import type { ExportPage } from "./types.js";
 import type { EntityPageView, EntityProblemView } from "../profile/types.js";
 
 /**
+ * The PUBLIC, path-safe DTO for one typed relation in the JSON export.
+ *
+ * Mirrors the {@link EntityPageView} omitted-for-default discipline: it NEVER
+ * carries an absolute path. `from`/`to` are already opaque `<entityType>/<slug>`
+ * EntityId strings (not filesystem paths), and the relation's `evidence`
+ * citations (which carry source paths) are DELIBERATELY OMITTED so no path
+ * leaks. Only the dedup/precondition `contentHash` and the typed `attributes`
+ * accompany the edge.
+ *
+ * @experimental Shape may change in a future release.
+ */
+export interface RelationView {
+  /** Stable relation handle (`rel_<ULID>`). */
+  id: string;
+  /** Relation-type id (a key of the profile's `relations` block). */
+  type: string;
+  /** The `from` endpoint EntityId (`<entityType>/<slug>`); never a filesystem path. */
+  from: string;
+  /** The `to` endpoint EntityId; never a filesystem path. */
+  to: string;
+  /** Typed relation attributes, as declared by the relation-type def. */
+  attributes: Record<string, unknown>;
+  /** Canonical content digest over `{type, from, to, attributes, evidence}`. */
+  contentHash: string;
+}
+
+/**
  * Monotonically-incremented envelope version.
  * Bump when a breaking field change lands; additive additions do not require a bump.
  */
@@ -75,6 +102,15 @@ export interface JsonExportProfileBlock {
   problems?: EntityProblemView[];
   /** Full problem count; equals `problems.length` (export is never capped). */
   problemTotal?: number;
+  /**
+   * Path-safe views of the live relation store, present ONLY when the store
+   * holds at least one relation; OMITTED for the built-in default and for any
+   * relation-LESS profile so the default export envelope is byte-identical. Each
+   * {@link RelationView} carries opaque EntityId endpoints and NO filesystem
+   * path. A fail-closed read (corrupt / too-new store) omits this field rather
+   * than surfacing partial relations.
+   */
+  relations?: RelationView[];
 }
 
 /** Top-level shape of the JSON export file. */

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -12,7 +12,39 @@
 import { loadNonDefaultProfile, collectEntityPagesWithMessages } from "../profile/block.js";
 import { toEntityPageView } from "../profile/types.js";
 import { PROFILE_BLOCK_VERSION } from "./json-export.js";
-import type { JsonExportProfileBlock } from "./json-export.js";
+import type { JsonExportProfileBlock, RelationView } from "./json-export.js";
+import type { LoadedProfile } from "../profile/types.js";
+import { readRelations } from "../relations/store-read.js";
+import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
+import type { RelationRef } from "../relations/types.js";
+
+/**
+ * Map an internal {@link RelationRef} to its public, path-safe {@link RelationView}:
+ * carry the EntityId endpoints (already opaque, not paths) and the typed
+ * attributes + content hash, and DROP `evidence` (whose citations carry source
+ * paths) so the export never leaks a filesystem path through a relation.
+ */
+function toRelationView(ref: RelationRef): RelationView {
+  return { id: ref.id, type: ref.type, from: ref.from, to: ref.to, attributes: ref.attributes, contentHash: ref.contentHash };
+}
+
+/**
+ * Read the live relation store for the export, returning path-safe views ONLY
+ * when the store holds relations. A relation-less profile yields `undefined`
+ * (no `relations` key, so the export stays byte-identical); a fail-closed read
+ * (corrupt / too-new) also yields `undefined` rather than partial relations —
+ * lint is the surface that reports a broken store.
+ */
+async function exportRelationViews(root: string, loaded: LoadedProfile): Promise<RelationView[] | undefined> {
+  if (loaded.profile.relations === undefined) return undefined;
+  try {
+    const { relations } = await readRelations(root);
+    return relations.length > 0 ? relations.map(toRelationView) : undefined;
+  } catch (error) {
+    if (error instanceof RelationStoreCorruptError || error instanceof RelationStoreTooNewError) return undefined;
+    throw error;
+  }
+}
 
 /**
  * Build the additive JSON-export profile block for a project root.
@@ -27,10 +59,12 @@ export async function buildExportProfileBlock(
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
   const { pages, problems } = await collectEntityPagesWithMessages(root, loaded);
+  const relations = await exportRelationViews(root, loaded);
   return {
     version: PROFILE_BLOCK_VERSION,
     profileId: loaded.profile.profileId,
     entityPages: pages.map((page) => toEntityPageView(page, true)),
     ...(problems.length > 0 ? { problems, problemTotal: problems.length } : {}),
+    ...(relations ? { relations } : {}),
   };
 }

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -15,6 +15,7 @@ import { PROFILE_BLOCK_VERSION } from "./json-export.js";
 import type { JsonExportProfileBlock, RelationView } from "./json-export.js";
 import type { LoadedProfile } from "../profile/types.js";
 import { readRelations } from "../relations/store-read.js";
+import { validateRelationAgainstProfile } from "../relations/relation-contract.js";
 import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
 import type { RelationRef } from "../relations/types.js";
 
@@ -30,16 +31,23 @@ function toRelationView(ref: RelationRef): RelationView {
 
 /**
  * Read the live relation store for the export, returning path-safe views ONLY
- * when the store holds relations. A relation-less profile yields `undefined`
- * (no `relations` key, so the export stays byte-identical); a fail-closed read
- * (corrupt / too-new) also yields `undefined` rather than partial relations —
- * lint is the surface that reports a broken store.
+ * for relations STILL VALID against the current profile. A relation-less profile
+ * yields `undefined` (no `relations` key, so the export stays byte-identical); a
+ * fail-closed read (corrupt / too-new) also yields `undefined` rather than partial
+ * relations — lint is the surface that reports a broken store. Relations the
+ * profile has outgrown (type removed / endpoint type disallowed / attributes now
+ * invalid) are OMITTED from this live snapshot but retained on disk; lint flags
+ * them as `relation-profile-invalid`.
  */
 async function exportRelationViews(root: string, loaded: LoadedProfile): Promise<RelationView[] | undefined> {
-  if (loaded.profile.relations === undefined) return undefined;
+  // Read the store even when the profile declares NO `relations` block: a
+  // relation-less project's store is empty (→ `undefined`, byte-identical), but
+  // a project whose `relations` block was removed while records remain must
+  // surface only those still valid (here: none) rather than stale ones.
   try {
     const { relations } = await readRelations(root);
-    return relations.length > 0 ? relations.map(toRelationView) : undefined;
+    const valid = relations.filter((rel) => validateRelationAgainstProfile(rel, loaded.profile).length === 0);
+    return valid.length > 0 ? valid.map(toRelationView) : undefined;
   } catch (error) {
     if (error instanceof RelationStoreCorruptError || error instanceof RelationStoreTooNewError) return undefined;
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
   JsonExportDocument,
   ExportJsonOptions,
   JsonExportProfileBlock,
+  RelationView,
 } from "./export/json-export.js";
 
 export {

--- a/src/profile/block.ts
+++ b/src/profile/block.ts
@@ -22,6 +22,8 @@ import { profileDigest } from "./digest.js";
 import { toEntityProblemView } from "./types.js";
 import type { EntityPage, EntityProblemView, LoadedProfile } from "./types.js";
 import { safeRealpath } from "../utils/path-confine.js";
+import { readRelations } from "../relations/store-read.js";
+import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
 
 /**
  * Load the active profile and return it ONLY when it is a non-default profile;
@@ -72,6 +74,17 @@ export interface ProfileSummaryBlock {
    * Present ONLY when there is at least one problem.
    */
   problemTotal?: number;
+  /**
+   * Live relation counts per relation type, present ONLY for a non-default
+   * profile whose `wiki/graph` store holds at least one relation. OMITTED for
+   * the built-in default and for any relation-LESS profile, so the default and
+   * relation-less status/viewer envelopes stay byte-identical. A corrupt /
+   * too-new store does NOT populate this — it surfaces through `problems`
+   * instead (fail-closed, never a silent zero).
+   */
+  relationCounts?: Record<string, number>;
+  /** Total live relation count; present alongside (and equal to the sum of) `relationCounts`. */
+  relationTotal?: number;
 }
 
 /**
@@ -108,6 +121,48 @@ async function toProblemViews(
 }
 
 /**
+ * The relation-store contribution to the summary block: per-type live counts
+ * (present only when non-empty) and at most one fail-closed read problem.
+ */
+interface RelationSummary {
+  relationCounts?: Record<string, number>;
+  relationTotal?: number;
+  problem?: EntityProblemView;
+}
+
+/** Map a fail-closed relation-store read error to a `relation-store` problem view. */
+function relationReadProblem(error: unknown): EntityProblemView {
+  if (error instanceof RelationStoreTooNewError || error instanceof RelationStoreCorruptError) {
+    return { kind: "relation-store", message: error.message };
+  }
+  throw error; // a non-store error (e.g. a confinement escape) is not ours to swallow
+}
+
+/**
+ * Read the live relation store for a non-default profile and reduce it to the
+ * additive summary contribution: per-type counts (OMITTED when the store is
+ * empty, so a relation-less profile gains no relation fields) and, on a
+ * fail-closed read, a single `relation-store` problem instead of a count.
+ *
+ * @param root - Absolute project root directory.
+ * @param loaded - The loaded non-default profile (its `relations` block gates).
+ * @returns The relation counts/total and/or a fail-closed problem.
+ */
+async function summarizeRelations(root: string, loaded: LoadedProfile): Promise<RelationSummary> {
+  if (loaded.profile.relations === undefined) return {};
+  let relations;
+  try {
+    ({ relations } = await readRelations(root));
+  } catch (error) {
+    return { problem: relationReadProblem(error) };
+  }
+  if (relations.length === 0) return {};
+  const counts: Record<string, number> = {};
+  for (const rel of relations) counts[rel.type] = (counts[rel.type] ?? 0) + 1;
+  return { relationCounts: counts, relationTotal: relations.length };
+}
+
+/**
  * Resolve the active profile and, for a NON-DEFAULT profile only, build the
  * shared summary block (profileId, digest, per-type entity counts, problems).
  *
@@ -122,17 +177,25 @@ async function toProblemViews(
  * @returns The summary block for a non-default profile, or `undefined` for the
  *   built-in default so the caller omits the `profile` key entirely.
  */
+/** Shape the combined problem views into the capped `problems`/`problemTotal` pair (omitted when empty). */
+function problemEnvelope(views: EntityProblemView[]): Pick<ProfileSummaryBlock, "problems" | "problemTotal"> {
+  if (views.length === 0) return {};
+  return { problems: views.slice(0, PROFILE_PROBLEM_CAP), problemTotal: views.length };
+}
+
 export async function collectProfileSummary(
   root: string,
 ): Promise<ProfileSummaryBlock | undefined> {
   const loaded = await loadNonDefaultProfile(root);
   if (loaded === undefined) return undefined;
   const { counts, problems } = await collectEntitySummary(root, loaded.profile);
-  const views = await toProblemViews(problems, root);
+  const { relationCounts, relationTotal, problem } = await summarizeRelations(root, loaded);
+  const views = [...(await toProblemViews(problems, root)), ...(problem ? [problem] : [])];
   return {
     profileId: loaded.profile.profileId,
     digest: loaded.digest,
     entityCounts: counts,
-    ...(views.length > 0 ? { problems: views.slice(0, PROFILE_PROBLEM_CAP), problemTotal: views.length } : {}),
+    ...problemEnvelope(views),
+    ...(relationCounts ? { relationCounts, relationTotal } : {}),
   };
 }

--- a/src/profile/block.ts
+++ b/src/profile/block.ts
@@ -23,7 +23,9 @@ import { toEntityProblemView } from "./types.js";
 import type { EntityPage, EntityProblemView, LoadedProfile } from "./types.js";
 import { safeRealpath } from "../utils/path-confine.js";
 import { readRelations } from "../relations/store-read.js";
+import { validateRelationAgainstProfile } from "../relations/relation-contract.js";
 import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
+import type { RelationRef } from "../relations/types.js";
 
 /**
  * Load the active profile and return it ONLY when it is a non-default profile;
@@ -138,18 +140,51 @@ function relationReadProblem(error: unknown): EntityProblemView {
   throw error; // a non-store error (e.g. a confinement escape) is not ours to swallow
 }
 
+/** A `relation-store` problem reporting the count of profile-invalid stored relations. */
+function relationProfileInvalidProblem(count: number): EntityProblemView {
+  return {
+    kind: "relation-store",
+    message: `${count} stored relation(s) are no longer valid against the current profile (retained, not counted as live)`,
+  };
+}
+
+/**
+ * Tally per-type counts over only the relations STILL VALID against the current
+ * profile; relations whose type/endpoints/attributes the profile has outgrown are
+ * excluded from the live counts and surfaced as a single `relation-store` problem.
+ */
+function tallyValidRelations(relations: RelationRef[], loaded: LoadedProfile): RelationSummary {
+  const counts: Record<string, number> = {};
+  let valid = 0;
+  let invalid = 0;
+  for (const rel of relations) {
+    if (validateRelationAgainstProfile(rel, loaded.profile).length > 0) { invalid += 1; continue; }
+    counts[rel.type] = (counts[rel.type] ?? 0) + 1;
+    valid += 1;
+  }
+  const problem = invalid > 0 ? relationProfileInvalidProblem(invalid) : undefined;
+  if (valid === 0) return { ...(problem ? { problem } : {}) };
+  return { relationCounts: counts, relationTotal: valid, ...(problem ? { problem } : {}) };
+}
+
 /**
  * Read the live relation store for a non-default profile and reduce it to the
- * additive summary contribution: per-type counts (OMITTED when the store is
- * empty, so a relation-less profile gains no relation fields) and, on a
- * fail-closed read, a single `relation-store` problem instead of a count.
+ * additive summary contribution: per-type counts of relations STILL VALID against
+ * the current profile (OMITTED when none are, so a relation-less or fully-stale
+ * profile gains no count fields), and a single `relation-store` problem on a
+ * fail-closed read OR when stored relations are no longer profile-valid (the
+ * invalid ones are retained on disk, never counted as live).
  *
  * @param root - Absolute project root directory.
  * @param loaded - The loaded non-default profile (its `relations` block gates).
- * @returns The relation counts/total and/or a fail-closed problem.
+ * @returns The valid relation counts/total and/or a problem.
  */
 async function summarizeRelations(root: string, loaded: LoadedProfile): Promise<RelationSummary> {
-  if (loaded.profile.relations === undefined) return {};
+  // The store is read even when the profile declares NO `relations` block: a
+  // relation-less project has no `wiki/graph` store, so the read returns empty
+  // (→ `{}`, byte-identical), but a project whose `relations` block was REMOVED
+  // while records remain on disk must still surface them as profile-invalid
+  // rather than silently vanishing.
   let relations;
   try {
     ({ relations } = await readRelations(root));
@@ -157,9 +192,7 @@ async function summarizeRelations(root: string, loaded: LoadedProfile): Promise<
     return { problem: relationReadProblem(error) };
   }
   if (relations.length === 0) return {};
-  const counts: Record<string, number> = {};
-  for (const rel of relations) counts[rel.type] = (counts[rel.type] ?? 0) + 1;
-  return { relationCounts: counts, relationTotal: relations.length };
+  return tallyValidRelations(relations, loaded);
 }
 
 /**

--- a/src/profile/field-contract.ts
+++ b/src/profile/field-contract.ts
@@ -131,6 +131,43 @@ function collectFieldValueViolations(
 }
 
 /**
+ * Validate a record of `values` against a set of `fieldDefs`, returning a list of
+ * PATH-FREE violation messages: one per name in `requiredNames` absent from
+ * `values`, plus one per present value that mismatches its declared type / enum /
+ * numeric bound. A value whose key is NOT in `fieldDefs` is ignored (extra values
+ * are allowed) — exactly the entity-field behaviour.
+ *
+ * This is the ONE field-contract core shared by {@link validateEntityFields}
+ * (entity frontmatter) and the relation-attribute validation, so an entity field
+ * and a relation attribute can never be checked against drifting rules (DRY). The
+ * optional `missingMessage` lets each caller phrase its own required-presence
+ * message (frontmatter "field" vs relation "attribute") while sharing the
+ * type/enum/min/max logic verbatim.
+ *
+ * @param values - The record of named values to validate (frontmatter / attributes).
+ * @param fieldDefs - The declared field definitions, keyed by name.
+ * @param requiredNames - Names that MUST be present in `values`.
+ * @param missingMessage - Optional formatter for a missing required name's message.
+ * @returns Zero or more PATH-FREE field-violation messages.
+ */
+export function validateFieldsAgainstDefs(
+  values: Record<string, unknown>,
+  fieldDefs: Record<string, FieldDef>,
+  requiredNames: Iterable<string>,
+  missingMessage: (name: string) => string = (name) =>
+    `Required field ${JSON.stringify(name)} is missing from frontmatter.`,
+): string[] {
+  const violations: string[] = [];
+  for (const field of requiredNames) {
+    if (!(field in values)) violations.push(missingMessage(field));
+  }
+  for (const [name, fieldDef] of Object.entries(fieldDefs)) {
+    collectFieldValueViolations(name, fieldDef, values[name], violations);
+  }
+  return violations;
+}
+
+/**
  * Validate a page's parsed frontmatter against its entity type's declared field
  * contract, returning a list of PATH-FREE violation messages (empty when the page
  * satisfies the contract). One message per missing required field, plus one per
@@ -138,7 +175,8 @@ function collectFieldValueViolations(
  *
  * A field is required when it appears in `def.requiredFields` OR carries
  * `FieldDef.required === true` (the union, de-duplicated). Pure and total — no
- * I/O, never throws, carries no path/entity-type context.
+ * I/O, never throws, carries no path/entity-type context. Delegates to the shared
+ * {@link validateFieldsAgainstDefs} core.
  *
  * @param frontmatter - The page's parsed frontmatter record.
  * @param def - The resolved entity type definition to validate against.
@@ -148,14 +186,5 @@ export function validateEntityFields(
   frontmatter: Record<string, unknown>,
   def: EntityTypeDef,
 ): string[] {
-  const violations: string[] = [];
-  for (const field of requiredFieldNames(def)) {
-    if (!(field in frontmatter)) {
-      violations.push(`Required field ${JSON.stringify(field)} is missing from frontmatter.`);
-    }
-  }
-  for (const [name, fieldDef] of Object.entries(def.fields ?? {})) {
-    collectFieldValueViolations(name, fieldDef, frontmatter[name], violations);
-  }
-  return violations;
+  return validateFieldsAgainstDefs(frontmatter, def.fields ?? {}, requiredFieldNames(def));
 }

--- a/src/profile/lifecycle.ts
+++ b/src/profile/lifecycle.ts
@@ -131,12 +131,14 @@ function isEvidencePresent(value: unknown): boolean {
  * (empty when the write obeys the FSM). The runtime counterpart to load-time
  * {@link validateLifecycle}.
  *
- * The `next` state is read from `frontmatter[lifecycle.field]`. When absent the
- * write is exempt (the lifecycle field is optional). When present it must be a
- * declared state; a change from a defined `prev` must follow a legal out-edge (a
- * create is not a transition); and any evidence the target state requires must be
- * present. Pure and total — no I/O, never throws, carries no path/entity-type
- * context.
+ * The `next` state is read from `frontmatter[lifecycle.field]`. When absent on a
+ * never-enrolled page (no `prev`) the write is exempt (the lifecycle field is
+ * optional on create); removing it from an ALREADY-ENROLLED page (a defined
+ * `prev`) is REJECTED, since deleting the field would otherwise bypass the
+ * illegal-transition + required-evidence gates. When present it must be a declared
+ * state; a change from a defined `prev` must follow a legal out-edge (a create is
+ * not a transition); and any evidence the target state requires must be present.
+ * Pure and total — no I/O, never throws, carries no path/entity-type context.
  *
  * @param lifecycle - The resolved lifecycle definition to validate against.
  * @param prev - The page's previous on-disk lifecycle-field value, or `undefined`
@@ -153,7 +155,17 @@ export function validateLifecycleTransition(
 ): string[] {
   const problems: string[] = [];
   const states = lifecycleStateSet(lifecycle);
-  if (!checkStateDeclared(next, states, problems)) return problems;
+  if (!checkStateDeclared(next, states, problems)) {
+    // An absent `next` is exempt ONLY on a never-enrolled page (no `prev`).
+    // Removing the field from an ALREADY-ENROLLED page would bypass the
+    // illegal-transition + required-evidence gates, so it is rejected.
+    if (next === undefined && prev !== undefined) {
+      problems.push(
+        `lifecycle field ${JSON.stringify(lifecycle.field)} cannot be removed from an enrolled page (was ${JSON.stringify(prev)})`,
+      );
+    }
+    return problems;
+  }
   checkTransitionEdge(lifecycle, prev, next, problems);
   checkRequiredEvidence(lifecycle, next, frontmatter, problems);
   return problems;

--- a/src/profile/lifecycle.ts
+++ b/src/profile/lifecycle.ts
@@ -117,12 +117,28 @@ function checkRequiredEvidence(
   }
 }
 
-/** True when an evidence value is present and non-empty (not "", not []). */
-function isEvidencePresent(value: unknown): boolean {
-  if (value === undefined || value === null) return false;
+/**
+ * True when a single evidence value is a NON-EMPTY scalar: a string with
+ * non-whitespace content, or a finite number. Everything else (booleans, the
+ * empty/whitespace string, NaN) is NOT a scalar justification.
+ */
+function isEvidenceScalar(value: unknown): boolean {
   if (typeof value === "string") return value.trim().length > 0;
-  if (Array.isArray(value)) return value.length > 0;
-  return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  return false;
+}
+
+/**
+ * True when an evidence value counts as PRESENT justification. Evidence is a
+ * non-empty string/number, or a NON-EMPTY array EVERY element of which is itself
+ * such a scalar. Bare objects and booleans are REJECTED — an object is not
+ * human-readable justification, and a bare `true`/`1`-as-boolean proves only that
+ * a key exists, not that a real reason was supplied. The gate must prove content,
+ * not mere key presence (FIX #7).
+ */
+function isEvidencePresent(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length > 0 && value.every(isEvidenceScalar);
+  return isEvidenceScalar(value);
 }
 
 /**

--- a/src/profile/lint.ts
+++ b/src/profile/lint.ts
@@ -132,6 +132,6 @@ export async function lintProfileEntities(
     results.push(...lintEntityPageContent(page));
     results.push(...checkLifecycleStates(page, profile.entities[page.entityType]?.lifecycle));
   }
-  results.push(...(await checkRelationStore(root, pages)));
+  results.push(...(await checkRelationStore(root, pages, profile)));
   return results;
 }

--- a/src/profile/lint.ts
+++ b/src/profile/lint.ts
@@ -17,12 +17,17 @@
  *      semantics, the schema, or source ownership are included — see
  *      {@link lintEntityPageContent}.
  *
- * Every finding carries the offending page/dir's `entityType` so callers can
- * group diagnostics by entity type.
+ *   3. The relation store is surfaced via {@link checkRelationStore}: dangling
+ *      endpoints, a tolerated torn line, and a fail-closed corrupt/too-new read.
+ *
+ * Every entity-page finding carries the offending page/dir's `entityType` so
+ * callers can group diagnostics by entity type; store-level relation findings
+ * are not page-scoped and carry none.
  */
 
 import { collectEntityPages, type EntityProblem, type EntityProblemKind } from "./collect.js";
 import { checkPageEmpty, checkPageMalformedCitations } from "../linter/rules.js";
+import { checkRelationStore } from "./relation-lint.js";
 import { lifecycleStateSet } from "./lifecycle.js";
 import type { ProfilePack, EntityPage, LifecycleDef } from "./types.js";
 import type { LintResult } from "../linter/types.js";
@@ -127,5 +132,6 @@ export async function lintProfileEntities(
     results.push(...lintEntityPageContent(page));
     results.push(...checkLifecycleStates(page, profile.entities[page.entityType]?.lifecycle));
   }
+  results.push(...(await checkRelationStore(root, pages)));
   return results;
 }

--- a/src/profile/relation-lint.ts
+++ b/src/profile/relation-lint.ts
@@ -21,8 +21,9 @@
 
 import { readRelations } from "../relations/store-read.js";
 import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
+import { validateRelationAgainstProfile } from "../relations/relation-contract.js";
 import type { RelationRef } from "../relations/types.js";
-import type { EntityId, EntityPage } from "./types.js";
+import type { EntityId, EntityPage, ProfilePack } from "./types.js";
 import type { LintResult } from "../linter/types.js";
 
 /** Rule id for a relation endpoint that references a non-existent page. */
@@ -33,6 +34,8 @@ const RELATION_STORE_TORN_RULE = "relation-store-torn";
 const RELATION_STORE_CORRUPT_RULE = "relation-store-corrupt";
 /** Rule id for a fail-closed unknown-future-schema-version read. */
 const RELATION_STORE_TOO_NEW_RULE = "relation-store-too-new";
+/** Rule id for a stored relation no longer valid against the CURRENT profile. */
+const RELATION_PROFILE_INVALID_RULE = "relation-profile-invalid";
 
 /** The lint `file` label for store-level (not page-level) relation findings. */
 const RELATION_STORE_FILE = "wiki/graph/relations.jsonl";
@@ -72,19 +75,44 @@ function danglingForRelation(rel: RelationRef, pageIds: Set<string>): LintResult
 }
 
 /**
+ * A `relation-profile-invalid` finding for a stored relation that no longer
+ * satisfies the CURRENT profile (type removed, endpoint type no longer allowed,
+ * or attributes now invalid). The record is RETAINED on disk — this only makes
+ * the profile-adaptation mismatch visible.
+ */
+function profileInvalidFinding(rel: RelationRef, reasons: string[]): LintResult {
+  return {
+    rule: RELATION_PROFILE_INVALID_RULE,
+    severity: "error",
+    file: RELATION_STORE_FILE,
+    message: `relation ${rel.id} (${rel.type}) is no longer valid against the profile: ${reasons.join(" ")}`,
+  };
+}
+
+/**
  * Surface the relation store's issues as additive lint findings.
  *
  * Reads the store fail-closed (a corrupt / too-new store becomes a single
  * store-level finding rather than a thrown error), reports each tolerated
- * problem (torn trailing line) as a warning, and flags every relation endpoint
- * that has no entity page among `pages` as a `dangling-relation` error.
+ * problem (torn trailing line) as a warning, flags every relation endpoint
+ * that has no entity page among `pages` as a `dangling-relation` error, and
+ * flags every stored relation no longer valid against the CURRENT `profile`
+ * (type removed / endpoint type disallowed / attributes now invalid) as a
+ * `relation-profile-invalid` error — records are RETAINED, only reclassified.
  *
  * @param root - Absolute project root directory.
  * @param pages - The non-default profile's collected entity pages (their `id`s
  *   are the page-existence set checked against each relation endpoint).
+ * @param profile - The CURRENT profile pack each stored relation is re-validated
+ *   against (profile-adaptation: a record whose type/endpoints/attributes the
+ *   profile has outgrown is flagged, not deleted).
  * @returns All relation-store findings (possibly empty).
  */
-export async function checkRelationStore(root: string, pages: EntityPage[]): Promise<LintResult[]> {
+export async function checkRelationStore(
+  root: string,
+  pages: EntityPage[],
+  profile: ProfilePack,
+): Promise<LintResult[]> {
   let read;
   try {
     read = await readRelations(root);
@@ -95,6 +123,10 @@ export async function checkRelationStore(root: string, pages: EntityPage[]): Pro
   }
   const pageIds = new Set<string>(pages.map((page) => page.id));
   const findings = read.problems.map(tornFinding);
-  for (const rel of read.relations) findings.push(...danglingForRelation(rel, pageIds));
+  for (const rel of read.relations) {
+    const reasons = validateRelationAgainstProfile(rel, profile);
+    if (reasons.length > 0) findings.push(profileInvalidFinding(rel, reasons));
+    findings.push(...danglingForRelation(rel, pageIds));
+  }
   return findings;
 }

--- a/src/profile/relation-lint.ts
+++ b/src/profile/relation-lint.ts
@@ -1,0 +1,100 @@
+/**
+ * @file src/profile/relation-lint.ts
+ * @description Relation-store lint findings, making the append-only relation
+ * store (`wiki/graph/relations.jsonl`) VISIBLE through the profile-aware lint
+ * runner — additively, alongside the entity-page findings.
+ *
+ * Three concerns, all fail-open or fail-closed (lint NEVER crashes):
+ *   - `dangling-relation` (error): a relation endpoint EntityId with no page on
+ *     disk. The relation references a page that does not exist, so an interlink
+ *     would dead-end. The finding names the relation id + the missing endpoint.
+ *   - `relation-store-torn` (warning): the reader tolerated and REPORTED a torn
+ *     trailing line (an incomplete final append). Surfaced verbatim so the
+ *     half-written record is visible, not silently dropped.
+ *   - `relation-store-corrupt` / `relation-store-too-new` (error): the reader
+ *     FAILED CLOSED (interior corruption / an unknown future schema version).
+ *     Caught here so lint reports the failure instead of throwing.
+ *
+ * A DEFAULT project (no `wiki/graph`) reads an EMPTY store, so this yields no
+ * findings and the default lint output stays byte-identical.
+ */
+
+import { readRelations } from "../relations/store-read.js";
+import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
+import type { RelationRef } from "../relations/types.js";
+import type { EntityId, EntityPage } from "./types.js";
+import type { LintResult } from "../linter/types.js";
+
+/** Rule id for a relation endpoint that references a non-existent page. */
+const DANGLING_RELATION_RULE = "dangling-relation";
+/** Rule id for a tolerated torn trailing line reported by the store reader. */
+const RELATION_STORE_TORN_RULE = "relation-store-torn";
+/** Rule id for a fail-closed interior-corruption read. */
+const RELATION_STORE_CORRUPT_RULE = "relation-store-corrupt";
+/** Rule id for a fail-closed unknown-future-schema-version read. */
+const RELATION_STORE_TOO_NEW_RULE = "relation-store-too-new";
+
+/** The lint `file` label for store-level (not page-level) relation findings. */
+const RELATION_STORE_FILE = "wiki/graph/relations.jsonl";
+
+/** Build the store-level finding a fail-closed read maps to, by error type. */
+function readErrorFinding(error: unknown): LintResult | null {
+  if (error instanceof RelationStoreTooNewError) {
+    return { rule: RELATION_STORE_TOO_NEW_RULE, severity: "error", file: RELATION_STORE_FILE, message: error.message };
+  }
+  if (error instanceof RelationStoreCorruptError) {
+    return { rule: RELATION_STORE_CORRUPT_RULE, severity: "error", file: RELATION_STORE_FILE, message: error.message };
+  }
+  return null;
+}
+
+/** Map one tolerated reader problem (e.g. a torn trailing line) to a finding. */
+function tornFinding(problem: string): LintResult {
+  return { rule: RELATION_STORE_TORN_RULE, severity: "warning", file: RELATION_STORE_FILE, message: problem };
+}
+
+/** A `dangling-relation` finding naming the relation id + the missing endpoint. */
+function danglingFinding(rel: RelationRef, side: "from" | "to", missing: EntityId): LintResult {
+  return {
+    rule: DANGLING_RELATION_RULE,
+    severity: "error",
+    file: RELATION_STORE_FILE,
+    message: `relation ${rel.id} (${rel.type}) ${side} endpoint ${missing} has no entity page`,
+  };
+}
+
+/** Findings for either endpoint of `rel` whose page is absent from `pageIds`. */
+function danglingForRelation(rel: RelationRef, pageIds: Set<string>): LintResult[] {
+  const findings: LintResult[] = [];
+  if (!pageIds.has(rel.from)) findings.push(danglingFinding(rel, "from", rel.from));
+  if (!pageIds.has(rel.to)) findings.push(danglingFinding(rel, "to", rel.to));
+  return findings;
+}
+
+/**
+ * Surface the relation store's issues as additive lint findings.
+ *
+ * Reads the store fail-closed (a corrupt / too-new store becomes a single
+ * store-level finding rather than a thrown error), reports each tolerated
+ * problem (torn trailing line) as a warning, and flags every relation endpoint
+ * that has no entity page among `pages` as a `dangling-relation` error.
+ *
+ * @param root - Absolute project root directory.
+ * @param pages - The non-default profile's collected entity pages (their `id`s
+ *   are the page-existence set checked against each relation endpoint).
+ * @returns All relation-store findings (possibly empty).
+ */
+export async function checkRelationStore(root: string, pages: EntityPage[]): Promise<LintResult[]> {
+  let read;
+  try {
+    read = await readRelations(root);
+  } catch (error) {
+    const finding = readErrorFinding(error);
+    if (finding) return [finding];
+    throw error; // a non-store error (e.g. confinement escape) is not ours to swallow
+  }
+  const pageIds = new Set<string>(pages.map((page) => page.id));
+  const findings = read.problems.map(tornFinding);
+  for (const rel of read.relations) findings.push(...danglingForRelation(rel, pageIds));
+  return findings;
+}

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -226,8 +226,18 @@ export function toEntityPageView(page: EntityPage, includeBody: boolean): Entity
  * @experimental Shape may change in a future release.
  */
 export interface EntityProblemView {
-  kind: EntityProblemKind;
-  entityType: string;
+  /**
+   * The problem kind. An entity-page/dir collector problem ({@link EntityProblemKind});
+   * `"relation-store"` for a fail-closed relation-store read (corrupt / too-new)
+   * surfaced through the SAME problems channel so a status/viewer envelope never
+   * reports a broken store as silently healthy.
+   */
+  kind: EntityProblemKind | "relation-store";
+  /**
+   * Declared entity type the problem belongs to. ABSENT for a store-level
+   * (`relation-store`) problem, which is not scoped to any entity type.
+   */
+  entityType?: string;
   /** Project-relative offending page path; ABSENT for directory-level problems. Never absolute. */
   path?: string;
   message: string;

--- a/src/profile/validate.ts
+++ b/src/profile/validate.ts
@@ -119,14 +119,44 @@ function validateRequiredFields(entityType: string, def: EntityTypeDef): void {
 }
 
 /**
+ * Frontmatter keys a transition's evidence may NEVER set, even if declared: the
+ * page `slug` (identity, runtime-dropped at transition time) is reserved here so
+ * a profile can never declare an unsatisfiable evidence requirement. The
+ * lifecycle `field` is reserved too (the transition WRITES it) and is added
+ * dynamically in {@link assertEvidenceFieldsDeclared}.
+ */
+const RESERVED_EVIDENCE_KEYS = new Set(["slug"]);
+
+/**
+ * Reject a profile whose `transitionRequirements` declares any evidence field
+ * that can never be satisfied via caller evidence — a RESERVED key (`slug`, or
+ * the lifecycle `field` the transition writes) — or that is NOT a DECLARED entity
+ * field. Requiring evidence fields to be declared makes them first-class typed
+ * fields, so the field contract enforces their type/content. Fails closed at
+ * profile LOAD, so an unsatisfiable requirement is never accepted.
+ */
+function assertEvidenceFieldsDeclared(where: string, lc: LifecycleDef, fields?: Record<string, FieldDef>): void {
+  const declared = fields ?? {};
+  for (const [state, evidenceFields] of Object.entries(lc.transitionRequirements ?? {})) {
+    for (const field of evidenceFields) {
+      const reserved = RESERVED_EVIDENCE_KEYS.has(field) || field === lc.field;
+      assert(!reserved, `${where}: transitionRequirements['${state}'] uses reserved evidence field '${field}'`);
+      assert(field in declared, `${where}: transitionRequirements['${state}'] evidence field '${field}' is not a declared field`);
+    }
+  }
+}
+
+/**
  * Validate a lifecycle FSM and return any unreachable states as warnings.
  *
  * Well-formedness (all throw on violation): the state set is the union of the
  * terminal states and every transition endpoint; initial ∈ states; terminal ⊆
  * states; terminal states have no outgoing transitions; every transition
- * endpoint ∈ states; every transitionRequirements key ∈ states; and if the
- * lifecycle `field` maps to a declared field, that field must be an enum whose
- * values equal the state set. Unreachable states are returned, not thrown.
+ * endpoint ∈ states; every transitionRequirements key ∈ states; every
+ * transitionRequirements evidence FIELD is a declared, non-reserved entity field
+ * (see {@link assertEvidenceFieldsDeclared}); and if the lifecycle `field` maps
+ * to a declared field, that field must be an enum whose values equal the state
+ * set. Unreachable states are returned, not thrown.
  */
 function validateLifecycle(entityType: string, lc: LifecycleDef, fields?: Record<string, FieldDef>): string[] {
   const where = `entity '${entityType}' lifecycle`;
@@ -143,6 +173,7 @@ function validateLifecycle(entityType: string, lc: LifecycleDef, fields?: Record
   for (const key of Object.keys(lc.transitionRequirements ?? {})) {
     assert(states.has(key), `${where}: transitionRequirements references unknown state '${key}'`);
   }
+  assertEvidenceFieldsDeclared(where, lc, fields);
   assertLifecycleEnum(where, lc, states, fields);
   return unreachableStates(lc, states).map((s) => `${where}: state '${s}' is unreachable from initial`);
 }

--- a/src/relations/digest.ts
+++ b/src/relations/digest.ts
@@ -3,8 +3,9 @@
  * @description Canonical content hashing for relations. Mirrors
  * `src/profile/digest.ts`: a SHA-256 over the RFC 8785 (JCS) canonicalization
  * of the content fields, so equal content yields an equal hash regardless of
- * key order or whitespace. The hash is the dedup key and the `preconditionHash`
- * a staged edit checks against.
+ * key order or whitespace. The hash is the DEDUP KEY (an append matching a live
+ * relation's hash is an idempotent no-op). An optimistic-concurrency
+ * `preconditionHash` use is reserved for future staged-relation edits.
  *
  * Symmetric-edge canonicalization: for a `symmetric` relation type, the edge
  * (a→b) and (b→a) are the SAME edge, so the endpoints are ordered

--- a/src/relations/relation-contract.ts
+++ b/src/relations/relation-contract.ts
@@ -1,0 +1,88 @@
+/**
+ * @file src/relations/relation-contract.ts
+ * @description The single, PURE relation-contract validators shared by the WRITE
+ * path (planner + store) and the READ surfaces (lint / status / export).
+ *
+ * Two concerns, both built on the ONE field-contract core
+ * ({@link validateFieldsAgainstDefs}) so a relation attribute is checked against
+ * exactly the same type/enum/min/max rules as an entity field (DRY):
+ *
+ *   - {@link validateRelationAttributes}: a relation's `attributes` against its
+ *     relation-type def's declared `attributes` (typed) + `requiredAttributes`
+ *     (presence). Used at write time so an attribute violating its declared type
+ *     never lands on disk.
+ *   - {@link validateRelationAgainstProfile}: a STORED relation re-checked against
+ *     the CURRENT profile — its type still declared, endpoints still within the
+ *     declared `from`/`to` entity sets, and attributes still satisfying the
+ *     contract. Used by the read surfaces to reclassify (never delete) records
+ *     that the profile has since outgrown.
+ *
+ * Both are pure (no I/O), never throw, and carry no path context — callers wrap
+ * each message into their own error/finding/problem shape.
+ */
+
+import { validateFieldsAgainstDefs } from "../profile/field-contract.js";
+import { parseEntityId, EntityIdError } from "../profile/identity.js";
+import type { EntityId, ProfilePack, RelationTypeDef } from "../profile/types.js";
+import type { RelationRef } from "./types.js";
+
+/**
+ * Validate a relation's `attributes` against its relation-type def: every declared
+ * attribute value must satisfy its `FieldDef` (type/enum/min/max), and every name
+ * in `requiredAttributes` must be present. An attribute NOT declared by the def is
+ * allowed (extra attributes, mirroring entity extra-frontmatter). Returns the
+ * PATH-FREE violation messages (empty when the attributes are valid).
+ *
+ * @param def - The resolved relation-type definition (its `attributes` is the schema).
+ * @param attributes - The relation instance's attributes.
+ * @returns Zero or more PATH-FREE attribute-violation messages.
+ */
+export function validateRelationAttributes(
+  def: RelationTypeDef,
+  attributes: Record<string, unknown>,
+): string[] {
+  return validateFieldsAgainstDefs(
+    attributes,
+    def.attributes ?? {},
+    def.requiredAttributes ?? [],
+    (name) => `missing required attribute '${name}'`,
+  );
+}
+
+/** True when an EntityId's entity type is in the allowed set for its endpoint side. */
+function endpointTypeAllowed(id: EntityId, allowed: string[]): boolean {
+  try {
+    return allowed.includes(parseEntityId(id).entityType);
+  } catch (err) {
+    if (err instanceof EntityIdError) return false;
+    throw err;
+  }
+}
+
+/**
+ * Re-validate a STORED relation against the CURRENT profile, returning the
+ * PATH-FREE reasons it is no longer valid (empty when it still satisfies the
+ * profile). A relation is invalid when its `type` is no longer declared, an
+ * endpoint's entity type is no longer within the def's declared `from`/`to` set,
+ * or its attributes no longer satisfy the declared field contract.
+ *
+ * This NEVER mutates or deletes — it only classifies, so the read surfaces can
+ * retain-and-warn (the spec's profile-adaptation policy).
+ *
+ * @param ref - The stored relation reference.
+ * @param profile - The current governing profile pack.
+ * @returns Zero or more PATH-FREE reasons the relation is now invalid.
+ */
+export function validateRelationAgainstProfile(ref: RelationRef, profile: ProfilePack): string[] {
+  const def = profile.relations?.[ref.type];
+  if (!def) return [`relation type ${JSON.stringify(ref.type)} is no longer declared by the profile`];
+  const reasons: string[] = [];
+  if (!endpointTypeAllowed(ref.from, def.from)) {
+    reasons.push(`relation ${ref.id} from endpoint ${ref.from} is no longer an allowed entity type`);
+  }
+  if (!endpointTypeAllowed(ref.to, def.to)) {
+    reasons.push(`relation ${ref.id} to endpoint ${ref.to} is no longer an allowed entity type`);
+  }
+  reasons.push(...validateRelationAttributes(def, ref.attributes));
+  return reasons;
+}

--- a/src/relations/relation-contract.ts
+++ b/src/relations/relation-contract.ts
@@ -60,6 +60,58 @@ function endpointTypeAllowed(id: EntityId, allowed: string[]): boolean {
 }
 
 /**
+ * Resolve the allowed entity-type set for ONE endpoint of a relation. A
+ * `directed` relation keeps roles distinct (`from` uses `def.from`, `to` uses
+ * `def.to`); a `symmetric` relation has NO inherent from/to, so each endpoint
+ * may be any type in `def.from ∪ def.to`. This is the SINGLE source of truth the
+ * write path (store/planner) and the read re-validation share, so a relation a
+ * write accepts is exactly one a read re-validates — they can never disagree on
+ * the same bytes.
+ *
+ * @param def - The relation-type definition.
+ * @returns The allowed entity types for, respectively, the `from` and `to` sides.
+ */
+function allowedEndpointSets(def: RelationTypeDef): { from: string[]; to: string[] } {
+  if (def.direction === "symmetric") {
+    const union = [...new Set([...def.from, ...def.to])];
+    return { from: union, to: union };
+  }
+  return { from: def.from, to: def.to };
+}
+
+/**
+ * Validate a relation's (already-canonical) endpoints against its relation-type
+ * def, returning PATH-FREE reasons either endpoint is disallowed (empty when both
+ * satisfy the def). For `symmetric` types both endpoints are checked against the
+ * combined `def.from ∪ def.to` set (a symmetric edge has no inherent direction);
+ * for `directed` types `from`/`to` are checked in declared order.
+ *
+ * The SHARED endpoint validator: the store and planner call it on the CANONICAL
+ * endpoints they are about to persist, and {@link validateRelationAgainstProfile}
+ * calls it on the stored canonical endpoints — so write and read AGREE.
+ *
+ * @param def - The relation-type definition.
+ * @param from - The `from` endpoint (in canonical order for symmetric types).
+ * @param to - The `to` endpoint (in canonical order for symmetric types).
+ * @returns Zero or more PATH-FREE disallowed-endpoint messages.
+ */
+export function validateRelationEndpoints(
+  def: RelationTypeDef,
+  from: EntityId,
+  to: EntityId,
+): string[] {
+  const allowed = allowedEndpointSets(def);
+  const reasons: string[] = [];
+  if (!endpointTypeAllowed(from, allowed.from)) {
+    reasons.push(`from endpoint ${from} is not an allowed entity type (expected one of ${allowed.from.join(", ")})`);
+  }
+  if (!endpointTypeAllowed(to, allowed.to)) {
+    reasons.push(`to endpoint ${to} is not an allowed entity type (expected one of ${allowed.to.join(", ")})`);
+  }
+  return reasons;
+}
+
+/**
  * Re-validate a STORED relation against the CURRENT profile, returning the
  * PATH-FREE reasons it is no longer valid (empty when it still satisfies the
  * profile). A relation is invalid when its `type` is no longer declared, an
@@ -77,11 +129,8 @@ export function validateRelationAgainstProfile(ref: RelationRef, profile: Profil
   const def = profile.relations?.[ref.type];
   if (!def) return [`relation type ${JSON.stringify(ref.type)} is no longer declared by the profile`];
   const reasons: string[] = [];
-  if (!endpointTypeAllowed(ref.from, def.from)) {
-    reasons.push(`relation ${ref.id} from endpoint ${ref.from} is no longer an allowed entity type`);
-  }
-  if (!endpointTypeAllowed(ref.to, def.to)) {
-    reasons.push(`relation ${ref.id} to endpoint ${ref.to} is no longer an allowed entity type`);
+  for (const reason of validateRelationEndpoints(def, ref.from, ref.to)) {
+    reasons.push(`relation ${ref.id} ${reason}`);
   }
   reasons.push(...validateRelationAttributes(def, ref.attributes));
   return reasons;

--- a/src/relations/store-read.ts
+++ b/src/relations/store-read.ts
@@ -22,9 +22,10 @@
  * remaining on disk for audit.
  */
 
-import { readFile } from "fs/promises";
+import { readFile, stat } from "fs/promises";
 import path from "path";
-import { RELATIONS_FILE } from "../utils/constants.js";
+import { RELATIONS_FILE, MAX_RELATION_STORE_BYTES } from "../utils/constants.js";
+import { parseEntityId, EntityIdError } from "../profile/identity.js";
 import type { RelationRef, RelationRecord } from "./types.js";
 import {
   RELATION_STORE_SCHEMA_VERSION,
@@ -41,16 +42,28 @@ export interface ReadRelationsResult {
   problems: string[];
 }
 
-/** Read the raw store file bytes, or null when the file is absent. */
+/**
+ * Read the raw store file bytes, or null when the file is absent. STATs the file
+ * FIRST and fails closed ({@link RelationStoreCorruptError}) when it exceeds
+ * {@link MAX_RELATION_STORE_BYTES}, so an attacker/sync-controlled multi-GB file
+ * is rejected before the whole-file read could exhaust memory.
+ */
 async function readStoreFile(root: string): Promise<string | null> {
   const { dir, exists } = await resolveGraphDir(root); // throws on symlink escape
   if (!exists) return null;
   const file = path.join(dir, path.basename(RELATIONS_FILE));
+  let size: number;
   try {
-    return await readFile(file, "utf-8");
+    size = (await stat(file)).size;
   } catch {
     return null; // dir exists but file does not → no relations yet
   }
+  if (size > MAX_RELATION_STORE_BYTES) {
+    throw new RelationStoreCorruptError(
+      `store file ${size} bytes exceeds the ${MAX_RELATION_STORE_BYTES}-byte cap`,
+    );
+  }
+  return readFile(file, "utf-8");
 }
 
 /** Parse and validate the header line, failing closed on an unknown future version. */
@@ -86,12 +99,32 @@ function parseRecord(line: string): RelationRecord {
   return rec as RelationRecord;
 }
 
-/** Verify a parsed record's stored checksum against a recomputation; throw on mismatch. */
+/**
+ * Re-assert both endpoints are slug-safe `<type>/<slug>` ids via
+ * {@link parseEntityId} (which validates both halves), symmetrical with the
+ * write path's endpoint validation. A well-formed-but-traversal endpoint (e.g.
+ * `from: "../../etc/passwd"`) is INTERIOR CORRUPTION, not a benign dangling page,
+ * so it fails closed — a future path-deriving consumer cannot inherit a traversal.
+ */
+function assertEndpointsSlugSafe(ref: RelationRef): void {
+  try {
+    parseEntityId(ref.from);
+    parseEntityId(ref.to);
+  } catch (err) {
+    if (err instanceof EntityIdError) {
+      throw new RelationStoreCorruptError(`relation ${ref.id} has a non-slug-safe endpoint: ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+/** Verify a parsed record's stored checksum + endpoint slug-safety; throw on either. */
 function verifyChecksum(record: RelationRecord): RelationRef {
   const { checksum, ...ref } = record;
   if (recordChecksum(ref) !== checksum) {
     throw new RelationStoreCorruptError(`checksum mismatch for relation ${ref.id}`);
   }
+  assertEndpointsSlugSafe(ref);
   return ref;
 }
 

--- a/src/relations/store-read.ts
+++ b/src/relations/store-read.ts
@@ -22,7 +22,6 @@
  * remaining on disk for audit.
  */
 
-import { readFile, stat } from "fs/promises";
 import path from "path";
 import { RELATIONS_FILE, MAX_RELATION_STORE_BYTES } from "../utils/constants.js";
 import { parseEntityId, EntityIdError } from "../profile/identity.js";
@@ -32,7 +31,7 @@ import {
   RelationStoreTooNewError,
   RelationStoreCorruptError,
 } from "./types.js";
-import { recordChecksum, resolveGraphDir } from "./store-record.js";
+import { recordChecksum, resolveGraphDir, openStoreFileRead } from "./store-record.js";
 
 /** The outcome of reading the store: live relations plus any tolerated problems. */
 export interface ReadRelationsResult {
@@ -43,27 +42,31 @@ export interface ReadRelationsResult {
 }
 
 /**
- * Read the raw store file bytes, or null when the file is absent. STATs the file
- * FIRST and fails closed ({@link RelationStoreCorruptError}) when it exceeds
- * {@link MAX_RELATION_STORE_BYTES}, so an attacker/sync-controlled multi-GB file
- * is rejected before the whole-file read could exhaust memory.
+ * Read the raw store file bytes, or null when the file is absent. Opens the leaf
+ * through the shared NO-FOLLOW {@link openStoreFileRead} (a symlinked leaf fails
+ * closed; the read never touches the path after open, so nothing can follow a
+ * link to out-of-tree bytes), then `fstat`s the HANDLE and fails closed
+ * ({@link RelationStoreCorruptError}) when it exceeds {@link MAX_RELATION_STORE_BYTES}
+ * — an attacker/sync-controlled multi-GB file is rejected before the whole-file
+ * read could exhaust memory. The handle is always closed in `finally`.
  */
 async function readStoreFile(root: string): Promise<string | null> {
-  const { dir, exists } = await resolveGraphDir(root); // throws on symlink escape
+  const { dir, exists } = await resolveGraphDir(root); // throws on symlink escape (DIR defense)
   if (!exists) return null;
   const file = path.join(dir, path.basename(RELATIONS_FILE));
-  let size: number;
+  const handle = await openStoreFileRead(file); // throws on symlink leaf (LEAF defense)
+  if (handle === null) return null; // dir exists but file does not → no relations yet
   try {
-    size = (await stat(file)).size;
-  } catch {
-    return null; // dir exists but file does not → no relations yet
+    const size = (await handle.stat()).size;
+    if (size > MAX_RELATION_STORE_BYTES) {
+      throw new RelationStoreCorruptError(
+        `store file ${size} bytes exceeds the ${MAX_RELATION_STORE_BYTES}-byte cap`,
+      );
+    }
+    return await handle.readFile("utf-8");
+  } finally {
+    await handle.close();
   }
-  if (size > MAX_RELATION_STORE_BYTES) {
-    throw new RelationStoreCorruptError(
-      `store file ${size} bytes exceeds the ${MAX_RELATION_STORE_BYTES}-byte cap`,
-    );
-  }
-  return readFile(file, "utf-8");
 }
 
 /** Parse and validate the header line, failing closed on an unknown future version. */

--- a/src/relations/store-record.ts
+++ b/src/relations/store-record.ts
@@ -18,7 +18,7 @@ import canonicalize from "canonicalize";
 import path from "path";
 import { lstat } from "fs/promises";
 import { WIKI_GRAPH_DIR } from "../utils/constants.js";
-import { safeRealpath, isInsideDir } from "../utils/path-confine.js";
+import { safeRealpath, isInsideDir, confineUnderRoot } from "../utils/path-confine.js";
 import type { RelationRef, RelationRecord, RelationStoreHeader } from "./types.js";
 import { RELATION_STORE_SCHEMA_VERSION } from "./types.js";
 
@@ -53,6 +53,13 @@ export function headerLine(): string {
  * project) FAILS CLOSED here by throwing. Returns `{ dir, exists }`: `exists`
  * is false when the directory is simply absent (the "no relations" state).
  *
+ * Confinement is layered: the shared {@link confineUnderRoot} primitive (with
+ * `mustExist:false`) realpath-checks the NEAREST EXISTING ANCESTOR of the graph
+ * dir, so even when `wiki/graph` is ABSENT, a symlinked `wiki` (or `root`) that
+ * escapes the project fails closed BEFORE any caller `mkdir`s the dir. When the
+ * leaf exists, the original lstat/realpath check (a symlinked `wiki/graph`)
+ * remains as defense in depth.
+ *
  * @param root - Absolute project root.
  * @returns The confined graph dir and whether it currently exists on disk.
  */
@@ -60,6 +67,9 @@ export async function resolveGraphDir(root: string): Promise<{ dir: string; exis
   const canonicalRoot = await safeRealpath(root);
   const base = canonicalRoot ?? path.resolve(root);
   const dir = path.join(base, WIKI_GRAPH_DIR);
+  // Confine the NEAREST EXISTING ANCESTOR first: a symlinked `wiki` parent (with
+  // `wiki/graph` absent) escaping root throws here, before any caller mkdir.
+  await confineUnderRoot(dir, base, { mustExist: false });
   let st;
   try {
     st = await lstat(dir);

--- a/src/relations/store-record.ts
+++ b/src/relations/store-record.ts
@@ -11,16 +11,29 @@
  * recomputed on read and compared. It detects a flipped byte anywhere in the
  * line independently of the content hash (which a writer could, in principle,
  * have written wrong).
+ *
+ * It also owns the shared NO-FOLLOW open primitive for the canonical store FILE
+ * leaf (`openStoreFileRead`/`openStoreFileAppend`). Both the read and the write
+ * path route through it, so a symlinked `relations.jsonl` leaf can never be
+ * followed to read from / append to an out-of-tree file. This is the LEAF
+ * defense; {@link resolveGraphDir} is the DIR defense — BOTH are required to
+ * confine the store, and routing every open through one primitive means this
+ * symlink-escape class cannot reappear at a new call site.
  */
 
 import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
 import canonicalize from "canonicalize";
 import path from "path";
-import { lstat } from "fs/promises";
+import { lstat, open } from "fs/promises";
 import { WIKI_GRAPH_DIR } from "../utils/constants.js";
 import { safeRealpath, isInsideDir, confineUnderRoot } from "../utils/path-confine.js";
 import type { RelationRef, RelationRecord, RelationStoreHeader } from "./types.js";
-import { RELATION_STORE_SCHEMA_VERSION } from "./types.js";
+import { RELATION_STORE_SCHEMA_VERSION, RelationStoreSymlinkError } from "./types.js";
+
+/** Default mode for a freshly-created store file (owner rw, group/other r). */
+const STORE_FILE_MODE = 0o644;
 
 /** Compute the per-record checksum over a relation's content (excludes `checksum`). */
 export function recordChecksum(ref: RelationRef): string {
@@ -84,4 +97,68 @@ export async function resolveGraphDir(root: string): Promise<{ dir: string; exis
     throw new Error(`relation graph directory escapes project root: ${WIKI_GRAPH_DIR}`);
   }
   return { dir: real, exists: true };
+}
+
+/**
+ * Fail closed unless `handle` is a REGULAR file: a FIFO/device/socket at the
+ * leaf is rejected just like a symlink, so the store open never lands on a
+ * surface a record could be diverted through. Closes the handle before throwing.
+ */
+async function assertRegularFile(handle: FileHandle): Promise<void> {
+  const st = await handle.stat();
+  if (!st.isFile()) {
+    await handle.close();
+    throw new RelationStoreSymlinkError("store file is not a regular file");
+  }
+}
+
+/**
+ * Open the canonical store FILE leaf for READING with `O_NOFOLLOW` — a symlinked
+ * leaf fails the open with `ELOOP`, which we fail closed on
+ * ({@link RelationStoreSymlinkError}), so a read never follows the link to
+ * out-of-tree bytes. An ABSENT file (`ENOENT`) returns `null` (caller treats as
+ * empty). After open the HANDLE is `fstat`ed and required to be a regular file.
+ * This is the LEAF defense complementing the {@link resolveGraphDir} DIR defense.
+ *
+ * @param file - The store file path inside the already-confined graph dir.
+ * @returns An open read handle, or `null` when the file is absent.
+ */
+export async function openStoreFileRead(file: string): Promise<FileHandle | null> {
+  let handle: FileHandle;
+  try {
+    handle = await open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null; // absent file → empty store
+    if (code === "ELOOP") throw new RelationStoreSymlinkError("store file is a symlink");
+    throw err;
+  }
+  await assertRegularFile(handle);
+  return handle;
+}
+
+/**
+ * Open the canonical store FILE leaf for APPEND with `O_NOFOLLOW` (creating it if
+ * absent, mode {@link STORE_FILE_MODE}) — a symlinked leaf fails the open with
+ * `ELOOP`, which we fail closed on ({@link RelationStoreSymlinkError}), so the
+ * append NEVER lands on an out-of-tree file. After open the HANDLE is `fstat`ed
+ * and required to be a regular file. The LEAF defense complementing the
+ * {@link resolveGraphDir} DIR defense.
+ *
+ * @param file - The store file path inside the already-confined graph dir.
+ * @returns An open append handle to a confirmed regular file.
+ */
+export async function openStoreFileAppend(file: string): Promise<FileHandle> {
+  const flags = fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW;
+  let handle: FileHandle;
+  try {
+    handle = await open(file, flags, STORE_FILE_MODE);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") {
+      throw new RelationStoreSymlinkError("store file is a symlink");
+    }
+    throw err;
+  }
+  await assertRegularFile(handle);
+  return handle;
 }

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -21,7 +21,7 @@
 
 import { open, mkdir } from "fs/promises";
 import path from "path";
-import { RELATIONS_FILE } from "../utils/constants.js";
+import { RELATIONS_FILE, MAX_RELATION_RECORD_BYTES } from "../utils/constants.js";
 import { acquireLock, releaseLock } from "../utils/lock.js";
 import { parseEntityId } from "../profile/identity.js";
 import type { EntityId, ProfilePack, RelationTypeDef } from "../profile/types.js";
@@ -76,10 +76,26 @@ function assertRequiredAttributes(def: RelationTypeDef, attributes: Record<strin
 }
 
 /**
+ * Reject a relation whose serialized on-disk record exceeds
+ * {@link MAX_RELATION_RECORD_BYTES}, so attacker-controlled attribute/evidence
+ * size cannot grow one record unbounded (nor reach the per-store cap with one
+ * line). Throws {@link RelationEndpointError} BEFORE any write.
+ */
+function assertRecordWithinCap(ref: RelationRef): void {
+  const bytes = Buffer.byteLength(serializeRecord(ref), "utf8");
+  if (bytes > MAX_RELATION_RECORD_BYTES) {
+    throw new RelationEndpointError(
+      `relation '${ref.type}' record ${bytes} bytes exceeds the ${MAX_RELATION_RECORD_BYTES}-byte cap`,
+    );
+  }
+}
+
+/**
  * Validate endpoints + required attributes against the relation-type def, then
  * build the {@link RelationRef}: canonicalize symmetric endpoints, mint the id
- * (or reuse `existingId` for an update), and compute the content hash. NOTHING
- * is written here — validation throwing leaves the store untouched.
+ * (or reuse `existingId` for an update), and compute the content hash. The
+ * serialized record size is capped LAST. NOTHING is written here — validation
+ * throwing leaves the store untouched.
  */
 function buildRelationRef(
   profile: ProfilePack,
@@ -93,7 +109,9 @@ function buildRelationRef(
   assertRequiredAttributes(def, attributes, input.type);
   const { from, to } = canonicalEndpoints(input.from, input.to, def.direction);
   const content = { type: input.type, from, to, attributes, evidence: input.evidence };
-  return { id: existingId ?? mintRelationId(), ...content, contentHash: relationContentHash(content) };
+  const ref: RelationRef = { id: existingId ?? mintRelationId(), ...content, contentHash: relationContentHash(content) };
+  assertRecordWithinCap(ref);
+  return ref;
 }
 
 /** Append one serialized record line to the store under O_APPEND, creating the dir/header. */

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -1,37 +1,45 @@
 /**
  * @file src/relations/store.ts
- * @description The WRITE half of the append-only relation store. Validates a
- * relation against its profile relation-type def, mints a stable `rel_<ULID>`
- * id, canonicalizes symmetric endpoints, and APPENDS the record (record +
- * checksum) under the project lock as a single writer. A new store gets a
- * header line first. The read half lives in `store-read.ts`.
+ * @description The WRITE half of the append-only relation store. Canonicalizes
+ * symmetric endpoints, validates the CANONICAL relation against its profile
+ * relation-type def, mints a stable `rel_<ULID>` id, and APPENDS the record
+ * (record + checksum) under the project lock as a single writer. A new store
+ * gets a header line first. The read half lives in `store-read.ts`.
  *
- * DURABILITY: appends use O_APPEND under {@link acquireLock}/{@link releaseLock}
- * so a single writer extends the file atomically (each line either lands whole
- * or, at worst, leaves a torn TRAILING line the reader tolerates and reports).
- * CONFINEMENT: the graph dir is resolved through {@link resolveGraphDir}, which
- * fails closed if `wiki/graph` is a symlink escaping root.
+ * DEDUP (FIX #6): under the lock, an append whose `contentHash` matches a LIVE
+ * relation short-circuits to that existing ref WITHOUT appending — so a
+ * symmetric (a→b) then (b→a) (which canonicalize identically) collapse to ONE
+ * record. Creates are idempotent on content.
+ *
+ * DURABILITY: appends use O_APPEND under a bounded-blocking project lock so a
+ * single writer extends the file. There is NO fsync: a clean process crash can
+ * leave a torn TRAILING line (the reader tolerates and reports it), but
+ * power-loss durability is NOT provided, and an interior tear fails the store
+ * closed. Appends FAIL CLOSED ({@link RelationStoreFullError}) at the read cap;
+ * {@link compactRelations} is the escape valve. CONFINEMENT: the graph dir is
+ * resolved through {@link resolveGraphDir}, which fails closed if `wiki/graph` is
+ * a symlink escaping root.
  *
  * UPDATE: because the store is append-only, {@link updateRelation} appends a
- * NEW record carrying the SAME `id` with a recomputed `contentHash`. The reader
- * returns the latest record per id, so the prior record is superseded while
- * staying on disk for audit. Changing `type`/`from`/`to` is a delete+create
- * (a different edge) and is NOT an update — callers pass only attributes/evidence.
+ * NEW record carrying the SAME `id` with a recomputed `contentHash`, under ONE
+ * lock with its base re-read (FIX #5, no lost update). The reader returns the
+ * latest record per id, so the prior record is superseded while staying on disk
+ * for audit. Changing `type`/`from`/`to` is a delete+create (a different edge)
+ * and is NOT an update — callers pass only attributes/evidence.
  */
 
-import { open, mkdir } from "fs/promises";
+import { open, mkdir, rename, stat, writeFile } from "fs/promises";
 import path from "path";
-import { RELATIONS_FILE, MAX_RELATION_RECORD_BYTES } from "../utils/constants.js";
-import { acquireLock, releaseLock } from "../utils/lock.js";
-import { parseEntityId } from "../profile/identity.js";
+import { RELATIONS_FILE, MAX_RELATION_RECORD_BYTES, MAX_RELATION_STORE_BYTES } from "../utils/constants.js";
+import { acquireLockBlocking, releaseLock } from "../utils/lock.js";
 import type { EntityId, ProfilePack, RelationTypeDef } from "../profile/types.js";
 import type { CitationRef, RelationRef } from "./types.js";
-import { RelationEndpointError } from "./types.js";
+import { RelationEndpointError, RelationStoreFullError } from "./types.js";
 import { mintRelationId } from "./ulid.js";
 import { canonicalEndpoints, relationContentHash } from "./digest.js";
 import { headerLine, serializeRecord, resolveGraphDir } from "./store-record.js";
 import { readRelations } from "./store-read.js";
-import { validateRelationAttributes } from "./relation-contract.js";
+import { validateRelationAttributes, validateRelationEndpoints, validateRelationAgainstProfile } from "./relation-contract.js";
 
 /** The caller-supplied content of a new relation (id + hash are derived). */
 export interface AppendRelationInput {
@@ -57,13 +65,18 @@ function relationDef(profile: ProfilePack, type: string): RelationTypeDef {
   return def;
 }
 
-/** Assert one endpoint's entity type is allowed on its side of the relation. */
-function assertEndpoint(id: EntityId, allowed: string[], side: "from" | "to", type: string): void {
-  const { entityType } = parseEntityId(id);
-  if (!allowed.includes(entityType)) {
-    throw new RelationEndpointError(
-      `relation '${type}' ${side} endpoint type '${entityType}' is not allowed (expected one of ${allowed.join(", ")})`,
-    );
+/**
+ * Assert a relation's CANONICAL endpoints satisfy the relation-type def via the
+ * SHARED {@link validateRelationEndpoints}, throwing on any violation. Called
+ * AFTER canonicalization so the WRITE enforces exactly what the READ
+ * ({@link validateRelationAgainstProfile}) re-validates on the same stored bytes —
+ * for a symmetric type whose `from`-type sorts after its `to`-type, the swap can
+ * never produce a record the read surfaces then flag invalid.
+ */
+function assertCanonicalEndpoints(def: RelationTypeDef, from: EntityId, to: EntityId, type: string): void {
+  const reasons = validateRelationEndpoints(def, from, to);
+  if (reasons.length > 0) {
+    throw new RelationEndpointError(`relation '${type}' ${reasons.join("; ")}`);
   }
 }
 
@@ -98,11 +111,14 @@ function assertRecordWithinCap(ref: RelationRef): void {
 }
 
 /**
- * Validate endpoints + required attributes against the relation-type def, then
- * build the {@link RelationRef}: canonicalize symmetric endpoints, mint the id
- * (or reuse `existingId` for an update), and compute the content hash. The
- * serialized record size is capped LAST. NOTHING is written here — validation
- * throwing leaves the store untouched.
+ * Build the {@link RelationRef}: canonicalize symmetric endpoints FIRST, then
+ * validate the CANONICAL endpoints + required attributes against the
+ * relation-type def, mint the id (or reuse `existingId` for an update), and
+ * compute the content hash. Canonicalize-THEN-validate (FIX #1) means the WRITE
+ * enforces exactly what the READ re-validates, so a symmetric edge whose
+ * `from`-type sorts after its `to`-type is never written swapped-then-rejected.
+ * The serialized record size is capped LAST. NOTHING is written here —
+ * validation throwing leaves the store untouched.
  */
 function buildRelationRef(
   profile: ProfilePack,
@@ -110,38 +126,45 @@ function buildRelationRef(
   existingId?: RelationRef["id"],
 ): RelationRef {
   const def = relationDef(profile, input.type);
-  assertEndpoint(input.from, def.from, "from", input.type);
-  assertEndpoint(input.to, def.to, "to", input.type);
+  const { from, to } = canonicalEndpoints(input.from, input.to, def.direction);
+  assertCanonicalEndpoints(def, from, to, input.type);
   const attributes = input.attributes ?? {};
   assertAttributesValid(def, attributes, input.type);
-  const { from, to } = canonicalEndpoints(input.from, input.to, def.direction);
   const content = { type: input.type, from, to, attributes, evidence: input.evidence };
   const ref: RelationRef = { id: existingId ?? mintRelationId(), ...content, contentHash: relationContentHash(content) };
   assertRecordWithinCap(ref);
   return ref;
 }
 
-/** Append one serialized record line to the store under O_APPEND, creating the dir/header. */
+/**
+ * Append one serialized record line to the store under O_APPEND, creating the
+ * dir/header. FAILS CLOSED with {@link RelationStoreFullError} (FIX #4) when the
+ * append would reach/exceed {@link MAX_RELATION_STORE_BYTES} — the same bound the
+ * reader rejects at — so the store can never be driven past the read cap into an
+ * unreadable-yet-appendable state. {@link compactRelations} is the escape valve.
+ */
 async function appendLine(root: string, ref: RelationRef): Promise<void> {
   const { dir } = await resolveGraphDir(root); // throws on symlink escape
   await mkdir(dir, { recursive: true });
   const file = path.join(dir, path.basename(RELATIONS_FILE));
   const handle = await open(file, "a");
   try {
-    if ((await handle.stat()).size === 0) {
-      await handle.write(headerLine());
+    const existing = (await handle.stat()).size;
+    const header = existing === 0 ? headerLine() : "";
+    const addition = Buffer.byteLength(header + serializeRecord(ref), "utf8");
+    if (existing + addition >= MAX_RELATION_STORE_BYTES) {
+      throw new RelationStoreFullError();
     }
+    if (header) await handle.write(header);
     await handle.write(serializeRecord(ref));
   } finally {
     await handle.close();
   }
 }
 
-/** Run `fn` while holding the project lock; release in a finally. */
+/** Run `fn` while holding the project lock (bounded-blocking acquire); release in a finally. */
 async function underLock<T>(root: string, fn: () => Promise<T>): Promise<T> {
-  if (!(await acquireLock(root))) {
-    throw new Error("could not acquire project lock for relation store write");
-  }
+  await acquireLockBlocking(root); // throws LockBusyError on timeout
   try {
     return await fn();
   } finally {
@@ -157,8 +180,10 @@ async function underLock<T>(root: string, fn: () => Promise<T>): Promise<T> {
  * The caller MUST already hold the project lock; this function acquires NOTHING,
  * so a planner-routed write path ({@link createRelation}) can take ONE lock and
  * run validation + append inside it without a nested-acquire deadlock. Validation
- * (endpoint entity types, required attributes) still runs BEFORE any write, so a
- * violation throws {@link RelationEndpointError} and writes nothing.
+ * (canonical endpoint entity types, required attributes) still runs BEFORE any
+ * write, so a violation throws {@link RelationEndpointError} and writes nothing.
+ * DEDUP (FIX #6): a content-hash match against a LIVE relation short-circuits to
+ * that ref WITHOUT appending, so the create is idempotent on content.
  *
  * @param root - Absolute project root.
  * @param profile - The governing profile pack (its `relations` block is the schema).
@@ -171,6 +196,9 @@ export async function appendRelationLocked(
   input: AppendRelationInput,
 ): Promise<RelationRef> {
   const ref = buildRelationRef(profile, input); // throws before any write
+  const { relations } = await readRelations(root); // under the caller's lock
+  const duplicate = relations.find((rel) => rel.contentHash === ref.contentHash);
+  if (duplicate) return duplicate; // idempotent create (FIX #6) — append nothing
   await appendLine(root, ref);
   return ref;
 }
@@ -204,6 +232,11 @@ export async function appendRelation(
  * reader returns the latest record per id, so this supersedes the prior one.
  * The relation's `type`/`from`/`to` are preserved from the existing record.
  *
+ * FIX #5: the base-record lookup and the append run UNDER ONE lock — a single
+ * locked read-modify-append, so two cross-process updates to the same id cannot
+ * read the same stale base and last-wins clobber each other (lost update). The
+ * base merged against is always the current on-disk latest.
+ *
  * @param root - Absolute project root.
  * @param profile - The governing profile pack.
  * @param id - The id of the relation to update.
@@ -216,19 +249,71 @@ export async function updateRelation(
   id: RelationRef["id"],
   patch: UpdateRelationPatch,
 ): Promise<RelationRef> {
-  const { relations } = await readRelations(root);
-  const existing = relations.find((rel) => rel.id === id);
-  if (!existing) {
-    throw new RelationEndpointError(`no relation with id '${id}' to update`);
+  return underLock(root, async () => {
+    const { relations } = await readRelations(root); // re-read INSIDE the lock
+    const existing = relations.find((rel) => rel.id === id);
+    if (!existing) {
+      throw new RelationEndpointError(`no relation with id '${id}' to update`);
+    }
+    const input: AppendRelationInput = {
+      type: existing.type,
+      from: existing.from,
+      to: existing.to,
+      attributes: patch.attributes ?? existing.attributes,
+      evidence: patch.evidence ?? existing.evidence,
+    };
+    const ref = buildRelationRef(profile, input, id);
+    await appendLine(root, ref);
+    return ref;
+  });
+}
+
+/** The byte sizes of the store file before and after a compaction. */
+export interface CompactionResult {
+  /** File size before compaction (bytes). */
+  before: number;
+  /** File size after compaction (bytes). */
+  after: number;
+}
+
+/** Stat a file's size, treating an absent file as zero bytes. */
+async function fileSize(file: string): Promise<number> {
+  try {
+    return (await stat(file)).size;
+  } catch {
+    return 0;
   }
-  const input: AppendRelationInput = {
-    type: existing.type,
-    from: existing.from,
-    to: existing.to,
-    attributes: patch.attributes ?? existing.attributes,
-    evidence: patch.evidence ?? existing.evidence,
-  };
-  const ref = buildRelationRef(profile, input, id);
-  await underLock(root, () => appendLine(root, ref));
-  return ref;
+}
+
+/** Serialize the header + the surviving records into one store-file body. */
+function compactedBody(records: RelationRef[]): string {
+  return headerLine() + records.map((ref) => serializeRecord(ref)).join("");
+}
+
+/**
+ * Compact the relation store IN PLACE (FIX #4): under the lock, read the
+ * latest-per-id records that are still VALID against `profile`, rewrite just the
+ * header + those records to a temp file in the confined graph dir, and
+ * atomic-rename it over `relations.jsonl`. Superseded/duplicate/now-invalid
+ * records are dropped, so the store SHRINKS — the escape valve that recovers a
+ * store driven up to {@link RelationStoreFullError}. The latest-per-id collapse
+ * is the reader's, so no live relation is lost.
+ *
+ * @param root - Absolute project root.
+ * @param profile - The governing profile pack (records invalid against it are dropped).
+ * @returns The store file's byte size before and after compaction.
+ */
+export async function compactRelations(root: string, profile: ProfilePack): Promise<CompactionResult> {
+  return underLock(root, async () => {
+    const { dir } = await resolveGraphDir(root); // throws on symlink escape
+    await mkdir(dir, { recursive: true });
+    const file = path.join(dir, path.basename(RELATIONS_FILE));
+    const before = await fileSize(file);
+    const { relations } = await readRelations(root);
+    const survivors = relations.filter((ref) => validateRelationAgainstProfile(ref, profile).length === 0);
+    const tmp = file + ".compact.tmp";
+    await writeFile(tmp, compactedBody(survivors), "utf8");
+    await rename(tmp, file);
+    return { before, after: await fileSize(file) };
+  });
 }

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -28,7 +28,8 @@
  * and is NOT an update — callers pass only attributes/evidence.
  */
 
-import { open, mkdir, rename, stat, writeFile } from "fs/promises";
+import { open, mkdir, rename, stat } from "fs/promises";
+import { randomBytes } from "node:crypto";
 import path from "path";
 import { RELATIONS_FILE, MAX_RELATION_RECORD_BYTES, MAX_RELATION_STORE_BYTES } from "../utils/constants.js";
 import { acquireLockBlocking, releaseLock } from "../utils/lock.js";
@@ -291,10 +292,36 @@ function compactedBody(records: RelationRef[]): string {
 }
 
 /**
+ * Write `body` to a RANDOM-named temp file inside the CONFINED graph dir, then
+ * atomic-rename it over `file`. The temp is opened with `"wx"` (O_CREAT|O_EXCL),
+ * so a pre-planted entry at that path — INCLUDING a symlink-to-FILE — makes the
+ * open throw `EEXIST` and compaction FAILS CLOSED, never following the link to
+ * overwrite an out-of-tree file. The random suffix means the temp path cannot be
+ * predicted and pre-targeted. The write goes through the file HANDLE (never a
+ * path), and the handle is always closed in `finally`.
+ *
+ * @param dir - The already-confined graph directory (from {@link resolveGraphDir}).
+ * @param file - The destination store file inside `dir`.
+ * @param body - The compacted store body to persist.
+ */
+async function writeCompactedAtomically(dir: string, file: string, body: string): Promise<void> {
+  const tmp = path.join(dir, `${path.basename(RELATIONS_FILE)}.compact.${randomBytes(8).toString("hex")}.tmp`);
+  const handle = await open(tmp, "wx"); // O_EXCL: refuses any pre-existing entry, incl. a symlink
+  try {
+    await handle.writeFile(body, "utf8");
+  } finally {
+    await handle.close();
+  }
+  await rename(tmp, file);
+}
+
+/**
  * Compact the relation store IN PLACE (FIX #4): under the lock, read the
  * latest-per-id records that are still VALID against `profile`, rewrite just the
- * header + those records to a temp file in the confined graph dir, and
- * atomic-rename it over `relations.jsonl`. Superseded/duplicate/now-invalid
+ * header + those records to a RANDOM-named, O_EXCL-created temp file in the
+ * confined graph dir (see {@link writeCompactedAtomically} — a pre-planted
+ * symlink at the temp path fails the open closed, never followed outside root),
+ * and atomic-rename it over `relations.jsonl`. Superseded/duplicate/now-invalid
  * records are dropped, so the store SHRINKS — the escape valve that recovers a
  * store driven up to {@link RelationStoreFullError}. The latest-per-id collapse
  * is the reader's, so no live relation is lost.
@@ -311,9 +338,7 @@ export async function compactRelations(root: string, profile: ProfilePack): Prom
     const before = await fileSize(file);
     const { relations } = await readRelations(root);
     const survivors = relations.filter((ref) => validateRelationAgainstProfile(ref, profile).length === 0);
-    const tmp = file + ".compact.tmp";
-    await writeFile(tmp, compactedBody(survivors), "utf8");
-    await rename(tmp, file);
+    await writeCompactedAtomically(dir, file, compactedBody(survivors));
     return { before, after: await fileSize(file) };
   });
 }

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -31,6 +31,7 @@ import { mintRelationId } from "./ulid.js";
 import { canonicalEndpoints, relationContentHash } from "./digest.js";
 import { headerLine, serializeRecord, resolveGraphDir } from "./store-record.js";
 import { readRelations } from "./store-read.js";
+import { validateRelationAttributes } from "./relation-contract.js";
 
 /** The caller-supplied content of a new relation (id + hash are derived). */
 export interface AppendRelationInput {
@@ -66,12 +67,18 @@ function assertEndpoint(id: EntityId, allowed: string[], side: "from" | "to", ty
   }
 }
 
-/** Assert every required attribute of the relation type is present in `attributes`. */
-function assertRequiredAttributes(def: RelationTypeDef, attributes: Record<string, unknown>, type: string): void {
-  for (const name of def.requiredAttributes ?? []) {
-    if (!(name in attributes)) {
-      throw new RelationEndpointError(`relation '${type}' is missing required attribute '${name}'`);
-    }
+/**
+ * Assert a relation's attributes satisfy the relation-type def's declared
+ * contract — required-attribute PRESENCE AND each declared attribute's
+ * type/enum/min/max (the SAME field contract entity fields enforce, via
+ * {@link validateRelationAttributes}). Any violation fails closed BEFORE any
+ * write, so a relation whose attribute mismatches its declared type is never
+ * appended.
+ */
+function assertAttributesValid(def: RelationTypeDef, attributes: Record<string, unknown>, type: string): void {
+  const violations = validateRelationAttributes(def, attributes);
+  if (violations.length > 0) {
+    throw new RelationEndpointError(`relation '${type}' has invalid attributes: ${violations.join(" ")}`);
   }
 }
 
@@ -106,7 +113,7 @@ function buildRelationRef(
   assertEndpoint(input.from, def.from, "from", input.type);
   assertEndpoint(input.to, def.to, "to", input.type);
   const attributes = input.attributes ?? {};
-  assertRequiredAttributes(def, attributes, input.type);
+  assertAttributesValid(def, attributes, input.type);
   const { from, to } = canonicalEndpoints(input.from, input.to, def.direction);
   const content = { type: input.type, from, to, attributes, evidence: input.evidence };
   const ref: RelationRef = { id: existingId ?? mintRelationId(), ...content, contentHash: relationContentHash(content) };

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -38,7 +38,7 @@ import type { CitationRef, RelationRef } from "./types.js";
 import { RelationEndpointError, RelationStoreFullError } from "./types.js";
 import { mintRelationId } from "./ulid.js";
 import { canonicalEndpoints, relationContentHash } from "./digest.js";
-import { headerLine, serializeRecord, resolveGraphDir } from "./store-record.js";
+import { headerLine, serializeRecord, resolveGraphDir, openStoreFileAppend } from "./store-record.js";
 import { readRelations } from "./store-read.js";
 import { validateRelationAttributes, validateRelationEndpoints, validateRelationAgainstProfile } from "./relation-contract.js";
 
@@ -139,16 +139,20 @@ function buildRelationRef(
 
 /**
  * Append one serialized record line to the store under O_APPEND, creating the
- * dir/header. FAILS CLOSED with {@link RelationStoreFullError} (FIX #4) when the
- * append would reach/exceed {@link MAX_RELATION_STORE_BYTES} — the same bound the
- * reader rejects at — so the store can never be driven past the read cap into an
- * unreadable-yet-appendable state. {@link compactRelations} is the escape valve.
+ * dir/header. The leaf is opened through the shared NO-FOLLOW
+ * {@link openStoreFileAppend} (the LEAF defense complementing the
+ * {@link resolveGraphDir} DIR defense): a symlinked `relations.jsonl` fails the
+ * open closed, so the append NEVER lands outside root. FAILS CLOSED with
+ * {@link RelationStoreFullError} (FIX #4) when the append would reach/exceed
+ * {@link MAX_RELATION_STORE_BYTES} — the same bound the reader rejects at — so the
+ * store can never be driven past the read cap into an unreadable-yet-appendable
+ * state. {@link compactRelations} is the escape valve.
  */
 async function appendLine(root: string, ref: RelationRef): Promise<void> {
-  const { dir } = await resolveGraphDir(root); // throws on symlink escape
+  const { dir } = await resolveGraphDir(root); // throws on symlink escape (DIR defense)
   await mkdir(dir, { recursive: true });
   const file = path.join(dir, path.basename(RELATIONS_FILE));
-  const handle = await open(file, "a");
+  const handle = await openStoreFileAppend(file); // throws on symlink leaf (LEAF defense)
   try {
     const existing = (await handle.stat()).size;
     const header = existing === 0 ? headerLine() : "";

--- a/src/relations/types.ts
+++ b/src/relations/types.ts
@@ -5,20 +5,26 @@
  *
  * A {@link RelationRef} is one typed edge between two entity pages. Its `id`
  * (`rel_<ULID>`) is allocated ONCE at creation and is NEVER derived from or
- * recomputed against content — it is the stable handle a staged edit or a
- * later update references. Its `contentHash` is the canonical RFC 8785 digest
- * over `{type, from, to, attributes, evidence}` and IS recomputed whenever
- * `attributes`/`evidence` change; it serves both as the dedup key and as the
- * `preconditionHash` a staged edit checks against before applying. Changing
- * `type`/`from`/`to` is a delete+create (a different edge), not an in-place
- * update.
+ * recomputed against content — it is the stable handle a later update
+ * references. Its `contentHash` is the canonical RFC 8785 digest over
+ * `{type, from, to, attributes, evidence}` and IS recomputed whenever
+ * `attributes`/`evidence` change; it is the DEDUP KEY — an append whose
+ * `contentHash` matches a live relation is an idempotent no-op (see
+ * `appendRelationLocked`). It is NOT yet an optimistic-concurrency precondition;
+ * a `preconditionHash`-style check is reserved for future staged-relation edits.
+ * Changing `type`/`from`/`to` is a delete+create (a different edge), not an
+ * in-place update.
  *
  * On disk each line is a {@link RelationRecord}: the `RelationRef` plus a
  * per-record `checksum` (sha256 of the canonical record-without-checksum form).
  * The first line of a non-empty store is a {@link RelationStoreHeader} carrying
  * the store `schemaVersion`. Readers FAIL CLOSED when that version exceeds
- * {@link RELATION_STORE_SCHEMA_VERSION}; a torn trailing line is tolerated and
- * reported; interior corruption fails closed for the whole store.
+ * {@link RELATION_STORE_SCHEMA_VERSION}.
+ *
+ * DURABILITY: a torn TRAILING line is tolerated on a clean process crash and
+ * reported. There is NO fsync, so power-loss durability is NOT provided; an
+ * interior tear (any malformed/bad-checksum line before the last) fails the
+ * store closed.
  */
 
 import type { EntityId } from "../profile/types.js";
@@ -46,8 +52,8 @@ export type RelationId = `rel_${string}`;
  * One typed edge between two entity pages.
  *
  * `id` is minted once and never recomputed; `contentHash` is the canonical
- * digest of the content fields and is recomputed on every attribute/evidence
- * update. See the file overview for the full lifecycle contract.
+ * digest of the content fields (the DEDUP KEY), recomputed on every
+ * attribute/evidence update. See the file overview for the full contract.
  */
 export interface RelationRef {
   /** Stable handle, allocated once at creation. */
@@ -114,5 +120,19 @@ export class RelationEndpointError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "RelationEndpointError";
+  }
+}
+
+/**
+ * Raised when an append would drive the store to/over
+ * {@link MAX_RELATION_STORE_BYTES} — the SAME bound the reader fails closed at.
+ * The append path fails closed BEFORE writing so the store can never be grown
+ * past the read cap into an unreadable-yet-appendable (bricked) state; the
+ * escape valve is {@link compactRelations}.
+ */
+export class RelationStoreFullError extends Error {
+  constructor() {
+    super("relation store is full; run compaction");
+    this.name = "RelationStoreFullError";
   }
 }

--- a/src/relations/types.ts
+++ b/src/relations/types.ts
@@ -115,6 +115,20 @@ export class RelationStoreCorruptError extends Error {
   }
 }
 
+/**
+ * Raised when the canonical store FILE leaf (`wiki/graph/relations.jsonl`) is a
+ * SYMLINK or non-regular file. The no-follow open fails closed here (ELOOP / a
+ * non-regular fstat), so a relation append can never land outside the project
+ * root and a read can never return out-of-tree bytes — the LEAF defense that
+ * complements the graph-DIR confinement (both are required).
+ */
+export class RelationStoreSymlinkError extends Error {
+  constructor(message: string) {
+    super(`relation store file leaf rejected: ${message}`);
+    this.name = "RelationStoreSymlinkError";
+  }
+}
+
 /** Raised when a relation's endpoints/attributes violate the relation-type def. */
 export class RelationEndpointError extends Error {
   constructor(message: string) {

--- a/src/trust/lifecycle-transition.ts
+++ b/src/trust/lifecycle-transition.ts
@@ -77,15 +77,49 @@ async function readExistingPage(root: string, def: EntityTypeDef, slug: string):
   return safeReadFile(real);
 }
 
+/** Frontmatter keys a transition's `evidence` may NEVER set, even if declared. */
+const RESERVED_EVIDENCE_KEYS: ReadonlySet<string> = new Set(["slug"]);
+
+/**
+ * Reduce caller-supplied `evidence` to ONLY the keys that are legitimately
+ * settable for THIS transition: the fields the entity's lifecycle declares as
+ * `transitionRequirements[toState]`, MINUS any reserved identity key. Any key the
+ * caller passes that is not a declared evidence field for the target state — a
+ * `title` clobber, a planted `slug`, arbitrary junk — is DROPPED (FIX #2). When
+ * the target state declares no requirements, NO evidence key is admitted.
+ *
+ * @param def - The (lifecycle-bearing) entity type definition.
+ * @param toState - The lifecycle state being transitioned into.
+ * @param evidence - The caller-supplied, untrusted evidence map.
+ * @returns Only the declared, non-reserved evidence key/value pairs.
+ */
+function allowedEvidence(def: EntityTypeDef, toState: string, evidence?: LifecycleEvidence): LifecycleEvidence {
+  const declared = def.lifecycle!.transitionRequirements?.[toState] ?? [];
+  const allowed: LifecycleEvidence = {};
+  for (const field of declared) {
+    if (RESERVED_EVIDENCE_KEYS.has(field)) continue;
+    if (evidence && Object.prototype.hasOwnProperty.call(evidence, field)) allowed[field] = evidence[field];
+  }
+  return allowed;
+}
+
 /**
  * Build the new page body for the transition: parse the existing body, set the
- * lifecycle field to `toState`, merge any `evidence` fields into the frontmatter,
- * and re-assemble `${buildFrontmatter(meta)}\n${body}` (the project's standard
- * page assembly). The prose body is preserved verbatim.
+ * lifecycle field to `toState`, merge ONLY the ALLOW-LISTED `evidence` fields
+ * (those declared as required for `toState`; see {@link allowedEvidence}) into the
+ * frontmatter, and re-assemble `${buildFrontmatter(meta)}\n${body}` (the project's
+ * standard page assembly). The prose body is preserved verbatim. The lifecycle
+ * `field` is written LAST so it always wins, and arbitrary caller keys
+ * (`title`/`slug`/junk) can never clobber existing frontmatter (FIX #2).
  */
-function buildTransitionedBody(existing: string, field: string, toState: string, evidence?: LifecycleEvidence): string {
+function buildTransitionedBody(
+  existing: string,
+  def: EntityTypeDef,
+  toState: string,
+  evidence?: LifecycleEvidence,
+): string {
   const { meta, body } = parseFrontmatter(existing);
-  const nextMeta = { ...meta, ...(evidence ?? {}), [field]: toState };
+  const nextMeta = { ...meta, ...allowedEvidence(def, toState, evidence), [def.lifecycle!.field]: toState };
   return `${buildFrontmatter(nextMeta)}\n${body}`;
 }
 
@@ -113,7 +147,7 @@ async function transitionUnderLock(
   evidence?: LifecycleEvidence,
 ): Promise<void> {
   const existing = await readExistingPage(root, def, slug);
-  const body = buildTransitionedBody(existing, def.lifecycle!.field, toState, evidence);
+  const body = buildTransitionedBody(existing, def, toState, evidence);
   const candidate: Pick<ReviewCandidate, "slug" | "body" | "targetEntityType"> = {
     slug,
     body,

--- a/src/trust/lifecycle-transition.ts
+++ b/src/trust/lifecycle-transition.ts
@@ -20,6 +20,7 @@
 import { loadNonDefaultProfile } from "../profile/block.js";
 import { resolveConfinedEntityPage } from "../profile/lifecycle-read.js";
 import { parseFrontmatter, buildFrontmatter, safeReadFile } from "../utils/markdown.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
 import { applyTypedCandidate } from "./promote.js";
 import type { EntityTypeDef } from "../profile/types.js";
 import type { ReviewCandidate } from "../utils/types.js";
@@ -37,6 +38,19 @@ export class LifecycleTransitionUnavailableError extends Error {
     super(`cannot transition lifecycle: ${detail}`);
     this.name = "LifecycleTransitionUnavailableError";
     void reason;
+  }
+}
+
+/**
+ * Thrown when {@link transitionLifecycle} cannot acquire the project lock —
+ * another process is writing this project. The transition is a read-modify-write,
+ * so it MUST run single-writer; without the lock the prev-state read and the
+ * apply could race (TOCTOU) and corrupt the journal. Fails CLOSED, writing nothing.
+ */
+export class LifecycleTransitionLockError extends Error {
+  constructor() {
+    super("cannot transition lifecycle: another llmwiki process is using this project (lock held)");
+    this.name = "LifecycleTransitionLockError";
   }
 }
 
@@ -76,13 +90,50 @@ function buildTransitionedBody(existing: string, field: string, toState: string,
 }
 
 /**
+ * The read-modify-write core of a transition, run WHILE THE CALLER ALREADY HOLDS
+ * the project lock. Reads the existing page + its prev lifecycle state, rewrites
+ * the lifecycle field (+ any `evidence`), and applies through the LOCK-FREE
+ * {@link applyTypedCandidate} (correct now that we hold the lock). Because the
+ * prev-state read and the apply both run under the one held lock, no concurrent
+ * writer can race between them.
+ *
+ * @param root - Absolute project root.
+ * @param entityType - The profile entity type whose page is transitioned.
+ * @param def - The resolved (lifecycle-bearing) entity type definition.
+ * @param slug - The page slug (the filename stem).
+ * @param toState - The lifecycle state to transition the page into.
+ * @param evidence - Optional frontmatter fields a target state requires (merged in).
+ */
+async function transitionUnderLock(
+  root: string,
+  entityType: string,
+  def: EntityTypeDef,
+  slug: string,
+  toState: string,
+  evidence?: LifecycleEvidence,
+): Promise<void> {
+  const existing = await readExistingPage(root, def, slug);
+  const body = buildTransitionedBody(existing, def.lifecycle!.field, toState, evidence);
+  const candidate: Pick<ReviewCandidate, "slug" | "body" | "targetEntityType"> = {
+    slug,
+    body,
+    targetEntityType: entityType,
+  };
+  await applyTypedCandidate(root, candidate as ReviewCandidate);
+}
+
+/**
  * Transition a typed entity page's lifecycle field to `toState` as a validated
- * page update. Loads the entity def (throwing {@link LifecycleTransitionUnavailableError}
- * when the type has no lifecycle), reads the existing page (throwing when it is
- * missing), rewrites its lifecycle field (+ any `evidence`), and applies the new
- * body through {@link applyTypedCandidate} — which RE-RUNS the PR2 lifecycle gate,
- * so an illegal transition or one missing required evidence is REFUSED there
- * (`LifecycleTransitionError` propagates) and the page is left unchanged.
+ * page update, UNDER THE PROJECT LOCK. Resolves the entity def (throwing
+ * {@link LifecycleTransitionUnavailableError} when the type has no lifecycle),
+ * acquires the project lock (throwing {@link LifecycleTransitionLockError} when
+ * another process holds it), then INSIDE the lock reads the existing page,
+ * rewrites its lifecycle field (+ any `evidence`), and applies the new body
+ * through {@link applyTypedCandidate} — which RE-RUNS the PR2 lifecycle gate, so
+ * an illegal transition or one missing required evidence is REFUSED there
+ * (`LifecycleTransitionError` propagates) and the page is left unchanged. The
+ * lock makes the prev-state read and the apply atomic (no TOCTOU); it is always
+ * released in `finally`.
  *
  * @param root - Absolute project root.
  * @param entityType - The profile entity type whose page is transitioned.
@@ -90,6 +141,7 @@ function buildTransitionedBody(existing: string, field: string, toState: string,
  * @param toState - The lifecycle state to transition the page into.
  * @param evidence - Optional frontmatter fields a target state requires (merged in).
  * @throws {LifecycleTransitionUnavailableError} When no profile/type/lifecycle/page.
+ * @throws {LifecycleTransitionLockError} When the project lock cannot be acquired.
  * @throws {LifecycleTransitionError} When the PR2 gate refuses the transition.
  */
 export async function transitionLifecycle(
@@ -100,12 +152,10 @@ export async function transitionLifecycle(
   evidence?: LifecycleEvidence,
 ): Promise<void> {
   const def = await resolveLifecycleDef(root, entityType);
-  const existing = await readExistingPage(root, def, slug);
-  const body = buildTransitionedBody(existing, def.lifecycle!.field, toState, evidence);
-  const candidate: Pick<ReviewCandidate, "slug" | "body" | "targetEntityType"> = {
-    slug,
-    body,
-    targetEntityType: entityType,
-  };
-  await applyTypedCandidate(root, candidate as ReviewCandidate);
+  if (!(await acquireLock(root))) throw new LifecycleTransitionLockError();
+  try {
+    await transitionUnderLock(root, entityType, def, slug, toState, evidence);
+  } finally {
+    await releaseLock(root);
+  }
 }

--- a/src/trust/relation-plan.ts
+++ b/src/trust/relation-plan.ts
@@ -20,6 +20,7 @@
 
 import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
 import { parseEntityId, EntityIdError } from "../profile/identity.js";
+import { validateRelationAttributes } from "../relations/relation-contract.js";
 import type { ProfilePack, RelationTypeDef } from "../profile/types.js";
 import type { AppendRelationInput } from "../relations/store.js";
 
@@ -76,16 +77,17 @@ function checkEndpoint(
 }
 
 /**
- * Check every required attribute of the relation type is present in the proposed
- * relation's attributes — the planner counterpart to the store's
- * `assertRequiredAttributes`. A missing required attribute yields a `block`.
+ * Check the proposed relation's attributes satisfy the relation-type def's
+ * declared contract — required-attribute PRESENCE AND each declared attribute's
+ * type/enum/min/max (the SAME field contract entity fields enforce, via
+ * {@link validateRelationAttributes}) — the planner counterpart to the store's
+ * `assertAttributesValid`. Any violation yields a `block`.
  */
-function checkRequiredAttributes(def: RelationTypeDef, input: AppendRelationInput): TrustCheckResult {
-  const code = "relation-required-attribute";
-  const attributes = input.attributes ?? {};
-  const missing = (def.requiredAttributes ?? []).filter((name) => !(name in attributes));
-  if (missing.length === 0) return pass(code, "all required relation attributes are present");
-  return block(code, `relation '${input.type}' is missing required attribute(s): ${missing.join(", ")}`);
+function checkAttributes(def: RelationTypeDef, input: AppendRelationInput): TrustCheckResult {
+  const code = "relation-attribute-contract";
+  const violations = validateRelationAttributes(def, input.attributes ?? {});
+  if (violations.length === 0) return pass(code, "relation attributes satisfy the declared contract");
+  return block(code, `relation '${input.type}' has invalid attributes: ${violations.join(" ")}`);
 }
 
 /**
@@ -101,7 +103,7 @@ function runMandatoryRelationChecks(profile: ProfilePack, input: AppendRelationI
     typeCheck,
     checkEndpoint(input.from, def.from, "from", input.type),
     checkEndpoint(input.to, def.to, "to", input.type),
-    checkRequiredAttributes(def, input),
+    checkAttributes(def, input),
   ];
 }
 

--- a/src/trust/relation-plan.ts
+++ b/src/trust/relation-plan.ts
@@ -1,26 +1,26 @@
 /**
  * @file src/trust/relation-plan.ts
- * @description The RELATION write planner — the relation-store analogue of the
- * page {@link planPageMutation}. It routes a proposed relation write through ONE
- * planner decision (CLP Invariant 4): it runs the mandatory relation checks
- * (endpoint validity against the profile relation-type def + required attributes)
- * and composes a {@link TrustDecision} via the SAME {@link composeTrustDecision}
- * the page path uses.
+ * @description The RELATION write planner. It runs the mandatory relation checks
+ * (type declared, CANONICAL endpoints valid against the profile relation-type
+ * def, required attributes) and composes a {@link TrustDecision} via the SAME
+ * {@link composeTrustDecision} the page path uses.
  *
- * This DOES NOT touch disk and mints no id — it is a pure decision over the
- * proposed relation. It RE-VALIDATES exactly what the store
- * ({@link appendRelationLocked}) also enforces, so it is defense in depth plus a
- * uniform decision shared by every surface: a relation write that the planner
- * would deny never reaches the store, and the store stays the final fail-closed
- * floor for a hand-built append that bypassed the planner.
+ * This SHARES only the trust DECISION composer with the page path — it is a
+ * separate write path, NOT the page planner/executor/journal. It DOES NOT touch
+ * disk and mints no id — a pure decision over the proposed relation. It
+ * RE-VALIDATES exactly what the store ({@link appendRelationLocked}) also
+ * enforces (canonicalize THEN validate, via the shared
+ * {@link validateRelationEndpoints}), so write and read agree on the same bytes:
+ * a relation the planner would deny never reaches the store, and the store stays
+ * the final fail-closed floor for a hand-built append that bypassed the planner.
  *
  * The relation surface is NOT review-routed, so a `block` composes to `deny`
  * (never `stage-for-review`): relation staging is out of scope for this slice.
  */
 
 import { composeTrustDecision, type TrustDecision, type TrustCheckResult } from "./decision.js";
-import { parseEntityId, EntityIdError } from "../profile/identity.js";
-import { validateRelationAttributes } from "../relations/relation-contract.js";
+import { validateRelationAttributes, validateRelationEndpoints } from "../relations/relation-contract.js";
+import { canonicalEndpoints } from "../relations/digest.js";
 import type { ProfilePack, RelationTypeDef } from "../profile/types.js";
 import type { AppendRelationInput } from "../relations/store.js";
 
@@ -53,27 +53,20 @@ function checkRelationTypeDeclared(profile: ProfilePack, type: string): TrustChe
 }
 
 /**
- * Check one endpoint's entity type is allowed on its side of the relation. A
- * non-`<type>/<slug>` id, or an endpoint whose entity type is outside the def's
- * declared `from`/`to` set, yields a `block` — the planner counterpart to the
- * store's `assertEndpoint`.
+ * Check the relation's CANONICAL endpoints against the def via the SHARED
+ * {@link validateRelationEndpoints} — the planner counterpart to the store's
+ * `assertCanonicalEndpoints`. Endpoints are canonicalized FIRST (FIX #1) so the
+ * planner judges exactly the bytes the store will persist and the read will
+ * re-validate; for a symmetric type each endpoint is checked against
+ * `def.from ∪ def.to`. A non-`<type>/<slug>` id, or a disallowed entity type,
+ * yields a `block`.
  */
-function checkEndpoint(
-  id: string,
-  allowed: string[],
-  side: "from" | "to",
-  type: string,
-): TrustCheckResult {
-  const code = `relation-endpoint-${side}`;
-  let entityType: string;
-  try {
-    ({ entityType } = parseEntityId(id as never));
-  } catch (err) {
-    if (err instanceof EntityIdError) return block(code, `relation '${type}' ${side} endpoint id is invalid: ${id}`);
-    throw err;
-  }
-  if (allowed.includes(entityType)) return pass(code, `relation '${type}' ${side} endpoint type '${entityType}' is allowed`);
-  return block(code, `relation '${type}' ${side} endpoint type '${entityType}' is not allowed`);
+function checkEndpoints(def: RelationTypeDef, input: AppendRelationInput): TrustCheckResult {
+  const code = "relation-endpoint";
+  const { from, to } = canonicalEndpoints(input.from, input.to, def.direction);
+  const reasons = validateRelationEndpoints(def, from, to);
+  if (reasons.length === 0) return pass(code, `relation '${input.type}' endpoints are allowed`);
+  return block(code, `relation '${input.type}' ${reasons.join("; ")}`);
 }
 
 /**
@@ -101,8 +94,7 @@ function runMandatoryRelationChecks(profile: ProfilePack, input: AppendRelationI
   if (!def) return [typeCheck];
   return [
     typeCheck,
-    checkEndpoint(input.from, def.from, "from", input.type),
-    checkEndpoint(input.to, def.to, "to", input.type),
+    checkEndpoints(def, input),
     checkAttributes(def, input),
   ];
 }

--- a/src/trust/relation-write.ts
+++ b/src/trust/relation-write.ts
@@ -1,21 +1,21 @@
 /**
  * @file src/trust/relation-write.ts
- * @description The trust-gated RELATION WRITE entry point — the relation analogue
- * of the page executor's planner→apply seam (CLP Invariant 4: a mutation routes
- * through ONE planner decision, then applies under ONE lock).
+ * @description The trust-gated RELATION WRITE entry point — shared by the SDK and CLI.
  *
- * {@link createRelation} is shared by the SDK and CLI. It plans the relation via
- * {@link planRelationMutation}; on any non-live-write decision it throws a typed
- * {@link RelationWriteDeniedError} and writes NOTHING. Only on
- * `allow`/`allow-with-warning` does it acquire the project lock ONCE and append
- * through the lock-free {@link appendRelationLocked}, releasing in `finally`.
+ * Relations use a SEPARATE write path. It SHARES the trust DECISION composer
+ * ({@link composeTrustDecision}, via {@link planRelationMutation}) with the page
+ * path, but it does NOT route through the page planner/executor/journal: relation
+ * writes are NOT journalled and are NOT atomic with page writes. They have their
+ * own append-only durability (a single locked append to `relations.jsonl`).
  *
- * Relations have their OWN append-only durability (PR4) under the lock — they are
- * deliberately NOT routed through the page temp-rename journal, so this path
- * leaves the page executor untouched.
+ * {@link createRelation} plans the relation; on any non-live-write decision it
+ * throws a typed {@link RelationWriteDeniedError} and writes NOTHING. Only on
+ * `allow`/`allow-with-warning` does it take the project lock ONCE (bounded-blocking,
+ * so concurrent writers serialize rather than spuriously fail) and append through
+ * the lock-free {@link appendRelationLocked}, releasing in `finally`.
  */
 
-import { acquireLock, releaseLock } from "../utils/lock.js";
+import { acquireLockBlocking, releaseLock } from "../utils/lock.js";
 import { appendRelationLocked, type AppendRelationInput } from "../relations/store.js";
 import { planRelationMutation } from "./relation-plan.js";
 import { loadNonDefaultProfile } from "../profile/block.js";
@@ -65,9 +65,7 @@ export async function createRelation(
   if (!LIVE_WRITE_DECISIONS.has(decision)) {
     throw new RelationWriteDeniedError(input.type, decision);
   }
-  if (!(await acquireLock(root))) {
-    throw new Error("could not acquire project lock for relation write");
-  }
+  await acquireLockBlocking(root); // serializes concurrent writers; throws LockBusyError on timeout
   try {
     return await appendRelationLocked(root, profile, input);
   } finally {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -102,6 +102,23 @@ export const WIKI_GRAPH_DIR = "wiki/graph";
 export const RELATIONS_FILE = "wiki/graph/relations.jsonl";
 
 /**
+ * Resource cap on the relation store file. The store is attacker/sync-controllable
+ * (a teammate or a synced checkout can replace it), and the reader slurps the whole
+ * file before any header/checksum validation. A multi-GB file or a giant single
+ * line would exhaust memory before the integrity check runs, so the reader STATs
+ * the file first and FAILS CLOSED above this bound — mirroring the page path's
+ * {@link MAX_SOURCE_CHARS} resource cap, scaled up for a whole-graph aggregate.
+ */
+export const MAX_RELATION_STORE_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Resource cap on a SINGLE relation record's serialized form on the write path.
+ * Bounds attacker-controlled attribute/evidence size before append so one record
+ * cannot grow unbounded (and so the per-store cap cannot be reached by one line).
+ */
+export const MAX_RELATION_RECORD_BYTES = MAX_SOURCE_CHARS;
+
+/**
  * Append-only activity journal at the project root, per Karpathy's llm-wiki
  * gist: a chronological record of what happened and when (ingests, compiles,
  * queries, lint passes). Lives at the root rather than under wiki/ because it

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -30,6 +30,54 @@ import * as output from "./output.js";
 const RECLAIM_SUFFIX = ".reclaim";
 const MAX_ACQUIRE_ATTEMPTS = 2;
 
+/** Default bound a blocking acquire waits before declaring the store busy. */
+const DEFAULT_BLOCKING_TIMEOUT_MS = 5_000;
+/** Default poll interval between blocking-acquire retries. */
+const DEFAULT_BLOCKING_INTERVAL_MS = 25;
+
+/** Options bounding a {@link acquireLockBlocking} retry loop. */
+export interface BlockingLockOptions {
+  /** Total time to keep retrying before throwing (ms). */
+  timeoutMs?: number;
+  /** Delay between retries (ms). */
+  intervalMs?: number;
+}
+
+/** Thrown when a bounded-blocking lock acquire times out without acquiring. */
+export class LockBusyError extends Error {
+  constructor(timeoutMs: number) {
+    super(`relation store busy after ${timeoutMs}ms`);
+    this.name = "LockBusyError";
+  }
+}
+
+/** Resolve after `ms` milliseconds (the poll backoff between acquire retries). */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Acquire the project lock, RETRYING with a short poll until it succeeds or
+ * `timeoutMs` elapses (then throwing {@link LockBusyError}). Unlike the fail-fast
+ * {@link acquireLock} (kept for compile), this serializes legitimate concurrent
+ * relation writers instead of spuriously failing the loser of a race. Each retry
+ * goes through {@link acquireLock}, so stale-lock reclamation still applies.
+ *
+ * @param root - Absolute project root.
+ * @param options - Optional timeout / poll-interval overrides.
+ * @throws {LockBusyError} When the lock stays held past `timeoutMs`.
+ */
+export async function acquireLockBlocking(root: string, options: BlockingLockOptions = {}): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BLOCKING_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_BLOCKING_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await acquireLock(root)) return;
+    if (Date.now() >= deadline) throw new LockBusyError(timeoutMs);
+    await delay(intervalMs);
+  }
+}
+
 /** Check whether a process with the given PID is still running. */
 function isProcessAlive(pid: number): boolean {
   try {

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -72,7 +72,11 @@ export async function acquireLockBlocking(root: string, options: BlockingLockOpt
   const intervalMs = options.intervalMs ?? DEFAULT_BLOCKING_INTERVAL_MS;
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    if (await acquireLock(root)) return;
+    // Intermediate retries acquire QUIETLY: a held lock is the EXPECTED steady
+    // state while we poll, so the per-attempt "Another compilation is running."
+    // warning would spam SDK/MCP callers that retry by design. The final
+    // LockBusyError is the clear signal on timeout.
+    if (await acquireLock(root, { quiet: true })) return;
     if (Date.now() >= deadline) throw new LockBusyError(timeoutMs);
     await delay(intervalMs);
   }
@@ -88,14 +92,25 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+/** Options for {@link acquireLock}. `quiet` suppresses the busy warning. */
+export interface AcquireLockOptions {
+  /** Suppress the "Another compilation is running." warning on a busy lock. */
+  quiet?: boolean;
+}
+
 /**
  * Acquire the compilation lock. Returns true if acquired, false if busy.
  *
  * Retries up to MAX_ACQUIRE_ATTEMPTS times to handle the case where the
  * first attempt cleans up a stale reclamation lock but cannot acquire it
  * in the same call (to avoid the double-winner race).
+ *
+ * @param root - Project root directory.
+ * @param options - When `quiet`, the busy-lock warning is suppressed (used by
+ *   {@link acquireLockBlocking}'s intermediate retries so by-design pollers stay
+ *   silent). The fail-fast CLI path leaves it unset and still prints the warning.
  */
-export async function acquireLock(root: string): Promise<boolean> {
+export async function acquireLock(root: string, options: AcquireLockOptions = {}): Promise<boolean> {
   const lockPath = path.join(root, LOCK_FILE);
   await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
 
@@ -107,7 +122,7 @@ export async function acquireLock(root: string): Promise<boolean> {
     // Lock exists. Check if the holding process is dead.
     const stale = await isLockStale(lockPath);
     if (!stale) {
-      output.status("!", output.warn("Another compilation is running."));
+      if (!options.quiet) output.status("!", output.warn("Another compilation is running."));
       return false;
     }
 
@@ -118,7 +133,7 @@ export async function acquireLock(root: string): Promise<boolean> {
     // Reclamation failed (e.g. cleaned up stale reclaim lock). Retry.
   }
 
-  output.status("!", output.warn("Could not acquire lock after retrying."));
+  if (!options.quiet) output.status("!", output.warn("Could not acquire lock after retrying."));
   return false;
 }
 

--- a/test/fixtures/profile-fixtures.ts
+++ b/test/fixtures/profile-fixtures.ts
@@ -19,7 +19,8 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect } from "vitest";
 import { PROFILE_FILE } from "../../src/utils/constants.js";
-import type { ProfilePack, EntityPageView } from "../../src/profile/types.js";
+import type { EntityId, ProfilePack, EntityPageView } from "../../src/profile/types.js";
+import { appendRelation } from "../../src/relations/store.js";
 
 /**
  * A minimal NON-DEFAULT profile: a single `notes` entity type at `wiki/notes`
@@ -165,6 +166,26 @@ export const RESEARCH_LITE_PROFILE = {
   },
 } as const;
 
+/**
+ * A research-lite profile EXTENDED with a `tests` relation type
+ * (`experiments → ideas`, directed, optional `metric` attribute). Kept separate
+ * from {@link RESEARCH_LITE_PROFILE} so the base fixture stays relation-LESS for
+ * tests that trim its entity set (a relation referencing a trimmed-away entity
+ * type would fail profile validation). Materialized via
+ * {@link buildResearchLiteRelationsProject} + {@link seedTestsRelation}.
+ */
+export const RESEARCH_LITE_RELATIONS_PROFILE = {
+  ...RESEARCH_LITE_PROFILE,
+  relations: {
+    tests: {
+      from: ["experiments"],
+      to: ["ideas"],
+      direction: "directed",
+      attributes: { metric: { type: "string" } },
+    },
+  },
+} as const;
+
 /** One slug-safe seed page per entity directory, keyed by repo-relative dir. */
 const SEED_PAGES: Record<string, string[]> = {
   "wiki/papers": ["attention-is-all-you-need", "scaling-laws"],
@@ -206,4 +227,45 @@ export async function buildResearchLiteProject(root: string): Promise<void> {
     await mkdir(path.join(root, dir), { recursive: true });
     for (const slug of slugs) await writeSeedPage(root, dir, slug);
   }
+}
+
+/**
+ * Materialize a research-lite project whose on-disk profile DECLARES the `tests`
+ * relation type ({@link RESEARCH_LITE_RELATIONS_PROFILE}). Builds the base
+ * project (entity dirs + seed pages), then overwrites the profile file so the
+ * read surfaces (status/export/lint) see the relations block.
+ *
+ * @param root - Absolute project root directory (must already exist).
+ */
+export async function buildResearchLiteRelationsProject(root: string): Promise<void> {
+  await buildResearchLiteProject(root);
+  await writeFile(
+    path.join(root, ".llmwiki", "profile.json"),
+    `${JSON.stringify(RESEARCH_LITE_RELATIONS_PROFILE, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+/**
+ * Append a `tests` relation (`experiments/<from>` → `ideas/<to>`) into a
+ * research-lite project's relation store, returning its minted ref. Used by the
+ * relation-lint/surfacing tests to seed both HEALTHY (both endpoints have seed
+ * pages) and DANGLING (a missing endpoint slug) relations.
+ *
+ * @param root - Absolute project root (must already be a research-lite project).
+ * @param fromSlug - The `experiments` endpoint slug.
+ * @param toSlug - The `ideas` endpoint slug.
+ * @returns The persisted relation reference.
+ */
+export async function seedTestsRelation(
+  root: string,
+  fromSlug: string,
+  toSlug: string,
+): Promise<{ id: string; type: string }> {
+  return appendRelation(root, RESEARCH_LITE_RELATIONS_PROFILE as ProfilePack, {
+    type: "tests",
+    from: `experiments/${fromSlug}` as EntityId,
+    to: `ideas/${toSlug}` as EntityId,
+    attributes: { metric: "f1" },
+  });
 }

--- a/test/fixtures/profile-fixtures.ts
+++ b/test/fixtures/profile-fixtures.ts
@@ -170,6 +170,11 @@ export const RESEARCH_LITE_PROFILE = {
           type: "enum",
           enum: ["proposed", "testing", "tested", "validated", "failed"],
         },
+        // Declared so the `failed` state can require it as transition evidence:
+        // the profile validator now demands every transitionRequirements field be
+        // a declared entity field (FIX 2). Extending fixtures attach
+        // `transitionRequirements: { failed: ["failureReason"] }`.
+        failureReason: { type: "string" },
       },
       lifecycle: {
         field: "status",

--- a/test/fixtures/profile-fixtures.ts
+++ b/test/fixtures/profile-fixtures.ts
@@ -39,6 +39,29 @@ export const SAMPLE_PROFILE: ProfilePack = {
   },
 };
 
+/** Stock `experiments` endpoint EntityId for the in-memory relation fixtures. */
+export const EXPERIMENT_A = "experiments/a" as EntityId;
+/** Stock `ideas` endpoint EntityId for the in-memory relation fixtures. */
+export const IDEA_B = "ideas/b" as EntityId;
+
+/**
+ * Build an in-memory NON-DEFAULT profile with `experiments` + `ideas` entity
+ * types and a caller-supplied `relations` block. Shared by the relation
+ * write-path / contract / confinement tests so they declare ONE entity shape and
+ * vary only the relation definitions under test.
+ *
+ * @param relations - The `relations` block to attach.
+ * @returns A complete {@link ProfilePack}.
+ */
+export function experimentsIdeasProfile(relations: ProfilePack["relations"]): ProfilePack {
+  return {
+    schemaVersion: 1,
+    profileId: "research",
+    entities: { experiments: { directory: "wiki/experiments" }, ideas: { directory: "wiki/ideas" } },
+    relations,
+  };
+}
+
 /** Write a profile.json into the project's `.llmwiki/` dir. */
 export async function writeProfileFile(root: string, pack: ProfilePack): Promise<void> {
   await mkdir(path.join(root, path.dirname(PROFILE_FILE)), { recursive: true });

--- a/test/fixtures/relation-confine.ts
+++ b/test/fixtures/relation-confine.ts
@@ -1,0 +1,39 @@
+/**
+ * @file test/fixtures/relation-confine.ts
+ * @description Shared scaffolding for the relation-store confinement suites
+ * (graph-DIR confinement and store-FILE-leaf no-follow). Both suites use the
+ * same directed-`tests` profile, the same `experiments/a -> ideas/b` append, and
+ * the same "a normal real-file store still appends + reads" regression. Hoisting
+ * them here removes the duplicated boilerplate (flagged by fallow) while each
+ * suite keeps its own symlink-planting and fail-closed assertions local.
+ */
+
+import { expect } from "vitest";
+import type { ProfilePack } from "../../src/profile/types.js";
+import { appendRelation } from "../../src/relations/store.js";
+import { readRelations } from "../../src/relations/store-read.js";
+import { experimentsIdeasProfile, EXPERIMENT_A, IDEA_B } from "./profile-fixtures.js";
+
+/** A non-default profile carrying a single directed `experiments -> ideas` `tests` relation. */
+export function relationConfineProfile(): ProfilePack {
+  return experimentsIdeasProfile({ tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } });
+}
+
+/** Append the canonical `experiments/a -> ideas/b` `tests` relation under `root`. */
+export function appendTestRelation(root: string): ReturnType<typeof appendRelation> {
+  return appendRelation(root, relationConfineProfile(), { type: "tests", from: EXPERIMENT_A, to: IDEA_B, attributes: {} });
+}
+
+/**
+ * Assert the happy path on a NORMAL (real-file) store: the append persists and a
+ * read returns exactly that one relation. The shared regression both confinement
+ * suites run so a hardening change can never silently break the normal path.
+ *
+ * @param root - The in-project temp root to append + read under.
+ */
+export async function expectNormalAppendAndRead(root: string): Promise<void> {
+  const ref = await appendTestRelation(root);
+  const { relations } = await readRelations(root);
+  expect(relations).toHaveLength(1);
+  expect(relations[0].id).toBe(ref.id);
+}

--- a/test/lifecycle-evidence-content.test.ts
+++ b/test/lifecycle-evidence-content.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @file test/lifecycle-evidence-content.test.ts
+ * @description Content-validation of required lifecycle evidence (FIX #7).
+ *
+ * `validateLifecycleTransition` gates a transition into a state whose
+ * `transitionRequirements` lists evidence fields. The gate must prove the
+ * evidence carries CONTENT (a non-empty string/number, or a non-empty array of
+ * such scalars), not merely that the key EXISTS: a bare object, a boolean, the
+ * empty/whitespace string, and `[]` must all be REJECTED.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateLifecycleTransition } from "../src/profile/lifecycle.js";
+import type { LifecycleDef } from "../src/profile/types.js";
+
+/** An `ideas`-like FSM whose `failed` state requires a `failureReason`. */
+const LIFECYCLE: LifecycleDef = {
+  field: "status",
+  initial: "proposed",
+  terminal: ["failed"],
+  transitions: { proposed: ["failed"] },
+  transitionRequirements: { failed: ["failureReason"] },
+};
+
+/** Validate a `proposed → failed` transition carrying `failureReason: value`. */
+function problemsFor(value: unknown): string[] {
+  return validateLifecycleTransition(LIFECYCLE, "proposed", "failed", {
+    status: "failed",
+    failureReason: value,
+  });
+}
+
+describe("lifecycle evidence content validation (FIX #7)", () => {
+  it("admits a non-empty string and a non-empty array of strings", () => {
+    expect(problemsFor("out of compute")).toEqual([]);
+    expect(problemsFor(["metric regressed", "ran out of budget"])).toEqual([]);
+  });
+
+  it("admits a finite number as evidence", () => {
+    expect(problemsFor(0.42)).toEqual([]);
+  });
+
+  it.each([
+    ["a bare object", { any: "obj" }],
+    ["a boolean true", true],
+    ["a whitespace-only string", "   "],
+    ["an empty array", []],
+    ["an array of objects", [{ k: "v" }]],
+  ])("rejects %s as missing required evidence", (_label, value) => {
+    const problems = problemsFor(value);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toMatch(/requires evidence field "failureReason"/);
+  });
+});

--- a/test/profile-lifecycle-enforce.test.ts
+++ b/test/profile-lifecycle-enforce.test.ts
@@ -56,6 +56,19 @@ async function stageIdeaCandidate(body: string): Promise<string> {
 }
 
 /**
+ * Assert promoting `body` for the seeded `ideas` page is REFUSED with a
+ * {@link LifecycleTransitionError} and the on-disk page still carries
+ * `status: <retained>` (unchanged). Shared by the illegal-transition and
+ * field-deletion refusal tests.
+ */
+async function expectPromoteRefused(body: string, retained: string): Promise<void> {
+  await expect(
+    applyTypedCandidate(root, { slug: IDEA, body, targetEntityType: "ideas" } as never),
+  ).rejects.toBeInstanceOf(LifecycleTransitionError);
+  expect(await readFile(path.join(root, "wiki/ideas", `${IDEA}.md`), "utf8")).toContain(`status: ${retained}`);
+}
+
+/**
  * Run a CLI command `fn` with `dir` as the cwd, console silenced, and
  * `process.exitCode` reset before/after — restoring everything in `finally`.
  * Shared so the chdir+mock boilerplate is not duplicated across tests.
@@ -83,10 +96,7 @@ describe("runtime lifecycle enforcement — transition on promote", () => {
   });
 
   it("refuses an illegal transition proposed → validated, leaving the page unchanged", async () => {
-    await expect(
-      applyTypedCandidate(root, { slug: IDEA, body: "---\nstatus: validated\n---\n\nSkip.\n", targetEntityType: "ideas" } as never),
-    ).rejects.toBeInstanceOf(LifecycleTransitionError);
-    expect(await readFile(path.join(root, "wiki/ideas", `${IDEA}.md`), "utf8")).toContain("status: proposed");
+    await expectPromoteRefused("---\nstatus: validated\n---\n\nSkip.\n", "proposed");
   });
 
   it("review approve refuses an illegal transition (exit 1, candidate retained)", async () => {
@@ -149,16 +159,45 @@ describe("runtime lifecycle enforcement — required evidence", () => {
   });
 
   it("refuses entering `failed` without the required `failureReason` evidence", async () => {
-    await expect(
-      applyTypedCandidate(root, { slug: IDEA, body: "---\nstatus: failed\n---\n\nNo reason.\n", targetEntityType: "ideas" } as never),
-    ).rejects.toBeInstanceOf(LifecycleTransitionError);
-    expect(await readFile(path.join(root, "wiki/ideas", `${IDEA}.md`), "utf8")).toContain("status: tested");
+    await expectPromoteRefused("---\nstatus: failed\n---\n\nNo reason.\n", "tested");
   });
 
   it("allows entering `failed` when the required evidence is present", async () => {
     const body = "---\nstatus: failed\nfailureReason: out of compute\n---\n\nDone.\n";
     const rel = await applyTypedCandidate(root, { slug: IDEA, body, targetEntityType: "ideas" } as never);
     expect(await readFile(path.join(root, rel), "utf8")).toContain("status: failed");
+  });
+});
+
+/**
+ * A profile whose `ideas` lifecycle field is OPTIONAL (no `requiredFields`, not
+ * enum-constrained), so a body with NO `status` reaches the lifecycle gate rather
+ * than the field-contract gate — isolating the lifecycle-DELETION check (FIX 3).
+ */
+const OPTIONAL_STATUS_PROFILE = {
+  ...RESEARCH_LITE_PROFILE,
+  entities: {
+    ...RESEARCH_LITE_PROFILE.entities,
+    ideas: { directory: "wiki/ideas", lifecycle: RESEARCH_LITE_PROFILE.entities.ideas.lifecycle },
+  },
+};
+
+describe("runtime lifecycle enforcement — field deletion (FIX 3)", () => {
+  beforeEach(async () => {
+    await writeFile(path.join(root, PROFILE_FILE), JSON.stringify(OPTIONAL_STATUS_PROFILE), "utf8");
+    await writeMarkdownPage(root, "wiki/ideas", IDEA, "---\nstatus: proposed\n---\n\nEnrolled.\n");
+  });
+
+  it("refuses removing the lifecycle field from an enrolled page", async () => {
+    await expectPromoteRefused("---\ntitle: No State\n---\n\nDropped.\n", "proposed");
+  });
+
+  it("allows creating a NEW page with no lifecycle field (no prev)", async () => {
+    const staged = await stageEntityPage(root, {
+      entityType: "ideas", slug: "stateless-new", body: "---\ntitle: Fresh\n---\n\nNo state yet.\n",
+      profile: OPTIONAL_STATUS_PROFILE, existingStagedCount: 0,
+    });
+    expect(staged).toMatchObject({ kind: "page" });
   });
 });
 

--- a/test/profile-validate.test.ts
+++ b/test/profile-validate.test.ts
@@ -261,6 +261,49 @@ describe("validateProfile — lifecycle FSM", () => {
     };
     expect(() => validateProfile(raw)).toThrow(/transitionRequirements|state/i);
   });
+
+  it("rejects a transitionRequirements field that is the reserved 'slug' key", () => {
+    const raw = baseProfile();
+    raw.entities.papers.fields = { status: { type: "enum", enum: ["draft", "done"] } };
+    raw.entities.papers.lifecycle = {
+      field: "status", initial: "draft", terminal: ["done"],
+      transitions: { draft: ["done"] }, transitionRequirements: { done: ["slug"] },
+    };
+    expect(() => validateProfile(raw)).toThrow(/reserved evidence field 'slug'/);
+  });
+
+  it("rejects a transitionRequirements field that is the lifecycle field itself", () => {
+    const raw = baseProfile();
+    raw.entities.papers.fields = { status: { type: "enum", enum: ["draft", "done"] } };
+    raw.entities.papers.lifecycle = {
+      field: "status", initial: "draft", terminal: ["done"],
+      transitions: { draft: ["done"] }, transitionRequirements: { done: ["status"] },
+    };
+    expect(() => validateProfile(raw)).toThrow(/reserved evidence field 'status'/);
+  });
+
+  it("rejects a transitionRequirements field that is not a declared entity field", () => {
+    const raw = baseProfile();
+    raw.entities.papers.fields = { status: { type: "enum", enum: ["draft", "done"] } };
+    raw.entities.papers.lifecycle = {
+      field: "status", initial: "draft", terminal: ["done"],
+      transitions: { draft: ["done"] }, transitionRequirements: { done: ["undeclaredField"] },
+    };
+    expect(() => validateProfile(raw)).toThrow(/evidence field 'undeclaredField' is not a declared field/);
+  });
+
+  it("accepts a transitionRequirements field that IS a declared entity field", () => {
+    const raw = baseProfile();
+    raw.entities.papers.fields = {
+      status: { type: "enum", enum: ["draft", "done"] },
+      reviewedBy: { type: "string" },
+    };
+    raw.entities.papers.lifecycle = {
+      field: "status", initial: "draft", terminal: ["done"],
+      transitions: { draft: ["done"] }, transitionRequirements: { done: ["reviewedBy"] },
+    };
+    expect(() => validateProfile(raw)).not.toThrow();
+  });
 });
 
 describe("validateProfile — field types", () => {

--- a/test/relation-attribute-contract.test.ts
+++ b/test/relation-attribute-contract.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @file test/relation-attribute-contract.test.ts
+ * @description Write-path enforcement of relation ATTRIBUTE contracts (audit
+ * FIX 2): a relation attribute is now run through the SAME field contract as an
+ * entity field (type / enum / min/max), not just required-presence.
+ *
+ * Covers: a relation whose attribute violates its declared type, enum, or
+ * min/max is rejected and nothing is appended — at BOTH the planner
+ * ({@link planRelationMutation} → deny) and the store ({@link appendRelation} →
+ * RelationEndpointError); a valid-attributes relation still appends; and an
+ * UNDECLARED extra attribute is allowed (mirrors entity extra-frontmatter).
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { appendRelation } from "../src/relations/store.js";
+import { readRelations } from "../src/relations/store-read.js";
+import { RelationEndpointError } from "../src/relations/types.js";
+import { planRelationMutation } from "../src/trust/relation-plan.js";
+import { experimentsIdeasProfile, EXPERIMENT_A as EXP_A, IDEA_B } from "./fixtures/profile-fixtures.js";
+
+/** A profile whose `tests` relation declares a bounded-number `confidence` + enum `kind`. */
+const profile = () => experimentsIdeasProfile({
+  tests: {
+    from: ["experiments"], to: ["ideas"], direction: "directed",
+    attributes: { confidence: { type: "number", min: 0, max: 1 }, kind: { type: "enum", enum: ["a", "b"] } },
+    requiredAttributes: ["confidence"],
+  },
+});
+
+let root = "";
+beforeEach(async () => { root = await mkdtemp(path.join(os.tmpdir(), "rel-attr-")); });
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+const write = (attributes: Record<string, unknown>) =>
+  appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes });
+
+const plan = (attributes: Record<string, unknown>) =>
+  planRelationMutation(profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes });
+
+describe("relation attribute contract enforcement (FIX 2)", () => {
+  it("store rejects a wrong-typed attribute and writes nothing", async () => {
+    await expect(write({ confidence: "x" })).rejects.toThrow(RelationEndpointError);
+    await expect(readRelations(root)).resolves.toMatchObject({ relations: [] });
+  });
+
+  it("store rejects an out-of-range number and a bad enum", async () => {
+    await expect(write({ confidence: 2 })).rejects.toThrow(/exceeds max/);
+    await expect(write({ confidence: 0.5, kind: "z" })).rejects.toThrow(/not one of/);
+  });
+
+  it("planner denies a contract-violating relation", () => {
+    expect(plan({ confidence: "x" }).decision).toBe("deny");
+  });
+
+  it("appends a valid-attributes relation (extra undeclared attr allowed)", async () => {
+    const ref = await write({ confidence: 0.5, kind: "a", note: "extra-ok" });
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].id).toBe(ref.id);
+  });
+});

--- a/test/relation-compaction-confine.test.ts
+++ b/test/relation-compaction-confine.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @file test/relation-compaction-confine.test.ts
+ * @description Confinement test for the compaction temp write (FIX 1).
+ *
+ * `compactRelations` rewrites the store via a RANDOM-named temp file opened with
+ * O_EXCL ("wx") inside the confined graph dir, then renames it over
+ * `relations.jsonl`. This proves the hardened discipline: a pre-planted SYMLINK at
+ * the (old, predictable) compaction temp path pointing OUT of the project must NOT
+ * be followed — compaction FAILS CLOSED, the outside file is UNCHANGED, and
+ * `relations.jsonl` is NOT replaced by a symlink. A normal compaction still
+ * collapses superseded records and shrinks the file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, symlink, readFile, lstat, writeFile, open } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { EntityId, ProfilePack } from "../src/profile/types.js";
+import { RELATIONS_FILE, WIKI_GRAPH_DIR } from "../src/utils/constants.js";
+import { appendRelation, updateRelation, compactRelations } from "../src/relations/store.js";
+import { readRelations } from "../src/relations/store-read.js";
+
+const EXP_A = "experiments/a" as EntityId;
+const IDEA_B = "ideas/b" as EntityId;
+
+/** A minimal directed-relation profile for the compaction tests. */
+function profile(): ProfilePack {
+  return {
+    schemaVersion: 1,
+    profileId: "research",
+    entities: { experiments: { directory: "wiki/experiments" }, ideas: { directory: "wiki/ideas" } },
+    relations: { tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } },
+  };
+}
+
+let root = "";
+let outside = "";
+const storePath = (): string => path.join(root, RELATIONS_FILE);
+/** The PREDICTABLE legacy compaction temp path (the symlink-clobber target). */
+const legacyTmp = (): string => path.join(root, WIKI_GRAPH_DIR, `${path.basename(RELATIONS_FILE)}.compact.tmp`);
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "rel-compact-"));
+  outside = await mkdtemp(path.join(os.tmpdir(), "rel-outside-"));
+});
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  if (outside) await rm(outside, { recursive: true, force: true });
+});
+
+describe("compaction temp-write confinement (FIX 1)", () => {
+  it("refuses a pre-planted symlink at the predictable temp path; outside file untouched", async () => {
+    const ref = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { a: "1" } });
+    await updateRelation(root, profile(), ref.id, { attributes: { a: "2" } });
+    const secret = path.join(outside, "secret.txt");
+    await writeFile(secret, "DO NOT OVERWRITE", "utf8");
+    await symlink(secret, legacyTmp()); // pre-plant the symlink-to-FILE clobber
+
+    await expect(compactRelations(root, profile())).resolves.toBeDefined();
+
+    expect(await readFile(secret, "utf8")).toBe("DO NOT OVERWRITE");
+    expect((await lstat(storePath())).isSymbolicLink()).toBe(false);
+  });
+
+  it("the O_EXCL ('wx') temp open FAILS CLOSED on a pre-existing symlink (the load-bearing primitive)", async () => {
+    const secret = path.join(outside, "secret.txt");
+    await writeFile(secret, "DO NOT OVERWRITE", "utf8");
+    const planted = path.join(root, "planted.tmp");
+    await symlink(secret, planted);
+
+    // The exact open the hardened compaction uses: a pre-existing entry (incl. a
+    // symlink-to-FILE) makes "wx" throw EEXIST — it is never followed.
+    await expect(open(planted, "wx")).rejects.toMatchObject({ code: "EEXIST" });
+    expect(await readFile(secret, "utf8")).toBe("DO NOT OVERWRITE");
+  });
+
+  it("normal compaction collapses superseded records and shrinks the file", async () => {
+    const ref = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { a: "1" } });
+    await updateRelation(root, profile(), ref.id, { attributes: { a: "2" } });
+    await updateRelation(root, profile(), ref.id, { attributes: { a: "3" } });
+
+    const { before, after } = await compactRelations(root, profile());
+
+    expect(after).toBeLessThan(before);
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].attributes).toEqual({ a: "3" });
+    expect((await lstat(storePath())).isSymbolicLink()).toBe(false);
+  });
+});

--- a/test/relation-contract.test.ts
+++ b/test/relation-contract.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @file test/relation-contract.test.ts
+ * @description Unit tests for the shared relation-contract validators (audit
+ * FIX 2 + FIX 4) and the lifecycle-deletion gate (FIX 3) — pure, no I/O.
+ *
+ * Covers: relation attributes validated against the declared FieldDef contract
+ * (type/enum/min/max), required-presence, extra-attribute tolerance; a stored
+ * relation re-validated against the CURRENT profile (type removed / endpoint
+ * disallowed / attribute now invalid); and that removing a lifecycle field from
+ * an ENROLLED page is rejected while a never-enrolled create stays exempt.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateRelationAttributes,
+  validateRelationAgainstProfile,
+} from "../src/relations/relation-contract.js";
+import { validateLifecycleTransition } from "../src/profile/lifecycle.js";
+import type { EntityId, LifecycleDef, RelationTypeDef } from "../src/profile/types.js";
+import type { RelationRef } from "../src/relations/types.js";
+import { experimentsIdeasProfile } from "./fixtures/profile-fixtures.js";
+
+/** A relation-type def with a bounded-number `confidence` and an enum `kind`. */
+const REL_DEF: RelationTypeDef = {
+  from: ["experiments"],
+  to: ["ideas"],
+  direction: "directed",
+  attributes: {
+    confidence: { type: "number", min: 0, max: 1 },
+    kind: { type: "enum", enum: ["a", "b"] },
+  },
+  requiredAttributes: ["confidence"],
+};
+
+/** A profile whose `tests` relation matches {@link REL_DEF}. */
+const profile = () => experimentsIdeasProfile({ tests: REL_DEF });
+
+/** A stored relation ref of type `tests` with the given attributes. */
+function ref(attributes: Record<string, unknown>): RelationRef {
+  return {
+    id: "rel_x", type: "tests",
+    from: "experiments/a" as EntityId, to: "ideas/b" as EntityId,
+    attributes, contentHash: "h",
+  };
+}
+
+describe("validateRelationAttributes (FIX 2)", () => {
+  it("accepts valid attributes and tolerates extra undeclared ones", () => {
+    expect(validateRelationAttributes(REL_DEF, { confidence: 0.5, extra: "ok" })).toEqual([]);
+  });
+
+  it("rejects a wrong-typed value, an out-of-range number, and a bad enum", () => {
+    expect(validateRelationAttributes(REL_DEF, { confidence: "x" })[0]).toMatch(/not a valid number/);
+    expect(validateRelationAttributes(REL_DEF, { confidence: 2 })[0]).toMatch(/exceeds max/);
+    expect(validateRelationAttributes(REL_DEF, { confidence: 0.5, kind: "z" })[0]).toMatch(/not one of/);
+  });
+
+  it("reports a missing required attribute", () => {
+    expect(validateRelationAttributes(REL_DEF, {})[0]).toMatch(/missing required attribute 'confidence'/);
+  });
+});
+
+describe("validateRelationAgainstProfile (FIX 4)", () => {
+  it("passes a still-valid stored relation", () => {
+    expect(validateRelationAgainstProfile(ref({ confidence: 0.5 }), profile())).toEqual([]);
+  });
+
+  it("flags a relation whose type the profile no longer declares", () => {
+    const p = profile();
+    delete p.relations!.tests;
+    expect(validateRelationAgainstProfile(ref({ confidence: 0.5 }), p)[0]).toMatch(/no longer declared/);
+  });
+
+  it("flags a relation whose attribute is now invalid under the profile", () => {
+    expect(validateRelationAgainstProfile(ref({ confidence: 9 }), profile())[0]).toMatch(/exceeds max/);
+  });
+});
+
+/** The research-lite `ideas` lifecycle FSM, abbreviated. */
+const LIFECYCLE: LifecycleDef = {
+  field: "status",
+  initial: "proposed",
+  terminal: ["validated"],
+  transitions: { proposed: ["testing"], testing: ["validated"] },
+};
+
+describe("validateLifecycleTransition — deletion gate (FIX 3)", () => {
+  it("rejects removing the field from an enrolled page", () => {
+    const problems = validateLifecycleTransition(LIFECYCLE, "proposed", undefined, {});
+    expect(problems[0]).toMatch(/cannot be removed from an enrolled page/);
+  });
+
+  it("allows a never-enrolled create with no lifecycle field", () => {
+    expect(validateLifecycleTransition(LIFECYCLE, undefined, undefined, {})).toEqual([]);
+  });
+
+  it("still passes a legal transition", () => {
+    expect(validateLifecycleTransition(LIFECYCLE, "proposed", "testing", { status: "testing" })).toEqual([]);
+  });
+});

--- a/test/relation-graph-confine.test.ts
+++ b/test/relation-graph-confine.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @file test/relation-graph-confine.test.ts
+ * @description Graph-parent confinement regression for the relation store
+ * (audit FIX 1): a symlinked `wiki` PARENT must fail closed even when
+ * `wiki/graph` itself does not yet exist, so a relation write can never mkdir +
+ * append OUTSIDE the project root.
+ *
+ * Covers: append fails closed (nothing created outside root) when `wiki` is a
+ * symlink escaping root and `wiki/graph` is absent; the normal (real dir) path
+ * still appends + reads; and an EXISTING symlinked `wiki/graph` still fails
+ * closed (regression of the prior leaf-only fix).
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, symlink, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { appendRelation } from "../src/relations/store.js";
+import { readRelations } from "../src/relations/store-read.js";
+import { experimentsIdeasProfile, EXPERIMENT_A as EXP_A, IDEA_B } from "./fixtures/profile-fixtures.js";
+
+/** A non-default profile with a directed `tests` relation. */
+const profile = () => experimentsIdeasProfile({ tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } });
+
+let root = "";
+let outside = "";
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "rel-confine-"));
+  outside = await mkdtemp(path.join(os.tmpdir(), "rel-out-"));
+});
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  if (outside) await rm(outside, { recursive: true, force: true });
+});
+
+const append = () => appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: {} });
+
+describe("relation graph-parent confinement (FIX 1)", () => {
+  it("fails closed when `wiki` is a symlinked escape and `wiki/graph` is absent", async () => {
+    await symlink(outside, path.join(root, "wiki")); // wiki -> outside; graph absent
+    await expect(append()).rejects.toThrow(/escapes project root/);
+    expect(existsSync(path.join(outside, "graph"))).toBe(false);
+    expect(await readdir(outside)).toEqual([]); // nothing written outside root
+  });
+
+  it("still appends + reads fine on the normal real-directory path", async () => {
+    const ref = await append();
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].id).toBe(ref.id);
+  });
+
+  it("still fails closed when `wiki/graph` itself is a symlink (prior-fix regression)", async () => {
+    await mkdir(path.join(root, "wiki"), { recursive: true });
+    await symlink(outside, path.join(root, "wiki", "graph"));
+    await expect(append()).rejects.toThrow(/escapes project root|not a directory/);
+  });
+});

--- a/test/relation-graph-confine.test.ts
+++ b/test/relation-graph-confine.test.ts
@@ -11,49 +11,31 @@
  * closed (regression of the prior leaf-only fix).
  */
 
-import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, symlink, readdir } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
+import { mkdir, symlink, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
-import { appendRelation } from "../src/relations/store.js";
-import { readRelations } from "../src/relations/store-read.js";
-import { experimentsIdeasProfile, EXPERIMENT_A as EXP_A, IDEA_B } from "./fixtures/profile-fixtures.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+import { appendTestRelation, expectNormalAppendAndRead } from "./fixtures/relation-confine.js";
 
-/** A non-default profile with a directed `tests` relation. */
-const profile = () => experimentsIdeasProfile({ tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } });
-
-let root = "";
-let outside = "";
-beforeEach(async () => {
-  root = await mkdtemp(path.join(os.tmpdir(), "rel-confine-"));
-  outside = await mkdtemp(path.join(os.tmpdir(), "rel-out-"));
-});
-afterEach(async () => {
-  if (root) await rm(root, { recursive: true, force: true });
-  if (outside) await rm(outside, { recursive: true, force: true });
-});
-
-const append = () => appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: {} });
+const ctx = useConfinementRoots("rel");
+const append = () => appendTestRelation(ctx.root);
 
 describe("relation graph-parent confinement (FIX 1)", () => {
   it("fails closed when `wiki` is a symlinked escape and `wiki/graph` is absent", async () => {
-    await symlink(outside, path.join(root, "wiki")); // wiki -> outside; graph absent
+    await symlink(ctx.outside, path.join(ctx.root, "wiki")); // wiki -> outside; graph absent
     await expect(append()).rejects.toThrow(/escapes project root/);
-    expect(existsSync(path.join(outside, "graph"))).toBe(false);
-    expect(await readdir(outside)).toEqual([]); // nothing written outside root
+    expect(existsSync(path.join(ctx.outside, "graph"))).toBe(false);
+    expect(await readdir(ctx.outside)).toEqual([]); // nothing written outside root
   });
 
   it("still appends + reads fine on the normal real-directory path", async () => {
-    const ref = await append();
-    const { relations } = await readRelations(root);
-    expect(relations).toHaveLength(1);
-    expect(relations[0].id).toBe(ref.id);
+    await expectNormalAppendAndRead(ctx.root);
   });
 
   it("still fails closed when `wiki/graph` itself is a symlink (prior-fix regression)", async () => {
-    await mkdir(path.join(root, "wiki"), { recursive: true });
-    await symlink(outside, path.join(root, "wiki", "graph"));
+    await mkdir(path.join(ctx.root, "wiki"), { recursive: true });
+    await symlink(ctx.outside, path.join(ctx.root, "wiki", "graph"));
     await expect(append()).rejects.toThrow(/escapes project root|not a directory/);
   });
 });

--- a/test/relation-lint.test.ts
+++ b/test/relation-lint.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @file test/relation-lint.test.ts
+ * @description Tests for relation-store lint (Phase 4 PR6) — making the
+ * append-only relation store VISIBLE through the profile-aware lint runner.
+ *
+ * Covers: a dangling relation (an endpoint EntityId with no page) yields a
+ * `dangling-relation` finding naming the relation id + missing endpoint; a
+ * healthy relation (both endpoints have pages) yields none; a torn trailing
+ * line surfaces a `relation-store-torn` finding (fail-open, tolerated); a
+ * corrupt / too-new store fails CLOSED into a `relation-store-corrupt` /
+ * `relation-store-too-new` finding rather than crashing lint; and a DEFAULT
+ * project (no wiki/graph) plus a relation-LESS non-default project emit NO
+ * relation findings (byte-identical default path).
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, appendFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { lint } from "../src/linter/index.js";
+import { RELATIONS_FILE, CONCEPTS_DIR } from "../src/utils/constants.js";
+import {
+  buildResearchLiteProject,
+  buildResearchLiteRelationsProject,
+  seedTestsRelation,
+} from "./fixtures/profile-fixtures.js";
+
+let root = "";
+
+/** Rule ids the relation-store lint emits (dangling + the three store-read codes). */
+const RELATION_RULES = ["dangling-relation", "relation-store-torn", "relation-store-corrupt", "relation-store-too-new"];
+
+/** All lint findings emitted by the relation-store check. */
+async function relationFindings(): Promise<{ rule: string; message: string }[]> {
+  const { results } = await lint(root);
+  return results.filter((r) => RELATION_RULES.includes(r.rule));
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "relation-lint-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("relation lint — dangling detection", () => {
+  beforeEach(async () => await buildResearchLiteRelationsProject(root));
+
+  it("flags a relation whose endpoint has no page (dangling-relation)", async () => {
+    const ref = await seedTestsRelation(root, "ablation-batch-size", "ghost-idea");
+    const findings = await relationFindings();
+    const dangling = findings.filter((f) => f.rule === "dangling-relation");
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0].message).toContain(ref.id);
+    expect(dangling[0].message).toContain("ideas/ghost-idea");
+  });
+
+  it("emits no finding for a healthy relation (both endpoints exist)", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    const findings = await relationFindings();
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe("relation lint — torn / corrupt / too-new (fail-closed, no crash)", () => {
+  beforeEach(async () => await buildResearchLiteRelationsProject(root));
+
+  it("surfaces a torn trailing line as relation-store-torn", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    await appendFile(path.join(root, RELATIONS_FILE), '{"id":"rel_torn","type":"tes');
+    const findings = await relationFindings();
+    expect(findings.some((f) => f.rule === "relation-store-torn")).toBe(true);
+  });
+
+  it("fails closed to relation-store-too-new instead of crashing lint", async () => {
+    await mkdir(path.join(root, path.dirname(RELATIONS_FILE)), { recursive: true });
+    await writeFile(path.join(root, RELATIONS_FILE), '{"kind":"relation-store-header","schemaVersion":99}\n');
+    const findings = await relationFindings();
+    expect(findings.some((f) => f.rule === "relation-store-too-new")).toBe(true);
+  });
+});
+
+describe("relation lint — no findings on default / relation-less paths", () => {
+  it("emits no relation findings for a DEFAULT project (no wiki/graph)", async () => {
+    await mkdir(path.join(root, CONCEPTS_DIR), { recursive: true });
+    await writeFile(path.join(root, CONCEPTS_DIR, "foo.md"), "---\ntitle: Foo\n---\n\nbody body body body body.\n");
+    const findings = await relationFindings();
+    expect(findings).toHaveLength(0);
+  });
+
+  it("emits no relation findings for a relation-less non-default project", async () => {
+    await buildResearchLiteProject(root);
+    const findings = await relationFindings();
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/test/relation-profile-adaptation.test.ts
+++ b/test/relation-profile-adaptation.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @file test/relation-profile-adaptation.test.ts
+ * @description Read-surface re-validation of STORED relations against the
+ * CURRENT profile (audit FIX 4): after a profile change drops a relation type,
+ * the on-disk record is RETAINED but reclassified — lint flags it
+ * `relation-profile-invalid`, status does NOT count it as live (surfaces a
+ * problem), and export omits it from the live `RelationView`s. A still-valid
+ * relation is counted / exported normally.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { lint } from "../src/linter/index.js";
+import { collectStatus } from "../src/status/collect.js";
+import { exportJson } from "../src/commands/export.js";
+import {
+  buildResearchLiteRelationsProject,
+  seedTestsRelation,
+  RESEARCH_LITE_PROFILE,
+} from "./fixtures/profile-fixtures.js";
+
+let root = "";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "rel-adapt-"));
+  await buildResearchLiteRelationsProject(root);
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+/** Overwrite the profile file with the relation-LESS profile (drops `tests`). */
+async function dropRelationType(): Promise<void> {
+  await writeFile(
+    path.join(root, ".llmwiki", "profile.json"),
+    `${JSON.stringify(RESEARCH_LITE_PROFILE, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+describe("stored relation re-validated against the current profile (FIX 4)", () => {
+  it("lint flags a relation whose type the profile no longer declares", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    await dropRelationType();
+    const { results } = await lint(root);
+    const finding = results.find((r) => r.rule === "relation-profile-invalid");
+    expect(finding?.message).toMatch(/no longer valid against the profile/);
+  });
+
+  it("status does not count the invalid relation as live; surfaces a problem", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    await dropRelationType();
+    const status = await collectStatus(root);
+    expect("relationCounts" in (status.profile ?? {})).toBe(false);
+    expect(status.profile?.problems?.some((p) => /no longer valid against the current profile/.test(p.message))).toBe(true);
+  });
+
+  it("export omits the invalid relation from the live RelationViews", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    await dropRelationType();
+    const doc = await exportJson(root);
+    expect("relations" in (doc.profile ?? {})).toBe(false);
+  });
+
+  it("a still-valid relation is counted and exported normally", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    const status = await collectStatus(root);
+    const doc = await exportJson(root);
+    expect(status.profile?.relationCounts).toEqual({ tests: 1 });
+    expect(doc.profile?.relations).toHaveLength(1);
+  });
+});

--- a/test/relation-store-audit.test.ts
+++ b/test/relation-store-audit.test.ts
@@ -12,7 +12,7 @@
  *    compactRelations collapses superseded records and shrinks the file.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, truncate } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
@@ -116,6 +116,19 @@ describe("FIX #3 — bounded-blocking acquire serializes writers", () => {
     await writeFile(path.join(root, LOCK_FILE), String(process.pid), "utf8");
     const attempt = acquireLockBlocking(root, { timeoutMs: 50, intervalMs: 10 });
     await expect(attempt).rejects.toBeInstanceOf(LockBusyError);
+  });
+
+  it("does NOT spam the busy warning on each intermediate retry (FIX 3)", async () => {
+    await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+    await writeFile(path.join(root, LOCK_FILE), String(process.pid), "utf8");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await acquireLockBlocking(root, { timeoutMs: 60, intervalMs: 10 }).catch(() => {});
+      const busyLines = logSpy.mock.calls.filter(([line]) => String(line).includes("Another compilation is running."));
+      expect(busyLines.length).toBeLessThanOrEqual(1);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });
 

--- a/test/relation-store-audit.test.ts
+++ b/test/relation-store-audit.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @file test/relation-store-audit.test.ts
+ * @description Tests for the Phase 4 relation-store audit fixes:
+ *  - FIX #1: validate-AFTER-canonicalize + symmetric endpoint sets (a symmetric
+ *    edge whose from-type sorts after its to-type writes and re-validates clean).
+ *  - FIX #6: contentHash dedup — (a→b) then (b→a) on a symmetric type, and two
+ *    identical directed creates, collapse to ONE record.
+ *  - FIX #5: updateRelation reads its base under ONE lock (no lost update).
+ *  - FIX #3: N concurrent appends serialize (all succeed); a held lock past the
+ *    timeout throws the busy error.
+ *  - FIX #4: appending at/over the store cap throws RelationStoreFullError;
+ *    compactRelations collapses superseded records and shrinks the file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, truncate } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { EntityId, ProfilePack } from "../src/profile/types.js";
+import { RELATIONS_FILE, MAX_RELATION_STORE_BYTES, LOCK_FILE, LLMWIKI_DIR } from "../src/utils/constants.js";
+import { appendRelation, updateRelation, compactRelations } from "../src/relations/store.js";
+import { readRelations } from "../src/relations/store-read.js";
+import { validateRelationAgainstProfile } from "../src/relations/relation-contract.js";
+import { RelationStoreFullError } from "../src/relations/types.js";
+import { acquireLockBlocking, LockBusyError } from "../src/utils/lock.js";
+
+const EXP_A = "experiments/a" as EntityId;
+const IDEA_B = "ideas/b" as EntityId;
+const ZETA_X = "zeta/x" as EntityId;
+const ALPHA_Y = "alpha/y" as EntityId;
+
+/** A profile whose symmetric `related` lists from:[zeta] AFTER to:[alpha] lexically. */
+function profile(): ProfilePack {
+  return {
+    schemaVersion: 1,
+    profileId: "research",
+    entities: {
+      experiments: { directory: "wiki/experiments" }, ideas: { directory: "wiki/ideas" },
+      zeta: { directory: "wiki/zeta" }, alpha: { directory: "wiki/alpha" },
+    },
+    relations: {
+      tests: { from: ["experiments"], to: ["ideas"], direction: "directed" },
+      related: { from: ["zeta"], to: ["alpha"], direction: "symmetric" },
+    },
+  };
+}
+
+let root = "";
+const storePath = (): string => path.join(root, RELATIONS_FILE);
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "rel-audit-"));
+});
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("FIX #1 — validate after canonicalize, symmetric endpoint sets", () => {
+  it("writes a symmetric zeta→alpha edge whose canonical form re-validates clean", async () => {
+    const ref = await appendRelation(root, profile(), { type: "related", from: ZETA_X, to: ALPHA_Y, attributes: {} });
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(validateRelationAgainstProfile(relations[0], profile())).toEqual([]);
+  });
+
+  it("a directed relation still validates from/to in declared order", async () => {
+    const bad = appendRelation(root, profile(), { type: "tests", from: IDEA_B, to: EXP_A, attributes: {} });
+    await expect(bad).rejects.toThrow(/not an allowed entity type/);
+  });
+});
+
+describe("FIX #6 — contentHash dedup (idempotent create)", () => {
+  it("(a→b) then (b→a) on a symmetric type collapse to ONE record (same id)", async () => {
+    const ab = await appendRelation(root, profile(), { type: "related", from: ZETA_X, to: ALPHA_Y, attributes: {} });
+    const ba = await appendRelation(root, profile(), { type: "related", from: ALPHA_Y, to: ZETA_X, attributes: {} });
+    expect(ba.id).toBe(ab.id);
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+  });
+
+  it("two identical directed creates collapse to one; a distinct edge does not", async () => {
+    const first = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: {} });
+    const dup = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: {} });
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: "ideas/c" as EntityId, attributes: {} });
+    expect(dup.id).toBe(first.id);
+    expect((await readRelations(root)).relations).toHaveLength(2);
+  });
+});
+
+describe("FIX #5 — updateRelation reads its base under one lock", () => {
+  it("merges against the current on-disk latest, not a stale read", async () => {
+    const ref = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { a: "1" } });
+    await updateRelation(root, profile(), ref.id, { attributes: { a: "2" } });
+    const updated = await updateRelation(root, profile(), ref.id, { evidence: [{ sourcePath: "s.md" }] });
+    expect(updated.attributes).toEqual({ a: "2" });
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].attributes).toEqual({ a: "2" });
+  });
+});
+
+describe("FIX #3 — bounded-blocking acquire serializes writers", () => {
+  it("N concurrent appends all succeed (serialized, no spurious throw)", async () => {
+    const writes = Array.from({ length: 20 }, (_, i) =>
+      appendRelation(root, profile(), { type: "tests", from: EXP_A, to: `ideas/n${i}` as EntityId, attributes: {} }),
+    );
+    const refs = await Promise.all(writes);
+    expect(new Set(refs.map((r) => r.id)).size).toBe(20);
+    expect((await readRelations(root)).relations).toHaveLength(20);
+  });
+
+  it("throws LockBusyError when the lock is held past the timeout", async () => {
+    await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+    // A lock file naming THIS (live) process PID is never stale, so the acquire
+    // can never reclaim it — it must time out and throw the busy error.
+    await writeFile(path.join(root, LOCK_FILE), String(process.pid), "utf8");
+    const attempt = acquireLockBlocking(root, { timeoutMs: 50, intervalMs: 10 });
+    await expect(attempt).rejects.toBeInstanceOf(LockBusyError);
+  });
+});
+
+describe("FIX #4 — append cap + compaction", () => {
+  it("appending at/over the store cap throws RelationStoreFullError (not corrupt)", async () => {
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: {} });
+    await truncate(storePath(), MAX_RELATION_STORE_BYTES - 10);
+    const attempt = appendRelation(root, profile(), { type: "tests", from: EXP_A, to: "ideas/z" as EntityId, attributes: {} });
+    await expect(attempt).rejects.toBeInstanceOf(RelationStoreFullError);
+  });
+
+  it("compactRelations collapses superseded records, shrinks the file, and reads/appends still work", async () => {
+    const ref = await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { a: "1" } });
+    await updateRelation(root, profile(), ref.id, { attributes: { a: "2" } });
+    await updateRelation(root, profile(), ref.id, { attributes: { a: "3" } });
+    const { before, after } = await compactRelations(root, profile());
+    expect(after).toBeLessThan(before);
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].attributes).toEqual({ a: "3" });
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: "ideas/c" as EntityId, attributes: {} });
+    expect((await readRelations(root)).relations).toHaveLength(2);
+  });
+});

--- a/test/relation-store-concurrent.test.ts
+++ b/test/relation-store-concurrent.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @file test/relation-store-concurrent.test.ts
+ * @description PROCESS-LEVEL concurrent-writer test for the append-only relation
+ * store (spec 08 requires a real cross-process test for JSONL stores; FIX #13).
+ *
+ * APPROACH: spawn N SEPARATE `node` subprocesses, each importing the PUBLIC SDK
+ * (`createWiki().createRelation`) from the BUILT `dist/index.js` (built once by
+ * the vitest global setup) and appending K relations with DISTINCT endpoint
+ * slugs (so content hashes differ and dedup never collapses them) against the
+ * SAME project root, all at once. Because `createRelation` takes the project lock
+ * with a BLOCKING acquire (prior commit 90b6952), the concurrent writers must
+ * SERIALIZE rather than interleave.
+ *
+ * The verification reuses `readRelations`, which checksum-verifies every line and
+ * FAILS CLOSED on any torn/interior record. So a green read with zero problems is
+ * itself proof that no line was torn or interleaved; we additionally assert the
+ * total equals N*K (none lost, none torn) and the header appears exactly once.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtemp, mkdir, rm, writeFile, readFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { RELATIONS_FILE } from "../src/utils/constants.js";
+import { readRelations } from "../src/relations/store-read.js";
+
+const exec = promisify(execFile);
+
+/** Absolute path to the BUILT public SDK bundle (built once by global setup). */
+const DIST_INDEX = path.resolve("dist/index.js");
+
+/** The two-entity, one-`tests`-relation profile each subprocess writes against. */
+const PROFILE = {
+  schemaVersion: 1,
+  profileId: "research",
+  entities: { experiments: { directory: "wiki/experiments" }, ideas: { directory: "wiki/ideas" } },
+  relations: { tests: { from: ["experiments"], to: ["ideas"], direction: "directed" } },
+};
+
+const WRITERS = 3;
+const APPENDS_PER_WRITER = 8;
+
+let root = "";
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "rel-concurrent-"));
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(path.join(root, ".llmwiki", "profile.json"), JSON.stringify(PROFILE), "utf8");
+});
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+/**
+ * Inline ESM worker source: append `APPENDS_PER_WRITER` `tests` relations whose
+ * `to` slug is `ideas/w<writer>-r<i>` — distinct per (writer, append) so no two
+ * collapse under content-hash dedup.
+ *
+ * @param writer - The writer index, namespacing this process's endpoint slugs.
+ * @returns A self-contained ESM script string to pass to `node -e`.
+ */
+function workerScript(writer: number): string {
+  return `import { createWiki } from ${JSON.stringify(DIST_INDEX)};
+const wiki = createWiki({ root: ${JSON.stringify(root)} });
+for (let i = 0; i < ${APPENDS_PER_WRITER}; i++) {
+  await wiki.createRelation({ type: "tests", from: "experiments/a", to: "ideas/w${writer}-r" + i });
+}`;
+}
+
+/** Spawn one writer subprocess (separate node process), resolving on clean exit. */
+function spawnWriter(writer: number): Promise<void> {
+  return exec("node", ["--input-type=module", "-e", workerScript(writer)]).then(() => undefined);
+}
+
+describe("relation store — concurrent writers (subprocess, spec 08)", () => {
+  it("serializes N processes' appends with no torn, lost, or interleaved records", async () => {
+    await Promise.all(Array.from({ length: WRITERS }, (_unused, w) => spawnWriter(w)));
+
+    const { relations, problems } = await readRelations(root);
+    expect(problems).toEqual([]); // checksum-verified read: any tear would surface here
+    expect(relations).toHaveLength(WRITERS * APPENDS_PER_WRITER);
+
+    const raw = await readFile(path.join(root, RELATIONS_FILE), "utf8");
+    const headers = raw.split("\n").filter((line) => line.includes("relation-store-header"));
+    expect(headers).toHaveLength(1);
+  }, 60_000);
+});

--- a/test/relation-store-leaf-symlink.test.ts
+++ b/test/relation-store-leaf-symlink.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @file test/relation-store-leaf-symlink.test.ts
+ * @description Leaf-defense regression for the relation store FILE (audit FIX):
+ * the graph DIR and the compaction TEMP leaf were confined, but the canonical
+ * store FILE leaf `wiki/graph/relations.jsonl` was NOT. A pre-planted SYMLINK at
+ * that leaf — pointing to an OUT-OF-TREE file that already carries a valid
+ * relation-store header — must NOT be followed: the no-follow open fails the
+ * append/read closed (ELOOP), so no record ever lands outside root and a read
+ * never returns the outside content.
+ *
+ * Covers: append/create fails closed (outside file UNCHANGED, leaf still a
+ * symlink — never written through); read fails closed (does not return the
+ * outside content); a NORMAL real-file store still appends + reads (regression).
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, symlink, writeFile, readFile, lstat } from "node:fs/promises";
+import path from "node:path";
+import { RELATIONS_FILE, WIKI_GRAPH_DIR } from "../src/utils/constants.js";
+import { readRelations } from "../src/relations/store-read.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+import { appendTestRelation, expectNormalAppendAndRead } from "./fixtures/relation-confine.js";
+
+const ctx = useConfinementRoots("rel-leaf");
+const storePath = (): string => path.join(ctx.root, RELATIONS_FILE);
+/** An out-of-tree file pre-seeded with a VALID relation-store header line. */
+const outsideStore = (): string => path.join(ctx.outside, "outside-store.jsonl");
+
+/** Plant `relations.jsonl` as a symlink to a header-bearing out-of-tree file. */
+async function plantLeafSymlink(): Promise<string> {
+  await mkdir(path.join(ctx.root, WIKI_GRAPH_DIR), { recursive: true });
+  const header = JSON.stringify({ kind: "relation-store-header", schemaVersion: 1 }) + "\n";
+  await writeFile(outsideStore(), header, "utf8");
+  await symlink(outsideStore(), storePath());
+  return header;
+}
+
+describe("relation store FILE-leaf no-follow (symlink write-escape)", () => {
+  it("append fails closed; outside file UNCHANGED and leaf still a symlink", async () => {
+    const header = await plantLeafSymlink();
+    await expect(appendTestRelation(ctx.root)).rejects.toThrow();
+    expect(await readFile(outsideStore(), "utf8")).toBe(header); // no record appended
+    expect((await lstat(storePath())).isSymbolicLink()).toBe(true); // never written through
+  });
+
+  it("read fails closed; does NOT return the outside content", async () => {
+    await plantLeafSymlink();
+    await expect(readRelations(ctx.root)).rejects.toThrow();
+  });
+
+  it("a NORMAL real-file store still appends + reads fine (regression)", async () => {
+    await expectNormalAppendAndRead(ctx.root);
+    expect((await lstat(storePath())).isSymbolicLink()).toBe(false);
+  });
+});

--- a/test/relation-store.test.ts
+++ b/test/relation-store.test.ts
@@ -11,13 +11,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, mkdir, readFile, writeFile, appendFile, symlink } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, readFile, writeFile, appendFile, symlink, truncate } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import type { EntityId, ProfilePack } from "../src/profile/types.js";
-import { RELATIONS_FILE } from "../src/utils/constants.js";
+import { RELATIONS_FILE, MAX_RELATION_STORE_BYTES, MAX_RELATION_RECORD_BYTES } from "../src/utils/constants.js";
 import { appendRelation, updateRelation } from "../src/relations/store.js";
 import { readRelations } from "../src/relations/store-read.js";
+import { recordChecksum } from "../src/relations/store-record.js";
+import type { RelationRef } from "../src/relations/types.js";
 import {
   RelationEndpointError,
   RelationStoreCorruptError,
@@ -46,6 +48,24 @@ afterEach(async () => { if (root) await rm(root, { recursive: true, force: true 
 
 /** Append-mode test profile + the on-disk store path. */
 const storePath = (): string => path.join(root, RELATIONS_FILE);
+
+/** Build a JSONL record line carrying a VALID checksum but caller-chosen endpoints. */
+function forgeRecord(parts: { type: string; from: string; to: string }): string {
+  const ref = {
+    id: "rel_forged0000000000000000000",
+    type: parts.type,
+    from: parts.from as EntityId,
+    to: parts.to as EntityId,
+    attributes: {},
+    contentHash: "deadbeef",
+  } as RelationRef;
+  return JSON.stringify({ ...ref, checksum: recordChecksum(ref) });
+}
+
+/** A well-formed valid-checksum trailing record, so the forged line is INTERIOR. */
+function serializeValidTail(): string {
+  return forgeRecord({ type: "tests", from: "experiments/tail", to: "ideas/tail" }) + "\n";
+}
 
 describe("appendRelation / readRelations round-trip", () => {
   it("persists a relation with a rel_ id and stable contentHash", async () => {
@@ -100,6 +120,47 @@ describe("durability: torn / corrupt / too-new", () => {
     await mkdir(path.dirname(storePath()), { recursive: true });
     await writeFile(storePath(), '{"kind":"relation-store-header","schemaVersion":99}\n');
     await expect(readRelations(root)).rejects.toThrow(RelationStoreTooNewError);
+  });
+});
+
+describe("resource caps (DoS — fail closed)", () => {
+  it("fails closed when the store file exceeds the byte cap", async () => {
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    // Sparse-grow the file past the cap without writing GBs; the stat-first guard
+    // must reject it before the full readFile/validation runs.
+    await truncate(storePath(), MAX_RELATION_STORE_BYTES + 1);
+    await expect(readRelations(root)).rejects.toThrow(RelationStoreCorruptError);
+  });
+
+  it("reads a normal (under-cap) store fine", async () => {
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    const { relations, problems } = await readRelations(root);
+    expect(problems).toEqual([]);
+    expect(relations).toHaveLength(1);
+  });
+
+  it("rejects a relation whose attributes exceed the per-record cap, writing nothing", async () => {
+    const huge = "z".repeat(MAX_RELATION_RECORD_BYTES + 1);
+    const bad = appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: huge } });
+    await expect(bad).rejects.toThrow(RelationEndpointError);
+    await expect(readRelations(root)).resolves.toMatchObject({ relations: [] });
+  });
+});
+
+describe("endpoint slug-safety re-validation on read (fail closed)", () => {
+  it("fails closed on an interior record with a traversal endpoint", async () => {
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    // A well-formed (valid-checksum) interior record whose `from` escapes its
+    // namespace must be rejected as interior corruption, not read back intact.
+    const forged = forgeRecord({ type: "tests", from: "../../etc/passwd", to: IDEA_B });
+    await appendFile(storePath(), forged + "\n");
+    await appendFile(storePath(), serializeValidTail());
+    await expect(readRelations(root)).rejects.toThrow(RelationStoreCorruptError);
+  });
+
+  it("reads valid endpoints fine", async () => {
+    await appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes: { note: "x" } });
+    await expect(readRelations(root)).resolves.toMatchObject({ relations: [{ from: EXP_A }] });
   });
 });
 

--- a/test/relation-surface.test.ts
+++ b/test/relation-surface.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @file test/relation-surface.test.ts
+ * @description Tests for relation READ surfacing (Phase 4 PR6) — relation
+ * counts in the additive status/viewer profile block and path-safe
+ * `RelationView`s in the JSON export profile block.
+ *
+ * Covers: status surfaces `relationCounts` (per type) + `relationTotal` for a
+ * project with relations; export surfaces the `RelationView`s (no absolute
+ * paths, no evidence file paths); a corrupt store surfaces a status `problem`
+ * (fail-closed, no crash); and a DEFAULT project plus a relation-less
+ * non-default project emit NO relation fields (status/export byte-identical).
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { collectStatus } from "../src/status/collect.js";
+import { exportJson } from "../src/commands/export.js";
+import { RELATIONS_FILE, CONCEPTS_DIR } from "../src/utils/constants.js";
+import {
+  buildResearchLiteProject,
+  buildResearchLiteRelationsProject,
+  seedTestsRelation,
+} from "./fixtures/profile-fixtures.js";
+
+let root = "";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "relation-surface-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("status profile block — relation counts", () => {
+  beforeEach(async () => await buildResearchLiteRelationsProject(root));
+
+  it("reports relationCounts per type and relationTotal", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    await seedTestsRelation(root, "ablation-batch-size", "curriculum-pretraining");
+    const status = await collectStatus(root);
+    expect(status.profile?.relationCounts).toEqual({ tests: 2 });
+    expect(status.profile?.relationTotal).toBe(2);
+  });
+
+  it("surfaces a corrupt store as a problem rather than crashing", async () => {
+    await mkdir(path.join(root, path.dirname(RELATIONS_FILE)), { recursive: true });
+    await writeFile(path.join(root, RELATIONS_FILE), '{"kind":"relation-store-header","schemaVersion":99}\n');
+    const status = await collectStatus(root);
+    expect(status.profile?.problems?.some((p) => /relation store/i.test(p.message))).toBe(true);
+    expect("relationCounts" in (status.profile ?? {})).toBe(false);
+  });
+});
+
+describe("export profile block — relation views (path-safe)", () => {
+  beforeEach(async () => await buildResearchLiteRelationsProject(root));
+
+  it("includes a RelationView per relation with no absolute paths", async () => {
+    const ref = await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    const doc = await exportJson(root);
+    expect(doc.profile?.relations).toHaveLength(1);
+    const view = doc.profile!.relations![0];
+    expect(view).toMatchObject({
+      id: ref.id, type: "tests",
+      from: "experiments/ablation-batch-size", to: "ideas/sparse-routing",
+    });
+    const json = JSON.stringify(doc.profile?.relations);
+    expect(json).not.toContain(root);
+    expect(json).not.toContain("evidence");
+  });
+});
+
+describe("relation fields — omitted on default / relation-less paths", () => {
+  it("a DEFAULT project emits no relationCounts or relations keys", async () => {
+    await writeFile(path.join(root, "x.md"), "x");
+    await mkdir(path.join(root, CONCEPTS_DIR), { recursive: true });
+    const status = await collectStatus(root);
+    const doc = await exportJson(root);
+    expect(status.profile).toBeUndefined();
+    expect("profile" in doc).toBe(false);
+  });
+
+  it("a relation-LESS non-default project emits no relation fields", async () => {
+    await buildResearchLiteProject(root);
+    const status = await collectStatus(root);
+    const doc = await exportJson(root);
+    expect("relationCounts" in (status.profile ?? {})).toBe(false);
+    expect("relationTotal" in (status.profile ?? {})).toBe(false);
+    expect("relations" in (doc.profile ?? {})).toBe(false);
+  });
+});

--- a/test/sdk-relation-lifecycle.test.ts
+++ b/test/sdk-relation-lifecycle.test.ts
@@ -74,6 +74,23 @@ describe("createWiki() relation + lifecycle round-trip", () => {
     expect(page).toContain("status: failed");
     expect(page).toContain("failureReason: out of compute");
   });
+
+  it("merges only declared evidence — clobber/identity keys are dropped (FIX #2)", async () => {
+    const pagePath = path.join(root, "wiki/ideas/sparse-routing.md");
+    await writeFile(pagePath, "---\nstatus: tested\ntitle: Original Title\n---\n\nBody.\n", "utf8");
+    const wiki = createWiki({ root });
+    await wiki.transitionLifecycle({
+      entityType: "ideas", slug: "sparse-routing", toState: "failed",
+      evidence: { failureReason: "ran out of budget", title: "overwritten", slug: "../../escape", junk: "y" },
+    });
+    const page = await readFile(pagePath, "utf8");
+    expect(page).toContain("status: failed");
+    expect(page).toContain("failureReason: ran out of budget");
+    expect(page).toContain("title: Original Title"); // untouched
+    expect(page).not.toContain("overwritten");
+    expect(page).not.toContain("escape");
+    expect(page).not.toContain("junk");
+  });
 });
 
 describe("transitionLifecycle — lock discipline", () => {

--- a/test/sdk-relation-lifecycle.test.ts
+++ b/test/sdk-relation-lifecycle.test.ts
@@ -13,9 +13,13 @@ import os from "node:os";
 import type { EntityId, ProfilePack } from "../src/profile/types.js";
 import { createWiki } from "../src/index.js";
 import { RelationsRequireProfileError } from "../src/trust/relation-write.js";
+import {
+  transitionLifecycle,
+  LifecycleTransitionLockError,
+} from "../src/trust/lifecycle-transition.js";
 import { LifecycleTransitionError } from "../src/profile/lifecycle.js";
 import { readRelations } from "../src/relations/store-read.js";
-import { PROFILE_FILE } from "../src/utils/constants.js";
+import { PROFILE_FILE, LOCK_FILE } from "../src/utils/constants.js";
 import { buildResearchLiteProject, RESEARCH_LITE_PROFILE } from "./fixtures/profile-fixtures.js";
 
 const EXP = "experiments/ablation-batch-size" as EntityId;
@@ -69,6 +73,23 @@ describe("createWiki() relation + lifecycle round-trip", () => {
     const page = await readFile(path.join(root, "wiki/ideas/sparse-routing.md"), "utf8");
     expect(page).toContain("status: failed");
     expect(page).toContain("failureReason: out of compute");
+  });
+});
+
+describe("transitionLifecycle — lock discipline", () => {
+  /**
+   * A lock file naming THIS (live) process PID is not stale, so acquireLock
+   * fails. The transition must refuse cleanly and leave the page UNCHANGED.
+   */
+  it("refuses cleanly when the project lock is held, leaving the page unchanged", async () => {
+    const pagePath = path.join(root, "wiki/ideas/sparse-routing.md");
+    const before = await readFile(pagePath, "utf8");
+    await writeFile(path.join(root, LOCK_FILE), String(process.pid), "utf8");
+
+    const attempt = transitionLifecycle(root, "ideas", "sparse-routing", "testing");
+    await expect(attempt).rejects.toBeInstanceOf(LifecycleTransitionLockError);
+
+    expect(await readFile(pagePath, "utf8")).toBe(before);
   });
 });
 

--- a/test/trust-relation-write.test.ts
+++ b/test/trust-relation-write.test.ts
@@ -61,6 +61,18 @@ describe("createRelation (planner-gated)", () => {
     await expect(bad).rejects.toBeInstanceOf(RelationWriteDeniedError);
     await expect(readRelations(root)).resolves.toMatchObject({ relations: [] });
   });
+
+  it("plans+writes a symmetric edge in reverse lexical order (planner agrees with the store)", async () => {
+    const symProfile = {
+      ...RESEARCH_LITE_PROFILE,
+      relations: { peers: { from: ["experiments"], to: ["ideas"], direction: "symmetric" } },
+    } as ProfilePack;
+    // ideas/... sorts before experiments/..., so the planner judges the CANONICAL
+    // (swapped) endpoints — a reversed symmetric write is allowed, not denied.
+    const ref = await createRelation(root, symProfile, { type: "peers", from: IDEA, to: EXP });
+    expect(ref.id).toMatch(/^rel_/);
+    expect((await readRelations(root)).relations).toHaveLength(1);
+  });
 });
 
 describe("transitionLifecycle (validated page update)", () => {


### PR DESCRIPTION
Top of the Phase 4 stack (do not merge yet). Makes the relation store visible.

- **Lint:** `checkRelationStore` reads the store fail-closed — a corrupt/too-new store surfaces a lint finding (never crashes lint), a torn trailing line surfaces a warning, and a relation whose from/to endpoint has no page is flagged `dangling-relation`.
- **Status/viewer:** the additive profile block gains optional `relationCounts`/`relationTotal` (per relation type), populated only when a non-default profile has a non-empty store; a fail-closed read surfaces a problem instead of crashing status.
- **JSON export:** the profile block gains an optional, path-safe `RelationView[]` DTO (id/type/from/to/attributes/contentHash — no paths).

Every new field is optional and omitted-for-default, so a default project and a relation-less non-default project emit no relation fields — status/export/lint byte-identical; full suite green (2203).

Deferred (noted): viewer graph filters and context-pack relation expansion.