### PR TITLE
feat(events): 4b PR1 — append-only hash-chained event store + audit on lifecycle/relation writes

### DIFF
--- a/src/events/event-digest.ts
+++ b/src/events/event-digest.ts
@@ -1,0 +1,49 @@
+/**
+ * @file src/events/event-digest.ts
+ * @description The chain digest for the event store. Mirrors the relation
+ * digest's canonicalize-then-sha256 pattern: a SHA-256 over the RFC 8785 (JCS)
+ * canonicalization of an event's CONTENT fields (`{id,type,origin,actor,payload,
+ * decision,at}`), so equal content yields an equal hash regardless of key order.
+ *
+ * This digest is the link material of the hash chain: the digest of record[i] is
+ * written verbatim into record[i+1].prevHash (the genesis record's prevHash is
+ * the fixed {@link GENESIS_PREV_HASH}, not a digest). A reader recomputes each
+ * record's digest and checks the successor's `prevHash` against it; any edit,
+ * reorder, or deletion of a record changes its digest and breaks the link.
+ *
+ * The digest intentionally covers the CONTENT (not `prevHash`/`checksum`): the
+ * chain link is the content's identity, and including `prevHash` would make the
+ * digest self-referential across records without adding tamper coverage that the
+ * successor's `prevHash` comparison does not already provide.
+ */
+
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+import type { EventContent } from "./types.js";
+
+/**
+ * Compute the canonical chain digest of an event's content fields.
+ *
+ * Returns the lowercase-hex SHA-256 of the RFC 8785 canonicalization of
+ * `{id,type,origin,actor,payload,decision,at}`. The result is what the NEXT
+ * record carries as its `prevHash`, and what {@link verifyHeadAnchor} compares
+ * the sealed head against for the LAST record.
+ *
+ * @param content - The event's content fields.
+ * @returns Lowercase hex SHA-256 of the canonical JSON form.
+ */
+export function eventPrevHash(content: EventContent): string {
+  const canonical = canonicalize({
+    id: content.id,
+    type: content.type,
+    origin: content.origin,
+    actor: content.actor,
+    payload: content.payload,
+    decision: content.decision,
+    at: content.at,
+  });
+  if (canonical === undefined) {
+    throw new Error("event canonicalization produced no output");
+  }
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}

