### PR TITLE
feat(events): 4b PR2 — fail-closed event-chain lint + event count in status

### DIFF
--- a/src/profile/block.ts
+++ b/src/profile/block.ts
@@ -26,6 +26,8 @@ import { readRelations } from "../relations/store-read.js";
 import { validateRelationAgainstProfile } from "../relations/relation-contract.js";
 import { RelationStoreCorruptError, RelationStoreTooNewError, RelationStoreSymlinkError } from "../relations/types.js";
 import type { RelationRef } from "../relations/types.js";
+import { readEvents } from "../events/store-read.js";
+import { EventStoreCorruptError, EventStoreTooNewError, EventStoreSymlinkError } from "../events/types.js";
 
 /**
  * Load the active profile and return it ONLY when it is a non-default profile;
@@ -87,6 +89,16 @@ export interface ProfileSummaryBlock {
   relationCounts?: Record<string, number>;
   /** Total live relation count; present alongside (and equal to the sum of) `relationCounts`. */
   relationTotal?: number;
+  /**
+   * Total events in the append-only hash-chained audit log, present ONLY for a
+   * non-default profile whose `wiki/graph` store holds at least one event.
+   * OMITTED for the built-in default and for any event-LESS profile, so the
+   * default and event-less status/viewer envelopes stay byte-identical. A
+   * corrupt / too-new / symlinked-leaf store OR a broken/truncated chain does
+   * NOT populate this — it surfaces through `problems` instead (fail-closed,
+   * never a silent count reported as healthy).
+   */
+  eventCount?: number;
 }
 
 /**
@@ -200,6 +212,67 @@ async function summarizeRelations(root: string, loaded: LoadedProfile): Promise<
 }
 
 /**
+ * The event-store contribution to the summary block: the total event count
+ * (present only for an intact, non-empty log) and at most one fail-closed read
+ * or broken-chain problem. The two are mutually exclusive — a tamper signal
+ * suppresses the count so a broken store is never reported as silently healthy.
+ */
+interface EventSummary {
+  eventCount?: number;
+  problem?: EntityProblemView;
+}
+
+/** Map a fail-closed event-store read error to an `event-store` problem view. */
+function eventReadProblem(error: unknown): EntityProblemView {
+  if (
+    error instanceof EventStoreTooNewError ||
+    error instanceof EventStoreCorruptError ||
+    error instanceof EventStoreSymlinkError
+  ) {
+    return { kind: "event-store", message: error.message };
+  }
+  throw error; // a non-store error (e.g. a confinement escape) is not ours to swallow
+}
+
+/** The torn-trailing-line prefix {@link readEvents} tags; any OTHER problem is a chain/anchor tamper signal. */
+const TORN_EVENT_PREFIX = "tolerated torn trailing line";
+
+/**
+ * Reduce a successful (non-throwing) {@link readEvents} result to the summary
+ * contribution. A chain-link break or head-anchor (truncation) mismatch is a
+ * tamper signal: surface it as an `event-store` problem and SUPPRESS the count
+ * (never report a broken chain as a healthy total). A torn trailing line is
+ * tolerated — the valid events before it are still counted.
+ */
+function summarizeReadEvents(read: { events: { length: number }; problems: string[] }): EventSummary {
+  const tamper = read.problems.find((p) => !p.startsWith(TORN_EVENT_PREFIX));
+  if (tamper !== undefined) return { problem: { kind: "event-store", message: tamper } };
+  if (read.events.length === 0) return {};
+  return { eventCount: read.events.length };
+}
+
+/**
+ * Read the hash-chained event store for a non-default profile and reduce it to
+ * the additive summary contribution: the total event count (OMITTED for an
+ * event-LESS store, so an event-less project's envelope stays byte-identical),
+ * and a single `event-store` problem on a fail-closed read (corrupt / too-new /
+ * symlink) OR a broken/truncated chain — in which case the count is suppressed
+ * rather than reported as a healthy total.
+ *
+ * @param root - Absolute project root directory.
+ * @returns The event count and/or a problem.
+ */
+async function summarizeEvents(root: string): Promise<EventSummary> {
+  let read;
+  try {
+    read = await readEvents(root);
+  } catch (error) {
+    return { problem: eventReadProblem(error) };
+  }
+  return summarizeReadEvents(read);
+}
+
+/**
  * Resolve the active profile and, for a NON-DEFAULT profile only, build the
  * shared summary block (profileId, digest, per-type entity counts, problems).
  *
@@ -227,12 +300,15 @@ export async function collectProfileSummary(
   if (loaded === undefined) return undefined;
   const { counts, problems } = await collectEntitySummary(root, loaded.profile);
   const { relationCounts, relationTotal, problem } = await summarizeRelations(root, loaded);
-  const views = [...(await toProblemViews(problems, root)), ...(problem ? [problem] : [])];
+  const { eventCount, problem: eventProblem } = await summarizeEvents(root);
+  const storeProblems = [...(problem ? [problem] : []), ...(eventProblem ? [eventProblem] : [])];
+  const views = [...(await toProblemViews(problems, root)), ...storeProblems];
   return {
     profileId: loaded.profile.profileId,
     digest: loaded.digest,
     entityCounts: counts,
     ...problemEnvelope(views),
     ...(relationCounts ? { relationCounts, relationTotal } : {}),
+    ...(eventCount !== undefined ? { eventCount } : {}),
   };
 }

--- a/src/profile/event-lint.ts
+++ b/src/profile/event-lint.ts
@@ -1,0 +1,102 @@
+/**
+ * @file src/profile/event-lint.ts
+ * @description Event-store lint findings, making the append-only HASH-CHAINED
+ * event store (`wiki/graph/events.jsonl`, CLP 4b) VISIBLE through the
+ * profile-aware lint runner — additively, alongside the relation findings.
+ *
+ * The audit log is tamper-EVIDENT, so the lint must be tamper-DETECTING: a
+ * broken/forked/reordered/interior-deleted chain, or a head-anchor mismatch
+ * (a truncated or wholesale-rewritten log), MUST surface — never silently pass.
+ *
+ * Four concerns, all fail-open or fail-closed (lint NEVER crashes):
+ *   - `event-chain-broken` (error): {@link readEvents} surfaced a chain-link
+ *     break OR a head-anchor mismatch as a `problem`. The chain no longer
+ *     verifies, so the log is tampered — a fail-closed ERROR.
+ *   - `event-store-torn` (warning): the reader tolerated and REPORTED a torn
+ *     trailing line (an incomplete final append, e.g. a crash mid-emit).
+ *     Surfaced so the half-written record is visible; events before it count.
+ *   - `event-store-corrupt` / `event-store-too-new` / `event-store-symlink`
+ *     (error): the reader FAILED CLOSED (interior corruption / an unknown future
+ *     schema version / a symlinked-or-non-regular store-file leaf). Caught here
+ *     so lint reports the failure instead of throwing.
+ *
+ * A DEFAULT or event-LESS project (no `events.jsonl`) reads an EMPTY store with
+ * no problems, so this yields no findings and lint output stays byte-identical.
+ */
+
+import { readEvents } from "../events/store-read.js";
+import {
+  EventStoreCorruptError,
+  EventStoreTooNewError,
+  EventStoreSymlinkError,
+} from "../events/types.js";
+import type { LintResult } from "../linter/types.js";
+
+/** Rule id for a broken/forked/reordered chain or a head-anchor (truncation) mismatch. */
+const EVENT_CHAIN_BROKEN_RULE = "event-chain-broken";
+/** Rule id for a tolerated torn trailing line reported by the store reader. */
+const EVENT_STORE_TORN_RULE = "event-store-torn";
+/** Rule id for a fail-closed interior-corruption read. */
+const EVENT_STORE_CORRUPT_RULE = "event-store-corrupt";
+/** Rule id for a fail-closed unknown-future-schema-version read. */
+const EVENT_STORE_TOO_NEW_RULE = "event-store-too-new";
+/** Rule id for a fail-closed symlinked/non-regular store-file leaf read. */
+const EVENT_STORE_SYMLINK_RULE = "event-store-symlink";
+
+/** The lint `file` label for store-level event findings. */
+const EVENT_STORE_FILE = "wiki/graph/events.jsonl";
+
+/**
+ * Distinguish a tolerated torn-trailing problem from a fail-closed chain/anchor
+ * problem. {@link readEvents} tags a torn line with this exact prefix (see
+ * `parseRecords`); every other surfaced problem (chain link / head anchor) is a
+ * tamper signal that must escalate to a fail-closed `event-chain-broken` error.
+ */
+const TORN_PROBLEM_PREFIX = "tolerated torn trailing line";
+
+/** Build the store-level finding a fail-closed read maps to, by error type. */
+function readErrorFinding(error: unknown): LintResult | null {
+  if (error instanceof EventStoreTooNewError) {
+    return { rule: EVENT_STORE_TOO_NEW_RULE, severity: "error", file: EVENT_STORE_FILE, message: error.message };
+  }
+  if (error instanceof EventStoreCorruptError) {
+    return { rule: EVENT_STORE_CORRUPT_RULE, severity: "error", file: EVENT_STORE_FILE, message: error.message };
+  }
+  if (error instanceof EventStoreSymlinkError) {
+    return { rule: EVENT_STORE_SYMLINK_RULE, severity: "error", file: EVENT_STORE_FILE, message: error.message };
+  }
+  return null;
+}
+
+/** Map one surfaced reader problem to a torn WARNING or a chain-broken ERROR finding. */
+function problemToFinding(problem: string): LintResult {
+  if (problem.startsWith(TORN_PROBLEM_PREFIX)) {
+    return { rule: EVENT_STORE_TORN_RULE, severity: "warning", file: EVENT_STORE_FILE, message: problem };
+  }
+  return { rule: EVENT_CHAIN_BROKEN_RULE, severity: "error", file: EVENT_STORE_FILE, message: problem };
+}
+
+/**
+ * Surface the event store's integrity issues as additive lint findings.
+ *
+ * Reads the store fail-closed (a corrupt / too-new / symlinked store becomes a
+ * single store-level ERROR finding rather than a thrown error), then maps every
+ * tolerated/surfaced reader problem to a finding: a torn trailing line to an
+ * `event-store-torn` WARNING, and any chain-link break or head-anchor mismatch
+ * (tamper evidence: edit/reorder/delete/truncate) to an `event-chain-broken`
+ * ERROR. A healthy or event-LESS store yields no findings.
+ *
+ * @param root - Absolute project root directory.
+ * @returns All event-store findings (possibly empty). Never throws a store error.
+ */
+export async function checkEventChain(root: string): Promise<LintResult[]> {
+  let read;
+  try {
+    read = await readEvents(root);
+  } catch (error) {
+    const finding = readErrorFinding(error);
+    if (finding) return [finding];
+    throw error; // a non-store error (e.g. a confinement escape) is not ours to swallow
+  }
+  return read.problems.map(problemToFinding);
+}

