### PR TITLE
fix(ollama): use native /api/chat format for structured tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Ollama structured tool calls** — `OllamaProvider.toolCall` now uses Ollama's native `POST /api/chat` with JSON-schema `format` (base URL derived from `OLLAMA_HOST`, preserving reverse-proxy path prefixes) instead of the OpenAI-compatible `tool_calls` path, which could return double-encoded `concepts` arrays and silently produce zero wiki pages. Affects all structured tool calls (concept extraction, rule extraction, query page selection, eval judge). Invalid `OLLAMA_HOST` values and empty `/api/chat` responses now throw instead of silently falling back or returning empty output. `parseConcepts` also coerces string-encoded `concepts` arrays as a defensive fallback. Embeddings continue to use `OLLAMA_HOST` / `OLLAMA_EMBEDDINGS_HOST` via the OpenAI-compatible `/v1` client.
+
 ## [0.11.0] - 2026-06-16
 
 Extends Open Knowledge Format support beyond the CLI: in-process SDK and MCP access to the OKF round-trip, and faithful reconstruction of an imported foreign bundle's original nested paths on re-export.

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -46,7 +46,7 @@ Either `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` satisfies authentication - 
 
 | Variable | Required | Description |
 |---|---|---|
-| `OLLAMA_HOST` | Yes (for `ollama` provider) | Ollama host URL for chat and tool calls. **Must include `/v1`** |
+| `OLLAMA_HOST` | Yes (for `ollama` provider) | Ollama host URL for chat and structured tool calls. **Must include `/v1`**. Structured tool calls use the native `/api/chat` endpoint on the same base URL with the `/v1` suffix removed (any path prefix is preserved, e.g. `https://proxy/ollama/v1` → `https://proxy/ollama/api/chat`) |
 | `OLLAMA_EMBEDDINGS_HOST` | No | Separate Ollama host URL for embeddings. When unset, embeddings use `OLLAMA_HOST` |
 
 ---

--- a/docs/configuration/providers.mdx
+++ b/docs/configuration/providers.mdx
@@ -141,14 +141,14 @@ See [Environment Variables](/configuration/environment-variables) for full timeo
   </Tab>
   <Tab title="Ollama">
 
-The `ollama` provider uses Ollama's OpenAI-compatible endpoint. It defaults to a 30-minute per-request timeout (instead of the 10-minute OpenAI default) to accommodate local models on modest hardware.
+The `ollama` provider uses Ollama's OpenAI-compatible endpoint for embeddings. All structured tool calls (concept extraction, rule extraction, query page selection, eval judge) use Ollama's native `/api/chat` endpoint with JSON-schema `format`, derived from `OLLAMA_HOST` with the `/v1` suffix removed while preserving any reverse-proxy path prefix. It defaults to a 30-minute per-request timeout (instead of the 10-minute OpenAI default) to accommodate local models on modest hardware.
 
 **Variables**
 
 | Variable | Required | Description |
 |---|---|---|
 | `LLMWIKI_PROVIDER` | Yes | Set to `ollama` |
-| `OLLAMA_HOST` | Yes | Ollama host URL for chat. **Include `/v1`** |
+| `OLLAMA_HOST` | Yes | Ollama host URL for chat and structured tool calls. **Include `/v1`** — the native `/api/chat` base URL is derived from this value (path prefix preserved) |
 | `LLMWIKI_MODEL` | No | Model name override |
 | `LLMWIKI_EMBEDDING_MODEL` | No | Embedding model override |
 | `OLLAMA_EMBEDDINGS_HOST` | No | Separate Ollama host for embeddings. When unset, embeddings use `OLLAMA_HOST` |

