### PR TITLE
Add a guided path for creating CLP profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The [`examples/basic/`](examples/basic/) directory includes a small pre-generate
 | `llmwiki compile` | Incrementally extract concepts and generate wiki pages. |
 | `llmwiki refresh --stale [--dry-run]` | Recompile changed owners of stale pages and clean selected orphaned ownership. |
 | `llmwiki template list\|inspect\|init` | Discover and install validated declarative profile templates. |
-| `llmwiki profile show\|validate\|diff` | Inspect, validate, and assess changes to the active profile. |
+| `llmwiki profile init\|show\|validate\|diff` | Create a minimal profile, inspect it, validate it, or assess profile changes. |
 | `llmwiki workflow ...` | Discover and drive profile-declared workflows, stages, gates, and outputs. |
 | `llmwiki artifact write\|verify` | Write trusted profile-declared artifacts and verify hash-pinned references. |
 | `llmwiki connector list\|run` | Discover first-party connectors and stage external records for review. |

--- a/docs/cli/profile.mdx
+++ b/docs/cli/profile.mdx
@@ -1,16 +1,40 @@
 ---
 title: "profile"
 sidebarTitle: "profile"
-description: "Inspect and validate the active wiki profile."
+description: "Create, inspect, and validate the active wiki profile."
 ---
 
-`llmwiki profile` is the read-only command group for the active profile.
+`llmwiki profile` creates a minimal local profile or inspects the active profile.
 A profile defines the typed entity directories, relations, lifecycles,
 artifacts, workflows, connector bindings, and content tiers that a project uses.
 
 If `.llmwiki/profile.json` is absent, llmwiki uses the built-in `default`
 profile. The default profile preserves the classic `wiki/concepts/` and
 `wiki/queries/` layout.
+
+## Create a minimal profile
+
+Use `profile init` in an empty project when you want to author a profile rather
+than install a complete template.
+
+```bash
+llmwiki profile init issue-tracker --entity issues
+```
+
+The command writes `.llmwiki/profile.json` and creates `wiki/issues/`. The
+generated profile requires a text `title` on every issue page. It validates the
+profile before writing and refuses if an active profile or typed project content
+already exists. There is no `--force` option.
+
+```text
+Created profile 'issue-tracker'
+wrote .llmwiki/profile.json
+created wiki/issues/
+next: llmwiki profile validate
+```
+
+See [Build your first profile](/guides/clp/build-your-first-profile) for the
+complete beginner walkthrough.
 
 ## Show the active profile
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,7 @@
                 "group": "Configurable Lifecycle Profiles",
                 "expanded": false,
                 "pages": [
+                  "guides/clp/build-your-first-profile",
                   "guides/autosci-research-workflow",
                   "guides/newsroom-editorial-workflow"
                 ]

--- a/docs/guides/clp/build-your-first-profile.mdx
+++ b/docs/guides/clp/build-your-first-profile.mdx
@@ -1,0 +1,332 @@
+---
+title: "Build your first profile"
+sidebarTitle: "Build your first profile"
+description: "Create a custom issue-tracker profile, add a valid page, and see llmwiki recognize it in about ten minutes."
+mode: "wide"
+---
+
+import { ProfileExplorer } from '/snippets/ProfileExplorer.jsx';
+import { starterProfileText, profileExplanations } from '/snippets/profile-onboarding-data.mdx';
+
+Create a small custom profile in a real local project. You will define issue
+pages, add one issue, check it, and make one controlled change to the rules.
+
+<CardGroup cols={3}>
+  <Card title="Skill level">Beginner</Card>
+  <Card title="Time">About 10 minutes</Card>
+  <Card title="Result">One valid custom issue page</Card>
+</CardGroup>
+
+## Before you start
+
+Install llmwiki 1.0 or later, then check the version in any directory.
+
+**Run in:** any directory<br />
+**Does:** confirms that the CLI is available<br />
+**Writes:** nothing
+
+```bash
+llmwiki --version
+```
+
+**You should see:** version `1.0.0` or later<br />
+**If it fails:** follow [Installation](/installation), then open a new terminal.
+
+## Your five steps
+
+1. Create an empty project and its profile.
+2. Validate and understand the generated file.
+3. Add your first issue.
+4. Check what llmwiki recognizes.
+5. Add a priority rule, see one useful warning, and repair the issue.
+
+## Step 1: Create the project
+
+Create and enter a new folder. Keep each command separate so it is clear which
+step failed if your shell reports an error.
+
+**Run in:** the folder where you keep projects<br />
+**Does:** creates the tutorial project folder<br />
+**Writes:** `issue-tracker-wiki/`
+
+```bash
+mkdir issue-tracker-wiki
+```
+
+**Run in:** the folder where you keep projects<br />
+**Does:** enters the project<br />
+**Writes:** nothing
+
+```bash
+cd issue-tracker-wiki
+```
+
+Now create the smallest useful profile.
+
+**Run in:** `issue-tracker-wiki/`<br />
+**Does:** defines one kind of page called `issues`<br />
+**Writes:** `.llmwiki/profile.json` and `wiki/issues/`
+
+```bash
+llmwiki profile init issue-tracker --entity issues
+```
+
+**You should see:**
+
+```text
+Created profile 'issue-tracker'
+wrote .llmwiki/profile.json
+created wiki/issues/
+next: llmwiki profile validate
+```
+
+**Checkpoint:** both paths shown above exist.<br />
+**If it fails:** use an empty project. The command refuses to replace an active
+profile or reinterpret existing wiki content. It never offers a force option.
+
+## Step 2: Validate and understand the profile
+
+**Run in:** `issue-tracker-wiki/`<br />
+**Does:** checks that every profile rule is supported and internally consistent<br />
+**Writes:** nothing
+
+```bash
+llmwiki profile validate
+```
+
+**You should see:**
+
+```text
+Profile 'issue-tracker' is valid
+```
+
+<Visibility for="humans">
+  <ProfileExplorer
+    profileText={starterProfileText}
+    explanations={profileExplanations}
+    continueTarget="step-3-add-your-first-issue"
+  />
+</Visibility>
+
+<Visibility for="agents">
+
+### Generated profile
+
+```json
+{
+  "schemaVersion": 1,
+  "profileId": "issue-tracker",
+  "displayName": "Issue Tracker",
+  "entities": {
+    "issues": {
+      "directory": "wiki/issues",
+      "titleField": "title",
+      "requiredFields": [
+        "title"
+      ],
+      "fields": {
+        "title": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+```
+
+1. **File format version (`schemaVersion`)** tells llmwiki which profile format the file uses.
+2. **Profile name (`profileId`, `displayName`)** supplies a stable internal name and readable label.
+3. **Kinds of pages (`entities`, `issues`)** declares that this project stores issue pages.
+4. **Where pages live (`directory`)** places issue pages in `wiki/issues/`.
+5. **Required page title (`titleField`, `requiredFields`, `fields.title`)** requires every issue to have a text title.
+
+</Visibility>
+
+**Checkpoint:** you can identify where issue pages belong and which information
+each issue must contain.
+
+## Step 3: Add your first issue
+
+Create `wiki/issues/explain-first-profile.md` with the following exact content.
+
+<Tabs>
+  <Tab title="macOS and Linux">
+
+**Run in:** `issue-tracker-wiki/`<br />
+**Does:** creates the first issue page<br />
+**Writes:** `wiki/issues/explain-first-profile.md`
+
+```bash
+cat > wiki/issues/explain-first-profile.md <<'EOF'
+---
+title: Explain the first profile
+---
+
+Explain why this project uses custom issue pages and what information every issue should contain.
+EOF
+```
+
+  </Tab>
+  <Tab title="PowerShell">
+
+**Run in:** `issue-tracker-wiki/`<br />
+**Does:** creates the first issue page<br />
+**Writes:** `wiki/issues/explain-first-profile.md`
+
+```powershell
+$content = @'
+---
+title: Explain the first profile
+---
+
+Explain why this project uses custom issue pages and what information every issue should contain.
+'@
+[IO.File]::WriteAllText(
+  "wiki/issues/explain-first-profile.md",
+  $content + "`n",
+  [Text.UTF8Encoding]::new($false)
+)
+```
+
+  </Tab>
+</Tabs>
+
+**Checkpoint:** the new Markdown file exists under `wiki/issues/`.<br />
+**If it fails:** confirm that you are inside `issue-tracker-wiki/` and that Step
+1 created `wiki/issues/`.
+
+## Step 4: Check what llmwiki recognizes
+
+First check the page against the active profile.
+
+**Run in:** `issue-tracker-wiki/`<br />
+**Does:** checks existing pages against the profile rules<br />
+**Writes:** `.llmwiki/last-lint.json`
+
+```bash
+llmwiki lint
+```
+
+**You should see:**
+
+```text
+0 error(s), 0 warning(s), 0 info
+```
+
+Then open the local read-only viewer.
+
+**Run in:** `issue-tracker-wiki/`<br />
+**Does:** starts a local viewer and asks your operating system to open it<br />
+**Writes:** nothing
+
+```bash
+llmwiki view --open
+```
+
+The port varies, so the readiness line looks like:
+
+```text
+Viewer ready at http://127.0.0.1:PORT
+```
+
+Open **Graph** and find `Explain the first profile`. The issue appears as a
+typed graph node. This proves llmwiki recognized the file under your profile;
+the current viewer does not open typed issue bodies as ordinary page routes.
+Press `Ctrl+C` in the terminal when you are finished.
+
+<Accordion title="The browser did not open">
+Run `llmwiki view` without `--open`, then copy the printed loopback URL into a
+browser. This is the normal approach over SSH, in a container, or on a headless
+machine.
+</Accordion>
+
+## Step 5: Add a rule and repair one issue
+
+Open `.llmwiki/profile.json`. Add `priority` to `requiredFields`, then add its
+definition beside `title` under `fields`. The complete result is below; the new
+parts are the second required field and the `priority` definition.
+
+```json
+{
+  "schemaVersion": 1,
+  "profileId": "issue-tracker",
+  "displayName": "Issue Tracker",
+  "entities": {
+    "issues": {
+      "directory": "wiki/issues",
+      "titleField": "title",
+      "requiredFields": [
+        "title",
+        "priority"
+      ],
+      "fields": {
+        "title": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "enum",
+          "enum": ["low", "normal", "high"]
+        }
+      }
+    }
+  }
+}
+```
+
+Validate the rules first.
+
+```bash
+llmwiki profile validate
+```
+
+It succeeds because the profile is valid. Now check the existing issue:
+
+```bash
+llmwiki lint
+```
+
+**You should see:**
+
+```text
+warning .../wiki/issues/explain-first-profile.md Required field "priority" is missing from frontmatter.
+0 error(s), 1 warning(s), 0 info
+```
+
+This warning is deliberate. Profile validation checks the rules themselves;
+lint checks your pages against those rules.
+
+Add one line to the issue's frontmatter:
+
+```yaml
+---
+title: Explain the first profile
+priority: normal
+---
+```
+
+Run both checks again:
+
+```bash
+llmwiki profile validate
+```
+
+```bash
+llmwiki lint
+```
+
+**You should see:** `0 error(s), 0 warning(s), 0 info`.
+
+<Check>
+You created a custom profile, added a page that follows it, changed one rule,
+and repaired the resulting warning. Every checkpoint is an ordinary project
+file that you can edit and commit.
+</Check>
+
+## Where to go next
+
+- Add allowed status changes to model `open`, `in-progress`, and `done`.
+- Add a `blocks` relation between issues.
+- Add a triage workflow.
+- Package your profile with [Profile templates](/configuration/profile-templates).
+- Follow [AutoSci Research Workflow](/guides/autosci-research-workflow) for artifacts, connectors, and research gates.
+- Follow [Newsroom Editorial Workflow](/guides/newsroom-editorial-workflow) for a smaller editorial model.

--- a/docs/guides/clp/build-your-first-profile.mdx
+++ b/docs/guides/clp/build-your-first-profile.mdx
@@ -181,6 +181,7 @@ title: Explain the first profile
 
 Explain why this project uses custom issue pages and what information every issue should contain.
 '@
+$content = $content -replace "\r`n", "`n"
 [IO.File]::WriteAllText(
   "wiki/issues/explain-first-profile.md",
   $content + "`n",

