### PR TITLE
docs: document graph health in eval harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Do not use llmwiki as a general static-site generator, a heavy ontology database
 - **Local viewer.** `llmwiki view` opens a read-only browser UI with search, page metadata, graph exploration, source-freshness badges, and citation chips.
 - **Review policy.** Generated pages can be auto-held for review when confidence, contradiction, schema, or provenance rules trip.
 - **Freshness repair.** `llmwiki lint` and `llmwiki next` surface stale/orphaned pages; `llmwiki refresh --stale` repairs changed knowledge without compiling unrelated new sources.
-- **Eval harness.** `llmwiki eval` reports health score, a per-page health distribution that flags the worst pages, citation coverage/precision, corpus stats, regression deltas, and optional judge-model citation support.
+- **Eval harness.** `llmwiki eval` reports health score, a per-page health distribution that flags the worst pages, wikilink-graph health, citation coverage/precision, corpus stats, regression deltas, and optional judge-model citation support.
 - **MCP server.** `llmwiki serve` exposes ingest, compile, query, lint, read, status, eval, context-pack, and OKF exchange tools to MCP-compatible agents.
 - **SDK.** `createWiki({ root })` drives ingest, compile, query, context, status, export, eval, and OKF import/export from TypeScript without shelling out.
 - **Open Knowledge Format exchange.** Export and import OKF bundles for portable, markdown-native knowledge exchange. External OKF imports are staged through the review queue by default; trusted bundles can be written live explicitly.

--- a/docs/cli/lint-eval.mdx
+++ b/docs/cli/lint-eval.mdx
@@ -70,7 +70,7 @@ llmwiki eval --suite full      # fast + LLM-as-judge citation support
 
 | Suite | What runs | LLM credentials needed? |
 |-------|-----------|------------------------|
-| `fast` (default) | Health score, per-page health distribution, citation coverage and precision, source utilization, corpus stats, regression deltas | No |
+| `fast` (default) | Health score, per-page health distribution, graph health, citation coverage and precision, source utilization, corpus stats, regression deltas | No |
 | `full` | Everything in `fast`, plus LLM-as-judge citation support scoring for a sample of claim/source pairs | Yes |
 
 <Note>
@@ -99,6 +99,9 @@ The fraction of a page's valid sources that are actually cited somewhere in the 
 
 **Claim-level citation rate**
 The fraction of citations that are pinned to specific line ranges (e.g. `^[source.md:42-58]`) rather than citing a whole file. Higher means tighter, more verifiable provenance.
+
+**Graph health**
+A topology view of the wiki's `[[wikilink]]` graph, computed from the same graph the local viewer renders. Reports unreferenced pages (no inbound links), the number of weakly connected components, average indegree, the top hub pages by total degree, and any dangling wikilink targets (links pointing at pages that don't exist). This is informational - a page with no inbound links is not necessarily wrong - and does not affect the health score.
 
 **Corpus stats**
 Page count, source count, total wiki characters, and embedding counts - appended to `.llmwiki/eval/history.jsonl` for trend tracking.


### PR DESCRIPTION
Documents the graph-health dimension added in #140: the README eval-harness bullet, the eval suite table, and a new "Graph health" entry under "What eval measures" covering unreferenced pages, weakly connected components, average indegree, hub pages, and dangling targets — noting it's informational and doesn't affect the health score.