--- a/src/compiler/prompts.ts
+++ b/src/compiler/prompts.ts
@@ -296,7 +296,11 @@ export function buildSeedPagePrompt(
 export function parseConcepts(toolOutput: string): ExtractedConcept[] {
   try {
     const parsed = JSON.parse(toolOutput);
-    const concepts: RawConcept[] = parsed.concepts ?? [];
+    let concepts: unknown = parsed.concepts ?? [];
+    if (typeof concepts === "string") {
+      concepts = JSON.parse(concepts);
+    }
+    if (!Array.isArray(concepts)) return [];
     return concepts.filter(isValidRawConcept).map(mapRawConcept);
   } catch {
     return [];

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,12 +1,18 @@
 /**
  * Ollama LLM provider implementation.
  *
- * Extends OpenAIProvider since Ollama exposes an OpenAI-compatible API.
- * Overrides only the constructor to set baseURL and disable API key auth.
+ * Extends OpenAIProvider for embeddings and other OpenAI-compatible calls.
+ * Structured tool calls use Ollama's native `/api/chat` endpoint with
+ * JSON-schema `format`, derived from `OLLAMA_HOST`.
  */
 
+import type { LLMMessage, LLMTool } from "../utils/provider.js";
 import { OpenAIProvider, readTimeoutEnv } from "./openai.js";
-import { EMBEDDING_MODELS, OLLAMA_DEFAULT_TIMEOUT_MS } from "../utils/constants.js";
+import {
+  EMBEDDING_MODELS,
+  OLLAMA_DEFAULT_HOST,
+  OLLAMA_DEFAULT_TIMEOUT_MS,
+} from "../utils/constants.js";
 
 /** Construction options for an Ollama-compatible provider. */
 interface OllamaProviderOptions {
@@ -32,20 +38,133 @@ function resolveOllamaTimeoutMs(explicit?: number): number {
   );
 }
 
-/** Ollama-backed LLM provider using the OpenAI-compatible endpoint. */
+/**
+ * Strip a trailing `/v1` OpenAI-compat suffix from a URL pathname while
+ * preserving any reverse-proxy prefix (e.g. `/ollama/v1` → `/ollama`).
+ */
+function stripOpenAiCompatSuffix(pathname: string): string {
+  const normalized = pathname.replace(/\/$/, "");
+  if (!normalized.endsWith("/v1")) return normalized;
+  return normalized.slice(0, -"/v1".length);
+}
+
+/**
+ * Derive the native Ollama REST base URL from an OpenAI-compatible base URL.
+ *
+ * `OLLAMA_HOST` must include `/v1` for the OpenAI-compatible client; native
+ * structured output calls `POST {base}/api/chat`, keeping any path prefix.
+ *
+ * @param openAiCompatibleBaseUrl - Value of `OLLAMA_HOST` (e.g. `http://localhost:11434/v1`).
+ * @returns Base URL without the `/v1` suffix, e.g. `http://localhost:11434`.
+ * @throws When the URL is present but not parseable.
+ */
+export function resolveOllamaNativeHost(openAiCompatibleBaseUrl?: string): string {
+  const raw = openAiCompatibleBaseUrl?.trim();
+  if (!raw) {
+    return resolveOllamaNativeHost(OLLAMA_DEFAULT_HOST);
+  }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Invalid OLLAMA_HOST URL: ${raw}`);
+  }
+  const pathname = stripOpenAiCompatSuffix(url.pathname);
+  return `${url.origin}${pathname}`;
+}
+
+/** Build the JSON body for Ollama's native structured `/api/chat` request. */
+function buildNativeChatBody(
+  model: string,
+  system: string,
+  messages: LLMMessage[],
+  schema: Record<string, unknown> | undefined,
+  maxTokens: number,
+): Record<string, unknown> {
+  return {
+    model,
+    messages: [{ role: "system", content: system }, ...messages],
+    format: schema,
+    stream: false,
+    options: { temperature: 0, num_predict: maxTokens },
+  };
+}
+
+/** Read assistant content from a successful Ollama `/api/chat` JSON body. */
+function readNativeChatContent(data: { message?: { content?: string } }): string {
+  const content = data.message?.content;
+  if (!content) {
+    throw new Error("Ollama /api/chat returned no message content");
+  }
+  return content;
+}
+
+/** POST to Ollama `/api/chat` and return the assistant message content string. */
+async function postNativeChat(
+  nativeBaseUrl: string,
+  body: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${nativeBaseUrl}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(`Ollama /api/chat failed (${response.status}): ${detail}`);
+    }
+    const data = (await response.json()) as { message?: { content?: string } };
+    return readNativeChatContent(data);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Ollama-backed LLM provider using native structured output for tool calls. */
 export class OllamaProvider extends OpenAIProvider {
+  private readonly nativeBaseUrl: string;
+  private readonly timeoutMs: number;
+
   constructor(model: string, options: OllamaProviderOptions) {
+    const timeoutMs = resolveOllamaTimeoutMs(options.timeoutMs);
     super(model, {
       baseURL: options.baseURL,
       apiKey: "ollama",
       embeddingsBaseURL: options.embeddingsBaseURL,
       embeddingModel: options.embeddingModel,
-      timeoutMs: resolveOllamaTimeoutMs(options.timeoutMs),
+      timeoutMs,
     });
+    this.nativeBaseUrl = resolveOllamaNativeHost(options.baseURL);
+    this.timeoutMs = timeoutMs;
   }
 
   /** Ollama ships a dedicated embedding model (nomic-embed-text). */
   protected override embeddingModel(): string {
     return this.configuredEmbeddingModel ?? EMBEDDING_MODELS.ollama;
+  }
+
+  /**
+   * Structured tool call via Ollama's native `/api/chat` + JSON schema `format`.
+   * Uses `OLLAMA_HOST` for the native base URL; `OLLAMA_EMBEDDINGS_HOST` is unchanged.
+   */
+  override async toolCall(
+    system: string,
+    messages: LLMMessage[],
+    tools: LLMTool[],
+    maxTokens: number,
+  ): Promise<string> {
+    const body = buildNativeChatBody(
+      this.model,
+      system,
+      messages,
+      tools[0]?.input_schema,
+      maxTokens,
+    );
+    return postNativeChat(this.nativeBaseUrl, body, this.timeoutMs);
   }
 }

--- a/test/confidence-metadata.test.ts
+++ b/test/confidence-metadata.test.ts
@@ -125,6 +125,22 @@ describe("parseConcepts handles new optional fields", () => {
     expect(concept.provenanceState).toBeUndefined();
     expect(concept.contradictedBy).toBeUndefined();
   });
+
+  it("parses concepts when Ollama double-encodes the array as a string", () => {
+    const raw = JSON.stringify({
+      concepts: JSON.stringify([
+        { concept: "Foo", summary: "Bar", is_new: true },
+      ]),
+    });
+    const result = parseConcepts(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.concept).toBe("Foo");
+  });
+
+  it("returns no concepts when a string-encoded concepts field is invalid JSON", () => {
+    const raw = JSON.stringify({ concepts: "not-json" });
+    expect(parseConcepts(raw)).toEqual([]);
+  });
 });
 
 describe("checkLowConfidencePages", () => {

--- a/test/providers/ollama.test.ts
+++ b/test/providers/ollama.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for OllamaProvider native structured output and host resolution.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CONCEPT_EXTRACTION_TOOL } from "../../src/compiler/prompts.js";
+import { OllamaProvider, resolveOllamaNativeHost } from "../../src/providers/ollama.js";
+
+const TOOL_MESSAGES = [{ role: "user" as const, content: "extract" }];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("resolveOllamaNativeHost", () => {
+  it("strips /v1 from OLLAMA_HOST-style URLs", () => {
+    expect(resolveOllamaNativeHost("http://localhost:11434/v1")).toBe("http://localhost:11434");
+    expect(resolveOllamaNativeHost("http://localhost:11434/v1/")).toBe("http://localhost:11434");
+  });
+
+  it("preserves reverse-proxy path prefixes before /v1", () => {
+    expect(resolveOllamaNativeHost("https://proxy.example.com/ollama/v1")).toBe(
+      "https://proxy.example.com/ollama",
+    );
+  });
+
+  it("preserves host and port from remote OLLAMA_HOST values", () => {
+    expect(resolveOllamaNativeHost("http://ollama.internal:11434/v1")).toBe(
+      "http://ollama.internal:11434",
+    );
+  });
+
+  it("throws when the URL is invalid", () => {
+    expect(() => resolveOllamaNativeHost("not-a-url")).toThrow(/Invalid OLLAMA_HOST URL/);
+  });
+
+  it("uses the default OLLAMA_HOST when unset", () => {
+    expect(resolveOllamaNativeHost()).toBe("http://localhost:11434");
+    expect(resolveOllamaNativeHost("   ")).toBe("http://localhost:11434");
+  });
+});
+
+describe("OllamaProvider.toolCall", () => {
+  it("calls native /api/chat with format schema instead of OpenAI tool_calls", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          content: JSON.stringify({
+            concepts: [{ concept: "X", summary: "Y", is_new: true }],
+          }),
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new OllamaProvider("llama3.1:latest", {
+      baseURL: "http://localhost:11434/v1",
+    });
+
+    const output = await provider.toolCall(
+      "system",
+      TOOL_MESSAGES,
+      [CONCEPT_EXTRACTION_TOOL],
+      4096,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:11434/api/chat",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.format).toEqual(CONCEPT_EXTRACTION_TOOL.input_schema);
+    expect(body.model).toBe("llama3.1:latest");
+    expect(body.think).toBeUndefined();
+    expect(JSON.parse(output).concepts).toHaveLength(1);
+  });
+
+  it("uses OLLAMA_EMBEDDINGS_HOST only for embeddings, not native tool calls", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          content: JSON.stringify({
+            concepts: [{ concept: "A", summary: "B", is_new: false }],
+          }),
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new OllamaProvider("llama3.1", {
+      baseURL: "http://chat-host:11434/v1",
+      embeddingsBaseURL: "http://embed-host:11435/v1",
+    });
+
+    await provider.toolCall("system", TOOL_MESSAGES, [CONCEPT_EXTRACTION_TOOL], 1024);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://chat-host:11434/api/chat",
+      expect.any(Object),
+    );
+  });
+
+  it("targets the proxied native base URL when OLLAMA_HOST has a path prefix", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: { content: JSON.stringify({ concepts: [] }) },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new OllamaProvider("llama3.1", {
+      baseURL: "https://proxy.example.com/ollama/v1",
+    });
+
+    await provider.toolCall("system", TOOL_MESSAGES, [CONCEPT_EXTRACTION_TOOL], 1024);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://proxy.example.com/ollama/api/chat",
+      expect.any(Object),
+    );
+  });
+
+  it("throws when OLLAMA_HOST is not a valid URL", () => {
+    expect(
+      () => new OllamaProvider("llama3.1", { baseURL: "not-a-url" }),
+    ).toThrow(/Invalid OLLAMA_HOST URL/);
+  });
+
+  it("throws when Ollama returns a non-OK HTTP status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "model not found",
+      }),
+    );
+
+    const provider = new OllamaProvider("llama3.1", {
+      baseURL: "http://localhost:11434/v1",
+    });
+
+    await expect(
+      provider.toolCall("system", TOOL_MESSAGES, [CONCEPT_EXTRACTION_TOOL], 1024),
+    ).rejects.toThrow(/Ollama \/api\/chat failed \(500\): model not found/);
+  });
+
+  it("throws when Ollama returns no message content", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ message: {} }),
+      }),
+    );
+
+    const provider = new OllamaProvider("llama3.1", {
+      baseURL: "http://localhost:11434/v1",
+    });
+
+    await expect(
+      provider.toolCall("system", TOOL_MESSAGES, [CONCEPT_EXTRACTION_TOOL], 1024),
+    ).rejects.toThrow(/returned no message content/);
+  });
+
+  it("aborts the request when timeoutMs elapses", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new OllamaProvider("llama3.1", {
+      baseURL: "http://localhost:11434/v1",
+      timeoutMs: 1000,
+    });
+
+    const promise = provider.toolCall(
+      "system",
+      TOOL_MESSAGES,
+      [CONCEPT_EXTRACTION_TOOL],
+      1024,
+    );
+    const rejection = expect(promise).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(1001);
+    await rejection;
+  });
+});

--- a/test/providers/ollama.test.ts
+++ b/test/providers/ollama.test.ts
@@ -7,6 +7,38 @@ import { CONCEPT_EXTRACTION_TOOL } from "../../src/compiler/prompts.js";
 import { OllamaProvider, resolveOllamaNativeHost } from "../../src/providers/ollama.js";
 
 const TOOL_MESSAGES = [{ role: "user" as const, content: "extract" }];
+const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1";
+const DEFAULT_TOOL_MAX_TOKENS = 1024;
+
+interface NativeFetchResponse {
+  ok: boolean;
+  status?: number;
+  text?: string;
+  json?: unknown;
+}
+
+function makeOllamaProvider(baseURL = DEFAULT_OLLAMA_BASE_URL): OllamaProvider {
+  return new OllamaProvider("llama3.1", { baseURL });
+}
+
+function stubNativeFetch(response: NativeFetchResponse): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: response.ok,
+      status: response.status,
+      text: async () => response.text ?? "",
+      json: async () => response.json,
+    }),
+  );
+}
+
+async function expectDefaultToolCallToReject(message: RegExp): Promise<void> {
+  const provider = makeOllamaProvider();
+  await expect(
+    provider.toolCall("system", TOOL_MESSAGES, [CONCEPT_EXTRACTION_TOOL], DEFAULT_TOOL_MAX_TOKENS),
+  ).rejects.toThrow(message);
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -131,40 +163,22 @@ describe("OllamaProvider.toolCall", () => {
   });
 
   it("throws when Ollama returns a non-OK HTTP status", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: async () => "model not found",
-      }),
-    );
-
-    const provider = new OllamaProvider("llama3.1", {
-      baseURL: "http://localhost:11434/v1",
+    stubNativeFetch({
+      ok: false,
+      status: 500,
+      text: "model not found",
     });
 
-    await expect(
-      provider.toolCall("system", TOOL_MESSAGES, [CONCEPT_EXTRACTION_TOOL], 1024),
-    ).rejects.toThrow(/Ollama \/api\/chat failed \(500\): model not found/);
+    await expectDefaultToolCallToReject(/Ollama \/api\/chat failed \(500\): model not found/);
   });
 
   it("throws when Ollama returns no message content", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ message: {} }),
-      }),
-    );
-
-    const provider = new OllamaProvider("llama3.1", {
-      baseURL: "http://localhost:11434/v1",
+    stubNativeFetch({
+      ok: true,
+      json: { message: {} },
     });
 
-    await expect(
-      provider.toolCall("system", TOOL_MESSAGES, [CONCEPT_EXTRACTION_TOOL], 1024),
-    ).rejects.toThrow(/returned no message content/);
+    await expectDefaultToolCallToReject(/returned no message content/);
   });
 
   it("aborts the request when timeoutMs elapses", async () => {


### PR DESCRIPTION
## Summary

Fixes concept extraction (and other structured tool calls) failing silently when using the Ollama provider with local models such as `llama3.1:latest`.

`OllamaProvider` previously inherited `OpenAIProvider.toolCall()`, which routes through the OpenAI-compatible `/v1/chat/completions` endpoint with `tool_choice: "required"`. With Ollama, that path sometimes returns `function.arguments` where array fields like `concepts` are double-encoded as JSON strings instead of native arrays:

```json
{ "concepts": "[{\"concept\":\"...\",\"summary\":\"...\",\"is_new\":true}]" }
```

`parseConcepts` then hits `concepts.filter is not a function`, catches the error, and returns `[]`. The compile pipeline surfaces `no concepts — will retry`, writes zero wiki pages, and still reports the source as "compiled" — a misleading partial success.

## Fix

### 1. `OllamaProvider.toolCall` — native structured output (primary)

Override `toolCall()` to call Ollama's native `POST /api/chat` with `format: tool.input_schema` (JSON-schema structured output). This applies to **all** structured tool calls in the pipeline: concept extraction, rule extraction, query page selection, and eval judge.

- Embeddings and other OpenAI-compatible calls continue to use `OLLAMA_HOST` / `OLLAMA_EMBEDDINGS_HOST` via the existing `/v1` client — unchanged.
- The native base URL is derived from `OLLAMA_HOST` by stripping the trailing `/v1` suffix while **preserving any reverse-proxy path prefix** (e.g. `https://proxy/ollama/v1` → `https://proxy/ollama/api/chat`).
- Uses `fetch` directly (no new `ollama` npm dependency).
- Respects `OLLAMA_TIMEOUT_MS` / `LLMWIKI_REQUEST_TIMEOUT_MS` via `AbortController`.

### 2. `parseConcepts` — defensive coercion (secondary)

Coerce `concepts` when it arrives as a JSON string, and return `[]` cleanly when it is not an array after coercion. This does not fix the root cause but protects against the same quirk from other providers/models.

## Error handling

Invalid `OLLAMA_HOST` values now throw at provider construction instead of silently falling back to localhost. Failed `/api/chat` HTTP responses and empty message content also throw with actionable error messages, rather than returning empty output that the pipeline misreads as "no concepts."

## Differences from initial investigation notes

The implementation follows the same two-change strategy documented in local investigation notes, with refinements discovered during implementation:

| Topic | Initial notes | Final implementation |
|---|---|---|
| Native host resolution | Strip to `protocol//host` only | Strip `/v1` from pathname but **keep path prefixes** for reverse proxies |
| Invalid `OLLAMA_HOST` | Silent fallback to localhost | **Throw** `Invalid OLLAMA_HOST URL: …` at construction |
| Request body | Included `think: false` | Omitted — not required for this use case |
| `parseConcepts` tests | Suggested new `test/compiler/prompts.test.ts` | Added to existing `test/confidence-metadata.test.ts` |
| `OllamaProvider` tests | Basic `/api/chat` + `format` mock | Extended: proxy path prefix, embeddings host isolation, HTTP errors, empty content, timeout abort |
| Docs | Note in providers page | Updated `providers.mdx` and `environment-variables.mdx` |

## Test plan

- [x] Unit: `parseConcepts` coerces string-encoded `concepts` array
- [x] Unit: `parseConcepts` returns `[]` when string-encoded `concepts` is invalid JSON
- [x] Unit: `OllamaProvider.toolCall` hits `/api/chat` with `format` schema (not OpenAI `tool_calls`)
- [x] Unit: reverse-proxy path prefix preserved in native URL
- [x] Unit: `OLLAMA_EMBEDDINGS_HOST` not used for native tool calls
- [x] Unit: invalid `OLLAMA_HOST`, HTTP errors, empty content, and timeout abort throw correctly
- [x] `npm test`, `npm run build`, `npx tsc --noEmit`
- [x] Manual: `LLMWIKI_PROVIDER=ollama llmwiki compile` against a local Ollama instance produces concept pages (not `no concepts — will retry`)

## Notes for operators behind a reverse proxy

`OLLAMA_HOST` must still include `/v1` for the OpenAI-compatible client. The proxy must route both:

- `/your-prefix/v1/*` → Ollama OpenAI-compatible API (embeddings)
- `/your-prefix/api/*` → Ollama native REST API (`/api/chat`)

## Related

Distinct from timeout ([#11](https://github.com/atomicstrata/llm-wiki-compiler/issues/11)) and context-window blowup ([#39](https://github.com/atomicstrata/llm-wiki-compiler/issues/39)) issues — this is **malformed structured output** on the OpenAI-compatible path, not a timeout or context problem.
