### PR TITLE
docs: add upgrade guide for 1.0

### DIFF
--- a/docs/concepts/how-it-works.mdx
+++ b/docs/concepts/how-it-works.mdx
@@ -59,7 +59,7 @@ Retrieval runs over the compiled wiki, not raw source chunks.
 
 <Steps>
   <Step title="Cosine similarity">
-    `.llmwiki/embeddings.json` v2 carries both page-level and chunk-level vectors. A query narrows hundreds of pages to a small top-K via cosine similarity over chunk embeddings.
+    `.llmwiki/embeddings.json` v3 carries page-level and chunk-level vectors under qualified page ids. A query narrows hundreds of pages to a small top-K via cosine similarity over chunk embeddings.
   </Step>
   <Step title="BM25 rerank">
     The candidate set is reranked using BM25 to boost lexically relevant pages that dense retrieval may have under-ranked.

--- a/docs/concepts/wiki-model.mdx
+++ b/docs/concepts/wiki-model.mdx
@@ -48,7 +48,7 @@ wiki/
     Tracks per-source SHA-256 content hashes and the concept slugs each source owns. On every compile, llmwiki compares live file hashes against this state to determine what needs reprocessing. This is what makes incremental compilation possible.
   </Card>
   <Card title="embeddings.json" icon="vector-square">
-    The v2 embedding store. Carries page-level and chunk-level vectors used by `llmwiki query` and `llmwiki context` for cosine-similarity retrieval. Updated incrementally alongside source changes - only chunks whose content changed are re-embedded.
+    The v3 embedding store. Carries page-level and chunk-level vectors under qualified page ids for `llmwiki query` and `llmwiki context` cosine-similarity retrieval. Updated incrementally alongside source changes - only chunks whose content changed are re-embedded.
   </Card>
   <Card title="candidates/" icon="clock">
     JSON records for pages held for review - either via `llmwiki compile --review`, triggered automatically by a review policy in `config.json`, or staged by `llmwiki import --okf`. Each candidate records exactly why it was held (low confidence, contradicted, schema-violating, provenance-violating, or imported from OKF). Rejected candidates move to `candidates/archive/` for audit.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,6 +25,7 @@
               "introduction",
               "quickstart",
               "installation",
+              "upgrading-to-1-0",
               "guides/open-knowledge-format"
             ]
           },

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -172,6 +172,9 @@ Variables in the shell environment take precedence over `.env` values.
 
 ## Next Steps
 
+Upgrading an existing 0.11 project? Follow [Upgrading from 0.11 to 1.0](/upgrading-to-1-0)
+for the compatibility checks and one-time embedding index transition.
+
 For a full reference on every provider option, proxy configuration, request timeouts, and output language settings, see [Provider Configuration](/configuration/providers).
 
 Ready to compile your first wiki? Head to the [Quickstart](/quickstart).

