### PR TITLE
fix(release): align npm provenance repository metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
-      - name: Verify package.json version matches payload
+      - name: Verify package identity matches payload and repository
         env:
           WANT: ${{ needs.resolve.outputs.version }}
         run: |
@@ -131,6 +131,12 @@ jobs:
             echo "::error::package.json at this SHA is ${actual}, payload says ${WANT}"; exit 1
           fi
           echo "ok: package.json is ${actual}"
+          actual_repository="$(node -p "require('./package.json').repository.url")"
+          expected_repository="git+https://github.com/${GITHUB_REPOSITORY}.git"
+          if [[ "${actual_repository}" != "${expected_repository}" ]]; then
+            echo "::error::package.json repository.url is ${actual_repository}, expected ${expected_repository}"; exit 1
+          fi
+          echo "ok: package repository is ${actual_repository}"
       - name: Refuse to republish an existing version
         env:
           WANT: ${{ needs.resolve.outputs.version }}

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
   "author": "Ethan Joffe",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/atomicmemory/llm-wiki-compiler.git"
+    "url": "git+https://github.com/atomicstrata/llm-wiki-compiler.git"
   },
-  "homepage": "https://github.com/atomicmemory/llm-wiki-compiler#readme",
+  "homepage": "https://github.com/atomicstrata/llm-wiki-compiler#readme",
   "bugs": {
-    "url": "https://github.com/atomicmemory/llm-wiki-compiler/issues"
+    "url": "https://github.com/atomicstrata/llm-wiki-compiler/issues"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## Summary

Correct the package repository metadata so npm Trusted Publishing can verify GitHub provenance for the v1.0.0 release. Add a fail-fast workflow assertion that the package repository URL matches the GitHub repository performing the publish.

## Why

The first v1.0.0 publish attempt completed the full release preflight but npm rejected publication because the package metadata still pointed at the repository’s former organization. No package version was published.

## Validation

- Full TypeScript, build, test, code-health, and package dry-run gates pass
- The public diff is limited to package metadata and the publish workflow
- `llm-wiki-compiler@1.0.0` remains unpublished pending this fix