--- a/docs/snippets/ProfileExplorer.jsx
+++ b/docs/snippets/ProfileExplorer.jsx
@@ -1,0 +1,125 @@
+/**
+ * Interactive explanation of the deterministic beginner profile.
+ * Profile text and explanation metadata are passed from the parent MDX page.
+ */
+export const ProfileExplorer = ({ profileText, explanations, continueTarget }) => {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [copyState, setCopyState] = useState("Copy profile")
+  const active = explanations[activeIndex]
+  const lines = profileText.split("\n")
+
+  const selectStep = (nextIndex) => {
+    const bounded = Math.max(0, Math.min(explanations.length - 1, nextIndex))
+    setActiveIndex(bounded)
+  }
+
+  const moveNext = () => {
+    if (activeIndex === explanations.length - 1) {
+      document.getElementById(continueTarget)?.focus()
+      document.getElementById(continueTarget)?.scrollIntoView({ behavior: "smooth", block: "start" })
+      return
+    }
+    selectStep(activeIndex + 1)
+  }
+
+  const copyProfile = async () => {
+    try {
+      await navigator.clipboard.writeText(profileText)
+      setCopyState("Copied")
+    } catch {
+      setCopyState("Copy unavailable")
+    }
+    window.setTimeout(() => setCopyState("Copy profile"), 1600)
+  }
+
+  const handleKeys = (event) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault()
+      selectStep(activeIndex - 1)
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault()
+      moveNext()
+    }
+  }
+
+  return (
+    <section
+      aria-label="Generated profile explorer"
+      onKeyDown={handleKeys}
+      className="my-8 overflow-hidden rounded-md border border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900"
+    >
+      <div className="border-b border-zinc-200 px-5 py-3 text-sm font-semibold text-zinc-700 dark:border-zinc-700 dark:text-zinc-200">
+        Your first profile, explained
+      </div>
+
+      <div className="grid lg:grid-cols-[minmax(220px,0.72fr)_minmax(300px,1fr)_minmax(300px,1fr)]">
+        <div className="border-b border-zinc-200 p-5 dark:border-zinc-700 lg:border-b-0 lg:border-r">
+          <p className="m-0 text-xs font-semibold uppercase text-emerald-700 dark:text-emerald-400">Local checkpoint</p>
+          <h3 className="mb-2 mt-3 text-base font-semibold text-zinc-950 dark:text-white">Create the profile</h3>
+          <pre className="overflow-x-auto rounded bg-zinc-950 p-3 text-xs leading-5 text-zinc-100"><code>llmwiki profile init issue-tracker --entity issues</code></pre>
+          <p className="mt-4 text-sm text-zinc-700 dark:text-zinc-300">Writes:</p>
+          <ul className="mt-1 text-sm text-zinc-700 dark:text-zinc-300">
+            <li><code>.llmwiki/profile.json</code></li>
+            <li><code>wiki/issues/</code></li>
+          </ul>
+          <p className="mt-4 text-sm text-zinc-600 dark:text-zinc-400">The command refuses to replace an existing profile or reinterpret existing wiki content.</p>
+        </div>
+
+        <div className="min-w-0 border-b border-zinc-200 dark:border-zinc-700 lg:border-b-0 lg:border-r">
+          <div className="flex min-h-12 items-center justify-between border-b border-zinc-200 px-4 dark:border-zinc-700">
+            <span className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">.llmwiki/profile.json</span>
+            <button type="button" onClick={copyProfile} className="min-h-11 px-2 text-sm font-semibold text-indigo-700 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-indigo-300">
+              {copyState}
+            </button>
+          </div>
+          <pre className="m-0 max-h-[34rem] overflow-auto bg-zinc-950 py-4 text-xs leading-6 text-zinc-300" aria-label="Complete generated profile">
+            <code>
+              {lines.map((line, index) => {
+                const lineNumber = index + 1
+                const highlighted = active.lines.includes(lineNumber)
+                return (
+                  <span key={lineNumber} className={`block border-l-4 px-3 ${highlighted ? "border-emerald-400 bg-emerald-950/70 font-semibold text-white" : "border-transparent"}`}>
+                    <span aria-hidden="true" className="mr-4 inline-block w-5 select-none text-right text-zinc-500">{lineNumber}</span>
+                    {line || " "}
+                  </span>
+                )
+              })}
+            </code>
+          </pre>
+        </div>
+
+        <div className="flex min-h-[24rem] min-w-0 flex-col bg-white p-5 dark:bg-zinc-950">
+          <div aria-live="polite" aria-atomic="true">
+            <p className="m-0 text-xs font-semibold uppercase text-emerald-700 dark:text-emerald-400">Step {activeIndex + 1} of {explanations.length}</p>
+            <h3 className="mb-1 mt-3 text-lg font-semibold text-zinc-950 dark:text-white">{active.title}</h3>
+            <p className="m-0 text-sm text-zinc-500 dark:text-zinc-400"><code>{active.key}</code></p>
+            <p className="mt-5 text-base leading-7 text-zinc-800 dark:text-zinc-200">{active.description}</p>
+            <h4 className="mb-1 mt-5 text-sm font-semibold text-zinc-950 dark:text-white">Why it matters</h4>
+            <p className="m-0 text-sm leading-6 text-zinc-700 dark:text-zinc-300">{active.importance}</p>
+          </div>
+
+          <div className="mt-auto pt-8">
+            <div className="mb-4 flex gap-2" aria-hidden="true">
+              {explanations.map((item, index) => (
+                <span key={item.title} className={`h-2 w-8 rounded-sm ${index === activeIndex ? "bg-emerald-600 dark:bg-emerald-400" : "bg-zinc-200 dark:bg-zinc-700"}`} />
+              ))}
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <button type="button" disabled={activeIndex === 0} onClick={() => selectStep(activeIndex - 1)} className="min-h-11 rounded border border-zinc-300 px-3 text-sm font-semibold text-zinc-800 disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-600 dark:text-zinc-100">
+                Previous
+              </button>
+              <button type="button" onClick={moveNext} className="min-h-11 rounded bg-indigo-700 px-3 text-sm font-semibold text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-indigo-500">
+                {activeIndex === explanations.length - 1 ? "Continue: Add an issue" : "Next"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="hidden print:block">
+        {explanations.map((item, index) => <p key={item.title}><strong>{index + 1}. {item.title}:</strong> {item.description} {item.importance}</p>)}
+      </div>
+    </section>
+  )
+}