--- a/src/profile/lint.ts
+++ b/src/profile/lint.ts
@@ -20,6 +20,11 @@
  *   3. The relation store is surfaced via {@link checkRelationStore}: dangling
  *      endpoints, a tolerated torn line, and a fail-closed corrupt/too-new read.
  *
+ *   4. The hash-chained event store is surfaced via {@link checkEventChain}: a
+ *      broken/forked/reordered chain or head-anchor (truncation) mismatch is a
+ *      fail-closed `event-chain-broken` error, a torn line a warning, and a
+ *      fail-closed corrupt/too-new/symlink read a store-level error.
+ *
  * Every entity-page finding carries the offending page/dir's `entityType` so
  * callers can group diagnostics by entity type; store-level relation findings
  * are not page-scoped and carry none.
@@ -28,6 +33,7 @@
 import { collectEntityPages, type EntityProblem, type EntityProblemKind } from "./collect.js";
 import { checkPageEmpty, checkPageMalformedCitations } from "../linter/rules.js";
 import { checkRelationStore } from "./relation-lint.js";
+import { checkEventChain } from "./event-lint.js";
 import { lifecycleStateSet } from "./lifecycle.js";
 import type { ProfilePack, EntityPage, LifecycleDef } from "./types.js";
 import type { LintResult } from "../linter/types.js";
