### PR TITLE
fix(security): harden atomicWrite + all temp-writers against the systemic leaf-symlink write-escape

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -858,7 +858,7 @@ async function generateMergedPage(
   }
 
   const pagePath = path.join(root, CONCEPTS_DIR, `${entry.slug}.md`);
-  const error = await writePageIfValid(pagePath, fullPage, entry.concept.concept);
+  const error = await writePageIfValid(root, pagePath, fullPage, entry.concept.concept);
   if (!error) await deleteCandidateBySlug(root, entry.slug);
   return { error: error ?? undefined, wrotePage: !error };
 }
@@ -1016,7 +1016,7 @@ async function generateSingleSeedPage(
   addObsidianMeta(frontmatterFields, seed.title, []);
   addModelProvenanceMeta(frontmatterFields);
   const frontmatter = buildFrontmatter(frontmatterFields);
-  const error = await writePageIfValid(pagePath, `${frontmatter}\n\n${pageBody}\n`, seed.title);
+  const error = await writePageIfValid(root, pagePath, `${frontmatter}\n\n${pageBody}\n`, seed.title);
   return error ? { slug, error } : { slug };
 }
 
@@ -1053,12 +1053,16 @@ async function extractConcepts(
 }
 
 /**
- * Validate and atomically write a wiki page, logging the result.
+ * Validate and atomically write a wiki page, logging the result. The write is
+ * root-confined (`confineRoot: root`) so a symlinked ANCESTOR on the page path
+ * fails closed rather than escaping the project root.
+ * @param root - Project root the write is confined under.
  * @param pagePath - Absolute path to write the page.
  * @param content - Full page content including frontmatter.
  * @param conceptTitle - Title for logging purposes.
  */
 async function writePageIfValid(
+  root: string,
   pagePath: string,
   content: string,
   conceptTitle: string,
@@ -1068,7 +1072,7 @@ async function writePageIfValid(
     return `Invalid page for "${conceptTitle}" — failed validation`;
   }
 
-  await atomicWrite(pagePath, content);
+  await atomicWrite(pagePath, content, { confineRoot: root });
   const slug = path.basename(pagePath, ".md");
   verbose(`page ${slug}: ${content.length} chars`);
   return null;

--- a/src/compiler/orphan.ts
+++ b/src/compiler/orphan.ts
@@ -20,6 +20,7 @@ import {
 import { findSharedConcepts } from "./deps.js";
 import * as output from "../utils/output.js";
 import { CONCEPTS_DIR } from "../utils/constants.js";
+import { isSafeFilenameComponent } from "../profile/identity.js";
 
 /**
  * Mark wiki pages as orphaned when their source is deleted.
@@ -77,6 +78,11 @@ export async function orphanUnownedFrozenPages(
  * @param reason - Human-readable reason for the log message.
  */
 async function orphanPage(root: string, slug: string, reason: string): Promise<void> {
+  // Belt-and-suspenders: even if state validation is bypassed, a non-safe slug
+  // (`../escape`, an absolute or separator-bearing string) must never path-join
+  // into an out-of-tree write. State read already gates this; this is the
+  // independent floor at the write site.
+  if (!isSafeFilenameComponent(slug)) return;
   const pagePath = path.join(root, CONCEPTS_DIR, `${slug}.md`);
   const content = await safeReadFile(pagePath);
   if (!content) return;
@@ -85,6 +91,6 @@ async function orphanPage(root: string, slug: string, reason: string): Promise<v
   if (meta.orphaned === true) return;
 
   const updated = content.replace("---\n", "---\norphaned: true\n");
-  await atomicWrite(pagePath, updated);
+  await atomicWrite(pagePath, updated, { confineRoot: root });
   output.status("⚠", output.warn(`Orphaned: ${slug}.md (${reason})`));
 }

--- a/src/compiler/rule-state.ts
+++ b/src/compiler/rule-state.ts
@@ -48,7 +48,7 @@ export async function readRuleState(root: string): Promise<WikiState> {
  */
 async function writeRuleState(root: string, state: WikiState): Promise<void> {
   const filePath = path.join(root, RULE_STATE_FILE);
-  await atomicWrite(filePath, JSON.stringify(state, null, 2));
+  await atomicWrite(filePath, JSON.stringify(state, null, 2), { confineRoot: root });
 }
 
 /**

--- a/src/compiler/rule-state.ts
+++ b/src/compiler/rule-state.ts
@@ -13,10 +13,11 @@
  * is always empty because rule extraction produces candidates, not pages.
  */
 
-import { readFile, writeFile, rename, mkdir } from "fs/promises";
+import { readFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { LLMWIKI_DIR, RULE_STATE_FILE } from "../utils/constants.js";
+import { RULE_STATE_FILE } from "../utils/constants.js";
+import { atomicWrite } from "../utils/markdown.js";
 import type { WikiState, SourceState } from "../utils/types.js";
 
 /** A fresh, empty rule-extraction state. */
@@ -40,13 +41,14 @@ export async function readRuleState(root: string): Promise<WikiState> {
   }
 }
 
-/** Atomically write rule-state.json (write .tmp then rename). */
+/**
+ * Atomically write rule-state.json via the shared hardened {@link atomicWrite}
+ * primitive (random O_EXCL temp + rename), so this cursor writer inherits the
+ * same leaf-symlink write-escape defenses rather than carrying its own temp+rename.
+ */
 async function writeRuleState(root: string, state: WikiState): Promise<void> {
-  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
   const filePath = path.join(root, RULE_STATE_FILE);
-  const tmpPath = `${filePath}.tmp`;
-  await writeFile(tmpPath, JSON.stringify(state, null, 2), "utf-8");
-  await rename(tmpPath, filePath);
+  await atomicWrite(filePath, JSON.stringify(state, null, 2));
 }
 
 /**

--- a/src/export/profile-block.ts
+++ b/src/export/profile-block.ts
@@ -16,7 +16,7 @@ import type { JsonExportProfileBlock, RelationView } from "./json-export.js";
 import type { LoadedProfile } from "../profile/types.js";
 import { readRelations } from "../relations/store-read.js";
 import { validateRelationAgainstProfile } from "../relations/relation-contract.js";
-import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
+import { RelationStoreCorruptError, RelationStoreTooNewError, RelationStoreSymlinkError } from "../relations/types.js";
 import type { RelationRef } from "../relations/types.js";
 
 /**
@@ -33,8 +33,8 @@ function toRelationView(ref: RelationRef): RelationView {
  * Read the live relation store for the export, returning path-safe views ONLY
  * for relations STILL VALID against the current profile. A relation-less profile
  * yields `undefined` (no `relations` key, so the export stays byte-identical); a
- * fail-closed read (corrupt / too-new) also yields `undefined` rather than partial
- * relations — lint is the surface that reports a broken store. Relations the
+ * fail-closed read (corrupt / too-new / symlinked-leaf) also yields `undefined`
+ * rather than partial relations — lint is the surface that reports a broken store. Relations the
  * profile has outgrown (type removed / endpoint type disallowed / attributes now
  * invalid) are OMITTED from this live snapshot but retained on disk; lint flags
  * them as `relation-profile-invalid`.
@@ -49,7 +49,13 @@ async function exportRelationViews(root: string, loaded: LoadedProfile): Promise
     const valid = relations.filter((rel) => validateRelationAgainstProfile(rel, loaded.profile).length === 0);
     return valid.length > 0 ? valid.map(toRelationView) : undefined;
   } catch (error) {
-    if (error instanceof RelationStoreCorruptError || error instanceof RelationStoreTooNewError) return undefined;
+    if (
+      error instanceof RelationStoreCorruptError ||
+      error instanceof RelationStoreTooNewError ||
+      error instanceof RelationStoreSymlinkError
+    ) {
+      return undefined;
+    }
     throw error;
   }
 }

--- a/src/profile/block.ts
+++ b/src/profile/block.ts
@@ -24,7 +24,7 @@ import type { EntityPage, EntityProblemView, LoadedProfile } from "./types.js";
 import { safeRealpath } from "../utils/path-confine.js";
 import { readRelations } from "../relations/store-read.js";
 import { validateRelationAgainstProfile } from "../relations/relation-contract.js";
-import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
+import { RelationStoreCorruptError, RelationStoreTooNewError, RelationStoreSymlinkError } from "../relations/types.js";
 import type { RelationRef } from "../relations/types.js";
 
 /**
@@ -81,8 +81,8 @@ export interface ProfileSummaryBlock {
    * profile whose `wiki/graph` store holds at least one relation. OMITTED for
    * the built-in default and for any relation-LESS profile, so the default and
    * relation-less status/viewer envelopes stay byte-identical. A corrupt /
-   * too-new store does NOT populate this — it surfaces through `problems`
-   * instead (fail-closed, never a silent zero).
+   * too-new / symlinked-leaf store does NOT populate this — it surfaces through
+   * `problems` instead (fail-closed, never a silent zero).
    */
   relationCounts?: Record<string, number>;
   /** Total live relation count; present alongside (and equal to the sum of) `relationCounts`. */
@@ -134,7 +134,11 @@ interface RelationSummary {
 
 /** Map a fail-closed relation-store read error to a `relation-store` problem view. */
 function relationReadProblem(error: unknown): EntityProblemView {
-  if (error instanceof RelationStoreTooNewError || error instanceof RelationStoreCorruptError) {
+  if (
+    error instanceof RelationStoreTooNewError ||
+    error instanceof RelationStoreCorruptError ||
+    error instanceof RelationStoreSymlinkError
+  ) {
     return { kind: "relation-store", message: error.message };
   }
   throw error; // a non-store error (e.g. a confinement escape) is not ours to swallow

--- a/src/profile/field-contract.ts
+++ b/src/profile/field-contract.ts
@@ -159,7 +159,12 @@ export function validateFieldsAgainstDefs(
 ): string[] {
   const violations: string[] = [];
   for (const field of requiredNames) {
-    if (!(field in values)) violations.push(missingMessage(field));
+    // Required means an OWN key whose value is not `undefined`: a key present but
+    // set to `undefined` (e.g. a JS attributes object `{rationale: undefined}`)
+    // is dropped by JSON.stringify/canonicalize on persist, so accepting it would
+    // store a record MISSING its required field yet report it valid. Treat an
+    // undefined value as absent so the required check fails closed.
+    if (!(field in values) || values[field] === undefined) violations.push(missingMessage(field));
   }
   for (const [name, fieldDef] of Object.entries(fieldDefs)) {
     collectFieldValueViolations(name, fieldDef, values[name], violations);

--- a/src/profile/relation-lint.ts
+++ b/src/profile/relation-lint.ts
@@ -11,16 +11,17 @@
  *   - `relation-store-torn` (warning): the reader tolerated and REPORTED a torn
  *     trailing line (an incomplete final append). Surfaced verbatim so the
  *     half-written record is visible, not silently dropped.
- *   - `relation-store-corrupt` / `relation-store-too-new` (error): the reader
- *     FAILED CLOSED (interior corruption / an unknown future schema version).
- *     Caught here so lint reports the failure instead of throwing.
+ *   - `relation-store-corrupt` / `relation-store-too-new` / `relation-store-symlink`
+ *     (error): the reader FAILED CLOSED (interior corruption / an unknown future
+ *     schema version / a symlinked-or-non-regular store-file leaf). Caught here so
+ *     lint reports the failure instead of throwing.
  *
  * A DEFAULT project (no `wiki/graph`) reads an EMPTY store, so this yields no
  * findings and the default lint output stays byte-identical.
  */
 
 import { readRelations } from "../relations/store-read.js";
-import { RelationStoreCorruptError, RelationStoreTooNewError } from "../relations/types.js";
+import { RelationStoreCorruptError, RelationStoreTooNewError, RelationStoreSymlinkError } from "../relations/types.js";
 import { validateRelationAgainstProfile } from "../relations/relation-contract.js";
 import type { RelationRef } from "../relations/types.js";
 import type { EntityId, EntityPage, ProfilePack } from "./types.js";
@@ -34,6 +35,8 @@ const RELATION_STORE_TORN_RULE = "relation-store-torn";
 const RELATION_STORE_CORRUPT_RULE = "relation-store-corrupt";
 /** Rule id for a fail-closed unknown-future-schema-version read. */
 const RELATION_STORE_TOO_NEW_RULE = "relation-store-too-new";
+/** Rule id for a fail-closed symlinked/non-regular store-file leaf read. */
+const RELATION_STORE_SYMLINK_RULE = "relation-store-symlink";
 /** Rule id for a stored relation no longer valid against the CURRENT profile. */
 const RELATION_PROFILE_INVALID_RULE = "relation-profile-invalid";
 
@@ -47,6 +50,9 @@ function readErrorFinding(error: unknown): LintResult | null {
   }
   if (error instanceof RelationStoreCorruptError) {
     return { rule: RELATION_STORE_CORRUPT_RULE, severity: "error", file: RELATION_STORE_FILE, message: error.message };
+  }
+  if (error instanceof RelationStoreSymlinkError) {
+    return { rule: RELATION_STORE_SYMLINK_RULE, severity: "error", file: RELATION_STORE_FILE, message: error.message };
   }
   return null;
 }

--- a/src/profile/validate.ts
+++ b/src/profile/validate.ts
@@ -28,7 +28,7 @@
  * Unreachable lifecycle states are collected as warnings, not errors.
  */
 
-import type { ProfilePack, EntityTypeDef, FieldDef, LifecycleDef, RelationTypeDef } from "./types.js";
+import type { ProfilePack, EntityTypeDef, FieldDef, FieldType, LifecycleDef, RelationTypeDef } from "./types.js";
 import { isSlugSafe } from "./identity.js";
 import { validateEntityDirectory } from "./paths.js";
 import { assertStructurallyValid } from "./schema-validator.js";
@@ -128,12 +128,33 @@ function validateRequiredFields(entityType: string, def: EntityTypeDef): void {
 const RESERVED_EVIDENCE_KEYS = new Set(["slug"]);
 
 /**
+ * Field types the runtime evidence gate ({@link isEvidencePresent} in
+ * `lifecycle.ts`) can satisfy: a non-empty string / number / slug / enum value
+ * (a non-empty enum value is a non-empty string), or a non-empty `string[]`.
+ * `boolean`, `object`, and `date` are EXCLUDED — the gate rejects booleans and
+ * objects (a bare `true` proves only key presence, not justification), and a
+ * `date` parses to a Date object the scalar gate cannot accept. A profile
+ * declaring an evidence field of an excluded type would LOAD but its target state
+ * could never be entered (a permanently dead state), so it is rejected at load.
+ */
+const EVIDENCE_COMPATIBLE_TYPES: ReadonlySet<FieldType> = new Set<FieldType>([
+  "string",
+  "number",
+  "integer",
+  "slug",
+  "string[]",
+  "enum",
+]);
+
+/**
  * Reject a profile whose `transitionRequirements` declares any evidence field
  * that can never be satisfied via caller evidence — a RESERVED key (`slug`, or
- * the lifecycle `field` the transition writes) — or that is NOT a DECLARED entity
- * field. Requiring evidence fields to be declared makes them first-class typed
- * fields, so the field contract enforces their type/content. Fails closed at
- * profile LOAD, so an unsatisfiable requirement is never accepted.
+ * the lifecycle `field` the transition writes), one that is NOT a DECLARED entity
+ * field, OR one whose declared `type` the runtime evidence gate can never satisfy
+ * (see {@link EVIDENCE_COMPATIBLE_TYPES} — `boolean`/`object`/`date` would make
+ * the target state permanently unreachable). Requiring evidence fields to be
+ * declared makes them first-class typed fields, so the field contract enforces
+ * their type/content. Fails closed at profile LOAD.
  */
 function assertEvidenceFieldsDeclared(where: string, lc: LifecycleDef, fields?: Record<string, FieldDef>): void {
   const declared = fields ?? {};
@@ -142,6 +163,11 @@ function assertEvidenceFieldsDeclared(where: string, lc: LifecycleDef, fields?: 
       const reserved = RESERVED_EVIDENCE_KEYS.has(field) || field === lc.field;
       assert(!reserved, `${where}: transitionRequirements['${state}'] uses reserved evidence field '${field}'`);
       assert(field in declared, `${where}: transitionRequirements['${state}'] evidence field '${field}' is not a declared field`);
+      const type = declared[field].type;
+      assert(
+        EVIDENCE_COMPATIBLE_TYPES.has(type),
+        `${where}: evidence field '${field}' has type '${type}' which can never satisfy the required-evidence gate`,
+      );
     }
   }
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -234,6 +234,12 @@ export interface Wiki {
    * write (undeclared type, disallowed endpoint, missing required attribute) —
    * nothing is written in either case. No LLM required.
    *
+   * READ-INTEGRATION STATUS: a created relation is a WRITE SUBSTRATE. It lands in
+   * the relation store and is surfaced in `status`, the JSON export, and lint —
+   * but NOT YET in context packs, semantic search / embeddings, the MOC, the
+   * viewer, or any agent-facing read path (those are planned). Do not assume a
+   * created relation participates in retrieval or rendering yet.
+   *
    * Foundation API — the shape may change in a future minor release.
    */
   createRelation(input: AppendRelationInput): Promise<RelationRef>;
@@ -247,6 +253,12 @@ export interface Wiki {
    * Throws `LifecycleTransitionUnavailableError` when the project has no profile,
    * the type is unknown, the type has no lifecycle, or the page does not exist.
    * No LLM required.
+   *
+   * READ-INTEGRATION STATUS: the transition writes the lifecycle-field value into
+   * the page — a WRITE SUBSTRATE surfaced in `status`, the JSON export, and lint,
+   * but NOT YET in context packs, semantic search / embeddings, the MOC, the
+   * viewer, or any agent-facing read path (those are planned). Do not assume the
+   * new lifecycle state participates in retrieval or rendering yet.
    *
    * Foundation API — the shape may change in a future minor release.
    */

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -33,6 +33,7 @@ import path from "path";
 import { LLMWIKI_DIR } from "../utils/constants.js";
 import { realpath } from "fs/promises";
 import { confineUnderRoot, safeRealpath, isInsideDir } from "../utils/path-confine.js";
+import { atomicWrite } from "../utils/markdown.js";
 import { note } from "../utils/output.js";
 
 /** Sentinel recorded when a target did not exist before the batch. */
@@ -91,18 +92,20 @@ async function readOrNull(filePath: string): Promise<string | null> {
   }
 }
 
-/** Atomically persist a batch's current state to its journal file. */
+/**
+ * Atomically persist a batch's current state to its journal file via the shared
+ * hardened {@link atomicWrite} primitive (random O_EXCL temp + rename), so the
+ * journal writer inherits the same leaf-symlink write-escape defenses rather than
+ * carrying its own bespoke temp+rename.
+ */
 async function persist(batch: JournalBatch): Promise<void> {
   const file = journalPath(batch.root, batch.batchId);
-  await mkdir(path.dirname(file), { recursive: true });
-  const tmp = `${file}.tmp`;
   const payload = {
     batchId: batch.batchId,
     status: batch.status,
     entries: batch.entries,
   };
-  await writeFile(tmp, JSON.stringify(payload, null, 2), "utf-8");
-  await rename(tmp, file);
+  await atomicWrite(file, JSON.stringify(payload, null, 2));
 }
 
 /**

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -105,7 +105,7 @@ async function persist(batch: JournalBatch): Promise<void> {
     status: batch.status,
     entries: batch.entries,
   };
-  await atomicWrite(file, JSON.stringify(payload, null, 2));
+  await atomicWrite(file, JSON.stringify(payload, null, 2), { confineRoot: batch.root });
 }
 
 /**

--- a/src/trust/journal.ts
+++ b/src/trust/journal.ts
@@ -73,6 +73,20 @@ function journalDir(root: string): string {
   return path.join(root, LLMWIKI_DIR, "journal");
 }
 
+/**
+ * Fail CLOSED (throw) BEFORE opening a batch when `.llmwiki/journal` — or any
+ * ancestor, e.g. a symlinked `.llmwiki` — escapes the project root. Confines the
+ * journal dir against the nearest existing ancestor via {@link confineUnderRoot},
+ * so a planted escaping symlink is rejected up front with a clear error rather
+ * than only at persist time. A confined real journal dir resolves cleanly (no-op).
+ */
+async function assertJournalDirConfined(root: string): Promise<void> {
+  // Pass the journal dir RELATIVE to root: confineUnderRoot resolves it against
+  // realpath(root), so an absolute path built from a pre-realpath root would be
+  // judged outside on a symlinked root (macOS /var → /private/var).
+  await confineUnderRoot(path.join(LLMWIKI_DIR, "journal"), root, { mustExist: false });
+}
+
 /** Absolute path to a batch's journal file. */
 function journalPath(root: string, batchId: string): string {
   return path.join(journalDir(root), `${batchId}.json`);
@@ -116,6 +130,10 @@ async function persist(batch: JournalBatch): Promise<void> {
  * @returns The opened, persisted {@link JournalBatch}.
  */
 export async function openBatch(root: string): Promise<JournalBatch> {
+  // FAIL CLOSED UP FRONT on a symlinked `.llmwiki/journal` escaping root, with a
+  // clear error, rather than relying solely on the persist-time `confineRoot`
+  // (defense in depth). A confined real journal dir is a no-op on the happy path.
+  await assertJournalDirConfined(root);
   const random = Math.random().toString(36).slice(2, 2 + BATCH_ID_RANDOM_CHARS);
   const batchId = `${Date.now()}-${process.pid}-${random}`;
   const batch: JournalBatch = { batchId, root, status: "pending", entries: [] };

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -22,9 +22,10 @@
  * acquires it cleanly via 'wx'.
  */
 
-import { open, readFile, unlink, mkdir } from "fs/promises";
+import { open, readFile, unlink } from "fs/promises";
 import path from "path";
-import { LLMWIKI_DIR, LOCK_FILE } from "./constants.js";
+import { LOCK_FILE } from "./constants.js";
+import { resolveConfinedPrivateDir } from "./private-dir.js";
 import * as output from "./output.js";
 
 const RECLAIM_SUFFIX = ".reclaim";
@@ -111,8 +112,19 @@ export interface AcquireLockOptions {
  *   silent). The fail-fast CLI path leaves it unset and still prints the warning.
  */
 export async function acquireLock(root: string, options: AcquireLockOptions = {}): Promise<boolean> {
-  const lockPath = path.join(root, LOCK_FILE);
-  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+  // FAIL CLOSED on a `.llmwiki` (or ancestor) that symlinks outside the root:
+  // resolving + creating the confined private dir throws on escape, so the lock
+  // file is NEVER created out-of-tree (the lock writer runs FIRST in the page
+  // mutation path, before the journal). A normal real `.llmwiki` resolves to
+  // itself, leaving the happy path byte-identical.
+  let privateDir: string;
+  try {
+    privateDir = await resolveConfinedPrivateDir(root);
+  } catch {
+    if (!options.quiet) output.status("!", output.warn("Lock directory escapes project root — refusing to lock."));
+    return false;
+  }
+  const lockPath = path.join(privateDir, path.basename(LOCK_FILE));
 
   for (let attempt = 0; attempt < MAX_ACQUIRE_ATTEMPTS; attempt++) {
     // Try atomic create — fails if file already exists

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,7 +4,8 @@
  * for wiki pages.
  */
 
-import { writeFile, rename, readFile, mkdir, lstat } from "fs/promises";
+import { rename, readFile, mkdir, lstat, open } from "fs/promises";
+import { randomBytes } from "node:crypto";
 import path from "path";
 import yaml from "js-yaml";
 import type {
@@ -128,22 +129,42 @@ export function parseFrontmatterStatus(content: string): {
   return { meta, body: match[2], hasFrontmatterBlock: true, malformedFrontmatter };
 }
 
+/** Bytes of randomness in the per-write temp-file suffix (→ 16 hex chars). */
+const TEMP_SUFFIX_BYTES = 8;
+
 /**
- * Atomically write a file (write to .tmp, then rename).
+ * Atomically write a file (write to a private temp, then rename).
  *
- * Defense against the confine→write race (S3): callers resolve `filePath` with
- * `confineUnderRoot(..., {mustExist:false})`, which returns a LEXICAL path after
- * checking the nearest EXISTING ancestor. Between that check and this write, the
- * final directory can be swapped for a symlink that escapes the project root, so
- * the rename would land outside root. `atomicWrite` lacks root context, so it
- * fails CLOSED on the actual escape vector: immediately before writing, it
- * `lstat`s the parent directory and refuses if it is a SYMLINK. Project writes
- * always target real directories, so this never rejects a legitimate write; it
- * matches the wider trust model (a symlinked dir is never trusted).
+ * This is the SHARED atomic-write primitive every wiki write routes through, so
+ * its symlink defenses are the single place the leaf-symlink write-escape class
+ * is closed. Two layers, both fail CLOSED:
+ *
+ *  1. PARENT DIR (confine→write race, S3): callers resolve `filePath` with
+ *     `confineUnderRoot(..., {mustExist:false})`, which returns a LEXICAL path
+ *     after checking the nearest EXISTING ancestor. Between that check and this
+ *     write, the final directory can be swapped for a symlink that escapes the
+ *     project root, so the rename would land outside root. `atomicWrite` lacks
+ *     root context, so it `lstat`s the parent directory and refuses if it is a
+ *     SYMLINK. Project writes always target real directories, so this never
+ *     rejects a legitimate write.
+ *
+ *  2. TEMP LEAF: the temp file gets a RANDOM name (`<basename>.<16-hex>.tmp`) and
+ *     is opened with `O_EXCL` (`open(..., "wx")`), which REFUSES any pre-existing
+ *     entry — including a pre-planted symlink — with `EEXIST`. A predictable
+ *     `<path>.tmp` leaf could be planted as a symlink so `writeFile` followed it
+ *     to an out-of-tree target; a random O_EXCL temp closes that. The content is
+ *     written THROUGH the handle (never re-opening the name), then `rename`d onto
+ *     the target — rename REPLACES a symlinked target rather than writing through
+ *     it, so the final destination being a symlink is already safe.
+ *
+ * Parity: for a normal write (no pre-existing temp) a random O_EXCL temp is
+ * observably identical to the old predictable temp — the destination bytes are
+ * byte-for-byte unchanged, so the frozen default goldens are unaffected.
  *
  * @param filePath - Absolute destination path (its parent must be a real dir).
  * @param content - File contents to write.
- * @throws If the resolved parent directory is a symlink (confine→write escape).
+ * @throws If the resolved parent directory is a symlink (confine→write escape),
+ *   or if the random temp leaf already exists (EEXIST — fail closed).
  */
 export async function atomicWrite(filePath: string, content: string): Promise<void> {
   const dir = path.dirname(filePath);
@@ -152,8 +173,14 @@ export async function atomicWrite(filePath: string, content: string): Promise<vo
   if (dirStat.isSymbolicLink()) {
     throw new Error(`refusing to write through a symlinked directory: ${dir}`);
   }
-  const tmpPath = filePath + ".tmp";
-  await writeFile(tmpPath, content, "utf-8");
+  const suffix = randomBytes(TEMP_SUFFIX_BYTES).toString("hex");
+  const tmpPath = `${filePath}.${suffix}.tmp`;
+  const handle = await open(tmpPath, "wx");
+  try {
+    await handle.writeFile(content, "utf-8");
+  } finally {
+    await handle.close();
+  }
   await rename(tmpPath, filePath);
 }
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -4,10 +4,11 @@
  * for wiki pages.
  */
 
-import { rename, readFile, mkdir, lstat, open } from "fs/promises";
+import { rename, readFile, mkdir, lstat, open, unlink, realpath } from "fs/promises";
 import { randomBytes } from "node:crypto";
 import path from "path";
 import yaml from "js-yaml";
+import { confineUnderRoot, isInsideDir } from "./path-confine.js";
 import type {
   ClaimCitation,
   ContradictionRef,
@@ -132,56 +133,122 @@ export function parseFrontmatterStatus(content: string): {
 /** Bytes of randomness in the per-write temp-file suffix (→ 16 hex chars). */
 const TEMP_SUFFIX_BYTES = 8;
 
+/** Options for {@link atomicWrite}. */
+export interface AtomicWriteOptions {
+  /**
+   * When provided, confine the write under this project root: the nearest
+   * EXISTING ancestor of `filePath` must realpath-resolve inside `confineRoot`
+   * BEFORE any directory is created, and `realpath(dir)` must still be inside it
+   * AFTER the mkdir (TOCTOU). A caller that OMITS this gets only the
+   * immediate-parent symlink guard (back-compat).
+   */
+  confineRoot?: string;
+}
+
 /**
  * Atomically write a file (write to a private temp, then rename).
  *
  * This is the SHARED atomic-write primitive every wiki write routes through, so
  * its symlink defenses are the single place the leaf-symlink write-escape class
- * is closed. Two layers, both fail CLOSED:
+ * is closed. The defenses fail CLOSED:
  *
- *  1. PARENT DIR (confine→write race, S3): callers resolve `filePath` with
- *     `confineUnderRoot(..., {mustExist:false})`, which returns a LEXICAL path
- *     after checking the nearest EXISTING ancestor. Between that check and this
- *     write, the final directory can be swapped for a symlink that escapes the
- *     project root, so the rename would land outside root. `atomicWrite` lacks
- *     root context, so it `lstat`s the parent directory and refuses if it is a
- *     SYMLINK. Project writes always target real directories, so this never
- *     rejects a legitimate write.
+ *  1. ANCESTOR DIR (opt-in via `confineRoot`): `mkdir(dir,{recursive})` would
+ *     otherwise CREATE an absent leaf THROUGH a symlinked ANCESTOR that escapes
+ *     root, after which a leaf-parent `lstat` sees a real dir and passes — so the
+ *     write escapes. With `confineRoot`, the nearest EXISTING ancestor's realpath
+ *     is verified inside root BEFORE any mkdir (and `realpath(dir)` re-checked
+ *     after mkdir to catch a TOCTOU swap). The no-symlink-escape guarantee holds
+ *     ONLY for callers that pass `confineRoot`; a caller that omits it gets just
+ *     the immediate-parent guard below.
  *
- *  2. TEMP LEAF: the temp file gets a RANDOM name (`<basename>.<16-hex>.tmp`) and
+ *  2. PARENT DIR (confine→write race): the final directory can be swapped for a
+ *     symlink between a caller's confine check and this write, so the rename
+ *     would land outside root. `atomicWrite` `lstat`s the parent directory and
+ *     refuses if it is a SYMLINK. Project writes always target real directories,
+ *     so this never rejects a legitimate write.
+ *
+ *  3. TEMP LEAF: the temp file gets a RANDOM name (`<basename>.<16-hex>.tmp`) and
  *     is opened with `O_EXCL` (`open(..., "wx")`), which REFUSES any pre-existing
- *     entry — including a pre-planted symlink — with `EEXIST`. A predictable
- *     `<path>.tmp` leaf could be planted as a symlink so `writeFile` followed it
- *     to an out-of-tree target; a random O_EXCL temp closes that. The content is
+ *     entry — including a pre-planted symlink — with `EEXIST`. The content is
  *     written THROUGH the handle (never re-opening the name), then `rename`d onto
- *     the target — rename REPLACES a symlinked target rather than writing through
- *     it, so the final destination being a symlink is already safe.
+ *     the target. On ANY failure after the temp is opened (write or rename) the
+ *     random temp is `unlink`ed best-effort before rethrowing, so a failed write
+ *     never leaves an orphan `*.tmp` behind (which would otherwise make an OKF
+ *     re-export's empty-dir gate see phantom content).
  *
- * Parity: for a normal write (no pre-existing temp) a random O_EXCL temp is
- * observably identical to the old predictable temp — the destination bytes are
- * byte-for-byte unchanged, so the frozen default goldens are unaffected.
+ * Parity: for a normal write a random O_EXCL temp is observably identical to the
+ * old predictable temp — the destination bytes are byte-for-byte unchanged, so
+ * the frozen default goldens are unaffected.
  *
  * @param filePath - Absolute destination path (its parent must be a real dir).
  * @param content - File contents to write.
+ * @param opts - Optional {@link AtomicWriteOptions} (e.g. `confineRoot`).
  * @throws If the resolved parent directory is a symlink (confine→write escape),
- *   or if the random temp leaf already exists (EEXIST — fail closed).
+ *   if `confineRoot` is given and an ancestor escapes root, or if the random temp
+ *   leaf already exists (EEXIST — fail closed).
  */
-export async function atomicWrite(filePath: string, content: string): Promise<void> {
+export async function atomicWrite(
+  filePath: string,
+  content: string,
+  opts?: AtomicWriteOptions,
+): Promise<void> {
   const dir = path.dirname(filePath);
+  if (opts?.confineRoot !== undefined) {
+    await assertAncestorInRoot(filePath, opts.confineRoot);
+  }
   await mkdir(dir, { recursive: true });
+  await assertParentNotSymlink(dir, opts?.confineRoot);
+  await writeViaTemp(filePath, content);
+}
+
+/**
+ * Fail closed BEFORE any mkdir when the nearest existing ancestor of `filePath`
+ * escapes `confineRoot`. Delegates to {@link confineUnderRoot} (mustExist:false),
+ * which realpath-checks the nearest existing path at or above the target.
+ *
+ * `filePath` is confined as a path RELATIVE to `confineRoot` so confinement is
+ * invariant to which symlink form of root it resolves under (e.g. `/var/…` vs the
+ * canonical `/private/var/…` on macOS) — an absolute target would otherwise pin
+ * to the non-canonical form and spuriously read as escaping.
+ */
+async function assertAncestorInRoot(filePath: string, confineRoot: string): Promise<void> {
+  const relPath = path.relative(confineRoot, filePath);
+  await confineUnderRoot(relPath, confineRoot, { mustExist: false });
+}
+
+/**
+ * Reject a symlinked parent directory. With `confineRoot`, ALSO re-check that the
+ * just-created `dir` realpath is still inside root (catches a post-mkdir TOCTOU
+ * ancestor swap that the pre-mkdir {@link assertAncestorInRoot} could not see).
+ */
+async function assertParentNotSymlink(dir: string, confineRoot?: string): Promise<void> {
   const dirStat = await lstat(dir);
   if (dirStat.isSymbolicLink()) {
     throw new Error(`refusing to write through a symlinked directory: ${dir}`);
   }
+  if (confineRoot !== undefined) {
+    const realRoot = await realpath(confineRoot);
+    const realDir = await realpath(dir);
+    if (!isInsideDir(realDir, realRoot)) {
+      throw new Error(`write directory escapes project root: ${dir}`);
+    }
+  }
+}
+
+/** Write `content` to a random O_EXCL temp, then rename onto `filePath`; clean up the temp on any failure. */
+async function writeViaTemp(filePath: string, content: string): Promise<void> {
   const suffix = randomBytes(TEMP_SUFFIX_BYTES).toString("hex");
   const tmpPath = `${filePath}.${suffix}.tmp`;
   const handle = await open(tmpPath, "wx");
   try {
     await handle.writeFile(content, "utf-8");
-  } finally {
     await handle.close();
+    await rename(tmpPath, filePath);
+  } catch (err) {
+    await handle.close().catch(() => {}); // guard double-close (rename failure)
+    await unlink(tmpPath).catch(() => {}); // best-effort: never leak an orphan temp
+    throw err;
   }
-  await rename(tmpPath, filePath);
 }
 
 /**

--- a/src/utils/private-dir.ts
+++ b/src/utils/private-dir.ts
@@ -1,0 +1,52 @@
+/**
+ * @file src/utils/private-dir.ts
+ * @description Confined resolver for the project's private `.llmwiki` directory —
+ * the single primitive every writer under `.llmwiki/` uses to fail CLOSED when
+ * that directory (or an ancestor of it) is a symlink escaping the project root.
+ *
+ * The lock writer (`acquireLock`/`tryCreateLock`) and the page intent journal
+ * (`openBatch`) both create files under `<root>/.llmwiki`. Without confinement a
+ * planted `root/.llmwiki -> <out-of-tree>` symlink lets `mkdir(..,{recursive})`
+ * follow the link and a lock/journal file land OUTSIDE the root. This resolver
+ * (1) confines `<root>/.llmwiki` under `realpath(root)` via {@link confineUnderRoot}
+ * (which rejects an existing symlinked dir/ancestor that escapes), (2) creates the
+ * confined directory, and (3) RE-checks after the mkdir that the realpath of the
+ * created directory still sits inside the root's realpath — closing the TOCTOU
+ * window where the link is swapped in between the lexical check and the mkdir. A
+ * normal real `.llmwiki` resolves to itself, so the happy path is unchanged.
+ */
+
+import { mkdir } from "fs/promises";
+import path from "path";
+import { LLMWIKI_DIR } from "./constants.js";
+import { confineUnderRoot, safeRealpath, isInsideDir } from "./path-confine.js";
+
+// `confineUnderRoot` resolves its target via `path.resolve(realpath(root), target)`,
+// so the target is passed RELATIVE to root (not as an absolute path built from the
+// pre-realpath root) — an absolute `<unrealpath-root>/.llmwiki` would be judged
+// outside the realpath'd root on platforms where root is itself a symlink (macOS
+// `/var` → `/private/var`) and spuriously rejected.
+
+/**
+ * Resolve `<root>/.llmwiki` to a confined absolute path, CREATING it, and FAIL
+ * CLOSED (throw) if it — or any ancestor — is a symlink escaping the project root.
+ *
+ * Mirrors the journal's `resolveConfinedJournalDir` confinement, but for the
+ * private-dir WRITE path: it confines the target lexically + against the nearest
+ * existing ancestor, makes the directory, then re-confines its post-`mkdir`
+ * realpath (TOCTOU). The returned path is safe to create lock/journal files under.
+ *
+ * @param root - Absolute project root the private dir hangs off.
+ * @returns The confined absolute path of `<root>/.llmwiki`.
+ * @throws When `.llmwiki` (or an ancestor) escapes the project root.
+ */
+export async function resolveConfinedPrivateDir(root: string): Promise<string> {
+  const confined = await confineUnderRoot(LLMWIKI_DIR, root, { mustExist: false });
+  await mkdir(confined, { recursive: true });
+  const realDir = await safeRealpath(confined);
+  const realRoot = (await safeRealpath(root)) ?? path.resolve(root);
+  if (realDir === null || !isInsideDir(realDir, realRoot)) {
+    throw new Error(`private dir escapes project root: ${LLMWIKI_DIR}`);
+  }
+  return realDir;
+}

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -19,11 +19,12 @@
  * is backed up to `.bak` and recovered as empty state instead.
  */
 
-import { readFile, writeFile, rename, mkdir, copyFile } from "fs/promises";
+import { readFile, copyFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { LLMWIKI_DIR, STATE_FILE } from "./constants.js";
+import { STATE_FILE } from "./constants.js";
 import { note } from "./output.js";
+import { atomicWrite } from "./markdown.js";
 import { mintConceptEntities } from "../state/migrate.js";
 import type { WikiState, SourceState } from "./types.js";
 
@@ -198,19 +199,18 @@ export async function readState(root: string): Promise<WikiState> {
   return classified.state;
 }
 
-/** Atomically write state.json (write .tmp then rename). */
+/**
+ * Atomically write state.json via the shared hardened {@link atomicWrite}
+ * primitive (random O_EXCL temp + rename), so the state writer inherits the same
+ * leaf-symlink write-escape defenses as every page write rather than carrying its
+ * own bespoke temp+rename.
+ */
 export async function writeState(root: string, state: WikiState): Promise<void> {
-  const dir = path.join(root, LLMWIKI_DIR);
-  await mkdir(dir, { recursive: true });
-
   const filePath = path.join(root, STATE_FILE);
-  const tmpPath = filePath + ".tmp";
-
   // Re-derive the v2 typed mirror at the single write choke point so no writer
   // can persist a desynced `entities` / `frozenEntities`. No-op for v1 states.
   const synced = syncEntityMirror(state);
-  await writeFile(tmpPath, JSON.stringify(synced, null, 2), "utf-8");
-  await rename(tmpPath, filePath);
+  await atomicWrite(filePath, JSON.stringify(synced, null, 2));
 }
 
 /**

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -19,12 +19,14 @@
  * is backed up to `.bak` and recovered as empty state instead.
  */
 
-import { readFile, copyFile } from "fs/promises";
+import { copyFile, open } from "fs/promises";
+import { constants as fsConstants } from "node:fs";
 import { existsSync } from "fs";
 import path from "path";
 import { STATE_FILE } from "./constants.js";
 import { note } from "./output.js";
 import { atomicWrite } from "./markdown.js";
+import { isSafeFilenameComponent } from "../profile/identity.js";
 import { mintConceptEntities } from "../state/migrate.js";
 import type { WikiState, SourceState } from "./types.js";
 
@@ -113,16 +115,50 @@ export async function readStateClassified(root: string): Promise<ClassifiedState
   const filePath = path.join(root, STATE_FILE);
   if (!existsSync(filePath)) return { status: "missing", state: emptyState() };
   try {
-    const raw = await readFile(filePath, "utf-8");
+    // A read error here (e.g. ELOOP on a symlinked state.json) falls through to
+    // the catch and classifies CORRUPT — fail closed, never read-through.
+    const raw = await readStateNoFollow(filePath);
     return classifyParsedState(JSON.parse(raw));
   } catch {
     return { status: "corrupt", state: emptyState() };
   }
 }
 
+/**
+ * Read `state.json` with `O_RDONLY | O_NOFOLLOW` so a SYMLINKED state.json fails
+ * the open (`ELOOP`) and is treated as corrupt rather than read THROUGH to
+ * attacker-chosen out-of-tree bytes (which feed `concepts` / `frozenSlugs` into
+ * orphan path-joins). Mirrors the relation store's `openStoreFileRead` leaf
+ * defense. The caller has already established the file exists; any open/read
+ * error (including a symlinked leaf) propagates so the caller's try/catch
+ * classifies it CORRUPT (fail closed).
+ */
+async function readStateNoFollow(filePath: string): Promise<string> {
+  const handle = await open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    return await handle.readFile("utf-8");
+  } finally {
+    await handle.close();
+  }
+}
+
 /** True when `value` is an array whose every element is a string. */
 function isStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/**
+ * True when `value` is a string array whose every element is a SAFE filename
+ * component (no `/`, `\`, `..`, leading dot, NUL). Stored `concepts` /
+ * `frozenSlugs` flow UNVALIDATED into `path.join(root, CONCEPTS_DIR, slug+'.md')`
+ * by the orphan pass, so a poisoned `../../escape` slug would mint an out-of-tree
+ * write. Gating slug-safety AT READ classifies a poisoned state CORRUPT (its
+ * existing fail-closed `.bak`+fresh path), defanging the chain regardless of how
+ * the bytes arrived. Compile slugs come from Unicode-aware `slugify`, so this
+ * uses the Unicode-tolerant {@link isSafeFilenameComponent}, NOT ASCII slug-safe.
+ */
+function isSafeSlugArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((s) => typeof s === "string" && isSafeFilenameComponent(s));
 }
 
 /** True when `value` is a non-null, non-array plain object. */
@@ -134,14 +170,14 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 function isValidSourceEntry(entry: unknown): boolean {
   if (!isPlainObject(entry)) return false;
   if (typeof entry.hash !== "string" || typeof entry.compiledAt !== "string") return false;
-  if (!isStringArray(entry.concepts)) return false;
+  if (!isSafeSlugArray(entry.concepts)) return false; // slugs path-join into orphan writes
   if ("entities" in entry && !isStringArray(entry.entities)) return false;
   return true;
 }
 
 /** True when every optional top-level frozen list, if present, is a string array. */
 function hasValidFrozenLists(parsed: Record<string, unknown>): boolean {
-  if ("frozenSlugs" in parsed && !isStringArray(parsed.frozenSlugs)) return false;
+  if ("frozenSlugs" in parsed && !isSafeSlugArray(parsed.frozenSlugs)) return false; // path-join into orphan writes
   if ("frozenEntities" in parsed && !isStringArray(parsed.frozenEntities)) return false;
   return true;
 }
@@ -210,7 +246,7 @@ export async function writeState(root: string, state: WikiState): Promise<void> 
   // Re-derive the v2 typed mirror at the single write choke point so no writer
   // can persist a desynced `entities` / `frozenEntities`. No-op for v1 states.
   const synced = syncEntityMirror(state);
-  await atomicWrite(filePath, JSON.stringify(synced, null, 2));
+  await atomicWrite(filePath, JSON.stringify(synced, null, 2), { confineRoot: root });
 }
 
 /**

--- a/test/atomic-write-ancestor-confine.test.ts
+++ b/test/atomic-write-ancestor-confine.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @file test/atomic-write-ancestor-confine.test.ts
+ * @description FIX 2 — atomicWrite's optional confineRoot closes the ancestor-
+ * symlink escape. `mkdir(dir,{recursive})` runs before the immediate-parent
+ * lstat guard, so an absent leaf below a symlinked ANCESTOR is created THROUGH
+ * the symlink and the leaf-parent lstat then sees a real dir and passes — the
+ * write escapes root. When `confineRoot` is provided, atomicWrite resolves the
+ * nearest existing ancestor's realpath and refuses (fail closed) before any
+ * mkdir if it escapes root. Omitting confineRoot preserves today's behavior.
+ */
+
+import { describe, it, expect } from "vitest";
+import { symlink, mkdir, readFile, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { atomicWrite } from "../src/utils/markdown.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+
+const ctx = useConfinementRoots("ancestor-confine");
+
+/** Plant a symlinked grandparent dir whose absent leaf escapes root. */
+async function plantEscapingAncestor(root: string, outside: string): Promise<string> {
+  const glink = path.join(root, "glink");
+  await symlink(outside, glink); // grandparent symlink → out of tree
+  return path.join(glink, "sub", "evil.md"); // leaf + parent absent
+}
+
+describe("atomicWrite ancestor-symlink confinement", () => {
+  it("fails closed with confineRoot when an ancestor dir is a symlink out of tree", async () => {
+    const { root, outside } = ctx;
+    const target = await plantEscapingAncestor(root, outside);
+
+    await expect(atomicWrite(target, "evil", { confineRoot: root })).rejects.toThrow();
+
+    expect(existsSync(path.join(outside, "sub"))).toBe(false); // nothing created outside
+  });
+
+  it("WITHOUT confineRoot keeps today's behavior (escape not blocked at ancestor)", async () => {
+    const { root, outside } = ctx;
+    const target = await plantEscapingAncestor(root, outside);
+    // Today's primitive only lstats the immediate parent (a real dir created
+    // through the symlink), so the write lands outside. This documents the gap
+    // that confineRoot closes; we assert the write does NOT throw on confinement.
+    await atomicWrite(target, "legacy");
+    expect(await readFile(path.join(outside, "sub", "evil.md"), "utf-8")).toBe("legacy");
+  });
+
+  it("a normal in-root write with confineRoot succeeds byte-identically", async () => {
+    const { root } = ctx;
+    const target = path.join(root, "wiki", "concepts", "x.md");
+    await atomicWrite(target, "body", { confineRoot: root });
+    expect(await readFile(target, "utf-8")).toBe("body");
+    expect((await readdir(path.dirname(target))).filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+
+  it("allows an in-root nested dir under confineRoot (no false rejection)", async () => {
+    const { root } = ctx;
+    await mkdir(path.join(root, "wiki"), { recursive: true });
+    const target = path.join(root, "wiki", "deep", "y.md");
+    await atomicWrite(target, "ok", { confineRoot: root });
+    expect(await readFile(target, "utf-8")).toBe("ok");
+  });
+});

--- a/test/atomic-write-symlink-hardening.test.ts
+++ b/test/atomic-write-symlink-hardening.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @file test/atomic-write-symlink-hardening.test.ts
+ * @description Close the systemic leaf-symlink WRITE-ESCAPE class at the shared
+ * atomic-write primitive. The old `writeFile(<path>.tmp)` FOLLOWED a pre-planted
+ * symlinked temp leaf, redirecting the write OUTSIDE the project root. The
+ * hardened `atomicWrite` uses a RANDOM temp name opened with `O_EXCL`, so a
+ * symlink at the predictable `<path>.tmp` is sidestepped and a symlink at the
+ * random temp would fail the open (EEXIST). These tests prove no write escapes
+ * root via the temp LEAF and that normal writes still succeed. (The symlinked
+ * parent-DIR guard is covered by atomic-write-confine-race.test.ts.)
+ */
+
+import { describe, it, expect } from "vitest";
+import { symlink, readdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { atomicWrite } from "../src/utils/markdown.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+
+const ctx = useConfinementRoots("leaf");
+
+describe("atomicWrite leaf-symlink write-escape hardening", () => {
+  it("sidesteps a symlink planted at the OLD predictable <path>.tmp name", async () => {
+    const { root, outside } = ctx;
+    const target = path.join(root, "page.md");
+    const sink = path.join(outside, "sink");
+    await writeFile(sink, "original", "utf-8");
+    await symlink(sink, `${target}.tmp`); // the old predictable temp leaf
+
+    await atomicWrite(target, "safe-body");
+
+    expect(await readFile(target, "utf-8")).toBe("safe-body"); // target written
+    expect(await readFile(sink, "utf-8")).toBe("original"); // outside untouched
+  });
+
+  // The symlinked-PARENT-DIR guard is covered by atomic-write-confine-race.test.ts;
+  // this suite owns the LEAF-symlink escape that the random O_EXCL temp closes.
+
+  it("still writes correctly to a real path (regression)", async () => {
+    const target = path.join(ctx.root, "sub", "page.md");
+    await atomicWrite(target, "body");
+    expect(await readFile(target, "utf-8")).toBe("body");
+  });
+
+  it("overwrites an existing real target without leaking a stale temp", async () => {
+    const { root } = ctx;
+    const target = path.join(root, "page.md");
+    await atomicWrite(target, "v1");
+    await atomicWrite(target, "v2");
+    expect(await readFile(target, "utf-8")).toBe("v2");
+    expect((await readdir(root)).filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+});

--- a/test/atomic-write-temp-cleanup.test.ts
+++ b/test/atomic-write-temp-cleanup.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @file test/atomic-write-temp-cleanup.test.ts
+ * @description FIX 1 — atomicWrite must not leak an orphan temp on a failed write.
+ *
+ * The random-named temp is opened with O_EXCL, then content is written and the
+ * handle renamed onto the target. If `rename` (or the write) throws — e.g. the
+ * target is a DIRECTORY (EISDIR) — the random temp would otherwise be left
+ * behind forever. An orphan `*.tmp` in an OKF export dir makes the next
+ * re-export throw because the empty-dir gate treats it as content. The fix
+ * unlinks the temp (best-effort) on any failure after it is opened.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, readdir, readFile } from "fs/promises";
+import path from "path";
+import { atomicWrite } from "../src/utils/markdown.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+
+const ctx = useConfinementRoots("temp-cleanup");
+
+describe("atomicWrite temp-file cleanup on failure", () => {
+  it("throws AND leaves no *.tmp orphan when the target is a directory", async () => {
+    const target = path.join(ctx.root, "page.md");
+    await mkdir(target); // make the rename target a directory → rename throws EISDIR
+
+    await expect(atomicWrite(target, "body")).rejects.toThrow();
+
+    const temps = (await readdir(ctx.root)).filter((f) => f.endsWith(".tmp"));
+    expect(temps).toHaveLength(0);
+  });
+
+  it("a normal write still succeeds and leaves no temp", async () => {
+    const target = path.join(ctx.root, "ok.md");
+    await atomicWrite(target, "hello");
+    expect(await readFile(target, "utf-8")).toBe("hello");
+    expect((await readdir(ctx.root)).filter((f) => f.endsWith(".tmp"))).toHaveLength(0);
+  });
+});

--- a/test/lock-private-dir-confine.test.ts
+++ b/test/lock-private-dir-confine.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @file test/lock-private-dir-confine.test.ts
+ * @description Audit FIX F1: `acquireLock` confines the private `.llmwiki` dir.
+ *
+ * Before this fix `acquireLock` did `mkdir(<root>/.llmwiki, {recursive})` and
+ * created the lock file with NO confinement. A planted `root/.llmwiki ->
+ * <out-of-tree>` symlink let the mkdir follow the link and the lock file land
+ * OUTSIDE the project root — and `acquireLock` runs FIRST in the page mutation
+ * path (before the journal write), so the escape happened up front.
+ *
+ * Now `acquireLock` resolves + creates the CONFINED private dir and fails CLOSED
+ * (returns false, no lock created) when `.llmwiki` (or an ancestor) escapes root.
+ * The journal `openBatch` likewise fails closed up front, so
+ * `applyApprovedMutations` over a symlinked `.llmwiki` writes NOTHING out of tree.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, symlink, readdir, access, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { acquireLock, releaseLock } from "../src/utils/lock.js";
+import { applyApprovedMutations } from "../src/trust/executor.js";
+import { LLMWIKI_DIR } from "../src/utils/constants.js";
+import { makeTrustRoot, cleanupTrustRoot, existsUnder } from "./trust/fixture.js";
+import type { PlannedMutation, RawPageRef } from "../src/trust/planner.js";
+
+const GOOD_BODY = "---\ntitle: Ok\n---\n\nbody\n";
+
+let root = "";
+let outsideDir = "";
+
+beforeEach(async () => {
+  root = await makeTrustRoot("lock-private-confine-");
+  outsideDir = await mkdtemp(path.join(tmpdir(), "lock-private-outside-"));
+});
+
+afterEach(async () => {
+  await cleanupTrustRoot(root);
+  if (outsideDir) await rm(outsideDir, { recursive: true, force: true });
+});
+
+/** True when a path exists on disk. */
+async function exists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+/** Plant `root/.llmwiki` as a symlink to an out-of-tree directory. */
+async function plantPrivateDirSymlink(): Promise<void> {
+  await symlink(outsideDir, path.join(root, LLMWIKI_DIR), "dir");
+}
+
+/** A hand-built default-page create mutation (its write target is in-tree). */
+function pageMutation(): PlannedMutation {
+  return {
+    kind: "page",
+    operation: "create",
+    target: { directory: "concepts", slug: "ok" } as RawPageRef,
+    body: GOOD_BODY,
+    provenance: { origin: "agent", decision: "allow", reviewRouted: false },
+  };
+}
+
+describe("FIX F1 — acquireLock confines the private .llmwiki dir", () => {
+  it("fails closed on a symlinked .llmwiki: no lock created, outside dir untouched", async () => {
+    await plantPrivateDirSymlink();
+    expect(await acquireLock(root)).toBe(false);
+    expect(await readdir(outsideDir)).toEqual([]); // no lock file leaked outside
+  });
+
+  it("a real .llmwiki acquires then releases normally (regression)", async () => {
+    expect(await acquireLock(root)).toBe(true);
+    expect(await existsUnder(root, `${LLMWIKI_DIR}/lock`)).toBe(true);
+    await releaseLock(root);
+    expect(await existsUnder(root, `${LLMWIKI_DIR}/lock`)).toBe(false);
+  });
+
+  it("applyApprovedMutations over a symlinked .llmwiki writes nothing out of tree", async () => {
+    await plantPrivateDirSymlink();
+    await expect(applyApprovedMutations(root, [pageMutation()])).rejects.toThrow(/could not acquire/);
+    expect(await readdir(outsideDir)).toEqual([]); // no journal / lock / page leaked
+    expect(await existsUnder(root, "wiki/concepts/ok.md")).toBe(false);
+  });
+
+  it("openBatch fails closed up front on a symlinked .llmwiki (held-lock path)", async () => {
+    // With the lock already (legitimately) held, a swapped-in escaping .llmwiki
+    // must still fail the journal open closed rather than persist out of tree.
+    const realPrivate = path.join(root, LLMWIKI_DIR);
+    await mkdir(realPrivate, { recursive: true });
+    await writeFile(path.join(realPrivate, "lock"), String(process.pid), "utf-8");
+    // Replace the real dir with an escaping symlink, holding the (now-orphaned) lock.
+    await rm(realPrivate, { recursive: true, force: true });
+    await plantPrivateDirSymlink();
+    const { openBatch } = await import("../src/trust/journal.js");
+    await expect(openBatch(root)).rejects.toThrow(/escapes project root/);
+    expect(await exists(path.join(outsideDir, "journal"))).toBe(false);
+  });
+});

--- a/test/profile-evidence-type-compat.test.ts
+++ b/test/profile-evidence-type-compat.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @file test/profile-evidence-type-compat.test.ts
+ * @description FIX 4 — a transitionRequirements evidence field must have a TYPE
+ * the runtime evidence gate (`isEvidencePresent`) can satisfy.
+ *
+ * `isEvidencePresent` accepts a non-empty string/number/slug/enum value or a
+ * non-empty array of such scalars, and REJECTS booleans and objects. A profile
+ * declaring a `boolean`-typed evidence field used to LOAD but the target state
+ * could NEVER be entered (a permanently dead state). Validation now rejects an
+ * evidence-incompatible type at LOAD with a clear message.
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateProfile, ProfileValidationError } from "../src/profile/validate.js";
+import type { ProfilePack, FieldType } from "../src/profile/types.js";
+
+/** A minimal valid profile with one declared evidence field of `type`. */
+function profileWithEvidenceType(type: FieldType): ProfilePack {
+  return {
+    schemaVersion: 1,
+    profileId: "research",
+    entities: {
+      papers: {
+        directory: "wiki/papers",
+        fields: {
+          status: { type: "enum", enum: ["draft", "done"] },
+          reason: { type, ...(type === "enum" ? { enum: ["a", "b"] } : {}) },
+        },
+        lifecycle: {
+          field: "status",
+          initial: "draft",
+          terminal: ["done"],
+          transitions: { draft: ["done"] },
+          transitionRequirements: { done: ["reason"] },
+        },
+      },
+    },
+  };
+}
+
+describe("evidence-field type compatibility at load (FIX 4)", () => {
+  it("rejects a boolean-typed evidence field", () => {
+    expect(() => validateProfile(profileWithEvidenceType("boolean"))).toThrow(ProfileValidationError);
+    expect(() => validateProfile(profileWithEvidenceType("boolean"))).toThrow(/can never satisfy/);
+  });
+
+  it("rejects a date-typed evidence field (gate cannot satisfy a Date value)", () => {
+    expect(() => validateProfile(profileWithEvidenceType("date"))).toThrow(/can never satisfy/);
+  });
+
+  for (const t of ["string", "number", "integer", "slug", "string[]", "enum"] as const) {
+    it(`accepts a ${t}-typed evidence field`, () => {
+      expect(() => validateProfile(profileWithEvidenceType(t))).not.toThrow();
+    });
+  }
+});

--- a/test/relation-required-undefined.test.ts
+++ b/test/relation-required-undefined.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @file test/relation-required-undefined.test.ts
+ * @description Fail-closed coverage for audit FIX F2: a REQUIRED field/attribute
+ * explicitly set to `undefined` must be rejected, not accepted.
+ *
+ * Before the fix, the required check used only `field in values`, so an own key
+ * present but valued `undefined` (e.g. a JS attributes object
+ * `{rationale: undefined}` on the SDK/runtime path) PASSED the required check —
+ * yet `JSON.stringify`/canonicalize DROP an `undefined` value, so the persisted
+ * record was MISSING its required field while being reported valid.
+ *
+ * Covers the runtime/SDK relation write path (`appendRelation`) and the shared
+ * entity-field validator (`validateEntityFields`): a required name valued
+ * `undefined` is rejected; a real value is accepted; an OPTIONAL declared field
+ * valued `undefined` is accepted (the key is dropped consistently on persist).
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { appendRelation } from "../src/relations/store.js";
+import { readRelations } from "../src/relations/store-read.js";
+import { RelationEndpointError } from "../src/relations/types.js";
+import { validateEntityFields } from "../src/profile/field-contract.js";
+import { experimentsIdeasProfile, EXPERIMENT_A as EXP_A, IDEA_B } from "./fixtures/profile-fixtures.js";
+import type { EntityTypeDef } from "../src/profile/types.js";
+
+/** A `tests` relation declaring a REQUIRED `confidence` and an OPTIONAL `kind`. */
+const profile = () => experimentsIdeasProfile({
+  tests: {
+    from: ["experiments"], to: ["ideas"], direction: "directed",
+    attributes: { confidence: { type: "number", min: 0, max: 1 }, kind: { type: "string" } },
+    requiredAttributes: ["confidence"],
+  },
+});
+
+let root = "";
+beforeEach(async () => { root = await mkdtemp(path.join(os.tmpdir(), "rel-req-undef-")); });
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+const write = (attributes: Record<string, unknown>) =>
+  appendRelation(root, profile(), { type: "tests", from: EXP_A, to: IDEA_B, attributes });
+
+describe("FIX F2 — required attribute/field set to undefined fails closed", () => {
+  it("rejects a required relation attribute valued undefined and appends nothing", async () => {
+    await expect(write({ confidence: undefined })).rejects.toThrow(RelationEndpointError);
+    await expect(readRelations(root)).resolves.toMatchObject({ relations: [] });
+  });
+
+  it("accepts a required attribute with a real value", async () => {
+    const ref = await write({ confidence: 0.5 });
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].id).toBe(ref.id);
+  });
+
+  it("accepts an OPTIONAL declared attribute valued undefined (key dropped on persist)", async () => {
+    const ref = await write({ confidence: 0.5, kind: undefined });
+    const { relations } = await readRelations(root);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].id).toBe(ref.id);
+    expect("kind" in relations[0].attributes).toBe(false);
+  });
+
+  it("shared entity-field validator rejects a required field valued undefined", () => {
+    const def: EntityTypeDef = { directory: "experiments", requiredFields: ["title"], fields: { title: { type: "string" } } };
+    expect(validateEntityFields({ title: undefined }, def)).toHaveLength(1);
+    expect(validateEntityFields({ title: "ok" }, def)).toEqual([]);
+  });
+});

--- a/test/relation-store-symlink-surfaces.test.ts
+++ b/test/relation-store-symlink-surfaces.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @file test/relation-store-symlink-surfaces.test.ts
+ * @description Audit FIX F3: a symlinked store-file leaf
+ * (`wiki/graph/relations.jsonl`) makes the no-follow reader throw
+ * `RelationStoreSymlinkError`. Before this fix only `RelationStoreCorruptError`
+ * /`RelationStoreTooNewError` were mapped, so the symlink error was UNCAUGHT and
+ * crashed status / lint / export.
+ *
+ * Each read surface must now map the symlink error into its SAME relation-store
+ * problem channel (status: a capped `problem`; lint: a fail-closed finding;
+ * export: omit relations) and never throw. A normal real-file store still
+ * counts / lints / exports (regression).
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { collectStatus } from "../src/status/collect.js";
+import { lint } from "../src/linter/index.js";
+import { exportJson } from "../src/commands/export.js";
+import { RELATIONS_FILE, WIKI_GRAPH_DIR } from "../src/utils/constants.js";
+import {
+  buildResearchLiteRelationsProject,
+  seedTestsRelation,
+} from "./fixtures/profile-fixtures.js";
+
+let root = "";
+let outsideDir = "";
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), "rel-symlink-surface-"));
+  outsideDir = await mkdtemp(path.join(tmpdir(), "rel-symlink-outside-"));
+  await buildResearchLiteRelationsProject(root);
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  if (outsideDir) await rm(outsideDir, { recursive: true, force: true });
+});
+
+/** Plant `relations.jsonl` as a symlink to a header-bearing out-of-tree file. */
+async function plantLeafSymlink(): Promise<void> {
+  await mkdir(path.join(root, WIKI_GRAPH_DIR), { recursive: true });
+  const outside = path.join(outsideDir, "outside-store.jsonl");
+  await writeFile(outside, '{"kind":"relation-store-header","schemaVersion":1}\n', "utf8");
+  await symlink(outside, path.join(root, RELATIONS_FILE));
+}
+
+describe("FIX F3 — symlinked relation store leaf maps to read surfaces", () => {
+  it("status surfaces a relation-store problem instead of crashing", async () => {
+    await plantLeafSymlink();
+    const status = await collectStatus(root);
+    expect(status.profile?.problems?.some((p) => /relation store/i.test(p.message))).toBe(true);
+    expect("relationCounts" in (status.profile ?? {})).toBe(false);
+  });
+
+  it("lint emits a fail-closed finding instead of throwing", async () => {
+    await plantLeafSymlink();
+    const { results } = await lint(root);
+    expect(results.some((r) => r.rule === "relation-store-symlink")).toBe(true);
+  });
+
+  it("export omits relations and does not throw", async () => {
+    await plantLeafSymlink();
+    const doc = await exportJson(root);
+    expect("relations" in (doc.profile ?? {})).toBe(false);
+  });
+
+  it("a normal real-file store still counts / lints / exports (regression)", async () => {
+    await seedTestsRelation(root, "ablation-batch-size", "sparse-routing");
+    const status = await collectStatus(root);
+    expect(status.profile?.relationTotal).toBe(1);
+    const { results } = await lint(root);
+    expect(results.some((r) => r.rule === "relation-store-symlink")).toBe(false);
+    const doc = await exportJson(root);
+    expect(doc.profile?.relations).toHaveLength(1);
+  });
+});

--- a/test/state-slug-safety.test.ts
+++ b/test/state-slug-safety.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @file test/state-slug-safety.test.ts
+ * @description FIX 3 — a symlinked / poisoned state.json must never mint an
+ * out-of-tree write.
+ *
+ * (a) `readStateClassified` validates every `concepts[]` / `frozenSlugs[]` entry
+ *     is a safe filename component; a `../../../escape` slug classifies CORRUPT.
+ * (b) `orphanPage` gates the slug, so even a bypassed validator can't path-join
+ *     a file outside root.
+ * (c) the state.json read is O_NOFOLLOW: a symlinked state.json fails closed
+ *     (corrupt), not read-through to outside content.
+ */
+
+import { describe, it, expect } from "vitest";
+import { symlink, writeFile, mkdir, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { readStateClassified } from "../src/utils/state.js";
+import { orphanUnownedFrozenPages } from "../src/compiler/orphan.js";
+import { STATE_FILE, LLMWIKI_DIR } from "../src/utils/constants.js";
+import { writeRawTestStateJson } from "./fixtures/state-json.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+
+const ctx = useConfinementRoots("state-slug");
+
+/** A valid v1 state shape with a single source whose `concepts` are caller-chosen. */
+function stateWithConcepts(concepts: string[]): string {
+  return JSON.stringify({
+    version: 1,
+    indexHash: "",
+    sources: { "a.md": { hash: "h", compiledAt: "t", concepts } },
+  });
+}
+
+describe("state.json slug safety (FIX 3)", () => {
+  it("(a) classifies corrupt when a concepts[] slug escapes root", async () => {
+    await writeRawTestStateJson(ctx.root, stateWithConcepts(["../../../escape"]));
+    expect((await readStateClassified(ctx.root)).status).toBe("corrupt");
+  });
+
+  it("(a) classifies corrupt when a frozenSlugs[] entry escapes root", async () => {
+    await writeRawTestStateJson(
+      ctx.root,
+      JSON.stringify({ version: 1, indexHash: "", sources: {}, frozenSlugs: ["../../x"] }),
+    );
+    expect((await readStateClassified(ctx.root)).status).toBe("corrupt");
+  });
+
+  it("(a) still reads a valid state with safe slugs", async () => {
+    await writeRawTestStateJson(ctx.root, stateWithConcepts(["safe-slug"]));
+    const result = await readStateClassified(ctx.root);
+    expect(result.status).toBe("ok");
+    expect(result.state.sources["a.md"].concepts).toEqual(["safe-slug"]);
+  });
+
+  it("(b) orphanPage never writes outside root for an unsafe frozen slug", async () => {
+    const { root, outside } = ctx;
+    await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
+    // The orphan flow joins root/CONCEPTS_DIR/<slug>.md; an escaping slug must be skipped.
+    await orphanUnownedFrozenPages(root, new Set([`../../../${path.basename(outside)}/secret`]));
+    expect(existsSync(path.join(path.dirname(outside), path.basename(outside), "secret.md"))).toBe(false);
+    expect((await readdir(outside)).filter((f) => f.endsWith(".md"))).toHaveLength(0);
+  });
+
+  it("(c) a symlinked state.json fails closed (corrupt), not read-through", async () => {
+    const { root, outside } = ctx;
+    const sink = path.join(outside, "leak.json");
+    await writeFile(sink, stateWithConcepts(["safe"]), "utf-8");
+    await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+    await symlink(sink, path.join(root, STATE_FILE)); // symlinked state.json → outside
+    expect((await readStateClassified(root)).status).toBe("corrupt");
+  });
+});

--- a/test/temp-writer-symlink-hardening.test.ts
+++ b/test/temp-writer-symlink-hardening.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @file test/temp-writer-symlink-hardening.test.ts
+ * @description The three bespoke temp+rename writers (state.json, rule-state.json,
+ * and the trust journal) now route through the hardened {@link atomicWrite}, so
+ * none of them can be redirected outside the project root by a symlink planted at
+ * the old predictable `<path>.tmp` leaf. Each test plants such a symlink, performs
+ * a normal write, and asserts the out-of-tree sink is untouched while the in-root
+ * target round-trips correctly.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, symlink, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { writeState, readState } from "../src/utils/state.js";
+import { updateRuleSourceState, readRuleState } from "../src/compiler/rule-state.js";
+import { openBatch, recordPreState } from "../src/trust/journal.js";
+import { STATE_FILE, RULE_STATE_FILE, LLMWIKI_DIR } from "../src/utils/constants.js";
+import { useConfinementRoots } from "./fixtures/confinement-roots.js";
+
+const ctx = useConfinementRoots("tw");
+
+/** Plant a symlink at `<file>.tmp` pointing at an out-of-tree sink. */
+async function plantTempSymlink(file: string): Promise<string> {
+  const sink = path.join(ctx.outside, "sink");
+  await writeFile(sink, "original", "utf-8");
+  await symlink(sink, `${file}.tmp`);
+  return sink;
+}
+
+describe("bespoke temp-writers route through hardened atomicWrite", () => {
+  it("writeState does not escape via a planted state.json.tmp symlink", async () => {
+    const { root } = ctx;
+    await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+    const sink = await plantTempSymlink(path.join(root, STATE_FILE));
+
+    await writeState(root, { version: 1, indexHash: "h", sources: {} });
+
+    expect(await readFile(sink, "utf-8")).toBe("original"); // outside untouched
+    expect((await readState(root)).indexHash).toBe("h"); // target round-trips
+  });
+
+  it("rule-state write does not escape via a planted rule-state.json.tmp symlink", async () => {
+    const { root } = ctx;
+    await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+    const sink = await plantTempSymlink(path.join(root, RULE_STATE_FILE));
+
+    await updateRuleSourceState(root, "a.md", { hash: "x", compiledAt: "t", concepts: [] });
+
+    expect(await readFile(sink, "utf-8")).toBe("original");
+    expect((await readRuleState(root)).sources["a.md"].hash).toBe("x");
+  });
+
+  it("journal persist does not escape via a planted journal.tmp symlink", async () => {
+    const { root } = ctx;
+    const batch = await openBatch(root); // writes the (empty) journal file
+    const sink = await plantTempSymlink(
+      path.join(root, LLMWIKI_DIR, "journal", `${batch.batchId}.json`),
+    );
+
+    await recordPreState(batch, path.join(root, "page.md")); // re-persists journal
+
+    expect(await readFile(sink, "utf-8")).toBe("original");
+    expect(batch.entries).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Stacked on PR #135 (do not merge yet). The symlink-write-escape class recurred FIVE times in the relation store (dir → compaction temp → store-file leaf), each fixed there. This closes the SAME class systemically across every other store, at the shared primitive.

The vector: every bespoke temp+rename writer did `writeFile(<path>.tmp, content)` then `rename` — and `writeFile` follows a symlinked `<path>.tmp`, so a pre-planted symlinked temp leaf redirects the write outside the project root (identical to the relation-compaction-temp bug).

- **`atomicWrite`** (the shared primitive, used by 16 files: page writes, index, MOC, candidates, …) now writes through a RANDOM-named temp opened with `open("wx")` (O_EXCL — refuses any pre-existing entry including a symlink → fail closed), then renames. The parent-dir lstat guard stays. Fixing the primitive once hardens every caller.
- **`writeState`**, **`writeRuleState`**, and the journal **`persist`** — which each had their own unguarded temp+rename — now route through the hardened `atomicWrite` (DRY).

Default page-write path byte-identical (a random O_EXCL temp produces identical destination bytes for a normal write — frozen goldens unchanged); full suite green (2267). Reads-following-a-symlinked-leaf (a lower-severity confusion vector, not a write-escape) are a noted follow-up.