--- a/docs/snippets/profile-onboarding-data.mdx
+++ b/docs/snippets/profile-onboarding-data.mdx
@@ -1,0 +1,57 @@
+export const starterProfileText = `{
+  "schemaVersion": 1,
+  "profileId": "issue-tracker",
+  "displayName": "Issue Tracker",
+  "entities": {
+    "issues": {
+      "directory": "wiki/issues",
+      "titleField": "title",
+      "requiredFields": [
+        "title"
+      ],
+      "fields": {
+        "title": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}`;
+
+export const profileExplanations = [
+  {
+    title: "File format version",
+    key: "schemaVersion",
+    lines: [2],
+    description: "Tells llmwiki which version of the profile format this file uses.",
+    importance: "Keep this at 1. llmwiki checks it before using any of the rules below."
+  },
+  {
+    title: "Profile name",
+    key: "profileId and displayName",
+    lines: [3, 4],
+    description: "Gives your project rules a stable internal name and a readable label.",
+    importance: "The internal name is used by tools. The readable label is what people see."
+  },
+  {
+    title: "Kinds of pages",
+    key: "entities and issues",
+    lines: [5, 6],
+    description: "Declares that this project stores a kind of page called an issue.",
+    importance: "You can add more page kinds later, such as projects, decisions, or customers."
+  },
+  {
+    title: "Where pages live",
+    key: "directory",
+    lines: [7],
+    description: "Places issue pages in the wiki/issues folder.",
+    importance: "llmwiki uses this folder to recognize which rules apply to each page."
+  },
+  {
+    title: "Required page title",
+    key: "titleField, requiredFields, and fields.title",
+    lines: [8, 9, 10, 11, 12, 13, 14, 15, 16],
+    description: "Requires every issue page to include a title made from text.",
+    importance: "If a page is missing its title, lint points to that page and explains the problem."
+  }
+];

--- a/src/cli/profile-commands.ts
+++ b/src/cli/profile-commands.ts
@@ -1,20 +1,32 @@
 /**
  * @file src/cli/profile-commands.ts
- * @description Registers the `profile` command group: read-only inspection
- * of the active wiki profile (`profile show`, `profile validate`,
- * `profile diff`). Moved out of `src/cli.ts` verbatim (pure move, no
- * behavior change) as part of the per-domain command split.
+ * @description Registers active-profile inspection plus the deterministic
+ * beginner `profile init` authoring command.
  */
 
 import type { Command } from "commander";
-import { profileShow, profileValidate, profileDiff } from "../commands/profile.js";
+import { profileShow, profileValidate, profileDiff, profileInit } from "../commands/profile.js";
 import { runExitCodeCommand } from "./shared.js";
 