@@ -133,5 +139,6 @@ export async function lintProfileEntities(
     results.push(...checkLifecycleStates(page, profile.entities[page.entityType]?.lifecycle));
   }
   results.push(...(await checkRelationStore(root, pages, profile)));
+  results.push(...(await checkEventChain(root)));
   return results;
 }

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -228,11 +228,13 @@ export function toEntityPageView(page: EntityPage, includeBody: boolean): Entity
 export interface EntityProblemView {
   /**
    * The problem kind. An entity-page/dir collector problem ({@link EntityProblemKind});
-   * `"relation-store"` for a fail-closed relation-store read (corrupt / too-new)
-   * surfaced through the SAME problems channel so a status/viewer envelope never
-   * reports a broken store as silently healthy.
+   * `"relation-store"` for a fail-closed relation-store read (corrupt / too-new);
+   * `"event-store"` for a fail-closed event-store read OR a broken/truncated
+   * hash chain. The store-level kinds are surfaced through the SAME problems
+   * channel so a status/viewer envelope never reports a broken store as silently
+   * healthy.
    */
-  kind: EntityProblemKind | "relation-store";
+  kind: EntityProblemKind | "relation-store" | "event-store";
   /**
    * Declared entity type the problem belongs to. ABSENT for a store-level
    * (`relation-store`) problem, which is not scoped to any entity type.

--- a/test/event-lint.test.ts
+++ b/test/event-lint.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @file test/event-lint.test.ts
+ * @description Tests for fail-closed EVENT-STORE lint (CLP 4b PR2) — making the
+ * append-only, hash-chained audit log (`wiki/graph/events.jsonl`) tamper-VISIBLE
+ * through the profile-aware lint runner.
+ *
+ * Covers: a HEALTHY chain (a couple of emitted events) yields NO event finding;
+ * a TAMPERED chain (reorder / interior-edit / truncation) fails CLOSED into an
+ * `event-chain-broken` error rather than passing silently; a torn trailing line
+ * surfaces an `event-store-torn` warning (events before it still counted); a
+ * too-new / symlinked / corrupt store fails closed into the matching store
+ * finding instead of crashing lint; and a DEFAULT project plus an event-LESS
+ * non-default project emit NO event findings (byte-identical default path).
+ */
+
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile, appendFile, symlink } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { lint } from "../src/linter/index.js";
+import { appendEvent } from "../src/events/store.js";
+import { EVENTS_FILE, CONCEPTS_DIR } from "../src/utils/constants.js";
+import { buildResearchLiteProject, buildResearchLiteRelationsProject } from "./fixtures/profile-fixtures.js";
+
+let root = "";
+
+/** Rule ids the event-store lint emits (chain-broken + torn + the three store-read codes). */
+const EVENT_RULES = ["event-chain-broken", "event-store-torn", "event-store-corrupt", "event-store-too-new", "event-store-symlink"];
+
+/** All lint findings emitted by the event-store check. */
+async function eventFindings(): Promise<{ rule: string; severity: string; message: string }[]> {
+  const { results } = await lint(root);
+  return results.filter((r) => EVENT_RULES.includes(r.rule));
+}
+
+const storePath = (): string => path.join(root, EVENTS_FILE);
+const evt = (n: string) => ({ type: "relation-create" as const, origin: "sdk", payload: { n }, at: "2024-01-01T00:00:00Z" });
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(os.tmpdir(), "event-lint-"));
+});
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+});
+
+describe("event lint — healthy chain", () => {
+  it("emits no event finding for an intact chain of emitted events", async () => {
+    await buildResearchLiteRelationsProject(root);
+    await appendEvent(root, evt("a"));
+    await appendEvent(root, evt("b"));
+    const findings = await eventFindings();
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe("event lint — tamper detection (fail-closed)", () => {
+  beforeEach(async () => await buildResearchLiteRelationsProject(root));
+
+  it("flags event-chain-broken when interior records are reordered", async () => {
+    await appendEvent(root, evt("a"));
+    await appendEvent(root, evt("b"));
+    await appendEvent(root, evt("c"));
+    const [header, r1, r2, r3] = (await readFile(storePath(), "utf8")).split("\n").filter(Boolean);
+    await writeFile(storePath(), [header, r2, r1, r3].join("\n") + "\n");
+    const findings = await eventFindings();
+    expect(findings.some((f) => f.rule === "event-chain-broken" && f.severity === "error")).toBe(true);
+  });
+
+  it("flags event-chain-broken when the log is truncated (head anchor mismatch)", async () => {
+    await appendEvent(root, evt("a"));
+    await appendEvent(root, evt("b"));
+    const lines = (await readFile(storePath(), "utf8")).split("\n").filter(Boolean);
+    await writeFile(storePath(), lines.slice(0, -1).join("\n") + "\n");
+    const findings = await eventFindings();
+    expect(findings.some((f) => f.rule === "event-chain-broken" && /head anchor/.test(f.message))).toBe(true);
+  });
+
+  it("fails closed to event-store-corrupt when an interior payload is edited", async () => {
+    await appendEvent(root, evt("a"));
+    await appendEvent(root, evt("b"));
+    const raw = await readFile(storePath(), "utf8");
+    await writeFile(storePath(), raw.replace('"n":"a"', '"n":"TAMPERED"'));
+    const findings = await eventFindings();
+    expect(findings.some((f) => f.rule === "event-store-corrupt" && f.severity === "error")).toBe(true);
+  });
+});
+
+describe("event lint — torn / too-new / symlink (no crash)", () => {
+  beforeEach(async () => await buildResearchLiteRelationsProject(root));
+
+  it("surfaces a torn trailing line as an event-store-torn warning", async () => {
+    await appendEvent(root, evt("a"));
+    await appendFile(storePath(), '{"id":"evt_torn","type":"rel');
+    const findings = await eventFindings();
+    const torn = findings.filter((f) => f.rule === "event-store-torn");
+    expect(torn).toHaveLength(1);
+    expect(torn[0].severity).toBe("warning");
+  });
+
+  it("fails closed to event-store-too-new instead of crashing lint", async () => {
+    await mkdir(path.dirname(storePath()), { recursive: true });
+    await writeFile(storePath(), '{"kind":"event-store-header","schemaVersion":99}\n');
+    const findings = await eventFindings();
+    expect(findings.some((f) => f.rule === "event-store-too-new" && f.severity === "error")).toBe(true);
+  });
+
+  it("fails closed to event-store-symlink when the events leaf is a symlink", async () => {
+    const outside = await mkdtemp(path.join(os.tmpdir(), "evt-leak-"));
+    await mkdir(path.dirname(storePath()), { recursive: true });
+    await writeFile(path.join(outside, "leak.jsonl"), "x");
+    await symlink(path.join(outside, "leak.jsonl"), storePath());
+    const findings = await eventFindings();
+    expect(findings.some((f) => f.rule === "event-store-symlink" && f.severity === "error")).toBe(true);
+    await rm(outside, { recursive: true, force: true });
+  });
+});
+
+describe("event lint — no findings on default / event-less paths", () => {
+  it("emits no event findings for a DEFAULT project (no wiki/graph)", async () => {
+    await mkdir(path.join(root, CONCEPTS_DIR), { recursive: true });
+    await writeFile(path.join(root, CONCEPTS_DIR, "foo.md"), "---\ntitle: Foo\n---\n\nbody body body body body.\n");
+    const findings = await eventFindings();
+    expect(findings).toHaveLength(0);
+  });
+
+  it("emits no event findings for an event-less non-default project", async () => {
+    await buildResearchLiteProject(root);
+    const findings = await eventFindings();
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/test/profile-status.test.ts
+++ b/test/profile-status.test.ts
@@ -14,12 +14,13 @@
  */
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { mkdtemp, rm, mkdir, writeFile, symlink } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, writeFile, readFile, symlink } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { collectStatus } from "../src/status/collect.js";
+import { appendEvent } from "../src/events/store.js";
 import { PROFILE_PROBLEM_CAP } from "../src/profile/block.js";
-import { PROFILE_FILE, CONCEPTS_DIR, QUERIES_DIR } from "../src/utils/constants.js";
+import { PROFILE_FILE, CONCEPTS_DIR, QUERIES_DIR, EVENTS_FILE } from "../src/utils/constants.js";
 
 let root = "";
 
@@ -154,5 +155,47 @@ describe("collectStatus — surfaces non-default problems (never silent)", () =>
     const dirProblem = result.profile!.problems!.find((p) => p.kind === "invalid-directory");
     expect(dirProblem).toBeDefined();
     expect("path" in dirProblem!).toBe(false);
+  });
+});
+
+/** Emit a chained event into the project's `wiki/graph` store. */
+const emitEvent = (n: string): Promise<unknown> =>
+  appendEvent(root, { type: "relation-create", origin: "sdk", payload: { n }, at: "2024-01-01T00:00:00Z" });
+
+/** Assert a fail-closed event store: an `event-store` problem present, the count suppressed. */
+async function expectEventStoreProblem(): Promise<void> {
+  const result = await collectStatus(root);
+  expect(result.profile?.problems?.some((p) => p.kind === "event-store")).toBe(true);
+  expect(result.profile && "eventCount" in result.profile).toBe(false);
+}
+
+describe("collectStatus — event store (count + fail-closed problem)", () => {
+  beforeEach(async () => await writeProfile(SAMPLE_PROFILE));
+
+  it("surfaces eventCount for a healthy chain and no event-store problem", async () => {
+    await emitEvent("a");
+    await emitEvent("b");
+    const result = await collectStatus(root);
+    expect(result.profile?.eventCount).toBe(2);
+    expect(result.profile?.problems?.some((p) => p.kind === "event-store")).toBeFalsy();
+  });
+
+  it("omits eventCount for an event-less non-default profile", async () => {
+    const result = await collectStatus(root);
+    expect(result.profile && "eventCount" in result.profile).toBe(false);
+  });
+
+  it("reports a tampered chain as a problem and suppresses the count (not silent)", async () => {
+    await emitEvent("a");
+    await emitEvent("b");
+    const lines = (await readFile(path.join(root, EVENTS_FILE), "utf8")).split("\n").filter(Boolean);
+    await writeFile(path.join(root, EVENTS_FILE), lines.slice(0, -1).join("\n") + "\n"); // truncate
+    await expectEventStoreProblem();
+  });
+
+  it("reports an unreadable (too-new) store as a problem without crashing", async () => {
+    await mkdir(path.join(root, path.dirname(EVENTS_FILE)), { recursive: true });
+    await writeFile(path.join(root, EVENTS_FILE), '{"kind":"event-store-header","schemaVersion":99}\n');
+    await expectEventStoreProblem();
   });
 });


### PR DESCRIPTION
Stacked on PR #137 (do not merge yet). Makes the event store's tamper-evidence actually enforced on read.

- A new `checkEventChain` lint rule reads the event store and fails closed on a broken/forked/reordered/interior-deleted chain or a head-anchor mismatch (truncation) → `event-chain-broken` error; a torn trailing line → warning; corrupt/too-new/symlinked store → fail-closed findings. Lint never throws a store error.
- Status gains an optional `eventCount`; a broken chain or unreadable store surfaces a capped problem and suppresses the count (never reports a bogus healthy total) instead of crashing.

Every event-store error type is mapped into both surfaces from the start (the recurring cross-surface lesson). Default + event-less projects emit no event fields — byte-identical; full suite green (2326).