### PR TITLE
Add secure template lifecycle and signing foundations

### DIFF
--- a/src/cli/template-commands.ts
+++ b/src/cli/template-commands.ts
@@ -9,7 +9,11 @@ import {
   templateInspectCommand,
   templateInitCommand,
   templateListCommand,
+  templateStatusCommand,
+  templateUpdateCommand,
   type TemplateInitOptions,
+  type TemplateStatusOptions,
+  type TemplateUpdateOptions,
 } from "../commands/template.js";
 import { runExitCodeCommand } from "./shared.js";
 
@@ -28,6 +32,21 @@ export function registerTemplateCommands(program: Command): void {
     .command("inspect <id>")
     .description("Inspect one builtin profile template")
     .action(async (id: string) => runExitCodeCommand(() => templateInspectCommand(id).then(() => 0)));
+
+  template
+    .command("status")
+    .description("Report installed template provenance and profile drift")
+    .option("--json", "Print a stable JSON status envelope")
+    .action(async (options: TemplateStatusOptions) => runExitCodeCommand(() => templateStatusCommand(options)));
+
+  template
+    .command("update [id]")
+    .description("Preview compatibility with a builtin template update")
+    .option("--dry-run", "Required: inspect compatibility without writing")
+    .option("--json", "Print a stable JSON update plan")
+    .action(async (id: string | undefined, options: TemplateUpdateOptions) =>
+      runExitCodeCommand(() => templateUpdateCommand(id, options)),
+    );
 
   template
     .command("init [id]")

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -9,6 +9,8 @@ import * as output from "../utils/output.js";
 import { profileDigest } from "../profile/digest.js";
 import { installBuiltinTemplate, installLocalTemplate } from "../profile/templates/install.js";
 import { getBuiltinTemplate, listBuiltinTemplates, summaryFor } from "../profile/templates/registry.js";
+import { collectTemplateStatus, type TemplateStatus } from "../profile/templates/status.js";
+import { planBuiltinTemplateUpdate, type TemplateUpdatePlan } from "../profile/templates/update.js";
 import type { DerivedTemplateCapabilities, ProfileTemplateSummary } from "../profile/templates/types.js";
 
 type InitSource = { kind: "id"; id: string } | { kind: "file"; path: string };
@@ -23,6 +25,17 @@ type InspectDetails = ProfileTemplateSummary & {
 export interface TemplateInitOptions {
   file?: string;
   force?: boolean;
+}
+
+/** Options accepted by `llmwiki template status`. */
+export interface TemplateStatusOptions {
+  json?: boolean;
+}
+
+/** Options accepted by the read-only R1 update planner. */
+export interface TemplateUpdateOptions {
+  dryRun?: boolean;
+  json?: boolean;
 }
 
 /** Print all inspectable builtin template summaries. */
@@ -54,6 +67,39 @@ export async function templateInitCommand(id: string | undefined, options: Templ
   printLockResult(result.lockWritten);
   console.log("next: llmwiki profile validate");
   return 0;
+}
+
+/** Report installed-template provenance and active-profile drift. */
+export async function templateStatusCommand(options: TemplateStatusOptions): Promise<number> {
+  const status = await collectTemplateStatus(process.cwd());
+  if (options.json) console.log(JSON.stringify(status, null, 2));
+  else printTemplateStatus(status);
+  return status.status === "installed-clean" || status.status === "untracked" ? 0 : 1;
+}
+
+/** Preview a compatible builtin update; R1 deliberately performs no write. */
+export async function templateUpdateCommand(id: string | undefined, options: TemplateUpdateOptions): Promise<number> {
+  if (!options.dryRun) throw new Error("template update is preview-only in this release; pass --dry-run");
+  const plan = await planBuiltinTemplateUpdate(process.cwd(), id);
+  if (options.json) console.log(JSON.stringify(plan, null, 2));
+  else printUpdatePlan(plan);
+  return plan.compatible ? 0 : 1;
+}
+
+function printUpdatePlan(plan: TemplateUpdatePlan): void {
+  output.header(`Template update ${plan.from} -> ${plan.to}`);
+  console.log(`compatible: ${plan.compatible}`);
+  if (plan.reasons.length === 0) console.log("no compatibility blockers");
+  for (const reason of plan.reasons) console.log(`- ${reason.kind}: ${reason.path ? `${reason.path}: ` : ""}${reason.message}`);
+}
+
+function printTemplateStatus(status: TemplateStatus): void {
+  output.header("Template status");
+  console.log(`status:     ${status.status}`);
+  console.log(`profileId:  ${status.profileId}`);
+  console.log(`templateId: ${status.templateId ?? "-"}`);
+  console.log(`version:    ${status.installedVersion ?? "-"}`);
+  console.log(`detail:     ${status.detail}`);
 }
 
 function findBuiltinSummary(id: string): ProfileTemplateSummary | undefined {

--- a/src/profile/templates/artifact-audit.ts
+++ b/src/profile/templates/artifact-audit.ts
@@ -1,0 +1,69 @@
+/**
+ * @file src/profile/templates/artifact-audit.ts
+ * @description Complete confined artifact-store audit for profile updates.
+ * Every stored artifact is verified, including records not referenced by pages.
+ */
+import { resolveArtifactRef } from "../../artifacts/resolve.js";
+import { artifactPaths, readArtifactManifest } from "../../artifacts/store.js";
+import { isSlugSafe } from "../identity.js";
+import type { ProfilePack } from "../types.js";
+import { confinedEntries } from "./corpus.js";
+
+const MAX_ARTIFACT_STORE_ENTRIES = 10_000;
+
+/** Return compatibility blockers for every unexpected or unhealthy artifact. */
+export async function auditArtifactStore(root: string, profile: ProfilePack): Promise<string[]> {
+  const types = await entries(root, "artifacts");
+  if (!Array.isArray(types)) return types === "absent" ? [] : ["artifact store is unreadable or unsafe"];
+  const reasons: string[] = [];
+  for (const artifactType of types) {
+    const def = profile.artifacts?.[artifactType];
+    if (!isSlugSafe(artifactType) || !def) {
+      reasons.push(`artifact store contains undeclared type ${JSON.stringify(artifactType)}`);
+      continue;
+    }
+    reasons.push(...await auditType(root, artifactType, def.fileName, profile));
+  }
+  return reasons;
+}
+
+async function auditType(
+  root: string,
+  artifactType: string,
+  fileName: string,
+  profile: ProfilePack,
+): Promise<string[]> {
+  const slugs = await entries(root, `artifacts/${artifactType}`);
+  if (!Array.isArray(slugs)) return [`artifact type directory is unreadable or unsafe: ${artifactType}`];
+  const reasons: string[] = [];
+  for (const slug of slugs) {
+    if (!isSlugSafe(slug)) reasons.push(`artifact store contains unsafe slug ${JSON.stringify(slug)}`);
+    else reasons.push(...await auditArtifact(root, artifactType, slug, fileName, profile));
+  }
+  return reasons;
+}
+
+async function auditArtifact(
+  root: string,
+  artifactType: string,
+  slug: string,
+  fileName: string,
+  profile: ProfilePack,
+): Promise<string[]> {
+  const relative = `artifacts/${artifactType}/${slug}`;
+  const leaves = await entries(root, relative);
+  if (!Array.isArray(leaves)) return [`artifact directory is unreadable or unsafe: ${relative}`];
+  const expected = new Set([fileName, `${fileName}.manifest.json`]);
+  if (leaves.some((leaf) => !expected.has(leaf))) return [`artifact directory contains unexpected files: ${relative}`];
+  const paths = artifactPaths(root, artifactType, slug, fileName);
+  const manifest = await readArtifactManifest(root, paths);
+  if (manifest.kind !== "ok") return [`artifact manifest is ${manifest.kind}: ${artifactType}/${slug}`];
+  const resolution = await resolveArtifactRef(root, profile, { artifactType, slug, sha256: manifest.manifest.sha256 });
+  return resolution.health === "ok" ? [] : [`artifact is ${resolution.health}: ${artifactType}/${slug}`];
+}
+
+async function entries(root: string, relative: string): Promise<string[] | "absent" | "unavailable"> {
+  const result = await confinedEntries(root, relative);
+  if (Array.isArray(result) && result.length > MAX_ARTIFACT_STORE_ENTRIES) return "unavailable";
+  return result;
+}

--- a/src/profile/templates/corpus.ts
+++ b/src/profile/templates/corpus.ts
@@ -88,7 +88,8 @@ async function collectArtifactReasons(root: string, reasons: string[]): Promise<
   if (result === "present") reasons.push("artifact store contains files");
 }
 
-async function confinedEntries(root: string, relativeDir: string): Promise<string[] | "absent" | "unavailable"> {
+/** List a profile-owned directory without following an escaping directory path. */
+export async function confinedEntries(root: string, relativeDir: string): Promise<string[] | "absent" | "unavailable"> {
   try {
     return await safeEntries(await confineUnderRoot(relativeDir, root, { mustExist: false }));
   } catch {
@@ -106,7 +107,8 @@ async function safeEntries(dir: string): Promise<string[] | "absent" | "unavaila
   }
 }
 
-async function firstFileUnder(root: string, relativeDir: string): Promise<"absent" | "present" | "unavailable"> {
+/** Detect any file below a confined profile-owned store with bounded recursion. */
+export async function firstFileUnder(root: string, relativeDir: string): Promise<"absent" | "present" | "unavailable"> {
   let confined: string;
   try {
     confined = await confineUnderRoot(relativeDir, root, { mustExist: false });

--- a/src/profile/templates/history-audit.ts
+++ b/src/profile/templates/history-audit.ts
@@ -1,0 +1,79 @@
+/**
+ * @file src/profile/templates/history-audit.ts
+ * @description Strict record-level audits for candidate and workflow history
+ * before a profile update can reinterpret project state.
+ */
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { resolveConfinedCandidatesDir } from "../../compiler/candidate-store-paths.js";
+import { readConfinedLeaf } from "../../utils/confined-read.js";
+import { CANDIDATES_ARCHIVE_DIR } from "../../utils/constants.js";
+import { isTerminalStatus } from "../../workflows/with-lock.js";
+import { readRun } from "../../workflows/store.js";
+import { confinedEntries } from "./corpus.js";
+
+const MAX_ARCHIVED_CANDIDATE_BYTES = 4 * 1024 * 1024;
+const MAX_HISTORY_ENTRIES = 10_000;
+
+/** Validate every archived candidate record through confined capped reads. */
+export async function auditCandidateArchive(root: string): Promise<string[]> {
+  let dir: string | null;
+  try {
+    dir = await resolveConfinedCandidatesDir(root, CANDIDATES_ARCHIVE_DIR);
+  } catch {
+    return ["candidate archive is unreadable or unsafe"];
+  }
+  if (dir === null) return [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return ["candidate archive is unreadable or unsafe"];
+  }
+  if (entries.length > MAX_HISTORY_ENTRIES) return ["candidate archive exceeds its entry cap"];
+  const reasons: string[] = [];
+  for (const entry of entries) reasons.push(...await auditCandidateLeaf(root, entry.name, entry.isFile()));
+  return reasons;
+}
+
+async function auditCandidateLeaf(root: string, name: string, isFile: boolean): Promise<string[]> {
+  if (!isFile || !name.endsWith(".json")) return [`candidate archive contains unexpected entry: ${name}`];
+  const expectedDir = path.join(root, CANDIDATES_ARCHIVE_DIR);
+  const read = await readConfinedLeaf(root, path.join(expectedDir, name), expectedDir, MAX_ARCHIVED_CANDIDATE_BYTES);
+  if (read.kind !== "ok") return [`archived candidate is unreadable or unsafe: ${name}`];
+  try {
+    const value = JSON.parse(read.body) as Record<string, unknown>;
+    const id = name.slice(0, -".json".length);
+    return validCandidate(value, id) ? [] : [`archived candidate is malformed: ${name}`];
+  } catch {
+    return [`archived candidate is malformed: ${name}`];
+  }
+}
+
+function validCandidate(value: Record<string, unknown>, expectedId: string): boolean {
+  return value.id === expectedId
+    && typeof value.title === "string"
+    && typeof value.slug === "string"
+    && typeof value.body === "string"
+    && Array.isArray(value.sources);
+}
+
+/** Validate every workflow-store entry and block every non-terminal run. */
+export async function auditWorkflowHistory(root: string): Promise<Array<{ kind: "store" | "workflow"; message: string }>> {
+  const entries = await confinedEntries(root, ".llmwiki/workflows/runs");
+  if (entries === "absent") return [];
+  if (entries === "unavailable" || entries.length > MAX_HISTORY_ENTRIES) {
+    return [{ kind: "store", message: "workflow store is unreadable, unsafe, or over its entry cap" }];
+  }
+  const reasons: Array<{ kind: "store" | "workflow"; message: string }> = [];
+  for (const name of entries) reasons.push(...await auditWorkflowLeaf(root, name));
+  return reasons;
+}
+
+async function auditWorkflowLeaf(root: string, name: string): Promise<Array<{ kind: "store" | "workflow"; message: string }>> {
+  if (!name.endsWith(".json")) return [{ kind: "store", message: `workflow store contains unexpected entry: ${name}` }];
+  const runId = name.slice(0, -".json".length);
+  const read = await readRun(root, runId);
+  if (read.status !== "ok") return [{ kind: "store", message: `workflow run ${runId} is unavailable` }];
+  return isTerminalStatus(read.run.status) ? [] : [{ kind: "workflow", message: `workflow run ${runId} is active` }];
+}

--- a/src/profile/templates/install.ts
+++ b/src/profile/templates/install.ts
@@ -11,11 +11,11 @@ import { atomicWrite } from "../../utils/markdown.js";
 import { profileDigest } from "../digest.js";
 import { loadProfile } from "../load.js";
 import { isTypedCorpusEmpty } from "./corpus.js";
+import { TEMPLATE_LOCK_FILE } from "./lock.js";
 import { getBuiltinTemplate } from "./registry.js";
 import type { ProfileTemplatePackage, TemplateLock, TemplateSourceType } from "./types.js";
 import { validateTemplatePackage } from "./validate.js";
 
-const TEMPLATE_LOCK_FILE = ".llmwiki/template-lock.json";
 const MAX_TEMPLATE_PACKAGE_BYTES = MAX_PROFILE_BYTES * 2;
 
 /** Options controlling profile template installation. */
@@ -113,7 +113,7 @@ async function tryWriteLock(root: string, pkg: ProfileTemplatePackage, sourceTyp
 
 async function writeLock(root: string, pkg: ProfileTemplatePackage, sourceType: TemplateSourceType): Promise<void> {
   const lock: TemplateLock = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     templateId: pkg.templateId,
     version: pkg.version,
     publisher: pkg.publisher,

--- a/src/profile/templates/lock.ts
+++ b/src/profile/templates/lock.ts
@@ -1,0 +1,144 @@
+/**
+ * @file src/profile/templates/lock.ts
+ * @description Strict, confined reader for advisory template provenance locks.
+ * Locks help status/update locate releases but never authorize runtime behavior.
+ */
+import path from "node:path";
+import { readCappedNoFollow } from "../../utils/confined-read.js";
+import { resolveExistingConfinedPrivateDir } from "../../utils/private-dir.js";
+import type {
+  RemoteTemplateProvenance,
+  TemplateLock,
+  TemplateLockV1,
+  TemplateLockV2,
+  TemplateSourceType,
+} from "./types.js";
+
+export const TEMPLATE_LOCK_FILE = ".llmwiki/template-lock.json";
+export const MAX_TEMPLATE_LOCK_BYTES = 64 * 1024;
+
+/** Structured read result; faults never masquerade as a missing lock. */
+export type TemplateLockRead =
+  | { kind: "ok"; lock: TemplateLock }
+  | { kind: "absent" }
+  | { kind: "malformed"; detail: string }
+  | { kind: "unavailable"; detail: string };
+
+const COMMON_KEYS = [
+  "schemaVersion", "templateId", "version", "publisher", "sourceType",
+  "installedAt", "profileDigest",
+] as const;
+const REMOTE_KEYS = ["coordinate", "packageDigest", "tap", "indexSequence", "publisherKeyId", "verifiedAt"] as const;
+
+/** Read an advisory lock through a resolved, confined `.llmwiki` directory. */
+export async function readTemplateLock(root: string): Promise<TemplateLockRead> {
+  let privateDir: string | null;
+  try {
+    privateDir = await resolveExistingConfinedPrivateDir(root);
+  } catch {
+    return { kind: "unavailable", detail: "private directory is unsafe" };
+  }
+  if (privateDir === null) return { kind: "absent" };
+  const read = await readCappedNoFollow(path.join(privateDir, "template-lock.json"), MAX_TEMPLATE_LOCK_BYTES);
+  if (read.kind === "absent") return { kind: "absent" };
+  if (read.kind === "unavailable") return { kind: "unavailable", detail: "lock leaf is unreadable or unsafe" };
+  return parseLockText(read.body);
+}
+
+/** Parse bounded lock JSON with exact-key and field-shape validation. */
+export function parseTemplateLock(raw: unknown): TemplateLockRead {
+  if (!isRecord(raw)) return malformed("lock must be an object");
+  if (raw.schemaVersion === 1) return parseV1(raw);
+  if (raw.schemaVersion === 2) return parseV2(raw);
+  return malformed("unsupported lock schemaVersion");
+}
+
+function parseLockText(body: string): TemplateLockRead {
+  try {
+    return parseTemplateLock(JSON.parse(body));
+  } catch {
+    return malformed("lock is not valid JSON");
+  }
+}
+
+function parseV1(raw: Record<string, unknown>): TemplateLockRead {
+  const problem = commonProblem(raw, new Set(COMMON_KEYS), ["builtin", "local"]);
+  if (problem) return malformed(problem);
+  return { kind: "ok", lock: commonLock(raw, 1) as TemplateLockV1 };
+}
+
+function parseV2(raw: Record<string, unknown>): TemplateLockRead {
+  const allowed = new Set<string>([...COMMON_KEYS, "remote"]);
+  const problem = commonProblem(raw, allowed, ["builtin", "local", "remote"]);
+  if (problem) return malformed(problem);
+  const sourceType = raw.sourceType as TemplateSourceType;
+  const parsed = parseOptionalRemote(raw.remote);
+  if (parsed.kind === "malformed") return parsed;
+  const remote = parsed.remote;
+  const consistencyProblem = remoteConsistencyProblem(sourceType, remote);
+  if (consistencyProblem) return malformed(consistencyProblem);
+  return { kind: "ok", lock: { ...(commonLock(raw, 2) as TemplateLockV2), ...(remote ? { remote } : {}) } };
+}
+
+function parseOptionalRemote(value: unknown):
+  | { kind: "ok"; remote?: RemoteTemplateProvenance }
+  | { kind: "malformed"; detail: string } {
+  if (value === undefined) return { kind: "ok" };
+  const remote = parseRemote(value);
+  return remote === null
+    ? { kind: "malformed", detail: "remote provenance is malformed" }
+    : { kind: "ok", remote };
+}
+
+function remoteConsistencyProblem(
+  sourceType: TemplateSourceType,
+  remote: RemoteTemplateProvenance | undefined,
+): string | null {
+  if (sourceType === "remote" && remote === undefined) return "remote source requires remote provenance";
+  if (sourceType !== "remote" && remote !== undefined) return "non-remote source cannot carry remote provenance";
+  return null;
+}
+
+function commonProblem(raw: Record<string, unknown>, allowed: Set<string>, sources: string[]): string | null {
+  if (Object.keys(raw).some((key) => !allowed.has(key))) return "lock contains unsupported fields";
+  for (const field of ["templateId", "version", "publisher", "installedAt", "profileDigest"]) {
+    if (!nonEmpty(raw[field])) return `${field} must be a non-empty string`;
+  }
+  if (!sources.includes(String(raw.sourceType))) return "sourceType is invalid for this lock schema";
+  if (!/^[0-9a-f]{64}$/.test(String(raw.profileDigest))) return "profileDigest must be lowercase SHA-256 hex";
+  return null;
+}
+
+function commonLock(raw: Record<string, unknown>, schemaVersion: 1 | 2): TemplateLock {
+  return {
+    schemaVersion,
+    templateId: raw.templateId as string,
+    version: raw.version as string,
+    publisher: raw.publisher as string,
+    sourceType: raw.sourceType as TemplateSourceType,
+    installedAt: raw.installedAt as string,
+    profileDigest: raw.profileDigest as string,
+  } as TemplateLock;
+}
+
+function parseRemote(value: unknown): RemoteTemplateProvenance | null {
+  if (!isRecord(value) || Object.keys(value).some((key) => !REMOTE_KEYS.includes(key as never))) return null;
+  for (const field of ["coordinate", "packageDigest", "tap", "publisherKeyId", "verifiedAt"]) {
+    if (!nonEmpty(value[field])) return null;
+  }
+  if (!/^sha256:[0-9a-f]{64}$/.test(String(value.packageDigest))) return null;
+  if (!Number.isSafeInteger(value.indexSequence) || Number(value.indexSequence) < 0) return null;
+  return value as unknown as RemoteTemplateProvenance;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function malformed(detail: string): TemplateLockRead {
+  return { kind: "malformed", detail };
+}

--- a/src/profile/templates/registry.ts
+++ b/src/profile/templates/registry.ts
@@ -8,7 +8,10 @@ import { AUTOSCI_TEMPLATE } from "./builtin/autosci.js";
 import { DEFAULT_TEMPLATE_SUMMARY } from "./builtin/default.js";
 import { NEWSROOM_TEMPLATE } from "./builtin/newsroom.js";
 
-const BUILTIN_TEMPLATES: readonly ProfileTemplatePackage[] = [
+// Retain historical releases here when a builtin advances. Secure update
+// planning must resolve the exact installed release, not reinterpret it as the
+// newest package carrying the same template id.
+const BUILTIN_TEMPLATE_RELEASES: readonly ProfileTemplatePackage[] = [
   AUTOSCI_TEMPLATE,
   NEWSROOM_TEMPLATE,
 ];
@@ -17,13 +20,80 @@ const BUILTIN_TEMPLATES: readonly ProfileTemplatePackage[] = [
 export function listBuiltinTemplates(): readonly ProfileTemplateSummary[] {
   return [
     DEFAULT_TEMPLATE_SUMMARY,
-    ...BUILTIN_TEMPLATES.map(summaryFor),
+    ...latestBuiltinTemplates().map(summaryFor),
   ];
 }
 
 /** Resolve an installable builtin template by id. `default` is intentionally absent. */
 export function getBuiltinTemplate(id: string): ProfileTemplatePackage | undefined {
-  return BUILTIN_TEMPLATES.find((template) => template.templateId === id);
+  return latestBuiltinTemplates().find((template) => template.templateId === id);
+}
+
+/** Resolve one immutable builtin release by its complete published identity. */
+export function getBuiltinTemplateRelease(
+  id: string,
+  version: string,
+  publisher: string,
+): ProfileTemplatePackage | undefined {
+  return BUILTIN_TEMPLATE_RELEASES.find((template) =>
+    template.templateId === id && template.version === version && template.publisher === publisher,
+  );
+}
+
+function latestBuiltinTemplates(): ProfileTemplatePackage[] {
+  const latest = new Map<string, ProfileTemplatePackage>();
+  for (const release of BUILTIN_TEMPLATE_RELEASES) {
+    const current = latest.get(release.templateId);
+    if (!current || compareTemplateVersions(release.version, current.version) > 0) latest.set(release.templateId, release);
+  }
+  return [...latest.values()];
+}
+
+/** Compare validated SemVer strings when selecting the latest builtin release. */
+export function compareTemplateVersions(left: string, right: string): number {
+  const [leftVersion, leftPre] = versionParts(left);
+  const [rightVersion, rightPre] = versionParts(right);
+  const a = leftVersion.split(".").map(Number);
+  const b = rightVersion.split(".").map(Number);
+  for (let index = 0; index < 3; index++) {
+    if (a[index] !== b[index]) return a[index] - b[index];
+  }
+  return comparePrerelease(leftPre, rightPre);
+}
+
+function versionParts(version: string): [string, string | undefined] {
+  const withoutBuild = version.split("+", 1)[0];
+  const separator = withoutBuild.indexOf("-");
+  return separator < 0
+    ? [withoutBuild, undefined]
+    : [withoutBuild.slice(0, separator), withoutBuild.slice(separator + 1)];
+}
+
+function comparePrerelease(left: string | undefined, right: string | undefined): number {
+  const presence = comparePrereleasePresence(left, right);
+  if (presence !== null) return presence;
+  const a = left!.split(".");
+  const b = right!.split(".");
+  for (let index = 0; index < Math.min(a.length, b.length); index++) {
+    const result = comparePrereleaseIdentifier(a[index], b[index]);
+    if (result !== 0) return result;
+  }
+  return a.length - b.length;
+}
+
+function comparePrereleasePresence(left: string | undefined, right: string | undefined): number | null {
+  if (left !== undefined && right !== undefined) return null;
+  if (left === right) return 0;
+  return left === undefined ? 1 : -1;
+}
+
+function comparePrereleaseIdentifier(left: string, right: string): number {
+  if (left === right) return 0;
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+  if (leftNumeric && rightNumeric) return Number(left) - Number(right);
+  if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+  return left.localeCompare(right);
 }
 
 /** Build one user-facing summary from a package. */

--- a/src/profile/templates/signing/canonical.ts
+++ b/src/profile/templates/signing/canonical.ts
@@ -1,0 +1,44 @@
+/**
+ * @file src/profile/templates/signing/canonical.ts
+ * @description Single RFC 8785 canonical-byte and SHA-256 implementation for
+ * every template signature and digest claim.
+ */
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+
+/** Return canonical UTF-8 bytes or reject values RFC 8785 cannot represent. */
+export function canonicalBytes(value: unknown): Buffer {
+  const text = canonicalize(value);
+  if (text === undefined) throw new Error("value cannot be canonically represented");
+  return Buffer.from(text, "utf8");
+}
+
+/** Hash canonical JSON using the protocol's prefixed digest representation. */
+export function canonicalDigest(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalBytes(value)).digest("hex")}`;
+}
+
+/** Publisher-signed package claim. */
+export function packageClaim(coordinate: string, payloadDigest: string): object {
+  return { coordinate, payloadDigest };
+}
+
+/** Publisher-key rotation claim signed by predecessor and successor. */
+export function rotationClaim(tap: string, rotation: {
+  publisher: string; fromKeyId: string; toKey: { keyId: string; publicKey: string }; effectiveSequence: number;
+}): object {
+  return {
+    tap,
+    publisher: rotation.publisher,
+    fromKeyId: rotation.fromKeyId,
+    toKey: rotation.toKey,
+    effectiveSequence: rotation.effectiveSequence,
+  };
+}
+
+/** Tap-root rotation claim signed by predecessor and successor. */
+export function tapRotationClaim(tap: string, rotation: {
+  fromKeyId: string; toKey: { keyId: string; publicKey: string }; effectiveSequence: number;
+}): object {
+  return { tap, fromKeyId: rotation.fromKeyId, toKey: rotation.toKey, effectiveSequence: rotation.effectiveSequence };
+}

--- a/src/profile/templates/signing/continuity.ts
+++ b/src/profile/templates/signing/continuity.ts
@@ -1,0 +1,95 @@
+/**
+ * @file src/profile/templates/signing/continuity.ts
+ * @description Pure publisher-pin, coordinate-immutability, revocation, and
+ * sequence transition logic for already tap-verified snapshots.
+ */
+import { verifyPublisherRotation } from "./verify.js";
+import type { VerifiedTapIndex } from "./verify.js";
+import type { PublisherKey, PublisherPinState, PublisherRotation } from "./types.js";
+
+/** Empty operator state for a newly configured tap. */
+export function emptyPublisherPinState(tap: string): PublisherPinState {
+  return { tap, highestSequence: -1, publishers: {}, coordinates: {}, revokedPackages: [], revokedPublisherKeys: [] };
+}
+
+/** Accept a verified index into immutable operator continuity state. */
+export function advancePublisherPins(index: VerifiedTapIndex, prior: PublisherPinState): PublisherPinState {
+  if (index.tap !== prior.tap) throw new Error("publisher pin state belongs to another tap");
+  if (index.sequence <= prior.highestSequence) throw new Error("tap index sequence rollback or replay");
+  assertCoordinateContinuity(index, prior);
+  const publishers = { ...prior.publishers };
+  for (const [name, announced] of Object.entries(index.publishers)) {
+    publishers[name] = acceptedPublisherKey(index, name, announced, publishers[name]);
+  }
+  const revokedPackages = union(prior.revokedPackages, revokedValues(index, "package"));
+  const revokedPublisherKeys = union(prior.revokedPublisherKeys, revokedValues(index, "publisher-key"));
+  assertNoRevokedActiveKeys(publishers, revokedPublisherKeys);
+  return {
+    tap: prior.tap,
+    highestSequence: index.sequence,
+    publishers,
+    coordinates: { ...prior.coordinates, ...Object.fromEntries(index.packages.map((entry) => [entry.coordinate, entry.payloadDigest])) },
+    revokedPackages,
+    revokedPublisherKeys,
+  };
+}
+
+/** Refuse packages or publisher keys revoked by any accepted snapshot. */
+export function assertPackageNotRevoked(state: PublisherPinState, digest: string, publisherKeyId: string): void {
+  if (state.revokedPackages.includes(digest)) throw new Error("package digest is revoked");
+  if (state.revokedPublisherKeys.includes(publisherKeyId)) throw new Error("publisher key is revoked");
+}
+
+function acceptedPublisherKey(
+  index: VerifiedTapIndex,
+  publisher: string,
+  announced: PublisherKey,
+  pinned: PublisherKey | undefined,
+): PublisherKey {
+  if (!pinned) return announced;
+  if (sameKey(pinned, announced)) return pinned;
+  const rotation = matchingRotation(index.rotations, publisher, pinned, announced, index.sequence);
+  if (!rotation) throw new Error(`publisher key changed without a valid rotation: ${publisher}`);
+  verifyPublisherRotation(index.tap, rotation, pinned);
+  return announced;
+}
+
+function matchingRotation(
+  rotations: PublisherRotation[],
+  publisher: string,
+  from: PublisherKey,
+  to: PublisherKey,
+  sequence: number,
+): PublisherRotation | undefined {
+  return rotations.find((item) => item.publisher === publisher
+    && item.fromKeyId === from.keyId
+    && sameKey(item.toKey, to)
+    && item.effectiveSequence === sequence);
+}
+
+function assertCoordinateContinuity(index: VerifiedTapIndex, prior: PublisherPinState): void {
+  for (const entry of index.packages) {
+    const existing = prior.coordinates[entry.coordinate];
+    if (existing !== undefined && existing !== entry.payloadDigest) {
+      throw new Error(`immutable coordinate remapped: ${entry.coordinate}`);
+    }
+  }
+}
+
+function assertNoRevokedActiveKeys(publishers: Record<string, PublisherKey>, revoked: string[]): void {
+  for (const [publisher, key] of Object.entries(publishers)) {
+    if (revoked.includes(key.keyId)) throw new Error(`active publisher key is revoked: ${publisher}`);
+  }
+}
+
+function revokedValues(index: VerifiedTapIndex, kind: "package" | "publisher-key"): string[] {
+  return index.revocations.filter((item) => item.kind === kind).map((item) => item.value);
+}
+
+function sameKey(left: PublisherKey, right: PublisherKey): boolean {
+  return left.keyId === right.keyId && left.publicKey === right.publicKey;
+}
+
+function union(left: string[], right: string[]): string[] {
+  return [...new Set([...left, ...right])];
+}

--- a/src/profile/templates/signing/continuity.ts
+++ b/src/profile/templates/signing/continuity.ts
@@ -9,7 +9,7 @@ import type { PublisherKey, PublisherPinState, PublisherRotation } from "./types
 
 /** Empty operator state for a newly configured tap. */
 export function emptyPublisherPinState(tap: string): PublisherPinState {
-  return { tap, highestSequence: -1, publishers: {}, coordinates: {}, revokedPackages: [], revokedPublisherKeys: [] };
+  return { tap, highestSequence: -1, publishers: {}, keyHistory: {}, coordinates: {}, revokedPackages: [], revokedPublisherKeys: [] };
 }
 
 /** Accept a verified index into immutable operator continuity state. */
@@ -18,8 +18,11 @@ export function advancePublisherPins(index: VerifiedTapIndex, prior: PublisherPi
   if (index.sequence <= prior.highestSequence) throw new Error("tap index sequence rollback or replay");
   assertCoordinateContinuity(index, prior);
   const publishers = { ...prior.publishers };
+  const keyHistory = { ...prior.keyHistory };
   for (const [name, announced] of Object.entries(index.publishers)) {
-    publishers[name] = acceptedPublisherKey(index, name, announced, publishers[name]);
+    const accepted = acceptedPublisherKeys(index, name, announced, publishers[name]);
+    accepted.forEach((key, index) => registerKey(keyHistory, name, key, index === 0));
+    publishers[name] = accepted.at(-1)!;
   }
   const revokedPackages = union(prior.revokedPackages, revokedValues(index, "package"));
   const revokedPublisherKeys = union(prior.revokedPublisherKeys, revokedValues(index, "publisher-key"));
@@ -28,6 +31,7 @@ export function advancePublisherPins(index: VerifiedTapIndex, prior: PublisherPi
     tap: prior.tap,
     highestSequence: index.sequence,
     publishers,
+    keyHistory,
     coordinates: { ...prior.coordinates, ...Object.fromEntries(index.packages.map((entry) => [entry.coordinate, entry.payloadDigest])) },
     revokedPackages,
     revokedPublisherKeys,
@@ -40,14 +44,14 @@ export function assertPackageNotRevoked(state: PublisherPinState, digest: string
   if (state.revokedPublisherKeys.includes(publisherKeyId)) throw new Error("publisher key is revoked");
 }
 
-function acceptedPublisherKey(
+function acceptedPublisherKeys(
   index: VerifiedTapIndex,
   publisher: string,
   announced: PublisherKey,
   pinned: PublisherKey | undefined,
-): PublisherKey {
-  if (!pinned) return announced;
-  if (sameKey(pinned, announced)) return pinned;
+): PublisherKey[] {
+  if (!pinned) return [announced];
+  if (sameKey(pinned, announced)) return [pinned];
   return followRotationChain(index, publisher, pinned, announced);
 }
 
@@ -56,11 +60,12 @@ function followRotationChain(
   publisher: string,
   pinned: PublisherKey,
   announced: PublisherKey,
-): PublisherKey {
+): PublisherKey[] {
   const rotations = rotationMap(index.rotations, publisher, index.sequence);
   let current = pinned;
   let previousSequence = -1;
   const visited = new Set<string>([current.keyId]);
+  const accepted = [current];
   while (!sameKey(current, announced)) {
     const rotation = rotations.get(current.keyId);
     if (!rotation) throw new Error(`publisher key changed without a valid rotation chain: ${publisher}`);
@@ -69,9 +74,24 @@ function followRotationChain(
     if (visited.has(rotation.toKey.keyId)) throw new Error(`publisher rotation cycle: ${publisher}`);
     visited.add(rotation.toKey.keyId);
     current = rotation.toKey;
+    accepted.push(current);
     previousSequence = rotation.effectiveSequence;
   }
-  return current;
+  return accepted;
+}
+
+function registerKey(
+  history: PublisherPinState["keyHistory"],
+  publisher: string,
+  key: PublisherKey,
+  allowExisting: boolean,
+): void {
+  const existing = history[key.keyId];
+  if (existing && (existing.publisher !== publisher || existing.publicKey !== key.publicKey)) {
+    throw new Error(`publisher key id was rebound: ${key.keyId}`);
+  }
+  if (existing && !allowExisting) throw new Error(`publisher rotation reuses historical key id: ${key.keyId}`);
+  history[key.keyId] = { publisher, publicKey: key.publicKey };
 }
 
 function rotationMap(

--- a/src/profile/templates/signing/continuity.ts
+++ b/src/profile/templates/signing/continuity.ts
@@ -48,23 +48,44 @@ function acceptedPublisherKey(
 ): PublisherKey {
   if (!pinned) return announced;
   if (sameKey(pinned, announced)) return pinned;
-  const rotation = matchingRotation(index.rotations, publisher, pinned, announced, index.sequence);
-  if (!rotation) throw new Error(`publisher key changed without a valid rotation: ${publisher}`);
-  verifyPublisherRotation(index.tap, rotation, pinned);
-  return announced;
+  return followRotationChain(index, publisher, pinned, announced);
 }
 
-function matchingRotation(
+function followRotationChain(
+  index: VerifiedTapIndex,
+  publisher: string,
+  pinned: PublisherKey,
+  announced: PublisherKey,
+): PublisherKey {
+  const rotations = rotationMap(index.rotations, publisher, index.sequence);
+  let current = pinned;
+  let previousSequence = -1;
+  const visited = new Set<string>([current.keyId]);
+  while (!sameKey(current, announced)) {
+    const rotation = rotations.get(current.keyId);
+    if (!rotation) throw new Error(`publisher key changed without a valid rotation chain: ${publisher}`);
+    if (rotation.effectiveSequence <= previousSequence) throw new Error(`publisher rotation sequence is not increasing: ${publisher}`);
+    verifyPublisherRotation(index.tap, rotation, current);
+    if (visited.has(rotation.toKey.keyId)) throw new Error(`publisher rotation cycle: ${publisher}`);
+    visited.add(rotation.toKey.keyId);
+    current = rotation.toKey;
+    previousSequence = rotation.effectiveSequence;
+  }
+  return current;
+}
+
+function rotationMap(
   rotations: PublisherRotation[],
   publisher: string,
-  from: PublisherKey,
-  to: PublisherKey,
-  sequence: number,
-): PublisherRotation | undefined {
-  return rotations.find((item) => item.publisher === publisher
-    && item.fromKeyId === from.keyId
-    && sameKey(item.toKey, to)
-    && item.effectiveSequence === sequence);
+  currentSequence: number,
+): Map<string, PublisherRotation> {
+  const result = new Map<string, PublisherRotation>();
+  for (const rotation of rotations) {
+    if (rotation.publisher !== publisher || rotation.effectiveSequence > currentSequence) continue;
+    if (result.has(rotation.fromKeyId)) throw new Error(`ambiguous publisher rotation chain: ${publisher}`);
+    result.set(rotation.fromKeyId, rotation);
+  }
+  return result;
 }
 
 function assertCoordinateContinuity(index: VerifiedTapIndex, prior: PublisherPinState): void {

--- a/src/profile/templates/signing/json.ts
+++ b/src/profile/templates/signing/json.ts
@@ -1,0 +1,132 @@
+/**
+ * @file src/profile/templates/signing/json.ts
+ * @description Bounded JSON parsing that rejects duplicate object keys before
+ * native JSON parsing can silently collapse them.
+ */
+
+/** Parse bounded JSON after validating depth, syntax, and key uniqueness. */
+export function parseBoundedUniqueJson(text: string, maxBytes: number, maxDepth = 32): unknown {
+  if (Buffer.byteLength(text, "utf8") > maxBytes) throw new Error("signed JSON exceeds its byte cap");
+  new JsonShapeScanner(text, maxDepth).scan();
+  return JSON.parse(text);
+}
+
+class JsonShapeScanner {
+  private position = 0;
+
+  constructor(private readonly text: string, private readonly maxDepth: number) {}
+
+  scan(): void {
+    this.scanValue(0);
+    this.skipSpace();
+    if (this.position !== this.text.length) this.fail("trailing content");
+  }
+
+  private scanValue(depth: number): void {
+    if (depth > this.maxDepth) this.fail("JSON nesting exceeds its depth cap");
+    this.skipSpace();
+    const char = this.text[this.position];
+    if (this.scanStructured(char, depth)) return;
+    this.scanScalar(char);
+  }
+
+  private scanStructured(char: string | undefined, depth: number): boolean {
+    if (char === "{") this.scanObject(depth + 1);
+    else if (char === "[") this.scanArray(depth + 1);
+    else return false;
+    return true;
+  }
+
+  private scanScalar(char: string | undefined): void {
+    if (char === '"') return void this.scanString();
+    if (char === "-" || isDigit(char)) return this.scanNumber();
+    if (char === "t") return this.scanLiteral("true");
+    if (char === "f") return this.scanLiteral("false");
+    if (char === "n") return this.scanLiteral("null");
+    this.fail("invalid JSON value");
+  }
+
+  private scanObject(depth: number): void {
+    this.position++;
+    const keys = new Set<string>();
+    if (this.consumeClosing("}")) return;
+    while (true) {
+      this.skipSpace();
+      const key = this.scanString();
+      if (keys.has(key)) this.fail(`duplicate JSON key: ${key}`);
+      keys.add(key);
+      this.expect(":");
+      this.scanValue(depth);
+      if (this.consumeClosing("}")) return;
+      this.expect(",");
+    }
+  }
+
+  private scanArray(depth: number): void {
+    this.position++;
+    if (this.consumeClosing("]")) return;
+    while (true) {
+      this.scanValue(depth);
+      if (this.consumeClosing("]")) return;
+      this.expect(",");
+    }
+  }
+
+  private scanString(): string {
+    this.skipSpace();
+    const start = this.position;
+    if (this.text[this.position++] !== '"') this.fail("expected JSON string");
+    while (this.position < this.text.length) {
+      const char = this.text[this.position++];
+      if (char === '"') return JSON.parse(this.text.slice(start, this.position)) as string;
+      if (char === "\\") this.scanEscape();
+      else if (char.charCodeAt(0) < 0x20) this.fail("control character in JSON string");
+    }
+    this.fail("unterminated JSON string");
+  }
+
+  private scanEscape(): void {
+    const escaped = this.text[this.position++];
+    if ('"\\/bfnrt'.includes(escaped)) return;
+    if (escaped !== "u") this.fail("invalid JSON escape");
+    const hex = this.text.slice(this.position, this.position + 4);
+    if (!/^[0-9a-fA-F]{4}$/.test(hex)) this.fail("invalid Unicode escape");
+    this.position += 4;
+  }
+
+  private scanNumber(): void {
+    const rest = this.text.slice(this.position);
+    const match = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(rest);
+    if (!match) this.fail("invalid JSON number");
+    this.position += match[0].length;
+  }
+
+  private scanLiteral(literal: string): void {
+    if (!this.text.startsWith(literal, this.position)) this.fail("invalid JSON literal");
+    this.position += literal.length;
+  }
+
+  private consumeClosing(char: string): boolean {
+    this.skipSpace();
+    if (this.text[this.position] !== char) return false;
+    this.position++;
+    return true;
+  }
+
+  private expect(char: string): void {
+    this.skipSpace();
+    if (this.text[this.position++] !== char) this.fail(`expected ${char}`);
+  }
+
+  private skipSpace(): void {
+    while (/\s/.test(this.text[this.position] ?? "")) this.position++;
+  }
+
+  private fail(message: string): never {
+    throw new Error(`${message} at byte ${this.position}`);
+  }
+}
+
+function isDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= "0" && char <= "9";
+}

--- a/src/profile/templates/signing/protocol.ts
+++ b/src/profile/templates/signing/protocol.ts
@@ -166,6 +166,22 @@ function validateIndexRelationships(index: SignedTapIndex): void {
     if (coordinate.publisher !== entry.publisher) throw new Error("package publisher differs from its coordinate");
     if (!(entry.publisher in index.publishers)) throw new Error("package publisher has no declared key");
   }
+  assertPublisherKeyIdsUnambiguous(index);
+}
+
+function assertPublisherKeyIdsUnambiguous(index: SignedTapIndex): void {
+  const owners = new Map<string, string>();
+  for (const [publisher, key] of Object.entries(index.publishers)) registerKeyOwner(owners, key.keyId, publisher);
+  for (const rotation of index.rotations) {
+    registerKeyOwner(owners, rotation.fromKeyId, rotation.publisher);
+    registerKeyOwner(owners, rotation.toKey.keyId, rotation.publisher);
+  }
+}
+
+function registerKeyOwner(owners: Map<string, string>, keyId: string, publisher: string): void {
+  const existing = owners.get(keyId);
+  if (existing !== undefined && existing !== publisher) throw new Error(`publisher key id is ambiguous: ${keyId}`);
+  owners.set(keyId, publisher);
 }
 
 function boundedArray(value: unknown, label: string): unknown[] {
@@ -217,7 +233,11 @@ function natural(value: unknown, label: string): number {
 
 function timestamp(value: unknown, label: string): string {
   const text = textField(value, label);
-  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(text) || Number.isNaN(Date.parse(text))) {
+  const parsed = Date.parse(text);
+  const normalized = text.includes(".") ? text : text.replace("Z", ".000Z");
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(text)
+    || Number.isNaN(parsed)
+    || new Date(parsed).toISOString() !== normalized) {
     throw new Error(`${label} must be an ISO-8601 UTC timestamp`);
   }
   return text;

--- a/src/profile/templates/signing/protocol.ts
+++ b/src/profile/templates/signing/protocol.ts
@@ -28,6 +28,13 @@ export interface TemplateCoordinate {
   version: string;
 }
 
+declare const PARSED_TAP_INDEX: unique symbol;
+declare const PARSED_SIGNED_PACKAGE: unique symbol;
+/** Tap index that passed bounded JSON and complete structural validation. */
+export type ParsedTapIndex = SignedTapIndex & { readonly [PARSED_TAP_INDEX]: true };
+/** Package envelope that passed bounded JSON and structural validation. */
+export type ParsedSignedPackage = SignedPackageEnvelope & { readonly [PARSED_SIGNED_PACKAGE]: true };
+
 /** Parse one unambiguous fully qualified package coordinate. */
 export function parseTemplateCoordinate(value: string): TemplateCoordinate {
   const match = COORDINATE.exec(value);
@@ -36,7 +43,7 @@ export function parseTemplateCoordinate(value: string): TemplateCoordinate {
 }
 
 /** Parse a signed package envelope from bounded unique-key JSON bytes. */
-export function parseSignedPackage(text: string): SignedPackageEnvelope {
+export function parseSignedPackage(text: string): ParsedSignedPackage {
   const obj = record(parseBoundedUniqueJson(text, MAX_SIGNED_PACKAGE_BYTES), "package envelope");
   exactKeys(obj, ["schemaVersion", "coordinate", "payload", "payloadDigest", "publisherSignature"]);
   equal(obj.schemaVersion, 1, "package schemaVersion must be 1");
@@ -48,11 +55,11 @@ export function parseSignedPackage(text: string): SignedPackageEnvelope {
     payload: record(obj.payload, "payload") as unknown as SignedPackageEnvelope["payload"],
     payloadDigest: digest(obj.payloadDigest),
     publisherSignature: signature(obj.publisherSignature),
-  };
+  } as ParsedSignedPackage;
 }
 
 /** Parse a signed tap index from bounded unique-key JSON bytes. */
-export function parseSignedTapIndex(text: string): SignedTapIndex {
+export function parseSignedTapIndex(text: string): ParsedTapIndex {
   const obj = record(parseBoundedUniqueJson(text, MAX_TAP_INDEX_BYTES), "tap index");
   exactKeys(obj, indexKeys(), ["tapKeyRotation"]);
   equal(obj.schemaVersion, 1, "tap index schemaVersion must be 1");
@@ -72,7 +79,7 @@ export function parseSignedTapIndex(text: string): SignedTapIndex {
     signature: signature(obj.signature),
   };
   validateIndexRelationships(index);
-  return index;
+  return index as ParsedTapIndex;
 }
 
 function indexKeys(): string[] {

--- a/src/profile/templates/signing/protocol.ts
+++ b/src/profile/templates/signing/protocol.ts
@@ -1,0 +1,221 @@
+/**
+ * @file src/profile/templates/signing/protocol.ts
+ * @description Strict bounded parsers for offline signed package and tap-index
+ * envelopes. Unknown fields and ambiguous coordinates are rejected.
+ */
+import type {
+  Ed25519Signature,
+  PublisherKey,
+  PublisherRotation,
+  SignedPackageEnvelope,
+  SignedTapIndex,
+  TapPackageEntry,
+  TapRevocation,
+  TapKeyRotation,
+} from "./types.js";
+import { parseBoundedUniqueJson } from "./json.js";
+
+const MAX_SIGNED_PACKAGE_BYTES = 2 * 1024 * 1024;
+const MAX_TAP_INDEX_BYTES = 4 * 1024 * 1024;
+const MAX_INDEX_ITEMS = 10_000;
+const SLUG = "[a-z0-9]+(?:-[a-z0-9]+)*";
+const COORDINATE = new RegExp(`^(${SLUG})/(${SLUG})/(${SLUG})@([0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?)$`);
+
+export interface TemplateCoordinate {
+  tap: string;
+  publisher: string;
+  templateId: string;
+  version: string;
+}
+
+/** Parse one unambiguous fully qualified package coordinate. */
+export function parseTemplateCoordinate(value: string): TemplateCoordinate {
+  const match = COORDINATE.exec(value);
+  if (!match) throw new Error(`invalid template coordinate: ${value}`);
+  return { tap: match[1], publisher: match[2], templateId: match[3], version: match[4] };
+}
+
+/** Parse a signed package envelope from bounded unique-key JSON bytes. */
+export function parseSignedPackage(text: string): SignedPackageEnvelope {
+  const obj = record(parseBoundedUniqueJson(text, MAX_SIGNED_PACKAGE_BYTES), "package envelope");
+  exactKeys(obj, ["schemaVersion", "coordinate", "payload", "payloadDigest", "publisherSignature"]);
+  equal(obj.schemaVersion, 1, "package schemaVersion must be 1");
+  const coordinate = textField(obj.coordinate, "coordinate");
+  parseTemplateCoordinate(coordinate);
+  return {
+    schemaVersion: 1,
+    coordinate,
+    payload: record(obj.payload, "payload") as unknown as SignedPackageEnvelope["payload"],
+    payloadDigest: digest(obj.payloadDigest),
+    publisherSignature: signature(obj.publisherSignature),
+  };
+}
+
+/** Parse a signed tap index from bounded unique-key JSON bytes. */
+export function parseSignedTapIndex(text: string): SignedTapIndex {
+  const obj = record(parseBoundedUniqueJson(text, MAX_TAP_INDEX_BYTES), "tap index");
+  exactKeys(obj, indexKeys(), ["tapKeyRotation"]);
+  equal(obj.schemaVersion, 1, "tap index schemaVersion must be 1");
+  const packages = boundedArray(obj.packages, "packages").map(packageEntry);
+  rejectDuplicateCoordinates(packages);
+  const index: SignedTapIndex = {
+    schemaVersion: 1,
+    tap: slug(obj.tap, "tap"),
+    sequence: natural(obj.sequence, "sequence"),
+    generatedAt: timestamp(obj.generatedAt, "generatedAt"),
+    expiresAt: timestamp(obj.expiresAt, "expiresAt"),
+    publishers: publisherMap(obj.publishers),
+    packages,
+    rotations: boundedArray(obj.rotations, "rotations").map(rotation),
+    ...(obj.tapKeyRotation === undefined ? {} : { tapKeyRotation: tapKeyRotation(obj.tapKeyRotation) }),
+    revocations: boundedArray(obj.revocations, "revocations").map(revocation),
+    signature: signature(obj.signature),
+  };
+  validateIndexRelationships(index);
+  return index;
+}
+
+function indexKeys(): string[] {
+  return ["schemaVersion", "tap", "sequence", "generatedAt", "expiresAt", "publishers", "packages", "rotations", "revocations", "signature", "tapKeyRotation"];
+}
+
+function signature(value: unknown): Ed25519Signature {
+  const obj = record(value, "signature");
+  exactKeys(obj, ["keyId", "algorithm", "value"]);
+  equal(obj.algorithm, "ed25519", "signature algorithm must be ed25519");
+  return { keyId: textField(obj.keyId, "signature.keyId"), algorithm: "ed25519", value: base64(obj.value, "signature.value") };
+}
+
+function publisherKey(value: unknown): PublisherKey {
+  const obj = record(value, "publisher key");
+  exactKeys(obj, ["keyId", "publicKey"]);
+  return { keyId: textField(obj.keyId, "publisher keyId"), publicKey: base64(obj.publicKey, "publisher publicKey") };
+}
+
+function publisherMap(value: unknown): Record<string, PublisherKey> {
+  const obj = record(value, "publishers");
+  if (Object.keys(obj).length > MAX_INDEX_ITEMS) throw new Error("publishers exceeds its item cap");
+  return Object.fromEntries(Object.entries(obj).map(([name, key]) => [slug(name, "publisher"), publisherKey(key)]));
+}
+
+function packageEntry(value: unknown): TapPackageEntry {
+  const obj = record(value, "package entry");
+  exactKeys(obj, ["coordinate", "publisher", "payloadDigest"]);
+  const coordinate = textField(obj.coordinate, "package coordinate");
+  parseTemplateCoordinate(coordinate);
+  return { coordinate, publisher: slug(obj.publisher, "package publisher"), payloadDigest: digest(obj.payloadDigest) };
+}
+
+function rotation(value: unknown): PublisherRotation {
+  const obj = record(value, "publisher rotation");
+  exactKeys(obj, ["publisher", "fromKeyId", "toKey", "effectiveSequence", "oldSignature", "newSignature"]);
+  return {
+    publisher: slug(obj.publisher, "rotation publisher"),
+    fromKeyId: textField(obj.fromKeyId, "rotation fromKeyId"),
+    toKey: publisherKey(obj.toKey),
+    effectiveSequence: natural(obj.effectiveSequence, "rotation effectiveSequence"),
+    oldSignature: signature(obj.oldSignature),
+    newSignature: signature(obj.newSignature),
+  };
+}
+
+function tapKeyRotation(value: unknown): TapKeyRotation {
+  const obj = record(value, "tap key rotation");
+  exactKeys(obj, ["fromKeyId", "toKey", "effectiveSequence", "oldSignature", "newSignature"]);
+  return {
+    fromKeyId: textField(obj.fromKeyId, "tap rotation fromKeyId"),
+    toKey: publisherKey(obj.toKey),
+    effectiveSequence: natural(obj.effectiveSequence, "tap rotation effectiveSequence"),
+    oldSignature: signature(obj.oldSignature),
+    newSignature: signature(obj.newSignature),
+  };
+}
+
+function revocation(value: unknown): TapRevocation {
+  const obj = record(value, "revocation");
+  exactKeys(obj, ["kind", "value", "reason", "revokedAt"]);
+  if (obj.kind !== "package" && obj.kind !== "publisher-key") throw new Error("revocation kind is invalid");
+  return {
+    kind: obj.kind,
+    value: obj.kind === "package" ? digest(obj.value) : textField(obj.value, "revocation value"),
+    reason: textField(obj.reason, "revocation reason"),
+    revokedAt: timestamp(obj.revokedAt, "revokedAt"),
+  };
+}
+
+function rejectDuplicateCoordinates(packages: TapPackageEntry[]): void {
+  const seen = new Set<string>();
+  for (const entry of packages) {
+    if (seen.has(entry.coordinate)) throw new Error(`duplicate package coordinate: ${entry.coordinate}`);
+    seen.add(entry.coordinate);
+  }
+}
+
+function validateIndexRelationships(index: SignedTapIndex): void {
+  if (Date.parse(index.generatedAt) >= Date.parse(index.expiresAt)) throw new Error("tap index expiry must follow generation");
+  for (const entry of index.packages) {
+    const coordinate = parseTemplateCoordinate(entry.coordinate);
+    if (coordinate.tap !== index.tap) throw new Error("package coordinate belongs to another tap");
+    if (coordinate.publisher !== entry.publisher) throw new Error("package publisher differs from its coordinate");
+    if (!(entry.publisher in index.publishers)) throw new Error("package publisher has no declared key");
+  }
+}
+
+function boundedArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  if (value.length > MAX_INDEX_ITEMS) throw new Error(`${label} exceeds its item cap`);
+  return value;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(obj: Record<string, unknown>, expected: string[], optional: string[] = []): void {
+  const allowed = new Set(expected);
+  if (Object.keys(obj).some((key) => !allowed.has(key))) throw new Error("signed object contains unsupported fields");
+  if (expected.some((key) => !optional.includes(key) && !(key in obj))) throw new Error("signed object is missing required fields");
+}
+
+function textField(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || Buffer.byteLength(value, "utf8") > 4096) {
+    throw new Error(`${label} must be a bounded non-empty string`);
+  }
+  return value;
+}
+
+function slug(value: unknown, label: string): string {
+  const text = textField(value, label);
+  if (!(new RegExp(`^${SLUG}$`)).test(text)) throw new Error(`${label} must be slug-safe`);
+  return text;
+}
+
+function digest(value: unknown): string {
+  const text = textField(value, "digest");
+  if (!/^sha256:[0-9a-f]{64}$/.test(text)) throw new Error("digest must be prefixed lowercase SHA-256 hex");
+  return text;
+}
+
+function base64(value: unknown, label: string): string {
+  const text = textField(value, label);
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(text)) throw new Error(`${label} must be base64`);
+  return text;
+}
+
+function natural(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative safe integer`);
+  return Number(value);
+}
+
+function timestamp(value: unknown, label: string): string {
+  const text = textField(value, label);
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(text) || Number.isNaN(Date.parse(text))) {
+    throw new Error(`${label} must be an ISO-8601 UTC timestamp`);
+  }
+  return text;
+}
+
+function equal(actual: unknown, expected: unknown, message: string): void {
+  if (actual !== expected) throw new Error(message);
+}

--- a/src/profile/templates/signing/types.ts
+++ b/src/profile/templates/signing/types.ts
@@ -72,6 +72,7 @@ export interface PublisherPinState {
   tap: string;
   highestSequence: number;
   publishers: Record<string, PublisherKey>;
+  keyHistory: Record<string, { publisher: string; publicKey: string }>;
   coordinates: Record<string, string>;
   revokedPackages: string[];
   revokedPublisherKeys: string[];

--- a/src/profile/templates/signing/types.ts
+++ b/src/profile/templates/signing/types.ts
@@ -1,0 +1,78 @@
+/**
+ * @file src/profile/templates/signing/types.ts
+ * @description Offline signed-template protocol DTOs. These records establish
+ * provenance only; they never authorize profile loading or installation.
+ */
+import type { ProfileTemplatePackage } from "../types.js";
+
+export interface Ed25519Signature {
+  keyId: string;
+  algorithm: "ed25519";
+  value: string;
+}
+
+export interface PublisherKey {
+  keyId: string;
+  publicKey: string;
+}
+
+export interface SignedPackageEnvelope {
+  schemaVersion: 1;
+  coordinate: string;
+  payload: ProfileTemplatePackage;
+  payloadDigest: string;
+  publisherSignature: Ed25519Signature;
+}
+
+export interface TapPackageEntry {
+  coordinate: string;
+  publisher: string;
+  payloadDigest: string;
+}
+
+export interface PublisherRotation {
+  publisher: string;
+  fromKeyId: string;
+  toKey: PublisherKey;
+  effectiveSequence: number;
+  oldSignature: Ed25519Signature;
+  newSignature: Ed25519Signature;
+}
+
+export interface TapKeyRotation {
+  fromKeyId: string;
+  toKey: PublisherKey;
+  effectiveSequence: number;
+  oldSignature: Ed25519Signature;
+  newSignature: Ed25519Signature;
+}
+
+export interface TapRevocation {
+  kind: "package" | "publisher-key";
+  value: string;
+  reason: string;
+  revokedAt: string;
+}
+
+export interface SignedTapIndex {
+  schemaVersion: 1;
+  tap: string;
+  sequence: number;
+  generatedAt: string;
+  expiresAt: string;
+  publishers: Record<string, PublisherKey>;
+  packages: TapPackageEntry[];
+  rotations: PublisherRotation[];
+  tapKeyRotation?: TapKeyRotation;
+  revocations: TapRevocation[];
+  signature: Ed25519Signature;
+}
+
+export interface PublisherPinState {
+  tap: string;
+  highestSequence: number;
+  publishers: Record<string, PublisherKey>;
+  coordinates: Record<string, string>;
+  revokedPackages: string[];
+  revokedPublisherKeys: string[];
+}

--- a/src/profile/templates/signing/verify.ts
+++ b/src/profile/templates/signing/verify.ts
@@ -1,0 +1,128 @@
+/**
+ * @file src/profile/templates/signing/verify.ts
+ * @description Native Ed25519 verification for tap indexes, package claims,
+ * payload digests, and publisher-key rotations.
+ */
+import { createPublicKey, verify } from "node:crypto";
+import type { ProfileTemplatePackage } from "../types.js";
+import { validateTemplatePackage } from "../validate.js";
+import { canonicalBytes, canonicalDigest, packageClaim, rotationClaim, tapRotationClaim } from "./canonical.js";
+import { parseTemplateCoordinate } from "./protocol.js";
+import type {
+  Ed25519Signature,
+  PublisherKey,
+  PublisherRotation,
+  PublisherPinState,
+  SignedPackageEnvelope,
+  SignedTapIndex,
+  TapKeyRotation,
+} from "./types.js";
+
+declare const VERIFIED_TAP_INDEX: unique symbol;
+/** Tap index whose signature, identity, and freshness were verified. */
+export type VerifiedTapIndex = SignedTapIndex & { readonly [VERIFIED_TAP_INDEX]: true };
+
+/** Typed refusal preserving the failed provenance layer. */
+class TemplateVerificationError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = "TemplateVerificationError";
+  }
+}
+
+/** Verify a tap snapshot against an explicitly trusted tap key and identity. */
+export function verifyTapIndex(
+  index: SignedTapIndex,
+  expectedTap: string,
+  trustedKey: PublisherKey,
+  now = new Date(),
+): VerifiedTapIndex {
+  if (index.tap !== expectedTap) refuse("wrong-tap", `expected tap ${expectedTap}, received ${index.tap}`);
+  if (index.signature.keyId !== trustedKey.keyId) refuse("wrong-key", "tap signature key does not match the trusted key");
+  if (Date.parse(index.expiresAt) <= now.getTime()) refuse("expired", "tap index is expired");
+  const { signature, ...claim } = index;
+  verifySignature(canonicalBytes(claim), signature, trustedKey, "tap-signature");
+  return index as VerifiedTapIndex;
+}
+
+/** Verify one package against the exact signed index entry and publisher key. */
+export function verifySignedPackage(
+  envelope: SignedPackageEnvelope,
+  index: VerifiedTapIndex,
+  state: PublisherPinState,
+  currentVersion: string,
+): ProfileTemplatePackage {
+  if (state.tap !== index.tap || state.highestSequence < index.sequence) {
+    refuse("unaccepted-index", "package index has not been accepted into continuity state");
+  }
+  const entry = index.packages.find((candidate) => candidate.coordinate === envelope.coordinate);
+  if (!entry) refuse("unknown-coordinate", "package coordinate is absent from the verified index");
+  if (envelope.coordinate !== entry.coordinate) refuse("wrong-coordinate", "package coordinate differs from index entry");
+  const coordinate = parseTemplateCoordinate(envelope.coordinate);
+  if (coordinate.publisher !== entry.publisher) refuse("wrong-publisher", "coordinate publisher differs from index entry");
+  const publisherKey = index.publishers[entry.publisher];
+  if (!publisherKey) refuse("unknown-publisher", "verified index has no key for the package publisher");
+  assertEvidenceNotRevoked(state, entry.payloadDigest, publisherKey.keyId);
+  const computed = canonicalDigest(envelope.payload);
+  if (computed !== envelope.payloadDigest || computed !== entry.payloadDigest) refuse("wrong-digest", "package payload digest does not match signed metadata");
+  verifySignature(canonicalBytes(packageClaim(envelope.coordinate, computed)), envelope.publisherSignature, publisherKey, "publisher-signature");
+  const pkg = validateTemplatePackage(envelope.payload, { currentVersion, sourceType: "remote" });
+  if (pkg.templateId !== coordinate.templateId || pkg.version !== coordinate.version || pkg.publisher !== coordinate.publisher) {
+    refuse("wrong-identity", "package payload identity differs from its coordinate");
+  }
+  return pkg;
+}
+
+/** Require both predecessor and successor signatures on a rotation claim. */
+export function verifyPublisherRotation(
+  tap: string,
+  rotation: PublisherRotation,
+  currentKey: PublisherKey,
+): void {
+  if (rotation.fromKeyId !== currentKey.keyId) refuse("rotation-predecessor", "rotation predecessor does not match the pinned key");
+  if (rotation.toKey.keyId === currentKey.keyId) refuse("rotation-key-id", "rotation successor must use a new key id");
+  if (rotation.oldSignature.keyId !== currentKey.keyId) refuse("rotation-old-key", "old rotation signature uses the wrong key");
+  if (rotation.newSignature.keyId !== rotation.toKey.keyId) refuse("rotation-new-key", "new rotation signature uses the wrong key");
+  const claim = canonicalBytes(rotationClaim(tap, rotation));
+  verifySignature(claim, rotation.oldSignature, currentKey, "rotation-old-signature");
+  verifySignature(claim, rotation.newSignature, rotation.toKey, "rotation-new-signature");
+}
+
+/** Require predecessor and successor signatures before replacing a tap root. */
+export function verifyTapKeyRotation(
+  tap: string,
+  rotation: TapKeyRotation,
+  currentKey: PublisherKey,
+): PublisherKey {
+  if (rotation.fromKeyId !== currentKey.keyId) refuse("tap-rotation-predecessor", "tap rotation predecessor does not match the trusted key");
+  if (rotation.toKey.keyId === currentKey.keyId) refuse("tap-rotation-key-id", "tap rotation successor must use a new key id");
+  if (rotation.oldSignature.keyId !== currentKey.keyId) refuse("tap-rotation-old-key", "old tap rotation signature uses the wrong key");
+  if (rotation.newSignature.keyId !== rotation.toKey.keyId) refuse("tap-rotation-new-key", "new tap rotation signature uses the wrong key");
+  const claim = canonicalBytes(tapRotationClaim(tap, rotation));
+  verifySignature(claim, rotation.oldSignature, currentKey, "tap-rotation-old-signature");
+  verifySignature(claim, rotation.newSignature, rotation.toKey, "tap-rotation-new-signature");
+  return rotation.toKey;
+}
+
+function verifySignature(bytes: Buffer, signature: Ed25519Signature, key: PublisherKey, code: string): void {
+  if (signature.algorithm !== "ed25519") refuse("algorithm", "only Ed25519 signatures are supported");
+  if (signature.keyId !== key.keyId) refuse("wrong-key", "signature key id does not match its verification key");
+  try {
+    const publicKey = createPublicKey({ key: Buffer.from(key.publicKey, "base64"), format: "der", type: "spki" });
+    if (publicKey.asymmetricKeyType !== "ed25519") refuse("malformed-key", "verification key is not Ed25519");
+    const signatureBytes = Buffer.from(signature.value, "base64");
+    if (signatureBytes.length !== 64 || !verify(null, bytes, publicKey, signatureBytes)) refuse(code, "signature verification failed");
+  } catch (error) {
+    if (error instanceof TemplateVerificationError) throw error;
+    refuse("malformed-key", "Ed25519 public key is malformed");
+  }
+}
+
+function assertEvidenceNotRevoked(state: PublisherPinState, digest: string, publisherKeyId: string): void {
+  if (state.revokedPackages.includes(digest)) refuse("revoked-package", "package digest is revoked");
+  if (state.revokedPublisherKeys.includes(publisherKeyId)) refuse("revoked-publisher", "publisher key is revoked");
+}
+
+function refuse(code: string, message: string): never {
+  throw new TemplateVerificationError(code, message);
+}

--- a/src/profile/templates/signing/verify.ts
+++ b/src/profile/templates/signing/verify.ts
@@ -17,6 +17,7 @@ import type {
 } from "./types.js";
 
 declare const VERIFIED_TAP_INDEX: unique symbol;
+const MAX_INDEX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 /** Tap index whose signature, identity, and freshness were verified. */
 export type VerifiedTapIndex = ParsedTapIndex & { readonly [VERIFIED_TAP_INDEX]: true };
 
@@ -38,6 +39,9 @@ export function verifyTapIndex(
   if (index.tap !== expectedTap) refuse("wrong-tap", `expected tap ${expectedTap}, received ${index.tap}`);
   if (index.signature.keyId !== trustedKey.keyId) refuse("wrong-key", "tap signature key does not match the trusted key");
   if (Date.parse(index.expiresAt) <= now.getTime()) refuse("expired", "tap index is expired");
+  if (Date.parse(index.generatedAt) > now.getTime() + MAX_INDEX_CLOCK_SKEW_MS) {
+    refuse("not-yet-valid", "tap index generation time is too far in the future");
+  }
   const { signature, ...claim } = index;
   verifySignature(canonicalBytes(claim), signature, trustedKey, "tap-signature");
   return index as VerifiedTapIndex;

--- a/src/profile/templates/signing/verify.ts
+++ b/src/profile/templates/signing/verify.ts
@@ -7,20 +7,18 @@ import { createPublicKey, verify } from "node:crypto";
 import type { ProfileTemplatePackage } from "../types.js";
 import { validateTemplatePackage } from "../validate.js";
 import { canonicalBytes, canonicalDigest, packageClaim, rotationClaim, tapRotationClaim } from "./canonical.js";
-import { parseTemplateCoordinate } from "./protocol.js";
+import { parseTemplateCoordinate, type ParsedSignedPackage, type ParsedTapIndex } from "./protocol.js";
 import type {
   Ed25519Signature,
   PublisherKey,
   PublisherRotation,
   PublisherPinState,
-  SignedPackageEnvelope,
-  SignedTapIndex,
   TapKeyRotation,
 } from "./types.js";
 
 declare const VERIFIED_TAP_INDEX: unique symbol;
 /** Tap index whose signature, identity, and freshness were verified. */
-export type VerifiedTapIndex = SignedTapIndex & { readonly [VERIFIED_TAP_INDEX]: true };
+export type VerifiedTapIndex = ParsedTapIndex & { readonly [VERIFIED_TAP_INDEX]: true };
 
 /** Typed refusal preserving the failed provenance layer. */
 class TemplateVerificationError extends Error {
@@ -32,7 +30,7 @@ class TemplateVerificationError extends Error {
 
 /** Verify a tap snapshot against an explicitly trusted tap key and identity. */
 export function verifyTapIndex(
-  index: SignedTapIndex,
+  index: ParsedTapIndex,
   expectedTap: string,
   trustedKey: PublisherKey,
   now = new Date(),
@@ -47,7 +45,7 @@ export function verifyTapIndex(
 
 /** Verify one package against the exact signed index entry and publisher key. */
 export function verifySignedPackage(
-  envelope: SignedPackageEnvelope,
+  envelope: ParsedSignedPackage,
   index: VerifiedTapIndex,
   state: PublisherPinState,
   currentVersion: string,

--- a/src/profile/templates/status.ts
+++ b/src/profile/templates/status.ts
@@ -1,0 +1,90 @@
+/**
+ * @file src/profile/templates/status.ts
+ * @description Read-only template provenance and profile-drift status.
+ * Advisory lock fields locate a release; independently resolved release bytes
+ * determine whether the active profile matches what was installed.
+ */
+import { profileDigest } from "../digest.js";
+import { loadProfile } from "../load.js";
+import { getBuiltinTemplate } from "./registry.js";
+import { readTemplateLock, type TemplateLockRead } from "./lock.js";
+import type { ProfileTemplatePackage, TemplateLock } from "./types.js";
+
+export type TemplateStatusKind =
+  | "untracked"
+  | "installed-clean"
+  | "locally-modified"
+  | "provenance-malformed"
+  | "provenance-unavailable"
+  | "source-release-unavailable";
+
+/** Stable status envelope for CLI text/JSON and future update planning. */
+export interface TemplateStatus {
+  schemaVersion: 1;
+  status: TemplateStatusKind;
+  profileId: string;
+  activeProfileDigest: string;
+  templateId: string | null;
+  installedVersion: string | null;
+  expectedProfileDigest: string | null;
+  detail: string;
+}
+
+/** Collect status without allowing advisory provenance to affect profile load. */
+export async function collectTemplateStatus(root: string): Promise<TemplateStatus> {
+  const loaded = await loadProfile(root);
+  const lockRead = await readTemplateLock(root);
+  const base = baseStatus(loaded.profile.profileId, loaded.digest, lockRead);
+  if (base) return base;
+  const lock = (lockRead as Extract<TemplateLockRead, { kind: "ok" }>).lock;
+  const release = resolveTrustedRelease(lock);
+  if (!release) return unavailableRelease(loaded.profile.profileId, loaded.digest, lock);
+  return compareRelease(loaded.profile.profileId, loaded.digest, lock, release);
+}
+
+function baseStatus(profileId: string, digest: string, read: TemplateLockRead): TemplateStatus | null {
+  if (read.kind === "absent") return status("untracked", profileId, digest, null, null, null, "no advisory template lock is present");
+  if (read.kind === "malformed") return status("provenance-malformed", profileId, digest, null, null, null, read.detail);
+  if (read.kind === "unavailable") return status("provenance-unavailable", profileId, digest, null, null, null, read.detail);
+  return null;
+}
+
+function resolveTrustedRelease(lock: TemplateLock): ProfileTemplatePackage | null {
+  if (lock.sourceType !== "builtin") return null;
+  const pkg = getBuiltinTemplate(lock.templateId);
+  if (!pkg || pkg.version !== lock.version || pkg.publisher !== lock.publisher) return null;
+  return pkg;
+}
+
+function compareRelease(profileId: string, activeDigest: string, lock: TemplateLock, pkg: ProfileTemplatePackage): TemplateStatus {
+  const expected = profileDigest(pkg.profile);
+  const isClean = activeDigest === expected;
+  return status(
+    isClean ? "installed-clean" : "locally-modified",
+    profileId,
+    activeDigest,
+    lock.templateId,
+    lock.version,
+    expected,
+    isClean ? "active profile matches the verified builtin release" : "active profile differs from the verified installed release",
+  );
+}
+
+function unavailableRelease(profileId: string, digest: string, lock: TemplateLock): TemplateStatus {
+  return status(
+    "source-release-unavailable", profileId, digest, lock.templateId, lock.version, null,
+    `cannot independently resolve ${lock.sourceType} release ${lock.templateId}@${lock.version}`,
+  );
+}
+
+function status(
+  kind: TemplateStatusKind,
+  profileId: string,
+  activeProfileDigest: string,
+  templateId: string | null,
+  installedVersion: string | null,
+  expectedProfileDigest: string | null,
+  detail: string,
+): TemplateStatus {
+  return { schemaVersion: 1, status: kind, profileId, activeProfileDigest, templateId, installedVersion, expectedProfileDigest, detail };
+}

--- a/src/profile/templates/types.ts
+++ b/src/profile/templates/types.ts
@@ -7,8 +7,8 @@
  */
 import type { ProfilePack } from "../types.js";
 
-/** Template source classes supported by the v0 installer. */
-export type TemplateSourceType = "builtin" | "local";
+/** Template source classes understood by package validation and provenance. */
+export type TemplateSourceType = "builtin" | "local" | "remote";
 
 /** Example bundle metadata. v0 permits only non-executable OKF examples. */
 export interface TemplateExample {
@@ -34,8 +34,8 @@ export interface ProfileTemplatePackage {
   examples?: TemplateExample[];
 }
 
-/** Advisory provenance written after a template install; never used as load authority. */
-export interface TemplateLock {
+/** Legacy advisory provenance written by llmwiki 1.0. */
+export interface TemplateLockV1 {
   schemaVersion: 1;
   templateId: string;
   version: string;
@@ -44,6 +44,31 @@ export interface TemplateLock {
   installedAt: string;
   profileDigest: string;
 }
+
+/** Verified remote release locator recorded by future remote installs. */
+export interface RemoteTemplateProvenance {
+  coordinate: string;
+  packageDigest: string;
+  tap: string;
+  indexSequence: number;
+  publisherKeyId: string;
+  verifiedAt: string;
+}
+
+/** Current advisory provenance. Runtime profile loading never reads this file. */
+export interface TemplateLockV2 {
+  schemaVersion: 2;
+  templateId: string;
+  version: string;
+  publisher: string;
+  sourceType: TemplateSourceType;
+  installedAt: string;
+  profileDigest: string;
+  remote?: RemoteTemplateProvenance;
+}
+
+/** Every advisory lock schema accepted by the reader. */
+export type TemplateLock = TemplateLockV1 | TemplateLockV2;
 
 /** User-facing summary for builtin template list/inspect output. */
 export interface ProfileTemplateSummary {

--- a/src/profile/templates/update.ts
+++ b/src/profile/templates/update.ts
@@ -1,0 +1,150 @@
+/**
+ * @file src/profile/templates/update.ts
+ * @description Read-only compatibility planning for template profile updates.
+ * It never writes and treats every unverifiable profile-owned store as unsafe.
+ */
+import canonicalize from "canonicalize";
+import { CANDIDATES_ARCHIVE_DIR, CANDIDATES_DIR } from "../../utils/constants.js";
+import { listRuns, readRun } from "../../workflows/store.js";
+import { isTerminalStatus } from "../../workflows/with-lock.js";
+import { diffProfiles, type PageDisposition, type ProfileDiffReport } from "../diff.js";
+import { profileDigest } from "../digest.js";
+import { loadProfile } from "../load.js";
+import { lintProfileEntities } from "../lint.js";
+import type { ProfilePack } from "../types.js";
+import type { ProfileTemplatePackage } from "./types.js";
+import { confinedEntries, firstFileUnder } from "./corpus.js";
+import { readTemplateLock } from "./lock.js";
+import { getBuiltinTemplate } from "./registry.js";
+
+/** One structured refusal reason from the corpus-wide compatibility audit. */
+export interface TemplateUpdateReason {
+  kind: "drift" | "page" | "lint" | "candidate" | "workflow" | "artifact" | "store";
+  message: string;
+  path?: string;
+}
+
+/** Complete dry-run result; `compatible` implies no reasons and no writes. */
+export interface TemplateUpdatePlan {
+  schemaVersion: 1;
+  compatible: boolean;
+  from: string;
+  to: string;
+  oldProfileDigest: string;
+  newProfileDigest: string;
+  diff: ProfileDiffReport;
+  reasons: TemplateUpdateReason[];
+}
+
+/** Plan a builtin update using an independently resolved installed release. */
+export async function planBuiltinTemplateUpdate(root: string, requestedId?: string): Promise<TemplateUpdatePlan> {
+  const lockRead = await readTemplateLock(root);
+  if (lockRead.kind !== "ok") throw new Error(`cannot plan update: template provenance is ${lockRead.kind}`);
+  const lock = lockRead.lock;
+  if (lock.sourceType !== "builtin") throw new Error("R1 update dry-run supports builtin installs only");
+  const base = getBuiltinTemplate(lock.templateId);
+  if (!base || base.version !== lock.version || base.publisher !== lock.publisher) {
+    throw new Error(`cannot independently resolve installed builtin ${lock.templateId}@${lock.version}`);
+  }
+  const candidateId = requestedId ?? lock.templateId;
+  if (candidateId !== lock.templateId) throw new Error("template update cannot change template identity");
+  const candidate = getBuiltinTemplate(candidateId);
+  if (!candidate) throw new Error(`unknown builtin template: ${candidateId}`);
+  return planTemplateUpdate(root, (await loadProfile(root)).profile, base, candidate);
+}
+
+/** Plan an update from independently verified base and candidate packages. */
+export async function planTemplateUpdate(
+  root: string,
+  active: ProfilePack,
+  base: ProfileTemplatePackage,
+  candidate: ProfileTemplatePackage,
+): Promise<TemplateUpdatePlan> {
+  const reasons: TemplateUpdateReason[] = [];
+  const activeDigest = profileDigest(active);
+  const baseDigest = profileDigest(base.profile);
+  if (activeDigest !== baseDigest) reasons.push({ kind: "drift", message: "active profile has local modifications" });
+  const diff = await diffProfiles(root, active, candidate.profile);
+  reasons.push(...diffReasons(diff));
+  reasons.push(...await lintReasons(root, candidate.profile));
+  reasons.push(...await candidateReasons(root));
+  reasons.push(...await workflowReasons(root));
+  reasons.push(...await artifactReasons(root, active, candidate.profile));
+  return {
+    schemaVersion: 1,
+    compatible: reasons.length === 0,
+    from: `${base.templateId}@${base.version}`,
+    to: `${candidate.templateId}@${candidate.version}`,
+    oldProfileDigest: activeDigest,
+    newProfileDigest: profileDigest(candidate.profile),
+    diff,
+    reasons,
+  };
+}
+
+function diffReasons(diff: ProfileDiffReport): TemplateUpdateReason[] {
+  const reasons: TemplateUpdateReason[] = diff.problems.map((problem) => ({ kind: "store", message: problem.message, path: problem.directory }));
+  for (const page of diff.pages) {
+    if (isSafeDisposition(page)) continue;
+    reasons.push({ kind: "page", message: `page is ${page.disposition}`, path: `${page.directory}/${page.stem}.md` });
+  }
+  return reasons;
+}
+
+function isSafeDisposition(page: PageDisposition): boolean {
+  return page.disposition === "unchanged" || page.disposition === "newly-supported";
+}
+
+async function lintReasons(root: string, profile: ProfilePack): Promise<TemplateUpdateReason[]> {
+  try {
+    const findings = await lintProfileEntities(root, profile);
+    return findings
+      .filter((finding) => !isContentOnlyFinding(finding.rule))
+      .map((finding) => ({ kind: "lint", message: `${finding.rule}: ${finding.message}`, path: finding.file }));
+  } catch (error) {
+    return [{ kind: "store", message: `candidate-profile validation is unavailable: ${errorMessage(error)}` }];
+  }
+}
+
+function isContentOnlyFinding(rule: string): boolean {
+  return rule === "empty-page" || rule === "malformed-claim-citation";
+}
+
+async function candidateReasons(root: string): Promise<TemplateUpdateReason[]> {
+  const pending = await confinedEntries(root, CANDIDATES_DIR);
+  if (pending === "unavailable") return [{ kind: "store", message: "candidate store is unreadable or unsafe" }];
+  const archived = await confinedEntries(root, CANDIDATES_ARCHIVE_DIR);
+  if (archived === "unavailable") return [{ kind: "store", message: "candidate archive is unreadable or unsafe" }];
+  if (Array.isArray(pending) && pending.some(isJsonFile)) {
+    return [{ kind: "candidate", message: "pending review candidates must be resolved before update" }];
+  }
+  return [];
+}
+
+async function workflowReasons(root: string): Promise<TemplateUpdateReason[]> {
+  const listed = await listRuns(root);
+  if (listed.status === "unavailable") return [{ kind: "store", message: `workflow store is unavailable: ${listed.detail}` }];
+  const reasons: TemplateUpdateReason[] = [];
+  for (const runId of listed.runIds) {
+    const read = await readRun(root, runId);
+    if (read.status !== "ok") reasons.push({ kind: "store", message: `workflow run ${runId} is unavailable` });
+    else if (!isTerminalStatus(read.run.status)) reasons.push({ kind: "workflow", message: `workflow run ${runId} is active` });
+  }
+  return reasons;
+}
+
+async function artifactReasons(root: string, active: ProfilePack, candidate: ProfilePack): Promise<TemplateUpdateReason[]> {
+  if (canonicalize(active.artifacts ?? {}) === canonicalize(candidate.artifacts ?? {})) return [];
+  const state = await firstFileUnder(root, "artifacts");
+  if (state === "unavailable") return [{ kind: "store", message: "artifact store is unreadable or unsafe" }];
+  if (state === "present") return [{ kind: "artifact", message: "artifact contracts changed while stored artifacts exist" }];
+  return [];
+}
+
+function isJsonFile(name: string): boolean {
+  return name.endsWith(".json");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/profile/templates/update.ts
+++ b/src/profile/templates/update.ts
@@ -4,9 +4,7 @@
  * It never writes and treats every unverifiable profile-owned store as unsafe.
  */
 import canonicalize from "canonicalize";
-import { CANDIDATES_ARCHIVE_DIR, CANDIDATES_DIR } from "../../utils/constants.js";
-import { listRuns, readRun } from "../../workflows/store.js";
-import { isTerminalStatus } from "../../workflows/with-lock.js";
+import { CANDIDATES_DIR } from "../../utils/constants.js";
 import { diffProfiles, type PageDisposition, type ProfileDiffReport } from "../diff.js";
 import { profileDigest } from "../digest.js";
 import { loadProfile } from "../load.js";
@@ -14,8 +12,10 @@ import { lintProfileEntities } from "../lint.js";
 import type { ProfilePack } from "../types.js";
 import type { ProfileTemplatePackage } from "./types.js";
 import { confinedEntries, firstFileUnder } from "./corpus.js";
+import { auditArtifactStore } from "./artifact-audit.js";
+import { auditCandidateArchive, auditWorkflowHistory } from "./history-audit.js";
 import { readTemplateLock } from "./lock.js";
-import { getBuiltinTemplate } from "./registry.js";
+import { getBuiltinTemplate, getBuiltinTemplateRelease } from "./registry.js";
 
 /** One structured refusal reason from the corpus-wide compatibility audit. */
 export interface TemplateUpdateReason {
@@ -24,9 +24,13 @@ export interface TemplateUpdateReason {
   path?: string;
 }
 
-/** Complete dry-run result; `compatible` implies no reasons and no writes. */
+/**
+ * Complete advisory dry-run result. `compatible` describes this read snapshot;
+ * it cannot authorize a later write because project state may change afterward.
+ */
 export interface TemplateUpdatePlan {
   schemaVersion: 1;
+  authority: "advisory";
   compatible: boolean;
   from: string;
   to: string;
@@ -42,8 +46,8 @@ export async function planBuiltinTemplateUpdate(root: string, requestedId?: stri
   if (lockRead.kind !== "ok") throw new Error(`cannot plan update: template provenance is ${lockRead.kind}`);
   const lock = lockRead.lock;
   if (lock.sourceType !== "builtin") throw new Error("R1 update dry-run supports builtin installs only");
-  const base = getBuiltinTemplate(lock.templateId);
-  if (!base || base.version !== lock.version || base.publisher !== lock.publisher) {
+  const base = getBuiltinTemplateRelease(lock.templateId, lock.version, lock.publisher);
+  if (!base) {
     throw new Error(`cannot independently resolve installed builtin ${lock.templateId}@${lock.version}`);
   }
   const candidateId = requestedId ?? lock.templateId;
@@ -60,6 +64,7 @@ export async function planTemplateUpdate(
   base: ProfileTemplatePackage,
   candidate: ProfileTemplatePackage,
 ): Promise<TemplateUpdatePlan> {
+  assertUpdateIdentity(active, base, candidate);
   const reasons: TemplateUpdateReason[] = [];
   const activeDigest = profileDigest(active);
   const baseDigest = profileDigest(base.profile);
@@ -72,6 +77,7 @@ export async function planTemplateUpdate(
   reasons.push(...await artifactReasons(root, active, candidate.profile));
   return {
     schemaVersion: 1,
+    authority: "advisory",
     compatible: reasons.length === 0,
     from: `${base.templateId}@${base.version}`,
     to: `${candidate.templateId}@${candidate.version}`,
@@ -80,6 +86,19 @@ export async function planTemplateUpdate(
     diff,
     reasons,
   };
+}
+
+function assertUpdateIdentity(
+  active: ProfilePack,
+  base: ProfileTemplatePackage,
+  candidate: ProfileTemplatePackage,
+): void {
+  if (base.templateId !== candidate.templateId) throw new Error("template update cannot change template identity");
+  if (base.publisher !== candidate.publisher) throw new Error("template update cannot change publisher identity");
+  if (base.sourceType !== candidate.sourceType) throw new Error("template update cannot change source identity");
+  if (active.profileId !== base.profile.profileId || candidate.profile.profileId !== base.profile.profileId) {
+    throw new Error("template update cannot change profile identity");
+  }
 }
 
 function diffReasons(diff: ProfileDiffReport): TemplateUpdateReason[] {
@@ -113,32 +132,23 @@ function isContentOnlyFinding(rule: string): boolean {
 async function candidateReasons(root: string): Promise<TemplateUpdateReason[]> {
   const pending = await confinedEntries(root, CANDIDATES_DIR);
   if (pending === "unavailable") return [{ kind: "store", message: "candidate store is unreadable or unsafe" }];
-  const archived = await confinedEntries(root, CANDIDATES_ARCHIVE_DIR);
-  if (archived === "unavailable") return [{ kind: "store", message: "candidate archive is unreadable or unsafe" }];
   if (Array.isArray(pending) && pending.some(isJsonFile)) {
     return [{ kind: "candidate", message: "pending review candidates must be resolved before update" }];
   }
-  return [];
+  return (await auditCandidateArchive(root)).map((message) => ({ kind: "store", message }));
 }
 
 async function workflowReasons(root: string): Promise<TemplateUpdateReason[]> {
-  const listed = await listRuns(root);
-  if (listed.status === "unavailable") return [{ kind: "store", message: `workflow store is unavailable: ${listed.detail}` }];
-  const reasons: TemplateUpdateReason[] = [];
-  for (const runId of listed.runIds) {
-    const read = await readRun(root, runId);
-    if (read.status !== "ok") reasons.push({ kind: "store", message: `workflow run ${runId} is unavailable` });
-    else if (!isTerminalStatus(read.run.status)) reasons.push({ kind: "workflow", message: `workflow run ${runId} is active` });
-  }
-  return reasons;
+  return auditWorkflowHistory(root);
 }
 
 async function artifactReasons(root: string, active: ProfilePack, candidate: ProfilePack): Promise<TemplateUpdateReason[]> {
-  if (canonicalize(active.artifacts ?? {}) === canonicalize(candidate.artifacts ?? {})) return [];
+  const audit = (await auditArtifactStore(root, candidate)).map((message) => ({ kind: "artifact" as const, message }));
+  if (canonicalize(active.artifacts ?? {}) === canonicalize(candidate.artifacts ?? {})) return audit;
   const state = await firstFileUnder(root, "artifacts");
-  if (state === "unavailable") return [{ kind: "store", message: "artifact store is unreadable or unsafe" }];
-  if (state === "present") return [{ kind: "artifact", message: "artifact contracts changed while stored artifacts exist" }];
-  return [];
+  if (state === "unavailable") return [...audit, { kind: "store", message: "artifact store is unreadable or unsafe" }];
+  if (state === "present") return [...audit, { kind: "artifact", message: "artifact contracts changed while stored artifacts exist" }];
+  return audit;
 }
 
 function isJsonFile(name: string): boolean {

--- a/test/fixtures/template-registry/README.md
+++ b/test/fixtures/template-registry/README.md
@@ -1,0 +1,19 @@
+# Template registry protocol fixture
+
+These public-only files are the interoperability contract for a future template
+registry service:
+
+- `package.json` is an immutable publisher-signed template envelope.
+- `index.json` is a tap-signed snapshot that binds the coordinate to the package
+  digest and publisher key.
+- `trust.json` contains the public keys required to verify the fixture.
+
+`test/profile-template-signing-fixture.test.ts` is the expected verdict: the
+index and package must verify offline and the payload must pass the ordinary
+remote-source template validator. Reordering JSON object keys must not affect
+verification because signatures cover RFC 8785 canonical bytes. Changing any
+payload, coordinate, digest, signer, or snapshot claim must fail.
+
+No private key, URL, credential, entitlement, or runtime authority is part of
+this fixture. A registry implementation can generate equivalent records in a
+separate repository and use this verifier as its compatibility oracle.

--- a/test/fixtures/template-registry/index.json
+++ b/test/fixtures/template-registry/index.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "tap": "official",
+  "sequence": 1,
+  "generatedAt": "2026-07-12T00:00:00Z",
+  "expiresAt": "2027-07-12T00:00:00Z",
+  "publishers": {
+    "atomicstrata": {
+      "keyId": "publisher-key-1",
+      "publicKey": "MCowBQYDK2VwAyEALxhYHe2T84VftJ/HrDCirlutF6xJg/EoZYCrQYBq+q8="
+    }
+  },
+  "packages": [
+    {
+      "coordinate": "official/atomicstrata/team@1.0.0",
+      "publisher": "atomicstrata",
+      "payloadDigest": "sha256:4a39b4041e21c92f6a0351624ddfe27ec7bcc924659014909c92418bb06f3416"
+    }
+  ],
+  "rotations": [],
+  "revocations": [],
+  "signature": {
+    "keyId": "tap-key-1",
+    "algorithm": "ed25519",
+    "value": "NQvlmLBDgJFmQtnZHYaVkCRzsjhVFedR4dIIx+c+oHq1mD7iTImIBsZ5t8VUXwv4pB7lE6tLJvU6cC3KA/ivCw=="
+  }
+}

--- a/test/fixtures/template-registry/package.json
+++ b/test/fixtures/template-registry/package.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "coordinate": "official/atomicstrata/team@1.0.0",
+  "payload": {
+    "schemaVersion": 1,
+    "templateId": "team",
+    "version": "1.0.0",
+    "displayName": "Team",
+    "publisher": "atomicstrata",
+    "sourceType": "remote",
+    "license": "MIT",
+    "minLlmwikiVersion": "1.0.0",
+    "profile": {
+      "schemaVersion": 1,
+      "profileId": "team",
+      "displayName": "Team",
+      "entities": {
+        "items": { "directory": "wiki/items" }
+      }
+    }
+  },
+  "payloadDigest": "sha256:4a39b4041e21c92f6a0351624ddfe27ec7bcc924659014909c92418bb06f3416",
+  "publisherSignature": {
+    "keyId": "publisher-key-1",
+    "algorithm": "ed25519",
+    "value": "YdYYJ7DSuTciaeXZChL80f6JwBnBG6UiOyol7SYnISDkroaeUPRSStqIAZpahZow5qljAYQ2/jDbDTQ6VRSrDw=="
+  }
+}

--- a/test/fixtures/template-registry/trust.json
+++ b/test/fixtures/template-registry/trust.json
@@ -1,0 +1,10 @@
+{
+  "tap": {
+    "keyId": "tap-key-1",
+    "publicKey": "MCowBQYDK2VwAyEA+Zh7GM2+2PTzR+DGzIIMyf9RW3z8iPX+y0ToR7vFF7Q="
+  },
+  "publisher": {
+    "keyId": "publisher-key-1",
+    "publicKey": "MCowBQYDK2VwAyEALxhYHe2T84VftJ/HrDCirlutF6xJg/EoZYCrQYBq+q8="
+  }
+}

--- a/test/fixtures/template-signing.ts
+++ b/test/fixtures/template-signing.ts
@@ -5,6 +5,12 @@
  */
 import { createPrivateKey, sign } from "node:crypto";
 import { canonicalBytes, canonicalDigest, packageClaim, rotationClaim, tapRotationClaim } from "../../src/profile/templates/signing/canonical.js";
+import {
+  parseSignedPackage,
+  parseSignedTapIndex,
+  type ParsedSignedPackage,
+  type ParsedTapIndex,
+} from "../../src/profile/templates/signing/protocol.js";
 import type {
   Ed25519Signature,
   PublisherKey,
@@ -33,6 +39,7 @@ export const PUBLISHER_KEY_2: PublisherKey = {
   keyId: "publisher-key-2",
   publicKey: "MCowBQYDK2VwAyEA1x7Pt3kbQIlLnFgNnx382iiEsA4v/h1YqKWzzIkYYuU=",
 };
+export const PUBLISHER_KEY_3: PublisherKey = { ...TAP_KEY, keyId: "publisher-key-3" };
 export const TAP_KEY_2: PublisherKey = { ...PUBLISHER_KEY_2, keyId: "tap-key-2" };
 
 export const COORDINATE = "official/atomicstrata/team@1.0.0";
@@ -62,6 +69,10 @@ export function signedPackage(payload = remotePackage()): SignedPackageEnvelope 
   };
 }
 
+export function parsedPackage(payload = remotePackage()): ParsedSignedPackage {
+  return parseSignedPackage(JSON.stringify(signedPackage(payload)));
+}
+
 export function signedIndex(overrides: Partial<SignedTapIndex> = {}): SignedTapIndex {
   const envelope = signedPackage();
   const unsigned: Omit<SignedTapIndex, "signature"> = {
@@ -79,6 +90,10 @@ export function signedIndex(overrides: Partial<SignedTapIndex> = {}): SignedTapI
   return { ...unsigned, signature: signClaim(unsigned, "tap", TAP_KEY.keyId) };
 }
 
+export function parsedIndex(overrides: Partial<SignedTapIndex> = {}): ParsedTapIndex {
+  return parseSignedTapIndex(JSON.stringify(signedIndex(overrides)));
+}
+
 export function signedRotation(sequence = 2): PublisherRotation {
   const base = {
     publisher: "atomicstrata",
@@ -91,6 +106,21 @@ export function signedRotation(sequence = 2): PublisherRotation {
     ...base,
     oldSignature: signClaim(claim, "publisher", PUBLISHER_KEY.keyId),
     newSignature: signClaim(claim, "publisher2", PUBLISHER_KEY_2.keyId),
+  };
+}
+
+export function signedSecondRotation(sequence = 3): PublisherRotation {
+  const base = {
+    publisher: "atomicstrata",
+    fromKeyId: PUBLISHER_KEY_2.keyId,
+    toKey: PUBLISHER_KEY_3,
+    effectiveSequence: sequence,
+  };
+  const claim = rotationClaim("official", base);
+  return {
+    ...base,
+    oldSignature: signClaim(claim, "publisher2", PUBLISHER_KEY_2.keyId),
+    newSignature: signClaim(claim, "tap", PUBLISHER_KEY_3.keyId),
   };
 }
 

--- a/test/fixtures/template-signing.ts
+++ b/test/fixtures/template-signing.ts
@@ -124,6 +124,21 @@ export function signedSecondRotation(sequence = 3): PublisherRotation {
   };
 }
 
+export function signedReturnRotation(sequence = 3): PublisherRotation {
+  const base = {
+    publisher: "atomicstrata",
+    fromKeyId: PUBLISHER_KEY_2.keyId,
+    toKey: PUBLISHER_KEY,
+    effectiveSequence: sequence,
+  };
+  const claim = rotationClaim("official", base);
+  return {
+    ...base,
+    oldSignature: signClaim(claim, "publisher2", PUBLISHER_KEY_2.keyId),
+    newSignature: signClaim(claim, "publisher", PUBLISHER_KEY.keyId),
+  };
+}
+
 export function signedTapRotation(sequence = 2): TapKeyRotation {
   const base = { fromKeyId: TAP_KEY.keyId, toKey: TAP_KEY_2, effectiveSequence: sequence };
   const claim = tapRotationClaim("official", base);

--- a/test/fixtures/template-signing.ts
+++ b/test/fixtures/template-signing.ts
@@ -1,0 +1,115 @@
+/**
+ * @file test/fixtures/template-signing.ts
+ * @description Deterministic Ed25519 keys and signed protocol records used only
+ * by offline template-signing tests.
+ */
+import { createPrivateKey, sign } from "node:crypto";
+import { canonicalBytes, canonicalDigest, packageClaim, rotationClaim, tapRotationClaim } from "../../src/profile/templates/signing/canonical.js";
+import type {
+  Ed25519Signature,
+  PublisherKey,
+  PublisherRotation,
+  SignedPackageEnvelope,
+  SignedTapIndex,
+  TapKeyRotation,
+} from "../../src/profile/templates/signing/types.js";
+import type { ProfileTemplatePackage } from "../../src/profile/templates/types.js";
+
+const PRIVATE_KEYS = {
+  tap: "MC4CAQAwBQYDK2VwBCIEIJze3m6WcKjBrVlTaqQkGbCbMSkdw3vTKRdmdaEpgJ30",
+  publisher: "MC4CAQAwBQYDK2VwBCIEIDO22AsRnfvQCs+w7bG+PYxSidQvcFRM0yw9f8ckqhV1",
+  publisher2: "MC4CAQAwBQYDK2VwBCIEILg07GXy1Qttpfks9JixoMEAct1mBKqusrVtTbdz9+RT",
+} as const;
+
+export const TAP_KEY: PublisherKey = {
+  keyId: "tap-key-1",
+  publicKey: "MCowBQYDK2VwAyEA+Zh7GM2+2PTzR+DGzIIMyf9RW3z8iPX+y0ToR7vFF7Q=",
+};
+export const PUBLISHER_KEY: PublisherKey = {
+  keyId: "publisher-key-1",
+  publicKey: "MCowBQYDK2VwAyEALxhYHe2T84VftJ/HrDCirlutF6xJg/EoZYCrQYBq+q8=",
+};
+export const PUBLISHER_KEY_2: PublisherKey = {
+  keyId: "publisher-key-2",
+  publicKey: "MCowBQYDK2VwAyEA1x7Pt3kbQIlLnFgNnx382iiEsA4v/h1YqKWzzIkYYuU=",
+};
+export const TAP_KEY_2: PublisherKey = { ...PUBLISHER_KEY_2, keyId: "tap-key-2" };
+
+export const COORDINATE = "official/atomicstrata/team@1.0.0";
+
+export function remotePackage(): ProfileTemplatePackage {
+  return {
+    schemaVersion: 1,
+    templateId: "team",
+    version: "1.0.0",
+    displayName: "Team",
+    publisher: "atomicstrata",
+    sourceType: "remote",
+    license: "MIT",
+    minLlmwikiVersion: "1.0.0",
+    profile: { schemaVersion: 1, profileId: "team", displayName: "Team", entities: { items: { directory: "wiki/items" } } },
+  };
+}
+
+export function signedPackage(payload = remotePackage()): SignedPackageEnvelope {
+  const payloadDigest = canonicalDigest(payload);
+  return {
+    schemaVersion: 1,
+    coordinate: COORDINATE,
+    payload,
+    payloadDigest,
+    publisherSignature: signClaim(packageClaim(COORDINATE, payloadDigest), "publisher", PUBLISHER_KEY.keyId),
+  };
+}
+
+export function signedIndex(overrides: Partial<SignedTapIndex> = {}): SignedTapIndex {
+  const envelope = signedPackage();
+  const unsigned: Omit<SignedTapIndex, "signature"> = {
+    schemaVersion: 1,
+    tap: "official",
+    sequence: 1,
+    generatedAt: "2026-07-12T00:00:00Z",
+    expiresAt: "2027-07-12T00:00:00Z",
+    publishers: { atomicstrata: PUBLISHER_KEY },
+    packages: [{ coordinate: COORDINATE, publisher: "atomicstrata", payloadDigest: envelope.payloadDigest }],
+    rotations: [],
+    revocations: [],
+    ...withoutSignature(overrides),
+  };
+  return { ...unsigned, signature: signClaim(unsigned, "tap", TAP_KEY.keyId) };
+}
+
+export function signedRotation(sequence = 2): PublisherRotation {
+  const base = {
+    publisher: "atomicstrata",
+    fromKeyId: PUBLISHER_KEY.keyId,
+    toKey: PUBLISHER_KEY_2,
+    effectiveSequence: sequence,
+  };
+  const claim = rotationClaim("official", base);
+  return {
+    ...base,
+    oldSignature: signClaim(claim, "publisher", PUBLISHER_KEY.keyId),
+    newSignature: signClaim(claim, "publisher2", PUBLISHER_KEY_2.keyId),
+  };
+}
+
+export function signedTapRotation(sequence = 2): TapKeyRotation {
+  const base = { fromKeyId: TAP_KEY.keyId, toKey: TAP_KEY_2, effectiveSequence: sequence };
+  const claim = tapRotationClaim("official", base);
+  return {
+    ...base,
+    oldSignature: signClaim(claim, "tap", TAP_KEY.keyId),
+    newSignature: signClaim(claim, "publisher2", TAP_KEY_2.keyId),
+  };
+}
+
+function signClaim(value: unknown, key: keyof typeof PRIVATE_KEYS, keyId: string): Ed25519Signature {
+  const privateKey = createPrivateKey({ key: Buffer.from(PRIVATE_KEYS[key], "base64"), format: "der", type: "pkcs8" });
+  return { keyId, algorithm: "ed25519", value: sign(null, canonicalBytes(value), privateKey).toString("base64") };
+}
+
+function withoutSignature(overrides: Partial<SignedTapIndex>): Partial<Omit<SignedTapIndex, "signature">> {
+  const { signature: _signature, ...rest } = overrides;
+  return rest;
+}

--- a/test/profile-template-cli.test.ts
+++ b/test/profile-template-cli.test.ts
@@ -115,4 +115,27 @@ describe("template CLI", () => {
       expect(run(root, ["template", "init", "autosci", "--file", "x.json"]).status).toBe(1);
     });
   });
+
+  it("reports verified builtin status and previews an update without writes", async () => {
+    await withRoot(async (root) => {
+      expect(run(root, ["template", "init", "autosci"]).status).toBe(0);
+      const before = await readFile(path.join(root, ".llmwiki/profile.json"), "utf8");
+      const status = run(root, ["template", "status", "--json"]);
+      const update = run(root, ["template", "update", "--dry-run", "--json"]);
+      expect(status.status).toBe(0);
+      expect(JSON.parse(status.stdout)).toMatchObject({ status: "installed-clean", templateId: "autosci" });
+      expect(update.status).toBe(0);
+      expect(JSON.parse(update.stdout)).toMatchObject({ compatible: true, reasons: [] });
+      expect(await readFile(path.join(root, ".llmwiki/profile.json"), "utf8")).toBe(before);
+    });
+  });
+
+  it("refuses an update command that omits the dry-run gate", async () => {
+    await withRoot(async (root) => {
+      expect(run(root, ["template", "init", "autosci"]).status).toBe(0);
+      const result = run(root, ["template", "update"]);
+      expect(result.status).toBe(1);
+      expect(result.stdout + result.stderr).toContain("pass --dry-run");
+    });
+  });
 });

--- a/test/profile-template-cli.test.ts
+++ b/test/profile-template-cli.test.ts
@@ -125,7 +125,7 @@ describe("template CLI", () => {
       expect(status.status).toBe(0);
       expect(JSON.parse(status.stdout)).toMatchObject({ status: "installed-clean", templateId: "autosci" });
       expect(update.status).toBe(0);
-      expect(JSON.parse(update.stdout)).toMatchObject({ compatible: true, reasons: [] });
+      expect(JSON.parse(update.stdout)).toMatchObject({ authority: "advisory", compatible: true, reasons: [] });
       expect(await readFile(path.join(root, ".llmwiki/profile.json"), "utf8")).toBe(before);
     });
   });

--- a/test/profile-template-install.test.ts
+++ b/test/profile-template-install.test.ts
@@ -35,7 +35,7 @@ describe("installBuiltinTemplate", () => {
     const loaded = await loadProfile(root);
     expect(loaded.profile.profileId).toBe("autosci");
     expect(await readJson(root, LOCK_FILE)).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       templateId: "autosci",
       version: "0.1.0",
       publisher: "atomicstrata",

--- a/test/profile-template-lock-read.test.ts
+++ b/test/profile-template-lock-read.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @file test/profile-template-lock-read.test.ts
+ * @description Exercises strict v1/v2 advisory-lock parsing and confined reads.
+ */
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_TEMPLATE_LOCK_BYTES,
+  parseTemplateLock,
+  readTemplateLock,
+  TEMPLATE_LOCK_FILE,
+} from "../src/profile/templates/lock.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+
+const BASE = {
+  templateId: "team",
+  version: "1.2.3",
+  publisher: "example",
+  sourceType: "local",
+  installedAt: "2026-07-12T00:00:00.000Z",
+  profileDigest: "a".repeat(64),
+};
+
+describe("parseTemplateLock", () => {
+  it("accepts legacy v1 and current v2 locks", () => {
+    expect(parseTemplateLock({ schemaVersion: 1, ...BASE })).toMatchObject({ kind: "ok", lock: { schemaVersion: 1 } });
+    expect(parseTemplateLock({ schemaVersion: 2, ...BASE })).toMatchObject({ kind: "ok", lock: { schemaVersion: 2 } });
+  });
+
+  it("accepts complete remote v2 provenance", () => {
+    const remote = {
+      coordinate: "official/example/team@1.2.3",
+      packageDigest: `sha256:${"b".repeat(64)}`,
+      tap: "official",
+      indexSequence: 4,
+      publisherKeyId: "ed25519:example",
+      verifiedAt: "2026-07-12T00:00:00.000Z",
+    };
+    const result = parseTemplateLock({ schemaVersion: 2, ...BASE, sourceType: "remote", remote });
+    expect(result).toMatchObject({ kind: "ok", lock: { sourceType: "remote", remote } });
+  });
+
+  it("rejects authority-looking extras and incomplete remote provenance", () => {
+    expect(parseTemplateLock({ schemaVersion: 2, ...BASE, trusted: true })).toMatchObject({ kind: "malformed" });
+    expect(parseTemplateLock({ schemaVersion: 2, ...BASE, sourceType: "remote" })).toMatchObject({ kind: "malformed" });
+    expect(parseTemplateLock({ schemaVersion: 2, ...BASE, remote: {} })).toMatchObject({ kind: "malformed" });
+  });
+});
+
+describe("readTemplateLock", () => {
+  it("distinguishes absent, malformed, and valid locks", async () => {
+    const root = await makeTempRoot("template-lock-read");
+    expect(await readTemplateLock(root)).toEqual({ kind: "absent" });
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(root, TEMPLATE_LOCK_FILE), "{broken", "utf8");
+    expect(await readTemplateLock(root)).toMatchObject({ kind: "malformed" });
+    await writeFile(path.join(root, TEMPLATE_LOCK_FILE), JSON.stringify({ schemaVersion: 2, ...BASE }), "utf8");
+    expect(await readTemplateLock(root)).toMatchObject({ kind: "ok", lock: { templateId: "team" } });
+  });
+
+  it("fails closed on symlinked and oversized lock leaves", async () => {
+    const root = await makeTempRoot("template-lock-unsafe");
+    const outside = await makeTempRoot("template-lock-outside");
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    const leaf = path.join(root, TEMPLATE_LOCK_FILE);
+    await writeFile(path.join(outside, "lock.json"), JSON.stringify({ schemaVersion: 2, ...BASE }), "utf8");
+    await symlink(path.join(outside, "lock.json"), leaf);
+    expect(await readTemplateLock(root)).toMatchObject({ kind: "unavailable" });
+  });
+
+  it("refuses an oversized regular lock without parsing it", async () => {
+    const root = await makeTempRoot("template-lock-oversize");
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(root, TEMPLATE_LOCK_FILE), "x".repeat(MAX_TEMPLATE_LOCK_BYTES + 1), "utf8");
+    expect(await readTemplateLock(root)).toMatchObject({ kind: "unavailable" });
+  });
+});

--- a/test/profile-template-registry.test.ts
+++ b/test/profile-template-registry.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { getConnectorDef } from "../src/connectors/registry.js";
 import type { ProfilePack } from "../src/profile/types.js";
 import { deriveTemplateCapabilities } from "../src/profile/templates/capabilities.js";
-import { getBuiltinTemplate, listBuiltinTemplates, summaryFor } from "../src/profile/templates/registry.js";
+import { compareTemplateVersions, getBuiltinTemplate, listBuiltinTemplates, summaryFor } from "../src/profile/templates/registry.js";
 import { TemplatePackageError, validateTemplatePackage } from "../src/profile/templates/validate.js";
 
 const MINIMAL_PROFILE: ProfilePack = {
@@ -156,6 +156,13 @@ describe("deriveTemplateCapabilities", () => {
 });
 
 describe("builtin template registry", () => {
+  it("orders stable and prerelease versions by SemVer precedence", () => {
+    expect(compareTemplateVersions("1.0.0", "1.0.0-rc.10")).toBeGreaterThan(0);
+    expect(compareTemplateVersions("1.0.0-rc.10", "1.0.0-rc.2")).toBeGreaterThan(0);
+    expect(compareTemplateVersions("1.0.0-1", "1.0.0-alpha")).toBeLessThan(0);
+    expect(compareTemplateVersions("1.0.0+build.2", "1.0.0+build.1")).toBe(0);
+  });
+
   it("keeps template installability policy on connector definitions", () => {
     expect(getConnectorDef("crossref")).toMatchObject({ templateInstallable: true });
     expect(getConnectorDef("fixture")).toMatchObject({ templateInstallable: false });

--- a/test/profile-template-signing-continuity.test.ts
+++ b/test/profile-template-signing-continuity.test.ts
@@ -5,8 +5,8 @@
 import { describe, expect, it } from "vitest";
 import { advancePublisherPins, assertPackageNotRevoked, emptyPublisherPinState } from "../src/profile/templates/signing/continuity.js";
 import { verifyTapIndex } from "../src/profile/templates/signing/verify.js";
-import type { SignedTapIndex } from "../src/profile/templates/signing/types.js";
-import { PUBLISHER_KEY_2, TAP_KEY, signedIndex, signedRotation } from "./fixtures/template-signing.js";
+import type { ParsedTapIndex } from "../src/profile/templates/signing/protocol.js";
+import { PUBLISHER_KEY_2, PUBLISHER_KEY_3, TAP_KEY, parsedIndex, signedIndex, signedRotation, signedSecondRotation } from "./fixtures/template-signing.js";
 
 describe("publisher continuity", () => {
   it("pins a first-seen publisher and coordinate", () => {
@@ -18,19 +18,19 @@ describe("publisher continuity", () => {
   it("refuses sequence replay and immutable-coordinate remapping", () => {
     const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
     expect(() => advancePublisherPins(verified(), state)).toThrow(/rollback or replay/);
-    const remapped = signedIndex({ sequence: 2, packages: [{ ...signedIndex().packages[0], payloadDigest: `sha256:${"a".repeat(64)}` }] });
+    const remapped = parsedIndex({ sequence: 2, packages: [{ ...signedIndex().packages[0], payloadDigest: `sha256:${"a".repeat(64)}` }] });
     expect(() => advancePublisherPins(verified(remapped), state)).toThrow(/coordinate remapped/);
   });
 
   it("refuses bare publisher replacement", () => {
     const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
-    const replacement = signedIndex({ sequence: 2, publishers: { atomicstrata: PUBLISHER_KEY_2 } });
+    const replacement = parsedIndex({ sequence: 2, publishers: { atomicstrata: PUBLISHER_KEY_2 } });
     expect(() => advancePublisherPins(verified(replacement), state)).toThrow(/without a valid rotation/);
   });
 
   it("accepts a dual-signed publisher rotation", () => {
     const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
-    const rotated = signedIndex({
+    const rotated = parsedIndex({
       sequence: 2,
       publishers: { atomicstrata: PUBLISHER_KEY_2 },
       rotations: [signedRotation(2)],
@@ -38,9 +38,37 @@ describe("publisher continuity", () => {
     expect(advancePublisherPins(verified(rotated), state).publishers.atomicstrata).toEqual(PUBLISHER_KEY_2);
   });
 
+  it("accepts rotation history after skipped snapshots", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    const current = parsedIndex({
+      sequence: 4,
+      publishers: { atomicstrata: PUBLISHER_KEY_3 },
+      rotations: [signedRotation(2), signedSecondRotation(3)],
+    });
+    expect(advancePublisherPins(verified(current), state).publishers.atomicstrata).toEqual(PUBLISHER_KEY_3);
+  });
+
+  it("refuses incomplete or ambiguous rotation history", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    const incomplete = parsedIndex({ sequence: 4, publishers: { atomicstrata: PUBLISHER_KEY_3 }, rotations: [signedSecondRotation(3)] });
+    expect(() => advancePublisherPins(verified(incomplete), state)).toThrow(/valid rotation chain/);
+    const ambiguous = parsedIndex({ sequence: 4, publishers: { atomicstrata: PUBLISHER_KEY_2 }, rotations: [signedRotation(2), signedRotation(3)] });
+    expect(() => advancePublisherPins(verified(ambiguous), state)).toThrow(/ambiguous/);
+  });
+
+  it("refuses a rotation history whose effective sequence goes backward", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    const reversed = parsedIndex({
+      sequence: 4,
+      publishers: { atomicstrata: PUBLISHER_KEY_3 },
+      rotations: [signedRotation(3), signedSecondRotation(2)],
+    });
+    expect(() => advancePublisherPins(verified(reversed), state)).toThrow(/sequence is not increasing/);
+  });
+
   it("accumulates revocations and refuses revoked evidence", () => {
     const digest = signedIndex().packages[0].payloadDigest;
-    const index = signedIndex({ revocations: [{ kind: "package", value: digest, reason: "compromised", revokedAt: "2026-07-12T01:00:00Z" }] });
+    const index = parsedIndex({ revocations: [{ kind: "package", value: digest, reason: "compromised", revokedAt: "2026-07-12T01:00:00Z" }] });
     const state = advancePublisherPins(verified(index), emptyPublisherPinState("official"));
     expect(() => assertPackageNotRevoked(state, digest, "publisher-key-1")).toThrow(/package digest is revoked/);
   });
@@ -50,6 +78,6 @@ describe("publisher continuity", () => {
   });
 });
 
-function verified(index: SignedTapIndex = signedIndex()) {
+function verified(index: ParsedTapIndex = parsedIndex()) {
   return verifyTapIndex(index, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
 }

--- a/test/profile-template-signing-continuity.test.ts
+++ b/test/profile-template-signing-continuity.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @file test/profile-template-signing-continuity.test.ts
+ * @description Publisher pin, rotation, revocation, rollback, and immutable-coordinate tests.
+ */
+import { describe, expect, it } from "vitest";
+import { advancePublisherPins, assertPackageNotRevoked, emptyPublisherPinState } from "../src/profile/templates/signing/continuity.js";
+import { verifyTapIndex } from "../src/profile/templates/signing/verify.js";
+import type { SignedTapIndex } from "../src/profile/templates/signing/types.js";
+import { PUBLISHER_KEY_2, TAP_KEY, signedIndex, signedRotation } from "./fixtures/template-signing.js";
+
+describe("publisher continuity", () => {
+  it("pins a first-seen publisher and coordinate", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    expect(state.publishers.atomicstrata.keyId).toBe("publisher-key-1");
+    expect(state.highestSequence).toBe(1);
+  });
+
+  it("refuses sequence replay and immutable-coordinate remapping", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    expect(() => advancePublisherPins(verified(), state)).toThrow(/rollback or replay/);
+    const remapped = signedIndex({ sequence: 2, packages: [{ ...signedIndex().packages[0], payloadDigest: `sha256:${"a".repeat(64)}` }] });
+    expect(() => advancePublisherPins(verified(remapped), state)).toThrow(/coordinate remapped/);
+  });
+
+  it("refuses bare publisher replacement", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    const replacement = signedIndex({ sequence: 2, publishers: { atomicstrata: PUBLISHER_KEY_2 } });
+    expect(() => advancePublisherPins(verified(replacement), state)).toThrow(/without a valid rotation/);
+  });
+
+  it("accepts a dual-signed publisher rotation", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    const rotated = signedIndex({
+      sequence: 2,
+      publishers: { atomicstrata: PUBLISHER_KEY_2 },
+      rotations: [signedRotation(2)],
+    });
+    expect(advancePublisherPins(verified(rotated), state).publishers.atomicstrata).toEqual(PUBLISHER_KEY_2);
+  });
+
+  it("accumulates revocations and refuses revoked evidence", () => {
+    const digest = signedIndex().packages[0].payloadDigest;
+    const index = signedIndex({ revocations: [{ kind: "package", value: digest, reason: "compromised", revokedAt: "2026-07-12T01:00:00Z" }] });
+    const state = advancePublisherPins(verified(index), emptyPublisherPinState("official"));
+    expect(() => assertPackageNotRevoked(state, digest, "publisher-key-1")).toThrow(/package digest is revoked/);
+  });
+
+  it("refuses crossing tap trust domains", () => {
+    expect(() => advancePublisherPins(verified(), emptyPublisherPinState("community"))).toThrow(/another tap/);
+  });
+});
+
+function verified(index: SignedTapIndex = signedIndex()) {
+  return verifyTapIndex(index, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
+}

--- a/test/profile-template-signing-continuity.test.ts
+++ b/test/profile-template-signing-continuity.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { advancePublisherPins, assertPackageNotRevoked, emptyPublisherPinState } from "../src/profile/templates/signing/continuity.js";
 import { verifyTapIndex } from "../src/profile/templates/signing/verify.js";
 import type { ParsedTapIndex } from "../src/profile/templates/signing/protocol.js";
-import { PUBLISHER_KEY_2, PUBLISHER_KEY_3, TAP_KEY, parsedIndex, signedIndex, signedRotation, signedSecondRotation } from "./fixtures/template-signing.js";
+import { PUBLISHER_KEY, PUBLISHER_KEY_2, PUBLISHER_KEY_3, TAP_KEY, parsedIndex, signedIndex, signedReturnRotation, signedRotation, signedSecondRotation } from "./fixtures/template-signing.js";
 
 describe("publisher continuity", () => {
   it("pins a first-seen publisher and coordinate", () => {
@@ -75,6 +75,28 @@ describe("publisher continuity", () => {
 
   it("refuses crossing tap trust domains", () => {
     expect(() => advancePublisherPins(verified(), emptyPublisherPinState("community"))).toThrow(/another tap/);
+  });
+
+  it("refuses reusing a historical key id for another publisher", () => {
+    const state = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    const rebound = parsedIndex({
+      sequence: 2,
+      publishers: { other: { ...PUBLISHER_KEY_2, keyId: PUBLISHER_KEY.keyId } },
+      packages: [],
+    });
+    expect(() => advancePublisherPins(verified(rebound), state)).toThrow(/key id was rebound/);
+  });
+
+  it("refuses rotating back to a publisher's retired key id", () => {
+    const initial = advancePublisherPins(verified(), emptyPublisherPinState("official"));
+    const rotated = parsedIndex({
+      sequence: 2, publishers: { atomicstrata: PUBLISHER_KEY_2 }, rotations: [signedRotation(2)],
+    });
+    const state = advancePublisherPins(verified(rotated), initial);
+    const returned = parsedIndex({
+      sequence: 3, publishers: { atomicstrata: PUBLISHER_KEY }, rotations: [signedReturnRotation(3)],
+    });
+    expect(() => advancePublisherPins(verified(returned), state)).toThrow(/reuses historical key id/);
   });
 });
 

--- a/test/profile-template-signing-fixture.test.ts
+++ b/test/profile-template-signing-fixture.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @file test/profile-template-signing-fixture.test.ts
+ * @description Cross-repository offline vector proving checked-in package and
+ * index bytes parse, verify, and validate without private keys or network I/O.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseSignedPackage, parseSignedTapIndex } from "../src/profile/templates/signing/protocol.js";
+import { advancePublisherPins, emptyPublisherPinState } from "../src/profile/templates/signing/continuity.js";
+import type { PublisherKey } from "../src/profile/templates/signing/types.js";
+import { verifySignedPackage, verifyTapIndex } from "../src/profile/templates/signing/verify.js";
+
+const FIXTURES = path.resolve("test/fixtures/template-registry");
+
+describe("template registry protocol fixture", () => {
+  it("verifies checked-in marketplace-compatible bytes offline", async () => {
+    const packageText = await readFile(path.join(FIXTURES, "package.json"), "utf8");
+    const indexText = await readFile(path.join(FIXTURES, "index.json"), "utf8");
+    const trust = JSON.parse(await readFile(path.join(FIXTURES, "trust.json"), "utf8")) as { tap: PublisherKey };
+    const index = verifyTapIndex(
+      parseSignedTapIndex(indexText), "official", trust.tap, new Date("2026-07-13T00:00:00Z"),
+    );
+    const state = advancePublisherPins(index, emptyPublisherPinState("official"));
+    const pkg = verifySignedPackage(parseSignedPackage(packageText), index, state, "1.0.0");
+    expect(pkg).toMatchObject({ templateId: "team", publisher: "atomicstrata", sourceType: "remote" });
+  });
+});

--- a/test/profile-template-signing-protocol.test.ts
+++ b/test/profile-template-signing-protocol.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @file test/profile-template-signing-protocol.test.ts
+ * @description Adversarial parser and canonicalization tests for signed templates.
+ */
+import { describe, expect, it } from "vitest";
+import { canonicalBytes } from "../src/profile/templates/signing/canonical.js";
+import { parseBoundedUniqueJson } from "../src/profile/templates/signing/json.js";
+import { parseSignedPackage, parseSignedTapIndex, parseTemplateCoordinate } from "../src/profile/templates/signing/protocol.js";
+import { signedIndex, signedPackage } from "./fixtures/template-signing.js";
+
+describe("signed template protocol parsing", () => {
+  it("canonicalizes reordered object keys to identical bytes", () => {
+    expect(canonicalBytes({ b: 2, a: 1 })).toEqual(canonicalBytes({ a: 1, b: 2 }));
+  });
+
+  it("rejects duplicate keys before native JSON parsing collapses them", () => {
+    expect(() => parseBoundedUniqueJson('{"tap":"official","tap":"evil"}', 1024)).toThrow(/duplicate JSON key/);
+  });
+
+  it("rejects excessive nesting and oversized JSON", () => {
+    expect(() => parseBoundedUniqueJson("[[[[0]]]]", 1024, 2)).toThrow(/depth cap/);
+    expect(() => parseBoundedUniqueJson(JSON.stringify({ x: "a".repeat(100) }), 10)).toThrow(/byte cap/);
+  });
+
+  it("parses exact package and index records", () => {
+    expect(parseSignedPackage(JSON.stringify(signedPackage())).coordinate).toContain("@1.0.0");
+    expect(parseSignedTapIndex(JSON.stringify(signedIndex())).tap).toBe("official");
+  });
+
+  it("rejects unknown fields and duplicate coordinates", () => {
+    expect(() => parseSignedPackage(JSON.stringify({ ...signedPackage(), authority: true }))).toThrow(/unsupported/);
+    const index = signedIndex();
+    index.packages.push(index.packages[0]);
+    expect(() => parseSignedTapIndex(JSON.stringify(index))).toThrow(/duplicate package coordinate/);
+  });
+
+  it("requires fully qualified, unambiguous coordinates", () => {
+    expect(parseTemplateCoordinate("official/atomicstrata/team@1.2.3")).toMatchObject({ templateId: "team", version: "1.2.3" });
+    expect(() => parseTemplateCoordinate("team@1.2.3")).toThrow(/invalid template coordinate/);
+    expect(() => parseTemplateCoordinate("official/atomicstrata/team/extra@1.2.3")).toThrow(/invalid template coordinate/);
+  });
+});

--- a/test/profile-template-signing-protocol.test.ts
+++ b/test/profile-template-signing-protocol.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { canonicalBytes } from "../src/profile/templates/signing/canonical.js";
 import { parseBoundedUniqueJson } from "../src/profile/templates/signing/json.js";
 import { parseSignedPackage, parseSignedTapIndex, parseTemplateCoordinate } from "../src/profile/templates/signing/protocol.js";
-import { signedIndex, signedPackage } from "./fixtures/template-signing.js";
+import { PUBLISHER_KEY, PUBLISHER_KEY_2, signedIndex, signedPackage } from "./fixtures/template-signing.js";
 
 describe("signed template protocol parsing", () => {
   it("canonicalizes reordered object keys to identical bytes", () => {
@@ -32,6 +32,14 @@ describe("signed template protocol parsing", () => {
     const index = signedIndex();
     index.packages.push(index.packages[0]);
     expect(() => parseSignedTapIndex(JSON.stringify(index))).toThrow(/duplicate package coordinate/);
+  });
+
+  it("rejects ambiguous publisher key ids and impossible timestamps", () => {
+    const duplicateKey = { ...PUBLISHER_KEY_2, keyId: PUBLISHER_KEY.keyId };
+    const ambiguous = signedIndex({ publishers: { atomicstrata: PUBLISHER_KEY, other: duplicateKey } });
+    expect(() => parseSignedTapIndex(JSON.stringify(ambiguous))).toThrow(/key id is ambiguous/);
+    const impossible = signedIndex({ generatedAt: "2026-02-31T00:00:00Z" });
+    expect(() => parseSignedTapIndex(JSON.stringify(impossible))).toThrow(/ISO-8601/);
   });
 
   it("requires fully qualified, unambiguous coordinates", () => {

--- a/test/profile-template-signing-verify.test.ts
+++ b/test/profile-template-signing-verify.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @file test/profile-template-signing-verify.test.ts
+ * @description Native Ed25519 tap and publisher verification regressions.
+ */
+import { describe, expect, it } from "vitest";
+import { advancePublisherPins, emptyPublisherPinState } from "../src/profile/templates/signing/continuity.js";
+import { verifySignedPackage, verifyTapIndex, verifyTapKeyRotation } from "../src/profile/templates/signing/verify.js";
+import { COORDINATE, TAP_KEY, TAP_KEY_2, signedIndex, signedPackage, signedTapRotation } from "./fixtures/template-signing.js";
+
+describe("signed template verification", () => {
+  it("accepts a valid tap index and package envelope", () => {
+    const index = verifyTapIndex(signedIndex(), "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
+    expect(verifySignedPackage(signedPackage(), index, accepted(index), "1.0.0").templateId).toBe("team");
+  });
+
+  it("refuses tampered tap metadata and wrong tap identity", () => {
+    const tampered = { ...signedIndex(), sequence: 2 };
+    expect(() => verifyTapIndex(tampered, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"))).toThrow(/signature/);
+    expect(() => verifyTapIndex(signedIndex(), "community", TAP_KEY, new Date("2026-07-13T00:00:00Z"))).toThrow(/expected tap/);
+  });
+
+  it("refuses expired indexes", () => {
+    expect(() => verifyTapIndex(signedIndex(), "official", TAP_KEY, new Date("2028-01-01T00:00:00Z"))).toThrow(/expired/);
+  });
+
+  it("refuses payload substitution even when the stored digest is unchanged", () => {
+    const envelope = signedPackage();
+    envelope.payload = { ...envelope.payload, displayName: "Attacker" };
+    const index = verifiedIndex();
+    expect(() => verifySignedPackage(envelope, index, accepted(index), "1.0.0")).toThrow(/digest/);
+  });
+
+  it("refuses coordinate and payload identity confusion", () => {
+    const envelope = signedPackage();
+    envelope.coordinate = COORDINATE.replace("team", "other");
+    const verified = verifiedIndex();
+    expect(() => verifySignedPackage(envelope, verified, accepted(verified), "1.0.0")).toThrow(/coordinate/);
+    const wrongIdentity = signedPackage({ ...envelope.payload, publisher: "attacker" });
+    const index = signedIndex({ packages: [{ ...signedIndex().packages[0], payloadDigest: wrongIdentity.payloadDigest }] });
+    const verifiedWrongIdentity = verifyTapIndex(index, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
+    expect(() => verifySignedPackage(wrongIdentity, verifiedWrongIdentity, accepted(verifiedWrongIdentity), "1.0.0"))
+      .toThrow(/identity/);
+  });
+
+  it("accepts only a dual-signed tap-root rotation", () => {
+    expect(verifyTapKeyRotation("official", signedTapRotation(), TAP_KEY)).toEqual(TAP_KEY_2);
+    const broken = signedTapRotation();
+    broken.newSignature.value = broken.oldSignature.value;
+    expect(() => verifyTapKeyRotation("official", broken, TAP_KEY)).toThrow(/signature/);
+  });
+
+  it("refuses a signed package after its digest is revoked", () => {
+    const digest = signedPackage().payloadDigest;
+    const raw = signedIndex({ revocations: [{ kind: "package", value: digest, reason: "withdrawn", revokedAt: "2026-07-12T01:00:00Z" }] });
+    const index = verifyTapIndex(raw, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
+    expect(() => verifySignedPackage(signedPackage(), index, accepted(index), "1.0.0")).toThrow(/revoked/);
+  });
+});
+
+function verifiedIndex() {
+  return verifyTapIndex(signedIndex(), "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
+}
+
+function accepted(index: ReturnType<typeof verifiedIndex>) {
+  return advancePublisherPins(index, emptyPublisherPinState("official"));
+}

--- a/test/profile-template-signing-verify.test.ts
+++ b/test/profile-template-signing-verify.test.ts
@@ -5,38 +5,39 @@
 import { describe, expect, it } from "vitest";
 import { advancePublisherPins, emptyPublisherPinState } from "../src/profile/templates/signing/continuity.js";
 import { verifySignedPackage, verifyTapIndex, verifyTapKeyRotation } from "../src/profile/templates/signing/verify.js";
-import { COORDINATE, TAP_KEY, TAP_KEY_2, signedIndex, signedPackage, signedTapRotation } from "./fixtures/template-signing.js";
+import { COORDINATE, TAP_KEY, TAP_KEY_2, parsedIndex, parsedPackage, signedIndex, signedTapRotation } from "./fixtures/template-signing.js";
 
 describe("signed template verification", () => {
   it("accepts a valid tap index and package envelope", () => {
-    const index = verifyTapIndex(signedIndex(), "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
-    expect(verifySignedPackage(signedPackage(), index, accepted(index), "1.0.0").templateId).toBe("team");
+    const index = verifyTapIndex(parsedIndex(), "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
+    expect(verifySignedPackage(parsedPackage(), index, accepted(index), "1.0.0").templateId).toBe("team");
   });
 
   it("refuses tampered tap metadata and wrong tap identity", () => {
-    const tampered = { ...signedIndex(), sequence: 2 };
+    const tampered = parsedIndex();
+    tampered.sequence = 2;
     expect(() => verifyTapIndex(tampered, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"))).toThrow(/signature/);
-    expect(() => verifyTapIndex(signedIndex(), "community", TAP_KEY, new Date("2026-07-13T00:00:00Z"))).toThrow(/expected tap/);
+    expect(() => verifyTapIndex(parsedIndex(), "community", TAP_KEY, new Date("2026-07-13T00:00:00Z"))).toThrow(/expected tap/);
   });
 
   it("refuses expired indexes", () => {
-    expect(() => verifyTapIndex(signedIndex(), "official", TAP_KEY, new Date("2028-01-01T00:00:00Z"))).toThrow(/expired/);
+    expect(() => verifyTapIndex(parsedIndex(), "official", TAP_KEY, new Date("2028-01-01T00:00:00Z"))).toThrow(/expired/);
   });
 
   it("refuses payload substitution even when the stored digest is unchanged", () => {
-    const envelope = signedPackage();
+    const envelope = parsedPackage();
     envelope.payload = { ...envelope.payload, displayName: "Attacker" };
     const index = verifiedIndex();
     expect(() => verifySignedPackage(envelope, index, accepted(index), "1.0.0")).toThrow(/digest/);
   });
 
   it("refuses coordinate and payload identity confusion", () => {
-    const envelope = signedPackage();
+    const envelope = parsedPackage();
     envelope.coordinate = COORDINATE.replace("team", "other");
     const verified = verifiedIndex();
     expect(() => verifySignedPackage(envelope, verified, accepted(verified), "1.0.0")).toThrow(/coordinate/);
-    const wrongIdentity = signedPackage({ ...envelope.payload, publisher: "attacker" });
-    const index = signedIndex({ packages: [{ ...signedIndex().packages[0], payloadDigest: wrongIdentity.payloadDigest }] });
+    const wrongIdentity = parsedPackage({ ...envelope.payload, publisher: "attacker" });
+    const index = parsedIndex({ packages: [{ ...signedIndex().packages[0], payloadDigest: wrongIdentity.payloadDigest }] });
     const verifiedWrongIdentity = verifyTapIndex(index, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
     expect(() => verifySignedPackage(wrongIdentity, verifiedWrongIdentity, accepted(verifiedWrongIdentity), "1.0.0"))
       .toThrow(/identity/);
@@ -50,15 +51,15 @@ describe("signed template verification", () => {
   });
 
   it("refuses a signed package after its digest is revoked", () => {
-    const digest = signedPackage().payloadDigest;
-    const raw = signedIndex({ revocations: [{ kind: "package", value: digest, reason: "withdrawn", revokedAt: "2026-07-12T01:00:00Z" }] });
+    const digest = parsedPackage().payloadDigest;
+    const raw = parsedIndex({ revocations: [{ kind: "package", value: digest, reason: "withdrawn", revokedAt: "2026-07-12T01:00:00Z" }] });
     const index = verifyTapIndex(raw, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
-    expect(() => verifySignedPackage(signedPackage(), index, accepted(index), "1.0.0")).toThrow(/revoked/);
+    expect(() => verifySignedPackage(parsedPackage(), index, accepted(index), "1.0.0")).toThrow(/revoked/);
   });
 });
 
 function verifiedIndex() {
-  return verifyTapIndex(signedIndex(), "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
+  return verifyTapIndex(parsedIndex(), "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"));
 }
 
 function accepted(index: ReturnType<typeof verifiedIndex>) {

--- a/test/profile-template-signing-verify.test.ts
+++ b/test/profile-template-signing-verify.test.ts
@@ -24,6 +24,11 @@ describe("signed template verification", () => {
     expect(() => verifyTapIndex(parsedIndex(), "official", TAP_KEY, new Date("2028-01-01T00:00:00Z"))).toThrow(/expired/);
   });
 
+  it("refuses an index generated beyond the clock-skew allowance", () => {
+    const future = parsedIndex({ generatedAt: "2027-01-01T00:00:00Z" });
+    expect(() => verifyTapIndex(future, "official", TAP_KEY, new Date("2026-07-13T00:00:00Z"))).toThrow(/future/);
+  });
+
   it("refuses payload substitution even when the stored digest is unchanged", () => {
     const envelope = parsedPackage();
     envelope.payload = { ...envelope.payload, displayName: "Attacker" };

--- a/test/profile-template-status.test.ts
+++ b/test/profile-template-status.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @file test/profile-template-status.test.ts
+ * @description Verifies advisory provenance cannot bless template drift.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { installBuiltinTemplate, installLocalTemplate } from "../src/profile/templates/install.js";
+import { collectTemplateStatus } from "../src/profile/templates/status.js";
+import { PROFILE_FILE } from "../src/utils/constants.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+
+describe("collectTemplateStatus", () => {
+  it("reports untracked for the implicit default profile", async () => {
+    const root = await makeTempRoot("template-status-default");
+    expect(await collectTemplateStatus(root)).toMatchObject({ status: "untracked", profileId: "default" });
+  });
+
+  it("reports a clean independently-resolved builtin install", async () => {
+    const root = await makeTempRoot("template-status-clean");
+    await installBuiltinTemplate(root, "newsroom", { force: false, currentVersion: "1.0.0" });
+    expect(await collectTemplateStatus(root)).toMatchObject({ status: "installed-clean", templateId: "newsroom" });
+  });
+
+  it("reports local modification even when the lock digest is forged to match", async () => {
+    const root = await makeTempRoot("template-status-drift");
+    await installBuiltinTemplate(root, "newsroom", { force: false, currentVersion: "1.0.0" });
+    const profilePath = path.join(root, PROFILE_FILE);
+    const profile = JSON.parse(await readFile(profilePath, "utf8")) as Record<string, unknown>;
+    await writeFile(profilePath, `${JSON.stringify({ ...profile, displayName: "Changed" }, null, 2)}\n`, "utf8");
+    const status = await collectTemplateStatus(root);
+    const lockPath = path.join(root, ".llmwiki/template-lock.json");
+    const lock = JSON.parse(await readFile(lockPath, "utf8")) as Record<string, unknown>;
+    await writeFile(lockPath, JSON.stringify({ ...lock, profileDigest: status.activeProfileDigest }), "utf8");
+    expect(await collectTemplateStatus(root)).toMatchObject({ status: "locally-modified" });
+  });
+
+  it("does not claim local package provenance is independently verified", async () => {
+    const root = await makeTempRoot("template-status-local");
+    const packageFile = path.join(root, "team.json");
+    await writeFile(packageFile, JSON.stringify(localPackage()), "utf8");
+    await installLocalTemplate(root, packageFile, { force: false, currentVersion: "1.0.0" });
+    expect(await collectTemplateStatus(root)).toMatchObject({ status: "source-release-unavailable" });
+  });
+});
+
+function localPackage(): Record<string, unknown> {
+  return {
+    schemaVersion: 1, templateId: "team", version: "1.0.0", displayName: "Team",
+    publisher: "example", sourceType: "local", license: "MIT", minLlmwikiVersion: "1.0.0",
+    profile: {
+      schemaVersion: 1, profileId: "team", displayName: "Team",
+      entities: { items: { directory: "wiki/items", titleField: "title", fields: { title: { type: "string", required: true } } } },
+    },
+  };
+}

--- a/test/profile-template-update-plan.test.ts
+++ b/test/profile-template-update-plan.test.ts
@@ -2,7 +2,7 @@
  * @file test/profile-template-update-plan.test.ts
  * @description Proves update planning is read-only and corpus-wide.
  */
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ProfilePack } from "../src/profile/types.js";
@@ -16,7 +16,7 @@ describe("planTemplateUpdate", () => {
     const profile = baseProfile();
     const before = await readFile(path.join(root, "wiki/items/one.md"), "utf8");
     const plan = await planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
-    expect(plan).toMatchObject({ compatible: true, reasons: [] });
+    expect(plan).toMatchObject({ authority: "advisory", compatible: true, reasons: [] });
     expect(await readFile(path.join(root, "wiki/items/one.md"), "utf8")).toBe(before);
   });
 
@@ -27,6 +27,20 @@ describe("planTemplateUpdate", () => {
     const plan = await planTemplateUpdate(root, active, pkg(base, "1.0.0"), pkg(active, "1.1.0"));
     expect(plan.compatible).toBe(false);
     expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "drift" }));
+  });
+
+  it("refuses template, publisher, source, and profile identity substitution", async () => {
+    const root = await seededRoot("update-plan-identity");
+    const profile = baseProfile();
+    const base = pkg(profile, "1.0.0");
+    await expect(planTemplateUpdate(root, profile, base, { ...pkg(profile, "1.1.0"), templateId: "other" }))
+      .rejects.toThrow(/template identity/);
+    await expect(planTemplateUpdate(root, profile, base, { ...pkg(profile, "1.1.0"), publisher: "other" }))
+      .rejects.toThrow(/publisher identity/);
+    await expect(planTemplateUpdate(root, profile, base, { ...pkg(profile, "1.1.0"), sourceType: "remote" }))
+      .rejects.toThrow(/source identity/);
+    const otherProfile = { ...profile, profileId: "other" };
+    await expect(planTemplateUpdate(root, profile, base, pkg(otherProfile, "1.1.0"))).rejects.toThrow(/profile identity/);
   });
 
   it("refuses a page orphaned by removing its entity type", async () => {
@@ -49,18 +63,36 @@ describe("planTemplateUpdate", () => {
     const root = await seededRoot("update-plan-candidate");
     await mkdir(path.join(root, ".llmwiki/candidates"), { recursive: true });
     await writeFile(path.join(root, ".llmwiki/candidates/pending.json"), "{broken", "utf8");
-    const profile = baseProfile();
-    const plan = await planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
+    const plan = await planBaseUpdate(root);
     expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "candidate" }));
   });
 
   it("refuses when archived candidate history is unreadable", async () => {
     const root = await seededRoot("update-plan-archive-fault");
-    await mkdir(path.join(root, ".llmwiki/candidates"), { recursive: true });
-    await writeFile(path.join(root, ".llmwiki/candidates/archive"), "not a directory", "utf8");
-    const profile = baseProfile();
-    const plan = await planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
+    await seedCandidateArchive(root, "archive", "not a directory");
+    const plan = await planBaseUpdate(root);
     expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "store", message: expect.stringMatching(/archive/) }));
+  });
+
+  it("refuses malformed archived candidates and unexpected workflow entries", async () => {
+    const root = await seededRoot("update-plan-history-records");
+    await seedCandidateArchive(root, "archive/bad.json", "{}");
+    await mkdir(path.join(root, ".llmwiki/workflows/runs"), { recursive: true });
+    await writeFile(path.join(root, ".llmwiki/workflows/runs/foreign.txt"), "unknown", "utf8");
+    const plan = await planBaseUpdate(root);
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "store", message: expect.stringMatching(/candidate.*malformed/) }));
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "store", message: expect.stringMatching(/workflow.*unexpected/) }));
+  });
+
+  it("refuses a symlinked archived candidate without reading its target", async () => {
+    const root = await seededRoot("update-plan-archive-symlink");
+    const outside = path.join(await makeTempRoot("update-plan-archive-outside"), "secret.json");
+    await writeFile(outside, JSON.stringify({ id: "leak", title: "Leak", slug: "leak", body: "secret", sources: [] }), "utf8");
+    await mkdir(path.join(root, ".llmwiki/candidates/archive"), { recursive: true });
+    await symlink(outside, path.join(root, ".llmwiki/candidates/archive/leak.json"));
+    const plan = await planBaseUpdate(root);
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "store", message: expect.stringMatching(/unexpected entry/) }));
+    expect(JSON.stringify(plan)).not.toContain("secret");
   });
 
   it("refuses artifact contract changes while artifact files exist", async () => {
@@ -71,6 +103,16 @@ describe("planTemplateUpdate", () => {
     const candidate = profileWithArtifact("result.txt");
     const plan = await planTemplateUpdate(root, active, pkg(active, "1.0.0"), pkg(candidate, "1.1.0"));
     expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "artifact" }));
+  });
+
+  it("refuses an unhealthy unreferenced artifact when contracts are unchanged", async () => {
+    const root = await seededRoot("update-plan-unreferenced-artifact");
+    await mkdir(path.join(root, "artifacts/result/run-1"), { recursive: true });
+    await writeFile(path.join(root, "artifacts/result/run-1/result.json"), "{}", "utf8");
+    await writeFile(path.join(root, "artifacts/result/run-1/result.json.manifest.json"), "{broken", "utf8");
+    const profile = profileWithArtifact("result.json");
+    const plan = await planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "artifact", message: expect.stringMatching(/manifest is malformed/) }));
   });
 });
 
@@ -113,4 +155,15 @@ function profileWithArtifact(fileName: string): ProfilePack {
       result: { contentKind: fileName.endsWith(".json") ? "json" : "text", fileName, maxBytes: 1024 },
     },
   };
+}
+
+async function seedCandidateArchive(root: string, relative: string, body: string): Promise<void> {
+  const target = path.join(root, ".llmwiki/candidates", relative);
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, body, "utf8");
+}
+
+async function planBaseUpdate(root: string) {
+  const profile = baseProfile();
+  return planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
 }

--- a/test/profile-template-update-plan.test.ts
+++ b/test/profile-template-update-plan.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @file test/profile-template-update-plan.test.ts
+ * @description Proves update planning is read-only and corpus-wide.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ProfilePack } from "../src/profile/types.js";
+import type { ProfileTemplatePackage } from "../src/profile/templates/types.js";
+import { planTemplateUpdate } from "../src/profile/templates/update.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+
+describe("planTemplateUpdate", () => {
+  it("accepts an unchanged profile with a valid live page and writes nothing", async () => {
+    const root = await seededRoot("update-plan-clean");
+    const profile = baseProfile();
+    const before = await readFile(path.join(root, "wiki/items/one.md"), "utf8");
+    const plan = await planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
+    expect(plan).toMatchObject({ compatible: true, reasons: [] });
+    expect(await readFile(path.join(root, "wiki/items/one.md"), "utf8")).toBe(before);
+  });
+
+  it("refuses active-profile drift even when the candidate is otherwise safe", async () => {
+    const root = await seededRoot("update-plan-drift");
+    const base = baseProfile();
+    const active = { ...base, displayName: "Locally changed" };
+    const plan = await planTemplateUpdate(root, active, pkg(base, "1.0.0"), pkg(active, "1.1.0"));
+    expect(plan.compatible).toBe(false);
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "drift" }));
+  });
+
+  it("refuses a page orphaned by removing its entity type", async () => {
+    const root = await seededRoot("update-plan-orphan");
+    const base = baseProfile();
+    const candidate = { ...base, entities: { notes: { directory: "wiki/notes" } } };
+    const plan = await planTemplateUpdate(root, base, pkg(base, "1.0.0"), pkg(candidate, "2.0.0"));
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "page" }));
+  });
+
+  it("refuses a newly required field missing from an existing page", async () => {
+    const root = await seededRoot("update-plan-field");
+    const base = baseProfile();
+    const candidate = baseProfile(true);
+    const plan = await planTemplateUpdate(root, base, pkg(base, "1.0.0"), pkg(candidate, "1.1.0"));
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "lint", message: expect.stringMatching(/field-violation/) }));
+  });
+
+  it("refuses pending candidate files without trusting their contents", async () => {
+    const root = await seededRoot("update-plan-candidate");
+    await mkdir(path.join(root, ".llmwiki/candidates"), { recursive: true });
+    await writeFile(path.join(root, ".llmwiki/candidates/pending.json"), "{broken", "utf8");
+    const profile = baseProfile();
+    const plan = await planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "candidate" }));
+  });
+
+  it("refuses when archived candidate history is unreadable", async () => {
+    const root = await seededRoot("update-plan-archive-fault");
+    await mkdir(path.join(root, ".llmwiki/candidates"), { recursive: true });
+    await writeFile(path.join(root, ".llmwiki/candidates/archive"), "not a directory", "utf8");
+    const profile = baseProfile();
+    const plan = await planTemplateUpdate(root, profile, pkg(profile, "1.0.0"), pkg(profile, "1.1.0"));
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "store", message: expect.stringMatching(/archive/) }));
+  });
+
+  it("refuses artifact contract changes while artifact files exist", async () => {
+    const root = await seededRoot("update-plan-artifacts");
+    await mkdir(path.join(root, "artifacts/result/run-1"), { recursive: true });
+    await writeFile(path.join(root, "artifacts/result/run-1/result.json"), "{}", "utf8");
+    const active = profileWithArtifact("result.json");
+    const candidate = profileWithArtifact("result.txt");
+    const plan = await planTemplateUpdate(root, active, pkg(active, "1.0.0"), pkg(candidate, "1.1.0"));
+    expect(plan.reasons).toContainEqual(expect.objectContaining({ kind: "artifact" }));
+  });
+});
+
+async function seededRoot(name: string): Promise<string> {
+  const root = await makeTempRoot(name);
+  await mkdir(path.join(root, "wiki/items"), { recursive: true });
+  await writeFile(path.join(root, "wiki/items/one.md"), "---\ntitle: One\n---\n\nUseful body.\n", "utf8");
+  return root;
+}
+
+function baseProfile(requirePriority = false): ProfilePack {
+  return {
+    schemaVersion: 1,
+    profileId: "team",
+    displayName: "Team",
+    entities: {
+      items: {
+        directory: "wiki/items",
+        titleField: "title",
+        fields: {
+          title: { type: "string", required: true },
+          ...(requirePriority ? { priority: { type: "string", required: true } } : {}),
+        },
+      },
+    },
+  };
+}
+
+function pkg(profile: ProfilePack, version: string): ProfileTemplatePackage {
+  return {
+    schemaVersion: 1, templateId: "team", version, displayName: "Team",
+    publisher: "example", sourceType: "local", license: "MIT", minLlmwikiVersion: "1.0.0", profile,
+  };
+}
+
+function profileWithArtifact(fileName: string): ProfilePack {
+  return {
+    ...baseProfile(),
+    artifacts: {
+      result: { contentKind: fileName.endsWith(".json") ? "json" : "text", fileName, maxBytes: 1024 },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds the lifecycle and cryptographic foundations for distributing profile templates safely. This PR deliberately remains offline-only: it defines update compatibility and provenance verification before introducing taps or remote fetching.

The lifecycle work adds template status and read-only update planning, with exact historical release resolution, local-drift detection, profile identity protection, and complete compatibility audits across pages, artifacts, review history, and workflow state. Update plans are explicitly advisory; a future update executor must repeat verification and compatibility checks while holding the project lock.

The signing work adds bounded, strict JSON parsing; canonical Ed25519 verification for tap indexes and template packages; immutable coordinates; rollback and revocation protection; publisher-key pinning; and dual-signed key rotation chains that remain usable when clients skip snapshots. Historical key reuse, cross-publisher key ambiguity, malformed timestamps, and future-dated indexes fail closed.

## Why

Remote template installation creates a new software-supply-chain boundary. Building lifecycle and signing first gives later tap and remote-install work stable, independently audited contracts instead of combining network access, trust-root management, corpus migration, and profile writes in one release.

## User impact

- Existing builtin and local template installation behavior is unchanged.
- Users can inspect installed-template status and preview compatible builtin updates without modifying their project.
- No network access, remote installation, or automatic profile update is introduced by this PR.

## Validation

- TypeScript typecheck
- Production build
- Full test suite: 4,110 passed, 3 skipped, 0 failed
- Fallow and CI-scoped Fallow checks
- Offline signing fixtures and adversarial update/signing regression tests