-/** Register the `profile` command group (`show`, `validate`, `diff`) on `program`. */
+/** Register the `profile` inspection and starter-authoring commands. */
 export function registerProfileCommands(program: Command): void {
   const profileCmd = program
     .command("profile")
-    .description("Inspect the active wiki profile (read-only: show, validate, diff)");
+    .description("Create or inspect the active wiki profile");
+
+  profileCmd
+    .command("init")
+    .description("Create a minimal editable profile in an empty project")
+    .argument("<profile-id>", "Lowercase profile name using letters, numbers, and hyphens")
+    .requiredOption("--entity <entity-type>", "First kind of page to model")
+    .action(async (profileId: string, options: { entity: string }) => {
+      try {
+        await profileInit(profileId, options);
+      } catch (err) {
+        console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+        process.exitCode = 1;
+      }
+    });
 
   profileCmd
     .command("show")

--- a/src/cli/profile-commands.ts
+++ b/src/cli/profile-commands.ts
@@ -19,14 +19,9 @@ export function registerProfileCommands(program: Command): void {
     .description("Create a minimal editable profile in an empty project")
     .argument("<profile-id>", "Lowercase profile name using letters, numbers, and hyphens")
     .requiredOption("--entity <entity-type>", "First kind of page to model")
-    .action(async (profileId: string, options: { entity: string }) => {
-      try {
-        await profileInit(profileId, options);
-      } catch (err) {
-        console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
-        process.exitCode = 1;
-      }
-    });
+    .action(async (profileId: string, options: { entity: string }) =>
+      runExitCodeCommand(() => profileInit(profileId, options)),
+    );
 
   profileCmd
     .command("show")

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -25,7 +25,8 @@ import { validateProfile } from "../profile/validate.js";
 import { isDefaultProfile } from "../profile/default.js";
 import { diffProfiles, DISPOSITIONS, type ProfileDiffReport } from "../profile/diff.js";
 import type { ProfilePack } from "../profile/types.js";
-import { installStarterProfile } from "../profile/scaffold.js";
+import { installStarterProfile, ProfileScaffoldError } from "../profile/scaffold.js";
+import { PROFILE_FILE } from "../utils/constants.js";
 
 /** Options accepted by `profile diff`. */
 export interface ProfileDiffOptions {
@@ -40,19 +41,27 @@ export interface ProfileInitOptions {
 }
 
 /** Author a deterministic minimal profile in an empty project. */
-export async function profileInit(profileId: string, options: ProfileInitOptions): Promise<void> {
+export async function profileInit(profileId: string, options: ProfileInitOptions): Promise<number> {
   try {
     const result = await installStarterProfile(process.cwd(), profileId, options.entity);
     console.log(`Created profile '${result.profileId}'`);
-    console.log("wrote .llmwiki/profile.json");
+    console.log(`wrote ${PROFILE_FILE}`);
     console.log(`created ${result.directory}/`);
     console.log("next: llmwiki profile validate");
+    return 0;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const outcomeKnown = /no profile was installed|profile was installed/i.test(message);
-    const suffix = outcomeKnown ? "" : " No profile was installed.";
+    const suffix = error instanceof ProfileScaffoldError
+      ? outcomeSuffix(error.outcome)
+      : " No profile was installed.";
     throw new Error(`${message}${suffix}`);
   }
+}
+
+/** Describe an install outcome without inferring state from error prose. */
+function outcomeSuffix(outcome: ProfileScaffoldError["outcome"]): string {
+  if (outcome === "not-installed") return " No profile was installed.";
+  return "";
 }
 
 /** Print the active profile's id, digest, and source. Read-only. */

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,5 +1,5 @@
 /**
- * Commander actions for `llmwiki profile` subcommands — all READ-ONLY.
+ * Commander actions for `llmwiki profile` inspection and starter authoring.
  *
  * - `profile show` prints the active profile's id, digest, and the file it was
  *   loaded from (or that it is the built-in default).
@@ -25,12 +25,34 @@ import { validateProfile } from "../profile/validate.js";
 import { isDefaultProfile } from "../profile/default.js";
 import { diffProfiles, DISPOSITIONS, type ProfileDiffReport } from "../profile/diff.js";
 import type { ProfilePack } from "../profile/types.js";
+import { installStarterProfile } from "../profile/scaffold.js";
 
 /** Options accepted by `profile diff`. */
 export interface ProfileDiffOptions {
   candidate?: string;
   from?: string;
   to?: string;
+}
+
+/** Options accepted by `profile init`. */
+export interface ProfileInitOptions {
+  entity: string;
+}
+
+/** Author a deterministic minimal profile in an empty project. */
+export async function profileInit(profileId: string, options: ProfileInitOptions): Promise<void> {
+  try {
+    const result = await installStarterProfile(process.cwd(), profileId, options.entity);
+    console.log(`Created profile '${result.profileId}'`);
+    console.log("wrote .llmwiki/profile.json");
+    console.log(`created ${result.directory}/`);
+    console.log("next: llmwiki profile validate");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const outcomeKnown = /no profile was installed|profile was installed/i.test(message);
+    const suffix = outcomeKnown ? "" : " No profile was installed.";
+    throw new Error(`${message}${suffix}`);
+  }
 }
 
 /** Print the active profile's id, digest, and source. Read-only. */

--- a/src/profile/scaffold.ts
+++ b/src/profile/scaffold.ts
@@ -7,22 +7,29 @@ import { lstat, mkdir, realpath, rmdir } from "node:fs/promises";
 import path from "node:path";
 import { atomicWrite } from "../utils/atomic-write.js";
 import { readCappedNoFollow } from "../utils/confined-read.js";
-import { MAX_PROFILE_BYTES, PROFILE_FILE } from "../utils/constants.js";
+import { CONCEPTS_DIR, MAX_PROFILE_BYTES, PROFILE_FILE, QUERIES_DIR } from "../utils/constants.js";
 import { acquireLockBlocking, releaseLock } from "../utils/lock.js";
 import { confineUnderRoot, isInsideDir } from "../utils/path-confine.js";
+import { resolveExistingConfinedPrivateDir } from "../utils/private-dir.js";
 import { isSlugSafe } from "./identity.js";
 import { loadProfile } from "./load.js";
 import { isTypedCorpusEmpty } from "./templates/corpus.js";
 import type { ProfilePack } from "./types.js";
 import { validateProfile } from "./validate.js";
 
+/** Whether a failed scaffold operation wrote its active profile. */
+export type ProfileInstallOutcome = "installed" | "not-installed" | "unknown";
+
 /** Error raised when a starter profile cannot be built or installed safely. */
-class ProfileScaffoldError extends Error {
-  constructor(message: string) {
+export class ProfileScaffoldError extends Error {
+  constructor(message: string, readonly outcome: ProfileInstallOutcome = "not-installed") {
     super(message);
     this.name = "ProfileScaffoldError";
   }
 }
+
+const RESERVED_PROFILE_NAMES = new Set(["default"]);
+const RESERVED_PAGE_TYPES = new Set([path.basename(CONCEPTS_DIR), path.basename(QUERIES_DIR)]);
 
 /** Convert a validated hyphenated identifier into an ASCII display name. */
 function displayNameFor(profileId: string): string {
@@ -33,16 +40,19 @@ function displayNameFor(profileId: string): string {
 }
 
 /** Require the existing lowercase identifier grammar with beginner-facing wording. */
-function assertBeginnerIdentifier(value: string, label: string): void {
+function assertBeginnerIdentifier(value: string, label: string, reserved: ReadonlySet<string>): void {
   if (!isSlugSafe(value)) {
     throw new ProfileScaffoldError(`${label} must use lowercase letters, numbers, and hyphens`);
+  }
+  if (reserved.has(value)) {
+    throw new ProfileScaffoldError(`${label} '${value}' is already used by llmwiki; choose a different name`);
   }
 }
 
 /** Build and validate the deterministic one-entity starter profile. */
 export function buildStarterProfile(profileId: string, entityType: string): ProfilePack {
-  assertBeginnerIdentifier(profileId, "Profile name");
-  assertBeginnerIdentifier(entityType, "Page type");
+  assertBeginnerIdentifier(profileId, "Profile name", RESERVED_PROFILE_NAMES);
+  assertBeginnerIdentifier(entityType, "Page type", RESERVED_PAGE_TYPES);
   const candidate: ProfilePack = {
     schemaVersion: 1,
     profileId,
@@ -61,7 +71,12 @@ export function buildStarterProfile(profileId: string, entityType: string): Prof
 
 /** Return the canonical bytes written by the starter-profile installer. */
 export function canonicalStarterProfileJson(profileId: string, entityType: string): string {
-  return `${JSON.stringify(buildStarterProfile(profileId, entityType), null, 2)}\n`;
+  return canonicalProfileJson(buildStarterProfile(profileId, entityType));
+}
+
+/** Serialize one already-validated starter profile deterministically. */
+function canonicalProfileJson(profile: ProfilePack): string {
+  return `${JSON.stringify(profile, null, 2)}\n`;
 }
 
 /** Successful scaffold installation details surfaced by the CLI. */
@@ -74,7 +89,11 @@ export interface ProfileScaffoldResult {
 /** Narrow test seam for deterministic post-directory write failure coverage. */
 export interface ProfileScaffoldDependencies {
   writeProfile?: (root: string, body: string) => Promise<void>;
+  confirmProfileCommit?: (root: string, body: string) => Promise<ProfileCommitStatus>;
 }
+
+/** Commit verification outcome after a profile write throws. */
+export type ProfileCommitStatus = "committed" | "absent" | "unknown";
 
 /** Atomically write the active profile as the scaffold's commit point. */
 async function writeProfile(root: string, body: string): Promise<void> {
@@ -123,10 +142,22 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** True when the intended profile bytes reached the commit path despite a late error. */
-async function profileCommitMatches(root: string, body: string): Promise<boolean> {
-  const read = await readCappedNoFollow(path.join(root, PROFILE_FILE), MAX_PROFILE_BYTES).catch(() => null);
-  return read?.kind === "ok" && read.body === body;
+/** Distinguish a committed profile, a confirmed absence, and an unreadable state. */
+async function confirmProfileCommit(root: string, body: string): Promise<ProfileCommitStatus> {
+  const privateDir = await resolveExistingConfinedPrivateDir(root).catch(() => undefined);
+  if (privateDir === undefined) return "unknown";
+  if (privateDir === null) return "absent";
+  const read = await readCappedNoFollow(path.join(privateDir, path.basename(PROFILE_FILE)), MAX_PROFILE_BYTES);
+  if (read.kind === "absent") return "absent";
+  if (read.kind !== "ok" || read.body !== body) return "unknown";
+  return "committed";
+}
+
+/** Render a refusal that distinguishes existing content from unreadable state. */
+function corpusRefusal(reasons: string[]): ProfileScaffoldError {
+  const unavailable = reasons.some((reason) => /unreadable|unsafe|problems/.test(reason));
+  const summary = unavailable ? "Project state could not be verified" : "Typed corpus is not empty";
+  return new ProfileScaffoldError(`${summary}.\n- ${reasons.join("\n- ")}`);
 }
 
 /** Install a minimal profile only when no existing typed corpus can be reinterpreted. */
@@ -141,23 +172,29 @@ export async function installStarterProfile(
   await acquireLockBlocking(root);
   try {
     const loaded = await loadProfile(root);
-    if (loaded.loadedFrom !== null) throw new ProfileScaffoldError("A profile already exists. No profile was installed.");
+    if (loaded.loadedFrom !== null) throw new ProfileScaffoldError("A profile already exists.");
     const probe = await isTypedCorpusEmpty(root, loaded, profile);
-    if (!probe.empty) {
-      throw new ProfileScaffoldError(`Typed corpus is not empty. No profile was installed.\n- ${probe.reasons.join("\n- ")}`);
-    }
+    if (!probe.empty) throw corpusRefusal(probe.reasons);
     const createdDirectory = await prepareEntityDirectory(root, directory);
-    const profileBody = canonicalStarterProfileJson(profileId, entityType);
+    const profileBody = canonicalProfileJson(profile);
     try {
       await (dependencies.writeProfile ?? writeProfile)(root, profileBody);
     } catch (error) {
-      if (await profileCommitMatches(root, profileBody)) {
+      const commit = await (dependencies.confirmProfileCommit ?? confirmProfileCommit)(root, profileBody);
+      if (commit === "committed") {
         throw new ProfileScaffoldError(
           `Profile was installed, but durability confirmation failed: ${errorMessage(error)}`,
+          "installed",
+        );
+      }
+      if (commit === "unknown") {
+        throw new ProfileScaffoldError(
+          `Installation state could not be confirmed after a write failure; no cleanup was attempted: ${errorMessage(error)}`,
+          "unknown",
         );
       }
       if (createdDirectory) await compensateDirectory(path.join(root, directory), error);
-      throw error;
+      throw new ProfileScaffoldError(errorMessage(error));
     }
     return { profileId, entityType, directory };
   } finally {

--- a/src/profile/scaffold.ts
+++ b/src/profile/scaffold.ts
@@ -1,0 +1,166 @@
+/**
+ * @file src/profile/scaffold.ts
+ * @description Builds and installs the minimal profile used by beginner onboarding.
+ */
+
+import { lstat, mkdir, realpath, rmdir } from "node:fs/promises";
+import path from "node:path";
+import { atomicWrite } from "../utils/atomic-write.js";
+import { readCappedNoFollow } from "../utils/confined-read.js";
+import { MAX_PROFILE_BYTES, PROFILE_FILE } from "../utils/constants.js";
+import { acquireLockBlocking, releaseLock } from "../utils/lock.js";
+import { confineUnderRoot, isInsideDir } from "../utils/path-confine.js";
+import { isSlugSafe } from "./identity.js";
+import { loadProfile } from "./load.js";
+import { isTypedCorpusEmpty } from "./templates/corpus.js";
+import type { ProfilePack } from "./types.js";
+import { validateProfile } from "./validate.js";
+
+/** Error raised when a starter profile cannot be built or installed safely. */
+class ProfileScaffoldError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProfileScaffoldError";
+  }
+}
+
+/** Convert a validated hyphenated identifier into an ASCII display name. */
+function displayNameFor(profileId: string): string {
+  return profileId
+    .split("-")
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+/** Require the existing lowercase identifier grammar with beginner-facing wording. */
+function assertBeginnerIdentifier(value: string, label: string): void {
+  if (!isSlugSafe(value)) {
+    throw new ProfileScaffoldError(`${label} must use lowercase letters, numbers, and hyphens`);
+  }
+}
+
+/** Build and validate the deterministic one-entity starter profile. */
+export function buildStarterProfile(profileId: string, entityType: string): ProfilePack {
+  assertBeginnerIdentifier(profileId, "Profile name");
+  assertBeginnerIdentifier(entityType, "Page type");
+  const candidate: ProfilePack = {
+    schemaVersion: 1,
+    profileId,
+    displayName: displayNameFor(profileId),
+    entities: {
+      [entityType]: {
+        directory: `wiki/${entityType}`,
+        titleField: "title",
+        requiredFields: ["title"],
+        fields: { title: { type: "string" } },
+      },
+    },
+  };
+  return validateProfile(candidate).profile;
+}
+
+/** Return the canonical bytes written by the starter-profile installer. */
+export function canonicalStarterProfileJson(profileId: string, entityType: string): string {
+  return `${JSON.stringify(buildStarterProfile(profileId, entityType), null, 2)}\n`;
+}
+
+/** Successful scaffold installation details surfaced by the CLI. */
+export interface ProfileScaffoldResult {
+  profileId: string;
+  entityType: string;
+  directory: string;
+}
+
+/** Narrow test seam for deterministic post-directory write failure coverage. */
+export interface ProfileScaffoldDependencies {
+  writeProfile?: (root: string, body: string) => Promise<void>;
+}
+
+/** Atomically write the active profile as the scaffold's commit point. */
+async function writeProfile(root: string, body: string): Promise<void> {
+  await atomicWrite(path.join(root, PROFILE_FILE), body, { confineRoot: root, durable: true });
+}
+
+/** Create or verify the declared entity directory and report command ownership. */
+async function prepareEntityDirectory(root: string, directory: string): Promise<boolean> {
+  const target = await confineUnderRoot(directory, root, { mustExist: false });
+  let created: string | undefined;
+  try {
+    created = await mkdir(target, { recursive: true });
+  } catch (error) {
+    throw new ProfileScaffoldError(`Entity directory is unsafe or cannot be created: ${directory}: ${errorMessage(error)}`);
+  }
+  await assertRealDirectory(root, target, directory);
+  return created !== undefined;
+}
+
+/** Verify the literal target is a real directory confined beneath the project. */
+async function assertRealDirectory(root: string, target: string, directory: string): Promise<void> {
+  const stat = await lstat(target);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new ProfileScaffoldError(`Entity directory is unsafe: ${directory}`);
+  }
+  const [realRoot, realTarget] = await Promise.all([realpath(root), realpath(target)]);
+  if (!isInsideDir(realTarget, realRoot)) {
+    throw new ProfileScaffoldError(`Entity directory escapes the project: ${directory}`);
+  }
+}
+
+/** Remove only an empty entity directory created by this failed operation. */
+async function compensateDirectory(target: string, originalError: unknown): Promise<never> {
+  try {
+    await rmdir(target);
+  } catch (cleanupError) {
+    throw new ProfileScaffoldError(
+      `${errorMessage(originalError)}; cleanup failed for ${target}: ${errorMessage(cleanupError)}`,
+    );
+  }
+  throw originalError;
+}
+
+/** Render an unknown failure for a stable operator-facing error. */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** True when the intended profile bytes reached the commit path despite a late error. */
+async function profileCommitMatches(root: string, body: string): Promise<boolean> {
+  const read = await readCappedNoFollow(path.join(root, PROFILE_FILE), MAX_PROFILE_BYTES).catch(() => null);
+  return read?.kind === "ok" && read.body === body;
+}
+
+/** Install a minimal profile only when no existing typed corpus can be reinterpreted. */
+export async function installStarterProfile(
+  root: string,
+  profileId: string,
+  entityType: string,
+  dependencies: ProfileScaffoldDependencies = {},
+): Promise<ProfileScaffoldResult> {
+  const profile = buildStarterProfile(profileId, entityType);
+  const directory = profile.entities[entityType].directory;
+  await acquireLockBlocking(root);
+  try {
+    const loaded = await loadProfile(root);
+    if (loaded.loadedFrom !== null) throw new ProfileScaffoldError("A profile already exists. No profile was installed.");
+    const probe = await isTypedCorpusEmpty(root, loaded, profile);
+    if (!probe.empty) {
+      throw new ProfileScaffoldError(`Typed corpus is not empty. No profile was installed.\n- ${probe.reasons.join("\n- ")}`);
+    }
+    const createdDirectory = await prepareEntityDirectory(root, directory);
+    const profileBody = canonicalStarterProfileJson(profileId, entityType);
+    try {
+      await (dependencies.writeProfile ?? writeProfile)(root, profileBody);
+    } catch (error) {
+      if (await profileCommitMatches(root, profileBody)) {
+        throw new ProfileScaffoldError(
+          `Profile was installed, but durability confirmation failed: ${errorMessage(error)}`,
+        );
+      }
+      if (createdDirectory) await compensateDirectory(path.join(root, directory), error);
+      throw error;
+    }
+    return { profileId, entityType, directory };
+  } finally {
+    await releaseLock(root);
+  }
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -107,7 +107,7 @@ export function parseFrontmatterStatus(content: string): {
   hasFrontmatterBlock: boolean;
   malformedFrontmatter: boolean;
 } {
-  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   if (!match) {
     return { meta: {}, body: content, hasFrontmatterBlock: false, malformedFrontmatter: false };
   }

--- a/src/wiki/collect.ts
+++ b/src/wiki/collect.ts
@@ -357,7 +357,7 @@ function scanToRawWikiPage(scan: RawEntityScan, pageDirectory: PageDirectory): R
     slug: scan.stem,
     pageDirectory,
     filePath: scan.filePath,
-    title,
+    ...(title === undefined ? {} : { title }),
     frontmatter: scan.frontmatter,
     body: scan.body,
     parseStatus: scan.parseStatus,

--- a/test/fixtures/managed-temp-roots.ts
+++ b/test/fixtures/managed-temp-roots.ts
@@ -1,0 +1,33 @@
+/**
+ * @file test/fixtures/managed-temp-roots.ts
+ * @description Tracks disposable project roots and common profile-state assertions.
+ */
+
+import { readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { expect } from "vitest";
+import { PROFILE_FILE } from "../../src/utils/constants.js";
+import { makeTempRoot } from "./temp-root.js";
+
+/** Create temp projects with one cleanup operation for test hooks. */
+export function managedTempRoots(): {
+  create: (label: string) => Promise<string>;
+  cleanup: () => Promise<void>;
+} {
+  const roots: string[] = [];
+  return {
+    create: async (label) => {
+      const root = await makeTempRoot(label);
+      roots.push(root);
+      return root;
+    },
+    cleanup: async () => {
+      await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+    },
+  };
+}
+
+/** Assert that a failed operation did not create the active profile. */
+export async function expectProfileAbsent(root: string): Promise<void> {
+  await expect(readFile(path.join(root, PROFILE_FILE), "utf8")).rejects.toThrow();
+}

--- a/test/frontmatter.test.ts
+++ b/test/frontmatter.test.ts
@@ -6,6 +6,16 @@ import {
   extractCitations,
 } from "../src/utils/markdown.js";
 
+function expectValidFrontmatter(content: string, expectedBody: string): void {
+  const status = parseFrontmatterStatus(content);
+  expect(status).toMatchObject({
+    hasFrontmatterBlock: true,
+    malformedFrontmatter: false,
+    meta: { title: "Test" },
+    body: expectedBody,
+  });
+}
+
 describe("buildFrontmatter", () => {
   it("wraps fields in YAML delimiters", () => {
     const result = buildFrontmatter({ title: "Test" });
@@ -108,11 +118,11 @@ describe("extractCitations", () => {
 
 describe("parseFrontmatterStatus", () => {
   it("flags well-formed frontmatter", () => {
-    const status = parseFrontmatterStatus("---\ntitle: Test\n---\nBody.");
-    expect(status.hasFrontmatterBlock).toBe(true);
-    expect(status.malformedFrontmatter).toBe(false);
-    expect(status.meta.title).toBe("Test");
-    expect(status.body).toBe("Body.");
+    expectValidFrontmatter("---\ntitle: Test\n---\nBody.", "Body.");
+  });
+
+  it("parses Windows CRLF frontmatter and preserves the body", () => {
+    expectValidFrontmatter("---\r\ntitle: Test\r\n---\r\nBody.\r\n", "Body.\r\n");
   });
 
   it("flags content without a frontmatter block", () => {

--- a/test/parity/__golden__/edge.collect.json
+++ b/test/parity/__golden__/edge.collect.json
@@ -400,17 +400,20 @@
     "title": "Bulk 24"
   },
   {
-    "body": "---\r\ntitle: CRLF\r\n---\r\n\r\n# CRLF\r\n\r\nLine one.\r\nLine two.\r\n",
+    "body": "\r\n# CRLF\r\n\r\nLine one.\r\nLine two.\r\n",
     "filePath": "<ROOT>/wiki/concepts/crlf.md",
-    "frontmatter": {},
+    "frontmatter": {
+      "title": "CRLF"
+    },
     "pageDirectory": "concepts",
     "parseStatus": {
-      "hasFrontmatterBlock": false,
-      "hasTitle": false,
+      "hasFrontmatterBlock": true,
+      "hasTitle": true,
       "malformedFrontmatter": false,
       "orphaned": false
     },
-    "slug": "crlf"
+    "slug": "crlf",
+    "title": "CRLF"
   },
   {
     "body": "",

--- a/test/profile-init-cli.test.ts
+++ b/test/profile-init-cli.test.ts
@@ -64,6 +64,18 @@ describe("profile init CLI", () => {
     await expectFailedInstall(result, root, /lowercase letters, numbers, and hyphens/i);
   });
 
+  it.each([
+    [["profile", "init", "default", "--entity", "issues"], /Profile name 'default'.*already used/i],
+    [["profile", "init", "issue-tracker", "--entity", "concepts"], /Page type 'concepts'.*already used/i],
+    [["profile", "init", "issue-tracker", "--entity", "queries"], /Page type 'queries'.*already used/i],
+  ])("rejects reserved names with beginner-facing guidance", async (args, message) => {
+    const root = await roots.create("profile-init-reserved");
+
+    const result = await runCLI(args as string[], root);
+
+    await expectFailedInstall(result, root, message as RegExp);
+  });
+
   it("help distinguishes profile authoring from templates", async () => {
     const root = await roots.create("profile-init-help");
 

--- a/test/profile-init-cli.test.ts
+++ b/test/profile-init-cli.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @file test/profile-init-cli.test.ts
+ * @description Built-CLI coverage for beginner profile scaffolding.
+ */
+
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { expectProfileAbsent, managedTempRoots } from "./fixtures/managed-temp-roots.js";
+import { runCLI } from "./fixtures/run-cli.js";
+
+const roots = managedTempRoots();
+
+async function expectFailedInstall(
+  result: Awaited<ReturnType<typeof runCLI>>,
+  root: string,
+  errorPattern: RegExp,
+): Promise<void> {
+  expect(result.code).not.toBe(0);
+  expect(result.stderr).toMatch(errorPattern);
+  expect(result.stderr).toMatch(/no profile was installed/i);
+  await expectProfileAbsent(root);
+}
+
+afterEach(roots.cleanup);
+
+describe("profile init CLI", () => {
+  it("creates a profile and prints stable next steps", async () => {
+    const root = await roots.create("profile-init-cli");
+
+    const result = await runCLI(["profile", "init", "issue-tracker", "--entity", "issues"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Created profile 'issue-tracker'");
+    expect(result.stdout).toContain("wrote .llmwiki/profile.json");
+    expect(result.stdout).toContain("created wiki/issues/");
+    expect(result.stdout).toContain("next: llmwiki profile validate");
+  });
+
+  it("writes a profile that the CLI validates", async () => {
+    const root = await roots.create("profile-init-validate");
+    await runCLI(["profile", "init", "issue-tracker", "--entity", "issues"], root);
+
+    const result = await runCLI(["profile", "validate"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Profile 'issue-tracker' is valid");
+  });
+
+  it("refuses populated projects and leaves no profile", async () => {
+    const root = await roots.create("profile-init-populated");
+    await writeFile(path.join(root, "wiki/concepts/existing.md"), "# Existing\n", "utf8");
+
+    const result = await runCLI(["profile", "init", "issue-tracker", "--entity", "issues"], root);
+
+    await expectFailedInstall(result, root, /typed corpus is not empty/i);
+  });
+
+  it("rejects invalid names without creating profile state", async () => {
+    const root = await roots.create("profile-init-invalid");
+
+    const result = await runCLI(["profile", "init", "Issue Tracker", "--entity", "issues"], root);
+
+    await expectFailedInstall(result, root, /lowercase letters, numbers, and hyphens/i);
+  });
+
+  it("help distinguishes profile authoring from templates", async () => {
+    const root = await roots.create("profile-init-help");
+
+    const result = await runCLI(["profile", "init", "--help"], root);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("minimal editable profile");
+    expect(result.stdout).toContain("--entity");
+  });
+});

--- a/test/profile-onboarding-docs.test.ts
+++ b/test/profile-onboarding-docs.test.ts
@@ -22,11 +22,34 @@ function exportedProfile(source: string): string {
   return `${match[1]}\n`;
 }
 
+function agentProfile(source: string): string {
+  const match = source.match(/<Visibility for="agents">[\s\S]*?```json\n([\s\S]*?)\n```/);
+  if (!match) throw new Error("agent-visible profile JSON is missing");
+  return `${match[1]}\n`;
+}
+
+function groupContaining(value: unknown, page: string): { expanded?: boolean; pages: string[] } | undefined {
+  if (Array.isArray(value)) return value.map((item) => groupContaining(item, page)).find(Boolean);
+  if (value === null || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (Array.isArray(record.pages) && record.pages.includes(page)) {
+    return { expanded: record.expanded as boolean | undefined, pages: record.pages as string[] };
+  }
+  return Object.values(record).map((item) => groupContaining(item, page)).find(Boolean);
+}
+
 describe("profile onboarding documentation", () => {
   it("uses the scaffold's canonical profile bytes", async () => {
     const data = await text(DATA_PATH);
+    const guide = await text(GUIDE_PATH);
+    const canonical = canonicalStarterProfileJson("issue-tracker", "issues");
 
-    expect(exportedProfile(data)).toBe(canonicalStarterProfileJson("issue-tracker", "issues"));
+    expect(exportedProfile(data)).toBe(canonical);
+    expect(agentProfile(guide)).toBe(canonical);
+    const lineCount = canonical.trimEnd().split("\n").length;
+    const highlighted = [...data.matchAll(/lines: \[([^\]]+)\]/g)]
+      .flatMap((match) => match[1].split(",").map(Number));
+    expect(highlighted.every((line) => line >= 1 && line <= lineCount)).toBe(true);
   });
 
   it("documents every command in the tested five-step flow", async () => {
@@ -39,6 +62,7 @@ describe("profile onboarding documentation", () => {
       "llmwiki lint",
       "llmwiki view --open",
     ]) expect(guide).toContain(command);
+    expect(guide).toContain('$content = $content -replace "\\r`n", "`n"');
   });
 
   it("provides complete human and agent explorer variants", async () => {
@@ -60,11 +84,11 @@ describe("profile onboarding documentation", () => {
   });
 
   it("publishes the tutorial first in the collapsed CLP guides group", async () => {
-    const docs = JSON.parse(await text(path.join(DOCS_ROOT, "docs.json"))) as Record<string, unknown>;
-    const serialized = JSON.stringify(docs);
+    const docs = JSON.parse(await text(path.join(DOCS_ROOT, "docs.json"))) as unknown;
+    const group = groupContaining(docs, "guides/clp/build-your-first-profile");
 
-    expect(serialized).toContain("guides/clp/build-your-first-profile");
-    expect(serialized.indexOf("guides/clp/build-your-first-profile"))
-      .toBeLessThan(serialized.indexOf("guides/autosci-research-workflow"));
+    expect(group).toBeDefined();
+    expect(group?.expanded).toBe(false);
+    expect(group?.pages[0]).toBe("guides/clp/build-your-first-profile");
   });
 });

--- a/test/profile-onboarding-docs.test.ts
+++ b/test/profile-onboarding-docs.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @file test/profile-onboarding-docs.test.ts
+ * @description Prevents the CLP beginner tutorial from drifting from the CLI.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { canonicalStarterProfileJson } from "../src/profile/scaffold.js";
+
+const DOCS_ROOT = path.join(process.cwd(), "docs");
+const GUIDE_PATH = path.join(DOCS_ROOT, "guides/clp/build-your-first-profile.mdx");
+const DATA_PATH = path.join(DOCS_ROOT, "snippets/profile-onboarding-data.mdx");
+
+async function text(filePath: string): Promise<string> {
+  return readFile(filePath, "utf8");
+}
+
+function exportedProfile(source: string): string {
+  const match = source.match(/export const starterProfileText = `([\s\S]*?)`;/);
+  if (!match) throw new Error("starterProfileText export is missing");
+  return `${match[1]}\n`;
+}
+
+describe("profile onboarding documentation", () => {
+  it("uses the scaffold's canonical profile bytes", async () => {
+    const data = await text(DATA_PATH);
+
+    expect(exportedProfile(data)).toBe(canonicalStarterProfileJson("issue-tracker", "issues"));
+  });
+
+  it("documents every command in the tested five-step flow", async () => {
+    const guide = await text(GUIDE_PATH);
+
+    for (const command of [
+      "llmwiki --version",
+      "llmwiki profile init issue-tracker --entity issues",
+      "llmwiki profile validate",
+      "llmwiki lint",
+      "llmwiki view --open",
+    ]) expect(guide).toContain(command);
+  });
+
+  it("provides complete human and agent explorer variants", async () => {
+    const guide = await text(GUIDE_PATH);
+    const data = await text(DATA_PATH);
+
+    expect(guide).toContain('<Visibility for="humans">');
+    expect(guide).toContain('<Visibility for="agents">');
+    for (const title of [
+      "File format version",
+      "Profile name",
+      "Kinds of pages",
+      "Where pages live",
+      "Required page title",
+    ]) {
+      expect(data).toContain(title);
+      expect(guide).toContain(title);
+    }
+  });
+
+  it("publishes the tutorial first in the collapsed CLP guides group", async () => {
+    const docs = JSON.parse(await text(path.join(DOCS_ROOT, "docs.json"))) as Record<string, unknown>;
+    const serialized = JSON.stringify(docs);
+
+    expect(serialized).toContain("guides/clp/build-your-first-profile");
+    expect(serialized.indexOf("guides/clp/build-your-first-profile"))
+      .toBeLessThan(serialized.indexOf("guides/autosci-research-workflow"));
+  });
+});

--- a/test/profile-onboarding-e2e.test.ts
+++ b/test/profile-onboarding-e2e.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @file test/profile-onboarding-e2e.test.ts
+ * @description Proves the documented five-step CLP onboarding flow.
+ */
+
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { PROFILE_FILE } from "../src/utils/constants.js";
+import type { ProfilePack } from "../src/profile/types.js";
+import { buildViewerSnapshot } from "../src/viewer/snapshot.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { runCLI } from "./fixtures/run-cli.js";
+
+const ISSUE_PATH = "wiki/issues/explain-first-profile.md";
+const ISSUE_BODY = `---
+title: Explain the first profile
+---
+
+Explain why this project uses custom issue pages and what information every issue should contain.
+`;
+
+let root = "";
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true });
+  root = "";
+});
+
+async function scaffoldTutorialProject(): Promise<void> {
+  root = await makeTempRoot("profile-onboarding-e2e");
+  const init = await runCLI(["profile", "init", "issue-tracker", "--entity", "issues"], root);
+  expect(init.code).toBe(0);
+  const validate = await runCLI(["profile", "validate"], root);
+  expect(validate.stdout).toContain("Profile 'issue-tracker' is valid");
+  await writeFile(path.join(root, ISSUE_PATH), ISSUE_BODY, "utf8");
+}
+
+async function addRequiredPriority(): Promise<void> {
+  const profilePath = path.join(root, PROFILE_FILE);
+  const profile = JSON.parse(await readFile(profilePath, "utf8")) as ProfilePack;
+  const issue = profile.entities.issues;
+  issue.requiredFields = [...(issue.requiredFields ?? []), "priority"];
+  issue.fields = { ...issue.fields, priority: {
+    type: "enum",
+    enum: ["low", "normal", "high"],
+  } };
+  await writeFile(profilePath, `${JSON.stringify(profile, null, 2)}\n`, "utf8");
+}
+
+describe("CLP profile onboarding", () => {
+  it("runs scaffold, validation, page, deliberate error, repair, and viewer proof", async () => {
+    await scaffoldTutorialProject();
+
+    const firstLint = await runCLI(["lint"], root);
+    expect(firstLint.code).toBe(0);
+    expect(firstLint.stdout).toMatch(/0 error\(s\).*0 warning\(s\).*0 info/s);
+    const snapshot = await buildViewerSnapshot(root);
+    expect(snapshot.profile?.entityCounts.issues).toBe(1);
+    expect(snapshot.graph.nodes.some((node) => node.id === "issues/explain-first-profile"))
+      .toBe(true);
+
+    await addRequiredPriority();
+    expect((await runCLI(["profile", "validate"], root)).code).toBe(0);
+    const brokenLint = await runCLI(["lint"], root);
+    expect(brokenLint.code).toBe(0);
+    expect(brokenLint.stdout).toMatch(/Required field "priority" is missing from frontmatter/);
+    expect(brokenLint.stdout).toMatch(/0 error\(s\).*1 warning\(s\).*0 info/s);
+
+    await writeFile(path.join(root, ISSUE_PATH), ISSUE_BODY.replace("title:", "priority: normal\ntitle:"), "utf8");
+    expect((await runCLI(["profile", "validate"], root)).code).toBe(0);
+    const repairedLint = await runCLI(["lint"], root);
+    expect(repairedLint.code).toBe(0);
+    expect(repairedLint.stdout).toMatch(/0 error\(s\).*0 warning\(s\).*0 info/s);
+  });
+});

--- a/test/profile-onboarding-e2e.test.ts
+++ b/test/profile-onboarding-e2e.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { PROFILE_FILE } from "../src/utils/constants.js";
 import type { ProfilePack } from "../src/profile/types.js";
 import { buildViewerSnapshot } from "../src/viewer/snapshot.js";
+import { stripAnsi } from "./fixtures/cli-runner.js";
 import { makeTempRoot } from "./fixtures/temp-root.js";
 import { runCLI } from "./fixtures/run-cli.js";
 
@@ -48,13 +49,18 @@ async function addRequiredPriority(): Promise<void> {
   await writeFile(profilePath, `${JSON.stringify(profile, null, 2)}\n`, "utf8");
 }
 
+function expectLintSummary(stdout: string, expected: [number, number, number]): void {
+  const summary = stripAnsi(stdout).match(/(\d+) error\(s\).*?(\d+) warning\(s\).*?(\d+) info/);
+  expect(summary?.slice(1).map(Number)).toEqual(expected);
+}
+
 describe("CLP profile onboarding", () => {
   it("runs scaffold, validation, page, deliberate error, repair, and viewer proof", async () => {
     await scaffoldTutorialProject();
 
     const firstLint = await runCLI(["lint"], root);
     expect(firstLint.code).toBe(0);
-    expect(firstLint.stdout).toMatch(/0 error\(s\).*0 warning\(s\).*0 info/s);
+    expectLintSummary(firstLint.stdout, [0, 0, 0]);
     const snapshot = await buildViewerSnapshot(root);
     expect(snapshot.profile?.entityCounts.issues).toBe(1);
     expect(snapshot.graph.nodes.some((node) => node.id === "issues/explain-first-profile"))
@@ -65,12 +71,12 @@ describe("CLP profile onboarding", () => {
     const brokenLint = await runCLI(["lint"], root);
     expect(brokenLint.code).toBe(0);
     expect(brokenLint.stdout).toMatch(/Required field "priority" is missing from frontmatter/);
-    expect(brokenLint.stdout).toMatch(/0 error\(s\).*1 warning\(s\).*0 info/s);
+    expectLintSummary(brokenLint.stdout, [0, 1, 0]);
 
     await writeFile(path.join(root, ISSUE_PATH), ISSUE_BODY.replace("title:", "priority: normal\ntitle:"), "utf8");
     expect((await runCLI(["profile", "validate"], root)).code).toBe(0);
     const repairedLint = await runCLI(["lint"], root);
     expect(repairedLint.code).toBe(0);
-    expect(repairedLint.stdout).toMatch(/0 error\(s\).*0 warning\(s\).*0 info/s);
+    expectLintSummary(repairedLint.stdout, [0, 0, 0]);
   });
 });

--- a/test/profile-scaffold-install.test.ts
+++ b/test/profile-scaffold-install.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @file test/profile-scaffold-install.test.ts
+ * @description Tests safe, locked installation of beginner profile scaffolds.
+ */
+
+import { mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadProfile } from "../src/profile/load.js";
+import {
+  canonicalStarterProfileJson,
+  installStarterProfile,
+} from "../src/profile/scaffold.js";
+import { PROFILE_FILE } from "../src/utils/constants.js";
+import { acquireLock, releaseLock } from "../src/utils/lock.js";
+import { expectProfileAbsent, managedTempRoots } from "./fixtures/managed-temp-roots.js";
+
+const roots = managedTempRoots();
+
+async function expectLockReleased(root: string): Promise<void> {
+  const acquired = await acquireLock(root, { quiet: true });
+  expect(acquired).toBe(true);
+  if (acquired) await releaseLock(root);
+}
+
+afterEach(roots.cleanup);
+
+describe("installStarterProfile", () => {
+  it("installs the exact starter profile and entity directory", async () => {
+    const root = await roots.create("profile-scaffold-install");
+
+    const result = await installStarterProfile(root, "issue-tracker", "issues");
+
+    expect(result).toEqual({ profileId: "issue-tracker", entityType: "issues", directory: "wiki/issues" });
+    expect(await readFile(path.join(root, PROFILE_FILE), "utf8"))
+      .toBe(canonicalStarterProfileJson("issue-tracker", "issues"));
+    expect((await loadProfile(root)).profile.profileId).toBe("issue-tracker");
+  });
+
+  it("refuses an existing profile without changing it", async () => {
+    const root = await roots.create("profile-scaffold-existing");
+    await installStarterProfile(root, "first-profile", "tickets");
+    const before = await readFile(path.join(root, PROFILE_FILE), "utf8");
+
+    await expect(installStarterProfile(root, "second-profile", "issues"))
+      .rejects.toThrow(/profile already exists/i);
+    expect(await readFile(path.join(root, PROFILE_FILE), "utf8")).toBe(before);
+  });
+
+  it("refuses a populated default wiki", async () => {
+    const root = await roots.create("profile-scaffold-default-content");
+    await writeFile(path.join(root, "wiki/concepts/existing.md"), "# Existing\n", "utf8");
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues"))
+      .rejects.toThrow(/typed corpus is not empty.*wiki\/concepts/is);
+    await expectProfileAbsent(root);
+  });
+
+  it("refuses existing typed stores", async () => {
+    const root = await roots.create("profile-scaffold-stores");
+    await mkdir(path.join(root, "artifacts/example"), { recursive: true });
+    await writeFile(path.join(root, "artifacts/example/result.txt"), "result", "utf8");
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues"))
+      .rejects.toThrow(/typed corpus is not empty/i);
+  });
+
+  it("removes only its empty directory when the profile write fails", async () => {
+    const root = await roots.create("profile-scaffold-compensate");
+    const failWrite = async (): Promise<void> => { throw new Error("injected write failure"); };
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues", { writeProfile: failWrite }))
+      .rejects.toThrow(/injected write failure/);
+    await expectProfileAbsent(root);
+    await expect(stat(path.join(root, "wiki/issues"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("never removes a pre-existing entity directory after failure", async () => {
+    const root = await roots.create("profile-scaffold-preserve-dir");
+    await mkdir(path.join(root, "wiki/issues"), { recursive: true });
+    const failWrite = async (): Promise<void> => { throw new Error("injected write failure"); };
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues", { writeProfile: failWrite }))
+      .rejects.toThrow(/injected write failure/);
+    expect((await stat(path.join(root, "wiki/issues"))).isDirectory()).toBe(true);
+    await writeFile(path.join(root, "wiki/issues/still-usable.txt"), "yes", "utf8");
+    expect(await readFile(path.join(root, "wiki/issues/still-usable.txt"), "utf8")).toBe("yes");
+  });
+
+  it("preserves a committed profile and directory after a late durability error", async () => {
+    const root = await roots.create("profile-scaffold-late-error");
+    const lateError = async (projectRoot: string, body: string): Promise<void> => {
+      await mkdir(path.join(projectRoot, ".llmwiki"), { recursive: true });
+      await writeFile(path.join(projectRoot, PROFILE_FILE), body, "utf8");
+      throw new Error("injected sync failure");
+    };
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues", { writeProfile: lateError }))
+      .rejects.toThrow(/profile was installed.*durability confirmation failed/i);
+    expect((await stat(path.join(root, "wiki/issues"))).isDirectory()).toBe(true);
+    expect(await readFile(path.join(root, PROFILE_FILE), "utf8"))
+      .toBe(canonicalStarterProfileJson("issue-tracker", "issues"));
+    await expectLockReleased(root);
+  });
+
+  it("serializes concurrent scaffold attempts under the project lock", async () => {
+    const root = await roots.create("profile-scaffold-concurrent");
+    let releaseWriter: () => void = () => undefined;
+    const writerMayFinish = new Promise<void>((resolve) => { releaseWriter = resolve; });
+    let reportWriterStarted: () => void = () => undefined;
+    const writerStarted = new Promise<void>((resolve) => { reportWriterStarted = resolve; });
+    const pausedWrite = async (projectRoot: string, body: string): Promise<void> => {
+      reportWriterStarted();
+      await writerMayFinish;
+      await mkdir(path.join(projectRoot, ".llmwiki"), { recursive: true });
+      await writeFile(path.join(projectRoot, PROFILE_FILE), body, "utf8");
+    };
+
+    const first = installStarterProfile(root, "issue-tracker", "issues", { writeProfile: pausedWrite });
+    await writerStarted;
+    const second = installStarterProfile(root, "other-profile", "tickets");
+    releaseWriter();
+
+    await expect(first).resolves.toMatchObject({ profileId: "issue-tracker" });
+    await expect(second).rejects.toThrow(/profile already exists/i);
+  });
+
+  it("fails closed for a symlinked entity directory", async () => {
+    const root = await roots.create("profile-scaffold-symlink");
+    const outside = await roots.create("profile-scaffold-outside");
+    await symlink(outside, path.join(root, "wiki/issues"));
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues"))
+      .rejects.toThrow(/unsafe|symlink|escapes/i);
+    await expectProfileAbsent(root);
+  });
+});

--- a/test/profile-scaffold-install.test.ts
+++ b/test/profile-scaffold-install.test.ts
@@ -3,7 +3,7 @@
  * @description Tests safe, locked installation of beginner profile scaffolds.
  */
 
-import { mkdir, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadProfile } from "../src/profile/load.js";
@@ -87,6 +87,32 @@ describe("installStarterProfile", () => {
     expect(await readFile(path.join(root, "wiki/issues/still-usable.txt"), "utf8")).toBe("yes");
   });
 
+  it("preserves the directory when commit confirmation is unavailable", async () => {
+    const root = await roots.create("profile-scaffold-unknown-commit");
+    const failWrite = async (): Promise<void> => { throw new Error("injected write failure"); };
+    const confirmProfileCommit = async (): Promise<"unknown"> => "unknown";
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues", {
+      writeProfile: failWrite,
+      confirmProfileCommit,
+    })).rejects.toMatchObject({ outcome: "unknown", message: expect.stringMatching(/could not be confirmed/i) });
+    expect((await stat(path.join(root, "wiki/issues"))).isDirectory()).toBe(true);
+    await expectProfileAbsent(root);
+  });
+
+  it("reports cleanup failure without hiding the original write error", async () => {
+    const root = await roots.create("profile-scaffold-cleanup-failure");
+    const failAfterContent = async (): Promise<void> => {
+      await writeFile(path.join(root, "wiki/issues/concurrent.txt"), "keep", "utf8");
+      throw new Error("injected write failure");
+    };
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues", { writeProfile: failAfterContent }))
+      .rejects.toThrow(/injected write failure.*cleanup failed/is);
+    expect(await readFile(path.join(root, "wiki/issues/concurrent.txt"), "utf8")).toBe("keep");
+    await expectProfileAbsent(root);
+  });
+
   it("preserves a committed profile and directory after a late durability error", async () => {
     const root = await roots.create("profile-scaffold-late-error");
     const lateError = async (projectRoot: string, body: string): Promise<void> => {
@@ -125,6 +151,17 @@ describe("installStarterProfile", () => {
     await expect(second).rejects.toThrow(/profile already exists/i);
   });
 
+  it("fails closed and releases the lock for a broken active profile", async () => {
+    const root = await roots.create("profile-scaffold-broken-profile");
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(root, PROFILE_FILE), "{broken", "utf8");
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues"))
+      .rejects.toThrow(/invalid json/i);
+    await expect(stat(path.join(root, "wiki/issues"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expectLockReleased(root);
+  });
+
   it("fails closed for a symlinked entity directory", async () => {
     const root = await roots.create("profile-scaffold-symlink");
     const outside = await roots.create("profile-scaffold-outside");
@@ -132,6 +169,28 @@ describe("installStarterProfile", () => {
 
     await expect(installStarterProfile(root, "issue-tracker", "issues"))
       .rejects.toThrow(/unsafe|symlink|escapes/i);
+    await expectProfileAbsent(root);
+  });
+
+  it("rejects a symlinked wiki parent without creating outside directories", async () => {
+    const root = await roots.create("profile-scaffold-parent-symlink");
+    const outside = await roots.create("profile-scaffold-parent-outside");
+    await rm(path.join(root, "wiki"), { recursive: true, force: true });
+    await symlink(outside, path.join(root, "wiki"));
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues"))
+      .rejects.toThrow(/could not be verified|unsafe/i);
+    await expect(stat(path.join(outside, "issues"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expectProfileAbsent(root);
+  });
+
+  it("reports an unreadable store as unverifiable rather than non-empty", async () => {
+    const root = await roots.create("profile-scaffold-unreadable-store");
+    const outside = await roots.create("profile-scaffold-store-outside");
+    await symlink(outside, path.join(root, "artifacts"));
+
+    await expect(installStarterProfile(root, "issue-tracker", "issues"))
+      .rejects.toThrow(/project state could not be verified.*artifact store is unreadable/is);
     await expectProfileAbsent(root);
   });
 });

--- a/test/profile-scaffold.test.ts
+++ b/test/profile-scaffold.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @file test/profile-scaffold.test.ts
+ * @description Verifies the deterministic beginner profile scaffold.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildStarterProfile,
+  canonicalStarterProfileJson,
+} from "../src/profile/scaffold.js";
+import { validateProfile } from "../src/profile/validate.js";
+
+const EXPECTED_PROFILE = {
+  schemaVersion: 1,
+  profileId: "issue-tracker",
+  displayName: "Issue Tracker",
+  entities: {
+    issues: {
+      directory: "wiki/issues",
+      titleField: "title",
+      requiredFields: ["title"],
+      fields: { title: { type: "string" } },
+    },
+  },
+};
+
+describe("buildStarterProfile", () => {
+  it("builds the exact validated issue-tracker profile", () => {
+    const profile = buildStarterProfile("issue-tracker", "issues");
+
+    expect(profile).toEqual(EXPECTED_PROFILE);
+    expect(validateProfile(profile).profile).toEqual(EXPECTED_PROFILE);
+  });
+
+  it.each([
+    ["Issue-Tracker", "issues"],
+    ["issue_tracker", "issues"],
+    ["issue-tracker", "Issue"],
+    ["issue-tracker", "../issues"],
+  ])("rejects unsafe identifiers: %s / %s", (profileId, entityType) => {
+    expect(() => buildStarterProfile(profileId, entityType)).toThrow(/lowercase letters, numbers, and hyphens/i);
+  });
+
+  it("title-cases hyphenated profile names deterministically", () => {
+    expect(buildStarterProfile("release-issue-tracker", "tickets").displayName)
+      .toBe("Release Issue Tracker");
+  });
+
+  it("serializes the canonical profile with a trailing newline", () => {
+    expect(canonicalStarterProfileJson("issue-tracker", "issues"))
+      .toBe(`${JSON.stringify(EXPECTED_PROFILE, null, 2)}\n`);
+  });
+});

--- a/test/profile-scaffold.test.ts
+++ b/test/profile-scaffold.test.ts
@@ -41,6 +41,15 @@ describe("buildStarterProfile", () => {
     expect(() => buildStarterProfile(profileId, entityType)).toThrow(/lowercase letters, numbers, and hyphens/i);
   });
 
+  it.each([
+    ["default", "issues", "Profile name 'default'"],
+    ["issue-tracker", "concepts", "Page type 'concepts'"],
+    ["issue-tracker", "queries", "Page type 'queries'"],
+  ])("explains reserved beginner identifiers: %s / %s", (profileId, entityType, message) => {
+    expect(() => buildStarterProfile(profileId, entityType))
+      .toThrow(`${message} is already used by llmwiki; choose a different name`);
+  });
+
   it("title-cases hyphenated profile names deterministically", () => {
     expect(buildStarterProfile("release-issue-tracker", "tickets").displayName)
       .toBe("Release Issue Tracker");


### PR DESCRIPTION
## Summary

CLP makes llmwiki adaptable to new domains, but authoring a first profile still required understanding the full profile schema up front. This PR adds a safe beginner path that takes a developer from an empty directory to a validated custom profile and typed page in about ten minutes.

The new `llmwiki profile init <profile-id> --entity <type>` command creates the smallest useful editable profile. It validates before writing, serializes concurrent project mutations, and refuses to reinterpret an existing profile or typed corpus. There is deliberately no force mode. Failed installs clean up only directories created by that attempt; commit confirmation distinguishes absent, committed, and unknown states so read faults cannot trigger destructive compensation.

The Mintlify guide, **Build your first profile**, teaches the same real workflow through five checkpoints: scaffold, inspect, create a typed page, verify it, then add and satisfy a new field rule. An interactive profile explorer explains the generated JSON field by field, with keyboard navigation, copy support, responsive layout, and a complete linear fallback for agent-readable documentation. AutoSci and Newsroom remain the next-step examples for richer profiles.

## User impact

- Developers can start profile authoring without copying a large example or learning every CLP capability first.
- Every tutorial checkpoint is an ordinary project file that can be edited and committed.
- Existing projects remain protected from accidental profile replacement or content reinterpretation.
- Windows-created Markdown with CRLF line endings is parsed correctly.
- Reserved beginner names fail early with actionable guidance.
- Documentation commands and generated profile bytes are regression-tested against the shipped CLI.

## Verification

- `npx tsc --noEmit`
- `npm run build`
- `npm test` — 4,059 passed, 3 skipped
- `npx fallow`
- `npm run fallow:ci`
- `npx fallow dupes --mode mild --changed-since origin/main`
- `npx mint validate`
- `npx mint broken-links`

## Browser QA

Rendered browser QA is approved for the interactive explorer, including its layout, navigation, and copy-oriented tutorial experience. The planned unfamiliar-developer observation remains tracked as product validation rather than a code correctness gate.

## Review focus

- Refusal, commit-confirmation, and cleanup semantics in the profile scaffold
- Tutorial accuracy and beginner-level language
- Responsive and keyboard behavior of the profile explorer
- Whether the five-step flow provides enough confidence before linking into the advanced CLP guides