--- a/docs/upgrading-to-1-0.mdx
+++ b/docs/upgrading-to-1-0.mdx
@@ -1,0 +1,119 @@
+---
+title: "Upgrading from 0.11 to 1.0"
+sidebarTitle: "Upgrade to 1.0"
+description: "Upgrade an existing llmwiki project to 1.0 without changing its default profile, and complete the one-time embedding index transition."
+---
+
+<Note>
+  Existing projects that use `wiki/concepts/` and `wiki/queries/` do not need a
+  profile or content migration. When `.llmwiki/profile.json` is absent, llmwiki
+  1.0 continues to use the implicit `default` profile and the classic directory
+  layout.
+</Note>
+
+## Before you upgrade
+
+llmwiki 0.11 and 1.0 both require Node.js 24 or newer:
+
+```bash
+node --version
+```
+
+Before the first 1.0 command that writes project state, commit or back up your
+project. Include `.llmwiki/` in the backup if you may need to restore the old
+embedding index; that directory is commonly excluded from version control.
+
+## Install 1.0
+
+```bash
+npm install -g llm-wiki-compiler@1
+llmwiki --version
+```
+
+Run these checks from the root of your existing project:
+
+```bash
+llmwiki profile show
+llmwiki profile validate
+llmwiki status
+llmwiki lint
+```
+
+For a classic project, `profile show` reports the built-in `default` profile.
+The upgrade does not create `.llmwiki/profile.json`, move pages, or reinterpret
+`wiki/concepts/` and `wiki/queries/` as a new domain model.
+
+## Refresh the embedding index
+
+llmwiki 1.0 advances `.llmwiki/embeddings.json` from v2 to v3. The v3 format
+uses qualified page ids so a concept and a profile-defined entity with the same
+slug cannot collide.
+
+The transition happens automatically on the next embedding-writing command,
+normally:
+
+```bash
+llmwiki compile
+```
+
+The migration content-checks existing vectors. It preserves vectors that map
+unambiguously to live pages and re-embeds entries that are stale or ambiguous.
+This command can call your configured embedding provider and incur its normal
+usage cost.
+
+Until the transition runs, semantic retrieval reports
+`embedding-index-outdated`. Lexical retrieval remains available, so you can
+defer the compile if you do not need semantic search immediately.
+
+## Check wiki symlinks
+
+Version 1.0 never reads a wiki file through a symlink whose target escapes the
+project root. This prevents out-of-project content from reaching prompts or
+generated pages.
+
+List symlinks before compiling:
+
+```bash
+find wiki -type l -print
+```
+
+In-project symlinks remain supported. For an escaping symlink, copy the content
+into the project or retarget the link beneath the project root. llmwiki drops
+an escaping wiki file and prints a warning instead of following it.
+
+## Do not install a template over an existing wiki
+
+The `autosci` and `newsroom` templates initialize new or empty typed projects.
+They are not migrations for an existing default wiki.
+
+Do not run either command in a populated project:
+
+```bash
+llmwiki template init autosci
+llmwiki template init newsroom
+```
+
+The installer checks the existing typed corpus and refuses the replacement,
+even when the project has no explicit profile file. To use a template, create a
+new project and move or import content deliberately.
+
+## State reset is not an upgrade step
+
+Do not run `llmwiki state reset` during a normal 0.11-to-1.0 upgrade. That
+command is a recovery tool for a corrupt state file or one written by a newer,
+forward-incompatible llmwiki build. Version 1.0 reads a healthy 0.11 state file
+without resetting it.
+
+## Upgrade checklist
+
+- `llmwiki --version` reports `1.0.0` or newer.
+- `llmwiki profile show` reports `default` for a classic project.
+- `llmwiki profile validate` succeeds.
+- Existing pages remain under `wiki/concepts/` and `wiki/queries/`.
+- `llmwiki status` and `llmwiki lint` complete without unexpected problems.
+- A subsequent `llmwiki compile` updates the embedding index when semantic
+  retrieval is in use.
+- Any wiki symlinks resolve within the project root.
+
+For the new profile system, see [Configurable Lifecycle Profiles](/concepts/configurable-lifecycle-profiles).
+For state-version recovery, see [State recovery](/troubleshooting/state-recovery).


### PR DESCRIPTION
## Summary

Add a practical upgrade guide for existing llmwiki 0.11 projects moving to 1.0. The guide makes the compatibility contract explicit: classic projects continue under the implicit default profile without moving or rewriting content.

It also documents the one-time v2-to-v3 embedding-index transition, the tightened policy for wiki symlinks that escape the project root, and why profile templates should only initialize new or empty projects.

## Documentation updates

- Add the upgrade guide to **Get Started** and link it from installation
- Explain validation steps for an existing default-profile project
- Correct the embedding-store version in the architecture reference pages

## Validation

- Mintlify strict build validation passes
- Mintlify reports no broken links
- TypeScript, build, 4,045 tests, and code-health gates pass