--- a/src/events/store-read.ts
+++ b/src/events/store-read.ts
@@ -1,0 +1,221 @@
+/**
+ * @file src/events/store-read.ts
+ * @description The READ half of the hash-chained event store: parse the
+ * append-only JSONL at `wiki/graph/events.jsonl` into the ordered event list,
+ * plus the chain/anchor verifiers PR2 surfaces through lint/status.
+ *
+ * Durability contract (mirrors the relation store):
+ *  - FIRST line is a header carrying `schemaVersion`; a version greater than
+ *    {@link EVENT_STORE_SCHEMA_VERSION} → FAIL CLOSED ({@link EventStoreTooNewError}).
+ *  - Every record carries a CHECKSUM, recomputed on read; a bad checksum or a
+ *    malformed record BEFORE the final line is interior corruption → FAIL CLOSED
+ *    ({@link EventStoreCorruptError}).
+ *  - A torn TRAILING line is TOLERATED and REPORTED as a `problem`.
+ *  - The graph dir's realpath is confined; a symlinked leaf/dir fails closed.
+ *  - Absent file → empty result.
+ *
+ * CHAIN: unlike corruption, a broken/forked/reordered chain or a head-anchor
+ * mismatch does NOT throw from {@link readEvents} — it is returned as a `problem`
+ * so a later lint/status surface (PR2) can report it. Callers that DEMAND an
+ * intact chain run {@link verifyEventChain}/{@link verifyHeadAnchor} and throw
+ * {@link EventStoreChainError} themselves.
+ */
+
+import path from "path";
+import { EVENTS_FILE, EVENTS_HEAD_FILE, MAX_RELATION_STORE_BYTES } from "../utils/constants.js";
+import { resolveConfinedPrivateDir } from "../utils/private-dir.js";
+import { readConfinedGraphStore, splitStoreRecords } from "../utils/jsonl-store.js";
+import type { EventRecord } from "./types.js";
+import {
+  EVENT_STORE_SCHEMA_VERSION,
+  GENESIS_PREV_HASH,
+  EventStoreTooNewError,
+  EventStoreCorruptError,
+  EventStoreSymlinkError,
+  EventStoreChainError,
+} from "./types.js";
+import { eventChecksum, openEventFileRead } from "./store-record.js";
+import { eventPrevHash } from "./event-digest.js";
+
+/** The outcome of reading the store: ordered events plus any tolerated/surfaced problems. */
+export interface ReadEventsResult {
+  /** Events in append (file) order. */
+  events: EventRecord[];
+  /** Human-readable notes (torn trailing line, chain break, head mismatch). */
+  problems: string[];
+}
+
+/** Read the raw store bytes, or null when absent — via the shared confined+capped reader. */
+function readStoreFile(root: string): Promise<string | null> {
+  return readConfinedGraphStore(root, {
+    fileName: path.basename(EVENTS_FILE),
+    makeSymlinkError: (reason) => new EventStoreSymlinkError(reason),
+    maxBytes: MAX_RELATION_STORE_BYTES,
+    makeOversizeError: (size) =>
+      new EventStoreCorruptError(`store file ${size} bytes exceeds the ${MAX_RELATION_STORE_BYTES}-byte cap`),
+  });
+}
+
+/** Parse and validate the header line, failing closed on an unknown future version. */
+function parseHeader(line: string): void {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new EventStoreCorruptError("header line is not valid JSON");
+  }
+  const header = parsed as { kind?: unknown; schemaVersion?: unknown };
+  if (header.kind !== "event-store-header" || typeof header.schemaVersion !== "number") {
+    throw new EventStoreCorruptError("first line is not a valid store header");
+  }
+  if (header.schemaVersion > EVENT_STORE_SCHEMA_VERSION) {
+    throw new EventStoreTooNewError(header.schemaVersion, EVENT_STORE_SCHEMA_VERSION);
+  }
+}
+
+/** Parse one record line into an {@link EventRecord}, validating its required shape. */
+function parseRecord(line: string): EventRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new EventStoreCorruptError("record line is not valid JSON");
+  }
+  const rec = parsed as Partial<EventRecord>;
+  const idOk = typeof rec.id === "string" && rec.id.startsWith("evt_");
+  if (!idOk || typeof rec.checksum !== "string" || typeof rec.prevHash !== "string" || typeof rec.type !== "string") {
+    throw new EventStoreCorruptError("record line is missing required fields");
+  }
+  return rec as EventRecord;
+}
+
+/** Verify a parsed record's stored checksum; throw {@link EventStoreCorruptError} on mismatch. */
+function verifyChecksum(record: EventRecord): EventRecord {
+  const { checksum, ...rest } = record;
+  if (eventChecksum(rest) !== checksum) {
+    throw new EventStoreCorruptError(`checksum mismatch for event ${record.id}`);
+  }
+  return record;
+}
+
+/**
+ * Parse every record line AFTER the header. A failure on any line except the LAST
+ * is interior corruption (fail closed); a failure on the last line is a torn
+ * trailing append — tolerated, reported via `problems`.
+ */
+function parseRecords(lines: string[], problems: string[]): EventRecord[] {
+  const events: EventRecord[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const isLast = i === lines.length - 1;
+    try {
+      events.push(verifyChecksum(parseRecord(lines[i])));
+    } catch (err) {
+      if (isLast) {
+        problems.push(`tolerated torn trailing line: ${(err as Error).message}`);
+        break;
+      }
+      throw err; // interior corruption → fail closed
+    }
+  }
+  return events;
+}
+
+/**
+ * Verify the hash chain over `events` (file order): the first record's `prevHash`
+ * must equal {@link GENESIS_PREV_HASH}, and each subsequent record's `prevHash`
+ * must equal the chain digest of its predecessor ({@link eventPrevHash}). An edit,
+ * reorder, deletion, or fork changes a digest and breaks a link.
+ *
+ * @param events - Events in append order.
+ * @returns `{ ok }`, with a `problem` describing the first broken link when not ok.
+ */
+export function verifyEventChain(events: EventRecord[]): { ok: boolean; problem?: string } {
+  for (let i = 0; i < events.length; i++) {
+    const expected = i === 0 ? GENESIS_PREV_HASH : eventPrevHash(events[i - 1]);
+    if (events[i].prevHash !== expected) {
+      return { ok: false, problem: `chain link broken at event ${i} (${events[i].id})` };
+    }
+  }
+  return { ok: true };
+}
+
+/** Read the sealed head-anchor digest, or null when it is absent. Confined + no-follow. */
+async function readHeadAnchor(root: string): Promise<string | null> {
+  const dir = await resolveConfinedPrivateDir(root); // throws on .llmwiki symlink escape
+  const file = path.join(dir, path.basename(EVENTS_HEAD_FILE));
+  const handle = await openEventFileRead(file); // no-follow; symlink → fail closed
+  if (handle === null) return null;
+  try {
+    return (await handle.readFile("utf-8")).trim();
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Verify the sealed HEAD anchor matches the LAST event: the anchor (the digest of
+ * the last event, written under `.llmwiki/events.head`) must equal
+ * {@link eventPrevHash} of the last event. A TRUNCATED log (last record dropped)
+ * or a wholesale rewrite leaves the anchor pointing at a now-absent digest, so
+ * the mismatch is detected. An empty store with no anchor is consistent (`ok`).
+ *
+ * @param root - Absolute project root.
+ * @param events - Events in append order (the last is anchored).
+ * @returns `{ ok }`, with a `problem` when the anchor and last event disagree.
+ */
+export async function verifyHeadAnchor(
+  root: string,
+  events: EventRecord[],
+): Promise<{ ok: boolean; problem?: string }> {
+  const anchor = await readHeadAnchor(root);
+  const expected = events.length === 0 ? null : eventPrevHash(events[events.length - 1]);
+  if (anchor === expected) return { ok: true };
+  return { ok: false, problem: `head anchor ${anchor ?? "<absent>"} does not match last event` };
+}
+
+/** Append chain + head-anchor problems (non-fatal) onto `problems`. */
+async function appendChainProblems(root: string, events: EventRecord[], problems: string[]): Promise<void> {
+  const chain = verifyEventChain(events);
+  if (!chain.ok && chain.problem) problems.push(chain.problem);
+  const anchor = await verifyHeadAnchor(root, events);
+  if (!anchor.ok && anchor.problem) problems.push(anchor.problem);
+}
+
+/**
+ * Read the event store into the ordered events plus any problems. Corruption /
+ * too-new / symlink fail CLOSED (throw); a torn trailing line, a broken chain,
+ * and a head-anchor mismatch are returned as `problems` (PR2 surfaces them).
+ *
+ * @param root - Absolute project root.
+ * @returns The events in append order and a list of problems.
+ */
+export async function readEvents(root: string): Promise<ReadEventsResult> {
+  const raw = await readStoreFile(root); // throws on symlink/too-new/corrupt
+  const recordLines = splitStoreRecords(raw, parseHeader);
+  if (recordLines === null) return { events: [], problems: [] };
+  const problems: string[] = [];
+  const events = parseRecords(recordLines, problems);
+  await appendChainProblems(root, events, problems);
+  return { events, problems };
+}
+
+/**
+ * Read the event store and FAIL CLOSED on a broken chain or head-anchor mismatch.
+ * The strict entry point for callers that demand a tamper-intact audit log:
+ * delegates to {@link readEvents} (so corruption/too-new/symlink still throw their
+ * own errors), then throws {@link EventStoreChainError} if any chain/anchor
+ * problem was surfaced. A torn TRAILING line alone is tolerated — only chain /
+ * head-anchor problems escalate to a throw.
+ *
+ * @param root - Absolute project root.
+ * @returns The events in append order (when the chain + anchor are intact).
+ * @throws {EventStoreChainError} When the chain is broken or the head anchor mismatches.
+ */
+export async function readEventsStrict(root: string): Promise<EventRecord[]> {
+  const { events } = await readEvents(root);
+  const chain = verifyEventChain(events);
+  if (!chain.ok) throw new EventStoreChainError(chain.problem ?? "chain verification failed");
+  const anchor = await verifyHeadAnchor(root, events);
+  if (!anchor.ok) throw new EventStoreChainError(anchor.problem ?? "head anchor mismatch");
+  return events;
+}

--- a/src/events/store-record.ts
+++ b/src/events/store-record.ts
@@ -1,0 +1,76 @@
+/**
+ * @file src/events/store-record.ts
+ * @description Shared record (de)serialization + leaf confinement for the EVENT
+ * store, mirroring `src/relations/store-record.ts`. Owns the per-record checksum,
+ * the header line, and the event-typed wrappers over the SHARED
+ * `src/utils/jsonl-store.ts` no-follow open + confined graph-dir primitives — so
+ * the event store inherits the relation store's symlink/regular-file hardening
+ * rather than re-deriving it.
+ *
+ * The checksum is a SHA-256 over the RFC 8785 canonicalization of the record's
+ * non-checksum fields (the {@link EventRecord} minus `checksum`, INCLUDING
+ * `prevHash`), recomputed and compared on read. It detects a flipped byte
+ * anywhere in the line independently of the chain digest.
+ */
+
+import { createHash } from "node:crypto";
+import type { FileHandle } from "node:fs/promises";
+import canonicalize from "canonicalize";
+import {
+  resolveConfinedGraphDir,
+  openGraphFileRead,
+  openGraphFileAppend,
+} from "../utils/jsonl-store.js";
+import type { EventRecord, EventStoreHeader } from "./types.js";
+import { EVENT_STORE_SCHEMA_VERSION, EventStoreSymlinkError } from "./types.js";
+
+/** The record fields the per-record checksum is computed over (all but `checksum`). */
+export type EventChecksumInput = Omit<EventRecord, "checksum">;
+
+/** Build the event store's typed symlink error from a reason string. */
+function eventSymlinkError(reason: string): Error {
+  return new EventStoreSymlinkError(reason);
+}
+
+/** Compute the per-record checksum over an event's content (excludes `checksum`). */
+export function eventChecksum(input: EventChecksumInput): string {
+  const canonical = canonicalize(input);
+  if (canonical === undefined) {
+    throw new Error("event record canonicalization produced no output");
+  }
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+/** Serialize an event (its non-checksum fields) to its on-disk JSONL line. */
+export function serializeEventRecord(input: EventChecksumInput): string {
+  const record: EventRecord = { ...input, checksum: eventChecksum(input) };
+  return JSON.stringify(record) + "\n";
+}
+
+/** The header line (with trailing newline) written when a store is created. */
+export function eventHeaderLine(): string {
+  const header: EventStoreHeader = {
+    kind: "event-store-header",
+    schemaVersion: EVENT_STORE_SCHEMA_VERSION,
+  };
+  return JSON.stringify(header) + "\n";
+}
+
+/**
+ * Resolve the confined graph dir for `root` (event-typed wrapper over the shared
+ * {@link resolveConfinedGraphDir}; a symlinked `wiki/graph` fails closed). The
+ * event store shares this dir with the relation store.
+ */
+export function resolveEventGraphDir(root: string): Promise<{ dir: string; exists: boolean }> {
+  return resolveConfinedGraphDir(root);
+}
+
+/** Open the event store FILE leaf for READING with `O_NOFOLLOW` (symlink → fail closed). */
+export function openEventFileRead(file: string): Promise<FileHandle | null> {
+  return openGraphFileRead(file, eventSymlinkError);
+}
+
+/** Open the event store FILE leaf for APPEND with `O_NOFOLLOW` (symlink → fail closed). */
+export function openEventFileAppend(file: string): Promise<FileHandle> {
+  return openGraphFileAppend(file, eventSymlinkError);
+}

--- a/src/events/store.ts
+++ b/src/events/store.ts
@@ -1,0 +1,157 @@
+/**
+ * @file src/events/store.ts
+ * @description The WRITE half of the append-only, hash-chained EVENT store.
+ * Builds an {@link EventRecord} (minting an `evt_<ULID>` id, chaining `prevHash`
+ * to the prior record's digest, computing the per-record checksum), APPENDS it to
+ * `wiki/graph/events.jsonl` through the shared NO-FOLLOW O_APPEND primitive
+ * (writing the header first when the store is empty), then SEALS the new record's
+ * digest into the head anchor at `.llmwiki/events.head`.
+ *
+ * LOCKING: {@link appendEventLocked} is the lock-free core — it MUST run under a
+ * lock the CALLER already holds, so an emit site that already holds the project
+ * lock for its mutation (a lifecycle transition / relation append) co-commits the
+ * event without a nested-acquire deadlock. {@link appendEvent} is the self-locking
+ * entry point. {@link recordEvent} dispatches between them on `opts.locked`.
+ *
+ * ORDERING / BEST-EFFORT: emit sites call this AFTER the durable mutation has
+ * landed, so the event is best-effort-after-mutation. A failed emit does NOT roll
+ * back the mutation; a crash between the mutation and the append leaves a missing
+ * trailing event — the torn-trailing case the reader tolerates and reports.
+ */
+
+import { mkdir } from "fs/promises";
+import path from "path";
+import { EVENTS_FILE, EVENTS_HEAD_FILE } from "../utils/constants.js";
+import { acquireLockBlocking, releaseLock } from "../utils/lock.js";
+import { atomicWrite } from "../utils/markdown.js";
+import { ulid } from "../relations/ulid.js";
+import type { EventContent, EventId, EventRecord, EventType } from "./types.js";
+import { GENESIS_PREV_HASH } from "./types.js";
+import {
+  eventChecksum,
+  eventHeaderLine,
+  serializeEventRecord,
+  resolveEventGraphDir,
+  openEventFileAppend,
+  type EventChecksumInput,
+} from "./store-record.js";
+import { eventPrevHash } from "./event-digest.js";
+import { readEvents } from "./store-read.js";
+
+/** The caller-supplied content of a new event (id, prevHash, checksum are derived). */
+export interface AppendEventInput {
+  type: EventType;
+  origin: string;
+  actor?: string;
+  payload: Record<string, unknown>;
+  decision?: string;
+  /** ISO-8601 emit timestamp; the caller supplies one (e.g. `new Date().toISOString()`). */
+  at: string;
+}
+
+/** Whether the caller already holds the project lock (skip the nested acquire). */
+export interface RecordEventOptions {
+  locked?: boolean;
+}
+
+/** Mint a fresh `evt_<ULID>` id, allocated once at emit. */
+function mintEventId(): EventId {
+  return `evt_${ulid()}`;
+}
+
+/** The chain digest of the LAST event (or {@link GENESIS_PREV_HASH} for an empty store). */
+function prevHashFor(events: EventRecord[]): string {
+  if (events.length === 0) return GENESIS_PREV_HASH;
+  return eventPrevHash(events[events.length - 1]);
+}
+
+/** Build the chained, checksummed {@link EventRecord} from caller input + the prior digest. */
+function buildEventRecord(input: AppendEventInput, prevHash: string): EventRecord {
+  const content: EventContent = {
+    id: mintEventId(),
+    type: input.type,
+    origin: input.origin,
+    actor: input.actor,
+    payload: input.payload,
+    decision: input.decision,
+    at: input.at,
+  };
+  const unchecked: EventChecksumInput = { ...content, prevHash };
+  return { ...unchecked, checksum: eventChecksum(unchecked) };
+}
+
+/** Append one record line to the store under O_APPEND, creating the dir/header. */
+async function appendLine(root: string, record: EventRecord): Promise<void> {
+  const { dir } = await resolveEventGraphDir(root); // throws on symlink escape (DIR)
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, path.basename(EVENTS_FILE));
+  const handle = await openEventFileAppend(file); // throws on symlink leaf (LEAF)
+  try {
+    const existing = (await handle.stat()).size;
+    if (existing === 0) await handle.write(eventHeaderLine());
+    const { checksum, ...rest } = record;
+    void checksum; // serializeEventRecord recomputes from the content fields
+    await handle.write(serializeEventRecord(rest));
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Seal the new record's chain digest into the confined `.llmwiki/events.head` anchor. */
+async function sealHeadAnchor(root: string, content: EventContent): Promise<void> {
+  await atomicWrite(path.join(root, EVENTS_HEAD_FILE), eventPrevHash(content), { confineRoot: root });
+}
+
+/**
+ * Append one event to the chained store WHILE THE CALLER ALREADY HOLDS the project
+ * lock (the lock-free core). Reads the current events to chain `prevHash` off the
+ * last record's digest, appends the new record, then seals its digest into the
+ * head anchor. The caller MUST already hold the lock; this acquires NOTHING, so an
+ * emit site can co-commit the event inside its mutation's lock region.
+ *
+ * @param root - Absolute project root.
+ * @param input - The new event's content.
+ * @returns The persisted {@link EventRecord}.
+ */
+export async function appendEventLocked(root: string, input: AppendEventInput): Promise<EventRecord> {
+  const { events } = await readEvents(root); // under the caller's lock
+  const record = buildEventRecord(input, prevHashFor(events));
+  await appendLine(root, record);
+  await sealHeadAnchor(root, record);
+  return record;
+}
+
+/**
+ * Append one event, self-locking via {@link acquireLockBlocking}/{@link releaseLock}.
+ * The entry point for callers that do NOT already hold the lock.
+ *
+ * @param root - Absolute project root.
+ * @param input - The new event's content.
+ * @returns The persisted {@link EventRecord}.
+ */
+export async function appendEvent(root: string, input: AppendEventInput): Promise<EventRecord> {
+  await acquireLockBlocking(root); // throws LockBusyError on timeout
+  try {
+    return await appendEventLocked(root, input);
+  } finally {
+    await releaseLock(root);
+  }
+}
+
+/**
+ * Record an event, dispatching on whether the caller already holds the lock:
+ * `opts.locked` uses the lock-free {@link appendEventLocked} (an emit site inside
+ * a held mutation lock), otherwise the self-locking {@link appendEvent}.
+ *
+ * @param root - Absolute project root.
+ * @param input - The new event's content.
+ * @param opts - When `locked`, skip the nested acquire (caller holds the lock).
+ * @returns The persisted {@link EventRecord}.
+ */
+export function recordEvent(
+  root: string,
+  input: AppendEventInput,
+  opts: RecordEventOptions = {},
+): Promise<EventRecord> {
+  return opts.locked ? appendEventLocked(root, input) : appendEvent(root, input);
+}

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,0 +1,120 @@
+/**
+ * @file src/events/types.ts
+ * @description Type surface for the append-only, HASH-CHAINED EVENT STORE
+ * (CLP 4b) — the tamper-evident audit log at `wiki/graph/events.jsonl`.
+ *
+ * Every lifecycle transition and relation write emits one {@link EventRecord}.
+ * Each record carries a `prevHash` linking it to the digest of the PRIOR record
+ * (the first record's `prevHash` is the fixed {@link GENESIS_PREV_HASH}), so the
+ * records form a chain: editing, reordering, or deleting any record breaks the
+ * link from its successor. A separate per-record `checksum` (sha256 of the
+ * record-without-checksum form) detects a single flipped byte independently of
+ * the chain — the SAME defense-in-depth split the relation store uses.
+ *
+ * On disk the first line of a non-empty store is an {@link EventStoreHeader}
+ * carrying `schemaVersion`; readers FAIL CLOSED when it exceeds
+ * {@link EVENT_STORE_SCHEMA_VERSION}. A sealed HEAD anchor (the digest of the
+ * last event, at `.llmwiki/events.head`) lets a reader detect a TRUNCATED or
+ * wholesale-rewritten log: the last record's digest must equal the anchor.
+ *
+ * DURABILITY: emit is best-effort AFTER the durable mutation, so a crash between
+ * the mutation and the append leaves a missing trailing event — the torn-trailing
+ * case the reader tolerates and reports. An interior tear / bad checksum / chain
+ * break is fail-closed (corrupt) or surfaced (chain) per the read contract.
+ */
+
+/** The event-store JSONL schema version readers understand. */
+export const EVENT_STORE_SCHEMA_VERSION = 1;
+
+/**
+ * The fixed `prevHash` of the FIRST event in a store — the chain's genesis
+ * anchor. A constant (not a real digest) so the first record's link is
+ * unambiguous and a reader can assert `events[0].prevHash === GENESIS_PREV_HASH`.
+ */
+export const GENESIS_PREV_HASH = "genesis";
+
+/** The kinds of mutation that emit an audit event. */
+export type EventType = "lifecycle-transition" | "relation-create" | "relation-update";
+
+/** An event id, always of the form `evt_<ULID>`. */
+export type EventId = `evt_${string}`;
+
+/** The content fields an event's chain digest is computed over (excludes prevHash/checksum). */
+export interface EventContent {
+  /** Stable handle, allocated once at emit. */
+  id: EventId;
+  /** Which mutation produced this event. */
+  type: EventType;
+  /** Where the mutation originated (e.g. `"sdk"`). */
+  origin: string;
+  /** Optional acting principal (user/agent), when known. */
+  actor?: string;
+  /** Mutation-specific detail (entity/slug/from/to/state etc.). */
+  payload: Record<string, unknown>;
+  /** Optional trust decision that routed the mutation. */
+  decision?: string;
+  /** ISO-8601 emit timestamp. */
+  at: string;
+}
+
+/**
+ * One audit event. `prevHash` links to the digest of the prior record (or
+ * {@link GENESIS_PREV_HASH} for the first); `checksum` is the per-record
+ * integrity hash. See the file overview for the full chain contract.
+ */
+export interface EventRecord extends EventContent {
+  /** Digest of the PRIOR record (genesis anchor for the first). */
+  prevHash: string;
+  /** sha256 of the canonical record-without-checksum (incl. prevHash). */
+  checksum: string;
+}
+
+/** The first line of a non-empty store, carrying its schema version. */
+export interface EventStoreHeader {
+  /** Discriminator marking this line as the header, not a record. */
+  kind: "event-store-header";
+  /** The store schema version; readers fail closed when it exceeds known. */
+  schemaVersion: number;
+}
+
+/** Raised when a store's `schemaVersion` exceeds the known version (fail closed). */
+export class EventStoreTooNewError extends Error {
+  constructor(found: number, known: number) {
+    super(`event store schemaVersion ${found} exceeds supported ${known}`);
+    this.name = "EventStoreTooNewError";
+  }
+}
+
+/** Raised when interior store content is corrupt (bad checksum / malformed line). */
+export class EventStoreCorruptError extends Error {
+  constructor(message: string) {
+    super(`event store corrupt: ${message}`);
+    this.name = "EventStoreCorruptError";
+  }
+}
+
+/**
+ * Raised when the canonical store FILE leaf (`wiki/graph/events.jsonl`) is a
+ * SYMLINK or non-regular file. The no-follow open fails closed here, so an event
+ * append can never land outside the project root and a read can never return
+ * out-of-tree bytes — the LEAF defense complementing the graph-DIR confinement.
+ */
+export class EventStoreSymlinkError extends Error {
+  constructor(message: string) {
+    super(`event store file leaf rejected: ${message}`);
+    this.name = "EventStoreSymlinkError";
+  }
+}
+
+/**
+ * Raised when the hash chain is broken, forked, reordered, or its sealed HEAD
+ * anchor does not match the last event — tamper evidence. Callers that demand an
+ * intact chain throw this; {@link readEvents} instead surfaces it as a `problem`
+ * so a later lint/status surface can report it without failing the read.
+ */
+export class EventStoreChainError extends Error {
+  constructor(message: string) {
+    super(`event store chain broken: ${message}`);
+    this.name = "EventStoreChainError";
+  }
+}

--- a/src/relations/store-read.ts
+++ b/src/relations/store-read.ts
@@ -25,13 +25,15 @@
 import path from "path";
 import { RELATIONS_FILE, MAX_RELATION_STORE_BYTES } from "../utils/constants.js";
 import { parseEntityId, EntityIdError } from "../profile/identity.js";
+import { readConfinedGraphStore, splitStoreRecords } from "../utils/jsonl-store.js";
 import type { RelationRef, RelationRecord } from "./types.js";
 import {
   RELATION_STORE_SCHEMA_VERSION,
   RelationStoreTooNewError,
   RelationStoreCorruptError,
+  RelationStoreSymlinkError,
 } from "./types.js";
-import { recordChecksum, resolveGraphDir, openStoreFileRead } from "./store-record.js";
+import { recordChecksum } from "./store-record.js";
 
 /** The outcome of reading the store: live relations plus any tolerated problems. */
 export interface ReadRelationsResult {
@@ -42,31 +44,21 @@ export interface ReadRelationsResult {
 }
 
 /**
- * Read the raw store file bytes, or null when the file is absent. Opens the leaf
- * through the shared NO-FOLLOW {@link openStoreFileRead} (a symlinked leaf fails
- * closed; the read never touches the path after open, so nothing can follow a
- * link to out-of-tree bytes), then `fstat`s the HANDLE and fails closed
- * ({@link RelationStoreCorruptError}) when it exceeds {@link MAX_RELATION_STORE_BYTES}
- * — an attacker/sync-controlled multi-GB file is rejected before the whole-file
- * read could exhaust memory. The handle is always closed in `finally`.
+ * Read the raw store file bytes, or null when the file is absent — via the shared
+ * {@link readConfinedGraphStore}, which resolves the confined graph dir, opens the
+ * leaf NO-FOLLOW (a symlinked leaf fails closed as {@link RelationStoreSymlinkError}),
+ * and `fstat`-fails-closed ({@link RelationStoreCorruptError}) above
+ * {@link MAX_RELATION_STORE_BYTES} before the whole-file read — so an
+ * attacker/sync-controlled multi-GB file cannot exhaust memory.
  */
-async function readStoreFile(root: string): Promise<string | null> {
-  const { dir, exists } = await resolveGraphDir(root); // throws on symlink escape (DIR defense)
-  if (!exists) return null;
-  const file = path.join(dir, path.basename(RELATIONS_FILE));
-  const handle = await openStoreFileRead(file); // throws on symlink leaf (LEAF defense)
-  if (handle === null) return null; // dir exists but file does not → no relations yet
-  try {
-    const size = (await handle.stat()).size;
-    if (size > MAX_RELATION_STORE_BYTES) {
-      throw new RelationStoreCorruptError(
-        `store file ${size} bytes exceeds the ${MAX_RELATION_STORE_BYTES}-byte cap`,
-      );
-    }
-    return await handle.readFile("utf-8");
-  } finally {
-    await handle.close();
-  }
+function readStoreFile(root: string): Promise<string | null> {
+  return readConfinedGraphStore(root, {
+    fileName: path.basename(RELATIONS_FILE),
+    makeSymlinkError: (reason) => new RelationStoreSymlinkError(reason),
+    maxBytes: MAX_RELATION_STORE_BYTES,
+    makeOversizeError: (size) =>
+      new RelationStoreCorruptError(`store file ${size} bytes exceeds the ${MAX_RELATION_STORE_BYTES}-byte cap`),
+  });
 }
 
 /** Parse and validate the header line, failing closed on an unknown future version. */
@@ -171,10 +163,9 @@ function parseRecords(lines: string[], problems: string[]): RelationRef[] {
  */
 export async function readRelations(root: string): Promise<ReadRelationsResult> {
   const raw = await readStoreFile(root); // throws on symlink escape
-  if (raw === null || raw.trim() === "") return { relations: [], problems: [] };
-  const lines = raw.split("\n").filter((line) => line.length > 0);
-  parseHeader(lines[0]);
+  const recordLines = splitStoreRecords(raw, parseHeader);
+  if (recordLines === null) return { relations: [], problems: [] };
   const problems: string[] = [];
-  const refs = parseRecords(lines.slice(1), problems);
+  const refs = parseRecords(recordLines, problems);
   return { relations: latestPerId(refs), problems };
 }

--- a/src/relations/store-record.ts
+++ b/src/relations/store-record.ts
@@ -12,28 +12,27 @@
  * line independently of the content hash (which a writer could, in principle,
  * have written wrong).
  *
- * It also owns the shared NO-FOLLOW open primitive for the canonical store FILE
- * leaf (`openStoreFileRead`/`openStoreFileAppend`). Both the read and the write
- * path route through it, so a symlinked `relations.jsonl` leaf can never be
- * followed to read from / append to an out-of-tree file. This is the LEAF
- * defense; {@link resolveGraphDir} is the DIR defense — BOTH are required to
- * confine the store, and routing every open through one primitive means this
- * symlink-escape class cannot reappear at a new call site.
+ * The NO-FOLLOW append primitive for the canonical store FILE leaf
+ * (`openStoreFileAppend`) and the confined graph-DIR resolver (`resolveGraphDir`)
+ * are thin relation-typed wrappers around the SHARED `src/utils/jsonl-store.ts`
+ * primitives (which the event store reuses). The write path routes through them,
+ * so a symlinked `relations.jsonl` leaf can never be followed to append to an
+ * out-of-tree file (the read path opens the leaf through the shared
+ * `readConfinedGraphStore`). This is the LEAF defense; {@link resolveGraphDir} is
+ * the DIR defense — BOTH are required to confine the store.
  */
 
 import { createHash } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import canonicalize from "canonicalize";
-import path from "path";
-import { lstat, open } from "fs/promises";
-import { WIKI_GRAPH_DIR } from "../utils/constants.js";
-import { safeRealpath, isInsideDir, confineUnderRoot } from "../utils/path-confine.js";
+import { resolveConfinedGraphDir, openGraphFileAppend } from "../utils/jsonl-store.js";
 import type { RelationRef, RelationRecord, RelationStoreHeader } from "./types.js";
 import { RELATION_STORE_SCHEMA_VERSION, RelationStoreSymlinkError } from "./types.js";
 
-/** Default mode for a freshly-created store file (owner rw, group/other r). */
-const STORE_FILE_MODE = 0o644;
+/** Build the relation store's typed symlink error from a reason string. */
+function relationSymlinkError(reason: string): Error {
+  return new RelationStoreSymlinkError(reason);
+}
 
 /** Compute the per-record checksum over a relation's content (excludes `checksum`). */
 export function recordChecksum(ref: RelationRef): string {
@@ -60,105 +59,27 @@ export function headerLine(): string {
 }
 
 /**
- * Resolve the trusted on-disk graph directory for `root`: `<realpath(root)>/wiki/graph`,
- * requiring it (if it exists) to be a REAL directory at that literal path. A
- * symlinked `wiki/graph` (which would redirect every read/write outside the
- * project) FAILS CLOSED here by throwing. Returns `{ dir, exists }`: `exists`
- * is false when the directory is simply absent (the "no relations" state).
- *
- * Confinement is layered: the shared {@link confineUnderRoot} primitive (with
- * `mustExist:false`) realpath-checks the NEAREST EXISTING ANCESTOR of the graph
- * dir, so even when `wiki/graph` is ABSENT, a symlinked `wiki` (or `root`) that
- * escapes the project fails closed BEFORE any caller `mkdir`s the dir. When the
- * leaf exists, the original lstat/realpath check (a symlinked `wiki/graph`)
- * remains as defense in depth.
+ * Resolve the trusted on-disk graph directory for `root`: the relation-typed
+ * wrapper over the shared {@link resolveConfinedGraphDir} (a symlinked
+ * `wiki/graph` or escaping ancestor fails closed). Returns `{ dir, exists }`;
+ * `exists` is false when the directory is simply absent (the "no relations" state).
  *
  * @param root - Absolute project root.
  * @returns The confined graph dir and whether it currently exists on disk.
  */
-export async function resolveGraphDir(root: string): Promise<{ dir: string; exists: boolean }> {
-  const canonicalRoot = await safeRealpath(root);
-  const base = canonicalRoot ?? path.resolve(root);
-  const dir = path.join(base, WIKI_GRAPH_DIR);
-  // Confine the NEAREST EXISTING ANCESTOR first: a symlinked `wiki` parent (with
-  // `wiki/graph` absent) escaping root throws here, before any caller mkdir.
-  await confineUnderRoot(dir, base, { mustExist: false });
-  let st;
-  try {
-    st = await lstat(dir);
-  } catch {
-    return { dir, exists: false }; // absent → no relations yet
-  }
-  if (!st.isDirectory()) {
-    throw new Error(`relation graph path is not a directory (symlink?): ${WIKI_GRAPH_DIR}`);
-  }
-  const real = await safeRealpath(dir);
-  if (real === null || !isInsideDir(real, base)) {
-    throw new Error(`relation graph directory escapes project root: ${WIKI_GRAPH_DIR}`);
-  }
-  return { dir: real, exists: true };
+export function resolveGraphDir(root: string): Promise<{ dir: string; exists: boolean }> {
+  return resolveConfinedGraphDir(root);
 }
 
 /**
- * Fail closed unless `handle` is a REGULAR file: a FIFO/device/socket at the
- * leaf is rejected just like a symlink, so the store open never lands on a
- * surface a record could be diverted through. Closes the handle before throwing.
- */
-async function assertRegularFile(handle: FileHandle): Promise<void> {
-  const st = await handle.stat();
-  if (!st.isFile()) {
-    await handle.close();
-    throw new RelationStoreSymlinkError("store file is not a regular file");
-  }
-}
-
-/**
- * Open the canonical store FILE leaf for READING with `O_NOFOLLOW` — a symlinked
- * leaf fails the open with `ELOOP`, which we fail closed on
- * ({@link RelationStoreSymlinkError}), so a read never follows the link to
- * out-of-tree bytes. An ABSENT file (`ENOENT`) returns `null` (caller treats as
- * empty). After open the HANDLE is `fstat`ed and required to be a regular file.
- * This is the LEAF defense complementing the {@link resolveGraphDir} DIR defense.
- *
- * @param file - The store file path inside the already-confined graph dir.
- * @returns An open read handle, or `null` when the file is absent.
- */
-export async function openStoreFileRead(file: string): Promise<FileHandle | null> {
-  let handle: FileHandle;
-  try {
-    handle = await open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") return null; // absent file → empty store
-    if (code === "ELOOP") throw new RelationStoreSymlinkError("store file is a symlink");
-    throw err;
-  }
-  await assertRegularFile(handle);
-  return handle;
-}
-
-/**
- * Open the canonical store FILE leaf for APPEND with `O_NOFOLLOW` (creating it if
- * absent, mode {@link STORE_FILE_MODE}) — a symlinked leaf fails the open with
- * `ELOOP`, which we fail closed on ({@link RelationStoreSymlinkError}), so the
- * append NEVER lands on an out-of-tree file. After open the HANDLE is `fstat`ed
- * and required to be a regular file. The LEAF defense complementing the
- * {@link resolveGraphDir} DIR defense.
+ * Open the canonical store FILE leaf for APPEND with `O_NOFOLLOW` (the
+ * relation-typed wrapper over the shared {@link openGraphFileAppend}). A symlinked
+ * leaf fails closed ({@link RelationStoreSymlinkError}). The LEAF defense
+ * complementing the {@link resolveGraphDir} DIR defense.
  *
  * @param file - The store file path inside the already-confined graph dir.
  * @returns An open append handle to a confirmed regular file.
  */
-export async function openStoreFileAppend(file: string): Promise<FileHandle> {
-  const flags = fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW;
-  let handle: FileHandle;
-  try {
-    handle = await open(file, flags, STORE_FILE_MODE);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ELOOP") {
-      throw new RelationStoreSymlinkError("store file is a symlink");
-    }
-    throw err;
-  }
-  await assertRegularFile(handle);
-  return handle;
+export function openStoreFileAppend(file: string): Promise<FileHandle> {
+  return openGraphFileAppend(file, relationSymlinkError);
 }

--- a/src/relations/store.ts
+++ b/src/relations/store.ts
@@ -41,6 +41,8 @@ import { canonicalEndpoints, relationContentHash } from "./digest.js";
 import { headerLine, serializeRecord, resolveGraphDir, openStoreFileAppend } from "./store-record.js";
 import { readRelations } from "./store-read.js";
 import { validateRelationAttributes, validateRelationEndpoints, validateRelationAgainstProfile } from "./relation-contract.js";
+import { appendEventLocked } from "../events/store.js";
+import type { EventType } from "../events/types.js";
 
 /** The caller-supplied content of a new relation (id + hash are derived). */
 export interface AppendRelationInput {
@@ -167,6 +169,22 @@ async function appendLine(root: string, ref: RelationRef): Promise<void> {
   }
 }
 
+/**
+ * Emit one relation audit event into the chained event store under the CALLER's
+ * held lock (the lock-free {@link appendEventLocked}). Called only after a real
+ * {@link appendLine} (a dedup hit appends nothing and emits nothing), so the
+ * event trails the durable mutation it records. Best-effort after-mutation: a
+ * failed emit does not roll back the relation append.
+ */
+async function emitRelationEvent(root: string, type: EventType, ref: RelationRef): Promise<void> {
+  await appendEventLocked(root, {
+    type,
+    origin: "sdk",
+    payload: { id: ref.id, relType: ref.type, from: ref.from, to: ref.to },
+    at: new Date().toISOString(),
+  });
+}
+
 /** Run `fn` while holding the project lock (bounded-blocking acquire); release in a finally. */
 async function underLock<T>(root: string, fn: () => Promise<T>): Promise<T> {
   await acquireLockBlocking(root); // throws LockBusyError on timeout
@@ -203,8 +221,9 @@ export async function appendRelationLocked(
   const ref = buildRelationRef(profile, input); // throws before any write
   const { relations } = await readRelations(root); // under the caller's lock
   const duplicate = relations.find((rel) => rel.contentHash === ref.contentHash);
-  if (duplicate) return duplicate; // idempotent create (FIX #6) — append nothing
+  if (duplicate) return duplicate; // idempotent create (FIX #6) — append nothing, emit nothing
   await appendLine(root, ref);
+  await emitRelationEvent(root, "relation-create", ref); // under the caller's lock, after the append
   return ref;
 }
 
@@ -269,6 +288,7 @@ export async function updateRelation(
     };
     const ref = buildRelationRef(profile, input, id);
     await appendLine(root, ref);
+    await emitRelationEvent(root, "relation-update", ref); // under the held lock, after the append
     return ref;
   });
 }

--- a/src/trust/lifecycle-transition.ts
+++ b/src/trust/lifecycle-transition.ts
@@ -21,6 +21,7 @@ import { loadNonDefaultProfile } from "../profile/block.js";
 import { resolveConfinedEntityPage } from "../profile/lifecycle-read.js";
 import { parseFrontmatter, buildFrontmatter, safeReadFile } from "../utils/markdown.js";
 import { acquireLock, releaseLock } from "../utils/lock.js";
+import { appendEventLocked } from "../events/store.js";
 import { applyTypedCandidate } from "./promote.js";
 import type { EntityTypeDef } from "../profile/types.js";
 import type { ReviewCandidate } from "../utils/types.js";
@@ -147,6 +148,7 @@ async function transitionUnderLock(
   evidence?: LifecycleEvidence,
 ): Promise<void> {
   const existing = await readExistingPage(root, def, slug);
+  const prev = parseFrontmatter(existing).meta[def.lifecycle!.field];
   const body = buildTransitionedBody(existing, def, toState, evidence);
   const candidate: Pick<ReviewCandidate, "slug" | "body" | "targetEntityType"> = {
     slug,
@@ -154,6 +156,39 @@ async function transitionUnderLock(
     targetEntityType: entityType,
   };
   await applyTypedCandidate(root, candidate as ReviewCandidate);
+  // Emit AFTER the page write lands, under the held lock so event + mutation
+  // co-commit. Best-effort: a failed emit does not roll back the transition.
+  await emitTransitionEvent(root, { entityType, slug, prev, toState, evidence });
+}
+
+/** The fields one lifecycle-transition audit event records about the transition. */
+interface TransitionEventFields {
+  entityType: string;
+  slug: string;
+  prev: unknown;
+  toState: string;
+  evidence?: LifecycleEvidence;
+}
+
+/**
+ * Emit one `lifecycle-transition` audit event into the chained event store under
+ * the CALLER's held lock (the lock-free {@link appendEventLocked}). Called only
+ * after {@link applyTypedCandidate} has durably written the page, so the event
+ * trails the mutation it records.
+ */
+async function emitTransitionEvent(root: string, fields: TransitionEventFields): Promise<void> {
+  await appendEventLocked(root, {
+    type: "lifecycle-transition",
+    origin: "sdk",
+    payload: {
+      entityType: fields.entityType,
+      slug: fields.slug,
+      from: fields.prev ?? null,
+      to: fields.toState,
+      evidenceKeys: Object.keys(fields.evidence ?? {}),
+    },
+    at: new Date().toISOString(),
+  });
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -102,6 +102,17 @@ export const WIKI_GRAPH_DIR = "wiki/graph";
 export const RELATIONS_FILE = "wiki/graph/relations.jsonl";
 
 /**
+ * The append-only, hash-chained EVENT STORE and its sealed head anchor. The
+ * store lives in the SAME confined `wiki/graph/` dir as the relation store; the
+ * head anchor (the digest of the last event) lives under the private `.llmwiki/`
+ * dir so truncation/rewrite of the log can be detected against a sealed value.
+ * A DEFAULT profile performs no lifecycle/relation mutations, so it never writes
+ * either file — its absence is the "no events" state, keeping parity unchanged.
+ */
+export const EVENTS_FILE = "wiki/graph/events.jsonl";
+export const EVENTS_HEAD_FILE = ".llmwiki/events.head";
+
+/**
  * Resource cap on the relation store file. The store is attacker/sync-controllable
  * (a teammate or a synced checkout can replace it), and the reader slurps the whole
  * file before any header/checksum validation. A multi-GB file or a giant single

--- a/src/utils/jsonl-store.ts
+++ b/src/utils/jsonl-store.ts
@@ -1,0 +1,210 @@
+/**
+ * @file src/utils/jsonl-store.ts
+ * @description Shared confinement + no-follow open primitives for the append-only
+ * JSONL stores under `wiki/graph/` (the relation store and the event store). Both
+ * stores live in the SAME confined graph directory and both need the identical
+ * symlink/regular-file hardening on their leaf file, so that hardening lives here
+ * ONCE — five audit rounds went into it, and a second store must inherit it rather
+ * than re-derive (and re-mis-derive) it.
+ *
+ * Two layered defenses, both required to confine a store:
+ *  - DIR defense ({@link resolveConfinedGraphDir}): `<realpath(root)>/wiki/graph`
+ *    must be a REAL directory at that literal path; a symlinked `wiki/graph` (or a
+ *    symlinked `wiki`/`root` ancestor, even when `graph` is absent) FAILS CLOSED.
+ *  - LEAF defense ({@link openGraphFileRead}/{@link openGraphFileAppend}): the
+ *    store FILE leaf is opened with `O_NOFOLLOW`, so a symlinked leaf fails the
+ *    open with `ELOOP` (mapped to the caller's typed symlink error) and the
+ *    open then `fstat`s the HANDLE, requiring a REGULAR file.
+ *
+ * The typed symlink error is INJECTED (`makeSymlinkError`) so each store throws
+ * its OWN error class while sharing one open path — a store can never reappear at
+ * a new call site without the no-follow leaf defense.
+ */
+
+import { constants as fsConstants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { lstat, open } from "fs/promises";
+import path from "path";
+import { WIKI_GRAPH_DIR } from "./constants.js";
+import { safeRealpath, isInsideDir, confineUnderRoot } from "./path-confine.js";
+
+/** Default mode for a freshly-created store file (owner rw, group/other r). */
+const STORE_FILE_MODE = 0o644;
+
+/** Builds a store-specific typed symlink error from a human-readable reason. */
+export type SymlinkErrorFactory = (reason: string) => Error;
+
+/** How a graph store reader opens its leaf and fails closed over the size cap. */
+export interface GraphStoreReadConfig {
+  /** Basename of the store file inside the confined graph dir (e.g. `events.jsonl`). */
+  fileName: string;
+  /** The store-typed symlink error factory for the no-follow open. */
+  makeSymlinkError: SymlinkErrorFactory;
+  /** Maximum store size before the read fails closed (DoS guard). */
+  maxBytes: number;
+  /** Builds the store-typed over-cap error from the offending byte size. */
+  makeOversizeError: (size: number) => Error;
+}
+
+/**
+ * Read a confined graph store file's raw bytes, or `null` when the dir/file is
+ * absent. Resolves the confined graph dir (DIR defense), opens the leaf with
+ * `O_NOFOLLOW` (LEAF defense), `fstat`s the HANDLE and FAILS CLOSED above
+ * `maxBytes` before the whole-file read (so an attacker/sync-controlled multi-GB
+ * file is rejected before it could exhaust memory), then reads the body. The
+ * handle is always closed in `finally`. Shared by the relation and event readers
+ * so the confinement + size-cap discipline is defined ONCE.
+ *
+ * @param root - Absolute project root.
+ * @param config - The store's leaf name, symlink/oversize errors, and size cap.
+ * @returns The raw file body, or `null` when the store is absent.
+ */
+export async function readConfinedGraphStore(
+  root: string,
+  config: GraphStoreReadConfig,
+): Promise<string | null> {
+  const { dir, exists } = await resolveConfinedGraphDir(root); // throws on symlink escape (DIR)
+  if (!exists) return null;
+  const file = path.join(dir, config.fileName);
+  const handle = await openGraphFileRead(file, config.makeSymlinkError); // throws on symlink leaf (LEAF)
+  if (handle === null) return null;
+  try {
+    const size = (await handle.stat()).size;
+    if (size > config.maxBytes) throw config.makeOversizeError(size);
+    return await handle.readFile("utf-8");
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Resolve the trusted on-disk graph directory for `root`:
+ * `<realpath(root)>/wiki/graph`, requiring it (if it exists) to be a REAL
+ * directory at that literal path. A symlinked `wiki/graph` (which would redirect
+ * every read/write outside the project) FAILS CLOSED here by throwing. Returns
+ * `{ dir, exists }`: `exists` is false when the directory is simply absent (the
+ * "no records yet" state).
+ *
+ * Confinement is layered: {@link confineUnderRoot} (with `mustExist:false`)
+ * realpath-checks the NEAREST EXISTING ANCESTOR of the graph dir, so even when
+ * `wiki/graph` is ABSENT, a symlinked `wiki` (or `root`) escaping the project
+ * fails closed BEFORE any caller `mkdir`s the dir. When the leaf exists, the
+ * lstat/realpath check (a symlinked `wiki/graph`) remains as defense in depth.
+ *
+ * @param root - Absolute project root.
+ * @returns The confined graph dir and whether it currently exists on disk.
+ */
+export async function resolveConfinedGraphDir(root: string): Promise<{ dir: string; exists: boolean }> {
+  const canonicalRoot = await safeRealpath(root);
+  const base = canonicalRoot ?? path.resolve(root);
+  const dir = path.join(base, WIKI_GRAPH_DIR);
+  await confineUnderRoot(dir, base, { mustExist: false });
+  let st;
+  try {
+    st = await lstat(dir);
+  } catch {
+    return { dir, exists: false }; // absent → no records yet
+  }
+  if (!st.isDirectory()) {
+    throw new Error(`graph path is not a directory (symlink?): ${WIKI_GRAPH_DIR}`);
+  }
+  const real = await safeRealpath(dir);
+  if (real === null || !isInsideDir(real, base)) {
+    throw new Error(`graph directory escapes project root: ${WIKI_GRAPH_DIR}`);
+  }
+  return { dir: real, exists: true };
+}
+
+/**
+ * Split a non-empty store body into its post-header RECORD lines, running the
+ * caller's `parseHeader` on the first line (which fails closed on an unknown
+ * future schema version). Returns `null` for an absent or whitespace-only body so
+ * the caller can return its own empty-store shape. Shared by the relation and
+ * event readers so the "drop blank lines, validate header, hand back records"
+ * preamble is defined ONCE.
+ *
+ * @param raw - The raw store body, or `null` when the store is absent.
+ * @param parseHeader - Validates the header line (throws on a too-new/invalid header).
+ * @returns The record lines after the header, or `null` when the store is empty.
+ */
+export function splitStoreRecords(
+  raw: string | null,
+  parseHeader: (line: string) => void,
+): string[] | null {
+  if (raw === null || raw.trim() === "") return null;
+  const lines = raw.split("\n").filter((line) => line.length > 0);
+  parseHeader(lines[0]);
+  return lines.slice(1);
+}
+
+/**
+ * Fail closed unless `handle` is a REGULAR file: a FIFO/device/socket at the leaf
+ * is rejected just like a symlink, so the store open never lands on a surface a
+ * record could be diverted through. Closes the handle before throwing.
+ */
+async function assertRegularFile(handle: FileHandle, makeSymlinkError: SymlinkErrorFactory): Promise<void> {
+  const st = await handle.stat();
+  if (!st.isFile()) {
+    await handle.close();
+    throw makeSymlinkError("store file is not a regular file");
+  }
+}
+
+/**
+ * Open a graph store FILE leaf for READING with `O_NOFOLLOW` — a symlinked leaf
+ * fails the open with `ELOOP`, mapped to the injected symlink error, so a read
+ * never follows the link to out-of-tree bytes. An ABSENT file (`ENOENT`) returns
+ * `null` (caller treats as empty). After open the HANDLE is `fstat`ed and
+ * required to be a regular file. The LEAF defense complementing the
+ * {@link resolveConfinedGraphDir} DIR defense.
+ *
+ * @param file - The store file path inside the already-confined graph dir.
+ * @param makeSymlinkError - Builds the store's typed symlink error.
+ * @returns An open read handle, or `null` when the file is absent.
+ */
+export async function openGraphFileRead(
+  file: string,
+  makeSymlinkError: SymlinkErrorFactory,
+): Promise<FileHandle | null> {
+  let handle: FileHandle;
+  try {
+    handle = await open(file, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null; // absent file → empty store
+    if (code === "ELOOP") throw makeSymlinkError("store file is a symlink");
+    throw err;
+  }
+  await assertRegularFile(handle, makeSymlinkError);
+  return handle;
+}
+
+/**
+ * Open a graph store FILE leaf for APPEND with `O_NOFOLLOW` (creating it if
+ * absent, mode {@link STORE_FILE_MODE}) — a symlinked leaf fails the open with
+ * `ELOOP`, mapped to the injected symlink error, so the append NEVER lands on an
+ * out-of-tree file. After open the HANDLE is `fstat`ed and required to be a
+ * regular file. The LEAF defense complementing the {@link resolveConfinedGraphDir}
+ * DIR defense.
+ *
+ * @param file - The store file path inside the already-confined graph dir.
+ * @param makeSymlinkError - Builds the store's typed symlink error.
+ * @returns An open append handle to a confirmed regular file.
+ */
+export async function openGraphFileAppend(
+  file: string,
+  makeSymlinkError: SymlinkErrorFactory,
+): Promise<FileHandle> {
+  const flags = fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW;
+  let handle: FileHandle;
+  try {
+    handle = await open(file, flags, STORE_FILE_MODE);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") {
+      throw makeSymlinkError("store file is a symlink");
+    }
+    throw err;
+  }
+  await assertRegularFile(handle, makeSymlinkError);
+  return handle;
+}

--- a/test/event-emit.test.ts
+++ b/test/event-emit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @file test/event-emit.test.ts
+ * @description Tests that lifecycle transitions and relation writes EMIT chained
+ * audit events (CLP 4b PR1): a transition appends a `lifecycle-transition` event,
+ * a relation create appends `relation-create`, an update appends `relation-update`,
+ * the events chain + the head anchor verifies, and a DEFAULT project (which makes
+ * no transitions/relations) writes no event store.
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { EntityId, ProfilePack } from "../src/profile/types.js";
+import { createWiki } from "../src/index.js";
+import { appendRelation, updateRelation } from "../src/relations/store.js";
+import { readEvents, verifyEventChain, verifyHeadAnchor } from "../src/events/store-read.js";
+import { buildResearchLiteRelationsProject, RESEARCH_LITE_RELATIONS_PROFILE } from "./fixtures/profile-fixtures.js";
+
+const EXP = "experiments/ablation-batch-size" as EntityId;
+const IDEA = "ideas/sparse-routing" as EntityId;
+const profile = (): ProfilePack => RESEARCH_LITE_RELATIONS_PROFILE as ProfilePack;
+
+let root = "";
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "evt-emit-"));
+  await buildResearchLiteRelationsProject(root);
+});
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+describe("lifecycle transition emits a chained event", () => {
+  it("appends a lifecycle-transition event that chains + anchors", async () => {
+    const wiki = createWiki({ root });
+    await wiki.transitionLifecycle({ entityType: "ideas", slug: "sparse-routing", toState: "testing" });
+    const { events, problems } = await readEvents(root);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("lifecycle-transition");
+    expect(events[0].payload).toMatchObject({ entityType: "ideas", slug: "sparse-routing", to: "testing" });
+    expect(problems).toEqual([]);
+    expect(verifyEventChain(events).ok).toBe(true);
+    expect((await verifyHeadAnchor(root, events)).ok).toBe(true);
+  });
+});
+
+describe("relation writes emit chained events", () => {
+  it("a relation create appends a relation-create event", async () => {
+    const wiki = createWiki({ root });
+    const ref = await wiki.createRelation({ type: "tests", from: EXP, to: IDEA });
+    const { events } = await readEvents(root);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("relation-create");
+    expect(events[0].payload).toMatchObject({ id: ref.id, relType: "tests", from: EXP, to: IDEA });
+  });
+
+  it("a relation update appends a relation-update event chained after the create", async () => {
+    const ref = await appendRelation(root, profile(), { type: "tests", from: EXP, to: IDEA });
+    await updateRelation(root, profile(), ref.id, { attributes: { note: "y" } });
+    const { events } = await readEvents(root);
+    expect(events.map((e) => e.type)).toEqual(["relation-create", "relation-update"]);
+    expect(verifyEventChain(events).ok).toBe(true);
+  });
+});
+
+describe("default project parity", () => {
+  it("a default project (no transitions/relations) writes no event store", async () => {
+    const def = await mkdtemp(path.join(os.tmpdir(), "evt-default-"));
+    try {
+      await expect(readEvents(def)).resolves.toEqual({ events: [], problems: [] });
+    } finally {
+      await rm(def, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/event-store.test.ts
+++ b/test/event-store.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @file test/event-store.test.ts
+ * @description Tests for the append-only, hash-chained EVENT store (CLP 4b PR1).
+ *
+ * Covers: append→readback with an `evt_` id; the first record's prevHash is
+ * GENESIS and the chain verifies; two events chain (record[1].prevHash ===
+ * digest(record[0])); the sealed head anchor matches the last event; an interior
+ * tamper / reorder breaks the chain (surfaced as a problem, not thrown); a
+ * truncation is caught by the head anchor; a torn trailing line is
+ * tolerated+reported; a symlinked leaf and a too-new schemaVersion fail closed;
+ * and a DEFAULT project reads empty.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, readFile, writeFile, appendFile, symlink } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { EVENTS_FILE, EVENTS_HEAD_FILE } from "../src/utils/constants.js";
+import { appendEvent, recordEvent } from "../src/events/store.js";
+import { readEvents, readEventsStrict, verifyEventChain, verifyHeadAnchor } from "../src/events/store-read.js";
+import { eventPrevHash } from "../src/events/event-digest.js";
+import {
+  EventStoreTooNewError,
+  EventStoreSymlinkError,
+  EventStoreCorruptError,
+  EventStoreChainError,
+  GENESIS_PREV_HASH,
+} from "../src/events/types.js";
+
+let root = "";
+beforeEach(async () => { root = await mkdtemp(path.join(os.tmpdir(), "evt-store-")); });
+afterEach(async () => { if (root) await rm(root, { recursive: true, force: true }); });
+
+const storePath = (): string => path.join(root, EVENTS_FILE);
+const input = (n: string) => ({ type: "relation-create" as const, origin: "sdk", payload: { n }, at: "2024-01-01T00:00:00Z" });
+
+describe("append / readback + chain", () => {
+  it("persists an evt_ event whose first prevHash is GENESIS and chain verifies", async () => {
+    const rec = await appendEvent(root, input("a"));
+    expect(rec.id).toMatch(/^evt_/);
+    const { events, problems } = await readEvents(root);
+    expect(problems).toEqual([]);
+    expect(events).toHaveLength(1);
+    expect(events[0].prevHash).toBe(GENESIS_PREV_HASH);
+    expect(verifyEventChain(events).ok).toBe(true);
+  });
+
+  it("chains two events: record[1].prevHash === digest(record[0])", async () => {
+    await appendEvent(root, input("a"));
+    await appendEvent(root, input("b"));
+    const { events } = await readEvents(root);
+    expect(events).toHaveLength(2);
+    expect(events[1].prevHash).toBe(eventPrevHash(events[0]));
+    expect(verifyEventChain(events).ok).toBe(true);
+  });
+
+  it("seals a head anchor matching the last event's digest", async () => {
+    await appendEvent(root, input("a"));
+    await appendEvent(root, input("b"));
+    const { events } = await readEvents(root);
+    const anchor = (await readFile(path.join(root, EVENTS_HEAD_FILE), "utf8")).trim();
+    expect(anchor).toBe(eventPrevHash(events[1]));
+    expect((await verifyHeadAnchor(root, events)).ok).toBe(true);
+  });
+
+  it("recordEvent({locked:false}) appends like appendEvent", async () => {
+    const rec = await recordEvent(root, input("a"));
+    const { events } = await readEvents(root);
+    expect(events).toMatchObject([{ id: rec.id }]);
+  });
+});
+
+describe("tamper / reorder / truncate detection", () => {
+  it("surfaces a chain problem when two records are reordered (checksums intact)", async () => {
+    await appendEvent(root, input("a"));
+    await appendEvent(root, input("b"));
+    await appendEvent(root, input("c"));
+    const lines = (await readFile(storePath(), "utf8")).split("\n").filter(Boolean);
+    const [header, r1, r2, r3] = lines; // swap r1<->r2: each record's checksum still valid
+    await writeFile(storePath(), [header, r2, r1, r3].join("\n") + "\n");
+    const { events, problems } = await readEvents(root);
+    expect(verifyEventChain(events).ok).toBe(false);
+    expect(problems.some((p) => /chain link broken/.test(p))).toBe(true);
+    await expect(readEventsStrict(root)).rejects.toBeInstanceOf(EventStoreChainError);
+  });
+
+  it("fails closed when an interior event's payload is edited (checksum break)", async () => {
+    await appendEvent(root, input("a"));
+    await appendEvent(root, input("b"));
+    const raw = await readFile(storePath(), "utf8");
+    await writeFile(storePath(), raw.replace('"n":"a"', '"n":"TAMPERED"'));
+    await expect(readEvents(root)).rejects.toBeInstanceOf(EventStoreCorruptError);
+  });
+
+  it("detects a truncated log (last record dropped) via the head anchor", async () => {
+    await appendEvent(root, input("a"));
+    await appendEvent(root, input("b"));
+    const lines = (await readFile(storePath(), "utf8")).split("\n").filter(Boolean);
+    await writeFile(storePath(), lines.slice(0, -1).join("\n") + "\n"); // drop last record
+    const { events, problems } = await readEvents(root);
+    expect((await verifyHeadAnchor(root, events)).ok).toBe(false);
+    expect(problems.some((p) => /head anchor/.test(p))).toBe(true);
+  });
+});
+
+describe("durability: torn / too-new / symlink / default", () => {
+  it("tolerates and reports a torn trailing line", async () => {
+    await appendEvent(root, input("a"));
+    await appendFile(storePath(), '{"id":"evt_torn","type":"rel');
+    const { events, problems } = await readEvents(root);
+    expect(events).toHaveLength(1);
+    expect(problems.some((p) => /torn trailing line/.test(p))).toBe(true);
+  });
+
+  it("fails closed when schemaVersion exceeds the known version", async () => {
+    await mkdir(path.dirname(storePath()), { recursive: true });
+    await writeFile(storePath(), '{"kind":"event-store-header","schemaVersion":99}\n');
+    await expect(readEvents(root)).rejects.toThrow(EventStoreTooNewError);
+  });
+
+  it("fails closed when the events leaf is a symlink", async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), "evt-escape-"));
+    await mkdir(path.dirname(storePath()), { recursive: true });
+    await writeFile(path.join(outside, "leak.jsonl"), "x");
+    await symlink(path.join(outside, "leak.jsonl"), storePath());
+    await expect(readEvents(root)).rejects.toBeInstanceOf(EventStoreSymlinkError);
+    await rm(outside, { recursive: true, force: true });
+  });
+
+  it("reads empty for a DEFAULT project with no wiki/graph", async () => {
+    await expect(readEvents(root)).resolves.toEqual({ events: [], problems: [] });
+  });
+});


### PR DESCRIPTION
First of the 4b stack (do not merge yet). Closes the audit gap that lifecycle transitions and relation writes were UNAUDITED (a spec requirement: "lifecycle transitions create audit events").

- New append-only `wiki/graph/events.jsonl` event store: `EventRecord` (`evt_<ULID>`, type, origin, payload, timestamp) with a per-record checksum, header schemaVersion (reader fails closed when newer), torn-trailing-line tolerance, and a **hash chain** (each record's `prevHash` = the prior record's canonical digest) whose head is anchored outside the log in a sealed `.llmwiki/events.head` — so an edited, reordered, deleted, or truncated history is detectable.
- Lifecycle transitions and relation create/update now emit a chained audit event under the same lock as the mutation.
- The relation store's hardened confinement/no-follow primitives were generalized into a shared `src/utils/jsonl-store.ts` that both stores use, so the event store inherits all the symlink/regular-file/size-cap hardening.

A default project makes no transitions/relations → no event store → default profile byte-identical; full suite green (2313).