### PR TITLE
Add graph health to eval harness

### DIFF
--- a/src/eval/graph-health.ts
+++ b/src/eval/graph-health.ts
@@ -76,21 +76,13 @@ function countComponents(nodes: GraphNode[], edges: GraphData["edges"], realIds:
   return components;
 }
 
-/** Compute top dangling targets by indegree from real pages. */
-function topDanglingTargets(
-  nodes: GraphNode[], edges: GraphData["edges"], realIds: Set<PageId>,
-): GraphHealthResult["topDangling"] {
-  const counts = new Map<string, number>();
-  for (const e of edges) {
-    const target = nodes.find((n) => n.id === e.target);
-    if (target?.isDangling && realIds.has(e.source)) {
-      counts.set(target.title, (counts.get(target.title) ?? 0) + 1);
-    }
-  }
-  return [...counts.entries()]
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+/** Top dangling targets by indegree, using ghost nodes' pre-computed degrees. */
+function topDanglingTargets(graph: GraphData): GraphHealthResult["topDangling"] {
+  return graph.nodes
+    .filter((n) => n.isDangling)
+    .sort((a, b) => b.degree - a.degree || a.id.localeCompare(b.id))
     .slice(0, MAX_TOP_DANGLING)
-    .map(([title, count]) => ({ title, referenceCount: count }));
+    .map((n) => ({ id: n.id, title: n.title, referenceCount: n.degree }));
 }
 
 /**
@@ -116,13 +108,19 @@ export async function evaluateGraphHealth(
     ? Math.round((totalIndegree / realNodes.length) * 100) / 100
     : 0;
 
+  const realOutdegrees = new Map<PageId, number>();
+  for (const e of graph.edges) {
+    if (realIds.has(e.source) && realIds.has(e.target)) {
+      realOutdegrees.set(e.source, (realOutdegrees.get(e.source) ?? 0) + 1);
+    }
+  }
   const hubPages: HubPage[] = realNodes
     .map((n) => {
       const indegree = realIndegrees.get(n.id) ?? 0;
-      const outdegree = graph.edges.filter((e) => e.source === n.id && realIds.has(e.target)).length;
-      return { slug: n.slug, indegree, outdegree, totalDegree: indegree + outdegree };
+      const outdegree = realOutdegrees.get(n.id) ?? 0;
+      return { id: n.id, indegree, outdegree, totalDegree: indegree + outdegree };
     })
-    .sort((a, b) => b.totalDegree - a.totalDegree || a.slug.localeCompare(b.slug))
+    .sort((a, b) => b.totalDegree - a.totalDegree || a.id.localeCompare(b.id))
     .slice(0, MAX_HUB_PAGES)
     .filter((h) => h.totalDegree > 0);
 
@@ -131,11 +129,11 @@ export async function evaluateGraphHealth(
   return {
     pageCount: realNodes.length,
     unreferencedCount: unreferenced.length,
-    unreferencedPages: unreferenced.map((n) => n.slug),
+    unreferencedPages: unreferenced.map((n) => n.id),
     componentCount: countComponents(graph.nodes, graph.edges, realIds),
     avgIndegree,
     hubPages,
     danglingCount: danglingNodes.length,
-    topDangling: topDanglingTargets(graph.nodes, graph.edges, realIds),
+    topDangling: topDanglingTargets(graph),
   };
 }

--- a/src/eval/graph-health.ts
+++ b/src/eval/graph-health.ts
@@ -36,8 +36,10 @@ function buildRealIndegrees(realIds: Set<PageId>, edges: GraphData["edges"]): Ma
   return map;
 }
 
-/** Weakly connected components (BFS over undirected real→real edges). */
-function countComponents(nodes: GraphNode[], edges: GraphData["edges"], realIds: Set<PageId>): number {
+/** Build undirected adjacency for real pages (real→real edges only, both directions). */
+function buildUndirectedAdj(
+  nodes: GraphNode[], edges: GraphData["edges"], realIds: Set<PageId>,
+): Map<PageId, Set<PageId>> {
   const adj = new Map<PageId, Set<PageId>>();
   for (const n of nodes) {
     if (!n.isDangling) adj.set(n.id, new Set());
@@ -48,19 +50,28 @@ function countComponents(nodes: GraphNode[], edges: GraphData["edges"], realIds:
       adj.get(e.target)?.add(e.source);
     }
   }
+  return adj;
+}
+
+/** BFS from a starting node, marking all reachable nodes as visited. */
+function bfsFrom(start: PageId, adj: Map<PageId, Set<PageId>>, visited: Set<PageId>): void {
+  const queue = [start];
+  visited.add(start);
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    for (const n of adj.get(cur) ?? []) {
+      if (!visited.has(n)) { visited.add(n); queue.push(n); }
+    }
+  }
+}
+
+/** Weakly connected components (undirected view over real pages). */
+function countComponents(nodes: GraphNode[], edges: GraphData["edges"], realIds: Set<PageId>): number {
+  const adj = buildUndirectedAdj(nodes, edges, realIds);
   const visited = new Set<PageId>();
   let components = 0;
   for (const id of adj.keys()) {
-    if (visited.has(id)) continue;
-    components++;
-    const queue = [id];
-    visited.add(id);
-    while (queue.length > 0) {
-      const cur = queue.shift()!;
-      for (const n of adj.get(cur) ?? []) {
-        if (!visited.has(n)) { visited.add(n); queue.push(n); }
-      }
-    }
+    if (!visited.has(id)) { components++; bfsFrom(id, adj, visited); }
   }
   return components;
 }

--- a/src/eval/graph-health.ts
+++ b/src/eval/graph-health.ts
@@ -1,0 +1,130 @@
+/**
+ * Graph health evaluator for the llmwiki eval harness.
+ *
+ * Builds on the existing viewer graph path (collectViewerPages +
+ * buildGraphData) so there is one source of truth for wikilink resolution,
+ * ghost-node representation, and graph topology. All metrics are derived
+ * from the viewer's immutable snapshot — no separate wikilink parser.
+ *
+ * Metrics:
+ *  - unreferencedPages: real pages with indegree=0 (not dangling ghosts).
+ *  - componentCount: weakly connected components over real pages.
+ *  - avgIndegree: average indegree across real pages (real→real edges only).
+ *  - hubPages: top 5 real pages by total degree (in + out), tie-broken by slug.
+ *  - danglingCount: total number of ghost (unresolved) wikilink targets.
+ *  - topDangling: up to 5 most-referenced dangling targets.
+ */
+
+import { collectViewerPages } from "../viewer/collect.js";
+import { buildGraphData } from "../viewer/graph.js";
+import type { ViewerPage, GraphData, GraphNode, PageId } from "../viewer/types.js";
+import type { GraphHealthResult, HubPage } from "./types.js";
+
+
+
+const MAX_HUB_PAGES = 5;
+const MAX_TOP_DANGLING = 5;
+
+/** Count indegree from real→real edges only (exclude edges involving ghosts). */
+function buildRealIndegrees(realIds: Set<PageId>, edges: GraphData["edges"]): Map<PageId, number> {
+  const map = new Map<PageId, number>();
+  for (const e of edges) {
+    if (realIds.has(e.source) && realIds.has(e.target)) {
+      map.set(e.target, (map.get(e.target) ?? 0) + 1);
+    }
+  }
+  return map;
+}
+
+/** Weakly connected components (BFS over undirected real→real edges). */
+function countComponents(nodes: GraphNode[], edges: GraphData["edges"], realIds: Set<PageId>): number {
+  const adj = new Map<PageId, Set<PageId>>();
+  for (const n of nodes) {
+    if (!n.isDangling) adj.set(n.id, new Set());
+  }
+  for (const e of edges) {
+    if (realIds.has(e.source) && realIds.has(e.target)) {
+      adj.get(e.source)?.add(e.target);
+      adj.get(e.target)?.add(e.source);
+    }
+  }
+  const visited = new Set<PageId>();
+  let components = 0;
+  for (const id of adj.keys()) {
+    if (visited.has(id)) continue;
+    components++;
+    const queue = [id];
+    visited.add(id);
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      for (const n of adj.get(cur) ?? []) {
+        if (!visited.has(n)) { visited.add(n); queue.push(n); }
+      }
+    }
+  }
+  return components;
+}
+
+/** Compute top dangling targets by indegree from real pages. */
+function topDanglingTargets(
+  nodes: GraphNode[], edges: GraphData["edges"], realIds: Set<PageId>,
+): GraphHealthResult["topDangling"] {
+  const counts = new Map<string, number>();
+  for (const e of edges) {
+    const target = nodes.find((n) => n.id === e.target);
+    if (target?.isDangling && realIds.has(e.source)) {
+      counts.set(target.title, (counts.get(target.title) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, MAX_TOP_DANGLING)
+    .map(([title, count]) => ({ title, referenceCount: count }));
+}
+
+/**
+ * Evaluate graph health for the current wiki.
+ * Returns null when there are no wiki pages (graph not measurable).
+ * @param root - Absolute path to the project root.
+ */
+export async function evaluateGraphHealth(
+  root: string,
+): Promise<GraphHealthResult | null> {
+  const pages = await collectViewerPages(root);
+  if (pages.length === 0) return null;
+
+  const graph = buildGraphData(pages);
+  const realNodes = graph.nodes.filter((n) => !n.isDangling);
+  const realIds = new Set(realNodes.map((n) => n.id));
+
+  const realIndegrees = buildRealIndegrees(realIds, graph.edges);
+  const unreferenced = realNodes.filter((n) => (realIndegrees.get(n.id) ?? 0) === 0);
+
+  const totalIndegree = [...realIndegrees.values()].reduce((s, v) => s + v, 0);
+  const avgIndegree = realNodes.length > 0
+    ? Math.round((totalIndegree / realNodes.length) * 100) / 100
+    : 0;
+
+  const hubPages: HubPage[] = realNodes
+    .map((n) => {
+      const indegree = realIndegrees.get(n.id) ?? 0;
+      const outdegree = graph.edges.filter((e) => e.source === n.id && realIds.has(e.target)).length;
+      return { slug: n.slug, indegree, outdegree, totalDegree: indegree + outdegree };
+    })
+    .sort((a, b) => b.totalDegree - a.totalDegree || a.slug.localeCompare(b.slug))
+    .slice(0, MAX_HUB_PAGES)
+    .filter((h) => h.totalDegree > 0);
+
+  const danglingNodes = graph.nodes.filter((n) => n.isDangling);
+
+  return {
+    pageCount: realNodes.length,
+    unreferencedCount: unreferenced.length,
+    unreferencedPages: unreferenced.map((n) => n.slug),
+    componentCount: countComponents(graph.nodes, graph.edges, realIds),
+    avgIndegree,
+    hubPages,
+    danglingCount: danglingNodes.length,
+    topDangling: topDanglingTargets(graph.nodes, graph.edges, realIds),
+  };
+}

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -11,12 +11,13 @@ import { evaluateCitationCoverage } from "./citation-coverage.js";
 import { evaluateSourceUtilization } from "./source-utilization.js";
 import { evaluateCitationDepth } from "./citation-depth.js";
 import { evaluatePageHealthDistribution } from "./page-health-distribution.js";
+import { evaluateGraphHealth } from "./graph-health.js";
 import { evaluateCitationSupport } from "./citation-support.js";
 import { collectStats, appendHistory, loadPreviousReport, loadLastFullReport } from "./stats.js";
 import { computeDelta } from "./delta.js";
 import { checkThresholds } from "./thresholds.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
-import type { EvalReport, HealthResult, CitationCoverageResult, SourceUtilizationResult, CitationDepthResult, PageHealthDistributionResult, CitationSupportResult, StatsResult } from "./types.js";
+import type { EvalReport, HealthResult, CitationCoverageResult, SourceUtilizationResult, CitationDepthResult, PageHealthDistributionResult, GraphHealthResult, CitationSupportResult, StatsResult } from "./types.js";
 
 export const DEFAULT_SAMPLE_SIZE = 20;
 
@@ -26,13 +27,14 @@ interface EvalComponents {
   sourceUtilization: SourceUtilizationResult;
   citationDepth: CitationDepthResult;
   pageHealthDistribution?: PageHealthDistributionResult;
+  graphHealth?: GraphHealthResult | null;
   stats: StatsResult;
   previousReport: EvalReport | null;
   citationSupport?: CitationSupportResult | null;
 }
 
 async function buildReport(root: string, components: EvalComponents, suite: "fast" | "full"): Promise<EvalReport> {
-  const { health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, stats, previousReport, citationSupport } = components;
+  const { health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, graphHealth, stats, previousReport, citationSupport } = components;
   const partial = {
     suite,
     timestamp: new Date().toISOString(),
@@ -41,6 +43,7 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
     sourceUtilization,
     citationDepth,
     ...(pageHealthDistribution ? { pageHealthDistribution } : {}),
+    ...(graphHealth ? { graphHealth } : {}),
     stats,
     ...(citationSupport ? { citationSupport } : {}),
   };
@@ -52,12 +55,13 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
 /** Run the full eval pipeline, optionally append to history, and return the report. */
 export async function runEval(root: string, suite: "fast" | "full", sampleSize: number, record = true): Promise<EvalReport> {
   if (suite === "full") ensureProviderAvailable();
-  const [health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, stats, previousReport, previousFullReport] = await Promise.all([
+  const [health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, graphHealth, stats, previousReport, previousFullReport] = await Promise.all([
     evaluateHealth(root),
     evaluateCitationCoverage(root),
     evaluateSourceUtilization(root),
     evaluateCitationDepth(root),
     evaluatePageHealthDistribution(root),
+    evaluateGraphHealth(root),
     collectStats(root),
     loadPreviousReport(root),
     suite === "full" ? loadLastFullReport(root) : Promise.resolve(null),
@@ -65,7 +69,7 @@ export async function runEval(root: string, suite: "fast" | "full", sampleSize: 
   const citationSupport = suite === "full"
     ? await evaluateCitationSupport(root, sampleSize, previousFullReport?.citationSupport?.sampledHashes ?? [])
     : undefined;
-  const report = await buildReport(root, { health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, stats, previousReport, citationSupport }, suite);
+  const report = await buildReport(root, { health, citationCoverage, sourceUtilization, citationDepth, pageHealthDistribution, graphHealth, stats, previousReport, citationSupport }, suite);
   if (record) await appendHistory(root, report);
   return report;
 }

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -213,10 +213,10 @@ function formatGraphHealth(report: EvalReport): string[] {
     line(),
     line(bold("Graph Health:")),
     line("  pages: " + g.pageCount + "  unreferenced: " + g.unreferencedCount + "  components: " + g.componentCount),
-    line("  avg indegree: " + g.avgIndegree.toFixed(1) + "  dangling: " + g.danglingCount),
+    line("  avg indegree: " + g.avgIndegree.toFixed(2) + "  dangling: " + g.danglingCount),
   ];
   if (g.hubPages.length > 0) {
-    const hubs = g.hubPages.map(function(h) { return h.slug + "(" + h.totalDegree + ")"; });
+    const hubs = g.hubPages.map((h) => h.id + "(" + h.totalDegree + ")");
     rows.push(line(dim("  Hubs: " + hubs.join(", "))));
   }
   return rows;

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -206,6 +206,22 @@ function formatPageHealthDistribution(report: EvalReport): string[] {
   return rows;
 }
 
+function formatGraphHealth(report: EvalReport): string[] {
+  const g = report.graphHealth;
+  if (!g || g.pageCount === 0) return [];
+  const rows = [
+    line(),
+    line(bold("Graph Health:")),
+    line("  pages: " + g.pageCount + "  unreferenced: " + g.unreferencedCount + "  components: " + g.componentCount),
+    line("  avg indegree: " + g.avgIndegree.toFixed(1) + "  dangling: " + g.danglingCount),
+  ];
+  if (g.hubPages.length > 0) {
+    const hubs = g.hubPages.map(function(h) { return h.slug + "(" + h.totalDegree + ")"; });
+    rows.push(line(dim("  Hubs: " + hubs.join(", "))));
+  }
+  return rows;
+}
+
 function formatStats(report: EvalReport): string[] {
   const s = report.stats;
   return [
@@ -238,6 +254,7 @@ export function formatTerminalReport(report: EvalReport): string {
     ...formatSourceUtilization(report),
     ...formatCitationDepth(report),
     ...formatPageHealthDistribution(report),
+    ...formatGraphHealth(report),
     ...formatSupport(report, delta),
     ...formatStats(report),
     ...formatViolations(report.thresholdViolations),

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -87,6 +87,30 @@ export interface PageHealthDistributionResult {
   worstPages: PageHealthEntry[];
 }
 
+export interface HubPage {
+  slug: string;
+  indegree: number;
+  outdegree: number;
+  totalDegree: number;
+}
+
+interface DanglingTarget {
+  title: string;
+  referenceCount: number;
+}
+
+export interface GraphHealthResult {
+  pageCount: number;
+  unreferencedCount: number;
+  unreferencedPages: string[];
+  componentCount: number;
+  avgIndegree: number;
+  hubPages: HubPage[];
+  danglingCount: number;
+  topDangling: DanglingTarget[];
+}
+
+
 
 export interface CitationJudgement {
   /** First 16 hex chars of SHA-256(claimText + spanText) — stable cache key. */
@@ -142,6 +166,7 @@ export interface EvalReport {
   sourceUtilization: SourceUtilizationResult;
   citationDepth: CitationDepthResult;
   pageHealthDistribution?: PageHealthDistributionResult;
+  graphHealth?: GraphHealthResult;
   citationSupport?: CitationSupportResult;
   stats: StatsResult;
   delta?: EvalDelta;

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -88,13 +88,14 @@ export interface PageHealthDistributionResult {
 }
 
 export interface HubPage {
-  slug: string;
+  id: string;
   indegree: number;
   outdegree: number;
   totalDegree: number;
 }
 
-interface DanglingTarget {
+export interface DanglingTarget {
+  id: string;
   title: string;
   referenceCount: number;
 }

--- a/test/eval-graph-health.test.ts
+++ b/test/eval-graph-health.test.ts
@@ -31,7 +31,7 @@ describe("evaluateGraphHealth", () => {
     expect(result).not.toBeNull();
     expect(result!.pageCount).toBe(1);
     expect(result!.unreferencedCount).toBe(1);
-    expect(result!.unreferencedPages).toContain("lonely");
+    expect(result!.unreferencedPages).toContain("concepts/lonely");
     expect(result!.componentCount).toBe(1);
     expect(result!.avgIndegree).toBe(0);
     expect(result!.danglingCount).toBe(0);
@@ -54,7 +54,7 @@ describe("evaluateGraphHealth", () => {
     const result = await evaluateGraphHealth(env.dir);
     // hub has indegree=2, outdegree=0 → totalDegree=2
     expect(result!.hubPages.length).toBeGreaterThan(0);
-    expect(result!.hubPages[0].slug).toBe("hub");
+    expect(result!.hubPages[0].id).toBe("concepts/hub");
     expect(result!.hubPages[0].indegree).toBe(2);
     expect(result!.hubPages[0].outdegree).toBe(0);
     expect(result!.hubPages[0].totalDegree).toBe(2);
@@ -76,6 +76,7 @@ describe("evaluateGraphHealth", () => {
     expect(result!.danglingCount).toBeGreaterThanOrEqual(1);
     expect(result!.topDangling.length).toBeGreaterThan(0);
     expect(result!.topDangling[0].title).toBe("Ghost");
+    expect(result!.topDangling[0].id).toBeDefined();
   });
 
   it("does not count dangling links in avgIndegree", async () => {
@@ -92,11 +93,11 @@ describe("evaluateGraphHealth", () => {
     const result = await evaluateGraphHealth(env.dir);
     // gamma has indegree 2. alpha and beta have indegree 0, outdegree 1.
     // Tie-break between alpha and beta → slug order (alpha < beta)
-    const slugs = result!.hubPages.map((h) => h.slug);
-    const alphaIdx = slugs.indexOf("alpha");
-    const betaIdx = slugs.indexOf("beta");
-    if (alphaIdx >= 0 && betaIdx >= 0) {
-      expect(alphaIdx).toBeLessThan(betaIdx);
-    }
+    const ids = result!.hubPages.map((h) => h.id);
+    const alphaIdx = ids.indexOf("concepts/alpha");
+    const betaIdx = ids.indexOf("concepts/beta");
+    expect(alphaIdx).toBeGreaterThanOrEqual(0);
+    expect(betaIdx).toBeGreaterThanOrEqual(0);
+    expect(alphaIdx).toBeLessThan(betaIdx);
   });
 });

--- a/test/eval-graph-health.test.ts
+++ b/test/eval-graph-health.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for src/eval/graph-health.ts.
+ */
+
+import { evaluateGraphHealth } from "../src/eval/graph-health.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+function fm(title: string, extra = ""): string {
+  return `---
+title: ${title}
+sources: []
+summary: A page about ${title}.
+createdAt: 2026-01-01
+updatedAt: 2026-01-01${extra}
+---
+
+`;
+}
+
+describe("evaluateGraphHealth", () => {
+  const env = useLintTempRoot("eval-gh");
+
+  it("returns null when no pages exist", async () => {
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result).toBeNull();
+  });
+
+  it("counts a single isolated page as unreferenced", async () => {
+    await env.writeConcept("lonely", fm("Lonely") + "No links.\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result).not.toBeNull();
+    expect(result!.pageCount).toBe(1);
+    expect(result!.unreferencedCount).toBe(1);
+    expect(result!.unreferencedPages).toContain("lonely");
+    expect(result!.componentCount).toBe(1);
+    expect(result!.avgIndegree).toBe(0);
+    expect(result!.danglingCount).toBe(0);
+  });
+
+  it("detects a bidirectional link correctly", async () => {
+    await env.writeConcept("a", fm("A") + "Links to B. [[B]]\n");
+    await env.writeConcept("b", fm("B") + "Links to A. [[A]]\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.pageCount).toBe(2);
+    expect(result!.unreferencedCount).toBe(0);
+    expect(result!.componentCount).toBe(1);
+    expect(result!.avgIndegree).toBe(1);
+  });
+
+  it("identifies hub pages by total degree", async () => {
+    await env.writeConcept("hub", fm("Hub") + "\n");
+    await env.writeConcept("a", fm("A") + "Links to hub. [[Hub]]\n");
+    await env.writeConcept("b", fm("B") + "Links to hub. [[Hub]]\n");
+    const result = await evaluateGraphHealth(env.dir);
+    // hub has indegree=2, outdegree=0 → totalDegree=2
+    expect(result!.hubPages.length).toBeGreaterThan(0);
+    expect(result!.hubPages[0].slug).toBe("hub");
+    expect(result!.hubPages[0].indegree).toBe(2);
+    expect(result!.hubPages[0].outdegree).toBe(0);
+    expect(result!.hubPages[0].totalDegree).toBe(2);
+  });
+
+  it("counts multiple connected components", async () => {
+    await env.writeConcept("a", fm("A") + "[[B]]\n");
+    await env.writeConcept("b", fm("B") + "[[A]]\n");
+    await env.writeConcept("c", fm("C") + "[[D]]\n");
+    await env.writeConcept("d", fm("D") + "[[C]]\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.pageCount).toBe(4);
+    expect(result!.componentCount).toBe(2);
+  });
+
+  it("counts dangling wikilink targets", async () => {
+    await env.writeConcept("real", fm("Real") + "Links to [[Ghost]].\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.danglingCount).toBeGreaterThanOrEqual(1);
+    expect(result!.topDangling.length).toBeGreaterThan(0);
+    expect(result!.topDangling[0].title).toBe("Ghost");
+  });
+
+  it("does not count dangling links in avgIndegree", async () => {
+    // A → B(ghost). avgIndegree should be 0 because ghost links don't count.
+    await env.writeConcept("a", fm("A") + "Links to [[Ghost]].\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.avgIndegree).toBe(0);
+  });
+
+  it("ties-break hub pages by slug", async () => {
+    await env.writeConcept("alpha", fm("Alpha") + "[[Gamma]]\n");
+    await env.writeConcept("beta", fm("Beta") + "[[Gamma]]\n");
+    await env.writeConcept("gamma", fm("Gamma") + "\n");
+    const result = await evaluateGraphHealth(env.dir);
+    // gamma has indegree 2. alpha and beta have indegree 0, outdegree 1.
+    // Tie-break between alpha and beta → slug order (alpha < beta)
+    const slugs = result!.hubPages.map((h) => h.slug);
+    const alphaIdx = slugs.indexOf("alpha");
+    const betaIdx = slugs.indexOf("beta");
+    if (alphaIdx >= 0 && betaIdx >= 0) {
+      expect(alphaIdx).toBeLessThan(betaIdx);
+    }
+  });
+});

--- a/test/eval-graph-health.test.ts
+++ b/test/eval-graph-health.test.ts
@@ -101,42 +101,19 @@ describe("evaluateGraphHealth", () => {
     expect(alphaIdx).toBeLessThan(betaIdx);
   });
 
-  it("distinguishes concept and query pages with the same slug", async () => {
+
+  it("uses namespaced ids so concept/query and dangling pages do not collide", async () => {
     await env.writeConcept("shared", fm("Concept Shared") + "[[Other]]\n");
     await env.writeQuery("shared", fm("Query Shared") + "[[Shared]]\n");
     await env.writeConcept("other", fm("Other") + "\n");
+    await env.writeConcept("p", fm("P") + "[[missing-a|TODO]]\n[[missing-b|TODO]]\n");
     const result = await evaluateGraphHealth(env.dir);
-    expect(result!.pageCount).toBe(3);
-    const ids = result!.hubPages.map((h) => h.id);
-    expect(ids).toContain("concepts/shared");
-    expect(ids).toContain("queries/shared");
-  });
-
-  it("keeps dangling targets distinct when they share a display title", async () => {
-    await env.writeConcept("page", fm("Page") + "[[missing-a|TODO]]\n[[missing-b|TODO]]\n");
-    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.pageCount).toBe(4);
+    const hubIds = result!.hubPages.map((h) => h.id);
+    expect(hubIds).toContain("concepts/shared");
+    expect(hubIds).toContain("queries/shared");
     expect(result!.danglingCount).toBe(2);
-    expect(result!.topDangling.length).toBe(2);
-    const idSet = new Set(result!.topDangling.map((d) => d.id));
-    expect(idSet.size).toBe(2);
-  })
-  it("distinguishes concept and query pages with the same slug", async () => {
-    await env.writeConcept("shared", fm("Concept Shared") + "[[Other]]\n");
-    await env.writeQuery("shared", fm("Query Shared") + "[[Shared]]\n");
-    await env.writeConcept("other", fm("Other") + "\n");
-    const result = await evaluateGraphHealth(env.dir);
-    expect(result!.pageCount).toBe(3);
-    const ids = result!.hubPages.map((h) => h.id);
-    expect(ids).toContain("concepts/shared");
-    expect(ids).toContain("queries/shared");
-  });
-
-  it("keeps dangling targets distinct when they share a display title", async () => {
-    await env.writeConcept("page", fm("Page") + "[[missing-a|TODO]]\n[[missing-b|TODO]]\n");
-    const result = await evaluateGraphHealth(env.dir);
-    expect(result!.danglingCount).toBe(2);
-    expect(result!.topDangling.length).toBe(2);
-    const idSet = new Set(result!.topDangling.map((d) => d.id));
-    expect(idSet.size).toBe(2);
+    const ghostIds = new Set(result!.topDangling.map((d) => d.id));
+    expect(ghostIds.size).toBe(2);
   });
 });

--- a/test/eval-graph-health.test.ts
+++ b/test/eval-graph-health.test.ts
@@ -100,4 +100,43 @@ describe("evaluateGraphHealth", () => {
     expect(betaIdx).toBeGreaterThanOrEqual(0);
     expect(alphaIdx).toBeLessThan(betaIdx);
   });
+
+  it("distinguishes concept and query pages with the same slug", async () => {
+    await env.writeConcept("shared", fm("Concept Shared") + "[[Other]]\n");
+    await env.writeQuery("shared", fm("Query Shared") + "[[Shared]]\n");
+    await env.writeConcept("other", fm("Other") + "\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.pageCount).toBe(3);
+    const ids = result!.hubPages.map((h) => h.id);
+    expect(ids).toContain("concepts/shared");
+    expect(ids).toContain("queries/shared");
+  });
+
+  it("keeps dangling targets distinct when they share a display title", async () => {
+    await env.writeConcept("page", fm("Page") + "[[missing-a|TODO]]\n[[missing-b|TODO]]\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.danglingCount).toBe(2);
+    expect(result!.topDangling.length).toBe(2);
+    const idSet = new Set(result!.topDangling.map((d) => d.id));
+    expect(idSet.size).toBe(2);
+  })
+  it("distinguishes concept and query pages with the same slug", async () => {
+    await env.writeConcept("shared", fm("Concept Shared") + "[[Other]]\n");
+    await env.writeQuery("shared", fm("Query Shared") + "[[Shared]]\n");
+    await env.writeConcept("other", fm("Other") + "\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.pageCount).toBe(3);
+    const ids = result!.hubPages.map((h) => h.id);
+    expect(ids).toContain("concepts/shared");
+    expect(ids).toContain("queries/shared");
+  });
+
+  it("keeps dangling targets distinct when they share a display title", async () => {
+    await env.writeConcept("page", fm("Page") + "[[missing-a|TODO]]\n[[missing-b|TODO]]\n");
+    const result = await evaluateGraphHealth(env.dir);
+    expect(result!.danglingCount).toBe(2);
+    expect(result!.topDangling.length).toBe(2);
+    const idSet = new Set(result!.topDangling.map((d) => d.id));
+    expect(idSet.size).toBe(2);
+  });
 });


### PR DESCRIPTION
Builds on the existing viewer graph path (collectViewerPages +                                     
  buildGraphData) as discussed in #78.                                                               
                                                                                                     
  - unreferenced pages (indegree=0), weakly connected components,                                    
    average indegree (real-to-real only), hub pages (top 5 by                                        
    total degree, tie-broken by slug), dangling targets                                              
  - graphHealth is optional on EvalReport                                                            
  - 8 tests, tsc clean                                                                               
                         