### PR TITLE
Add signed template taps and remote discovery

### DIFF
--- a/docs/cli/template.mdx
+++ b/docs/cli/template.mdx
@@ -1,7 +1,7 @@
 ---
 title: "template"
 sidebarTitle: "template"
-description: "List, inspect, and install profile templates."
+description: "Install local templates and discover signed remote releases."
 ---
 
 Profile templates are install-time packages for `.llmwiki/profile.json`.
@@ -60,3 +60,41 @@ candidates, or unresolved typed-store problems cause a refusal.
 
 `llmwiki template init default` never writes a profile. The default profile is
 already active when `.llmwiki/profile.json` is absent.
+
+## Manage remote taps
+
+```bash
+llmwiki template tap add <name> <https-index-url> \
+  --key-id <key-id> \
+  (--key-file <path> | --key-base64 <value>)
+
+llmwiki template tap list [--json]
+llmwiki template tap refresh <name> [--json]
+llmwiki template tap remove <name>
+```
+
+`tap add`, `tap list`, and `tap remove` do not access the network. `tap remove`
+disables the source and retains its key, sequence, publisher pins, revocations,
+and coordinate history.
+
+## Search signed indexes
+
+```bash
+llmwiki template search <query> [--tap <name>] [--json]
+```
+
+Search reads only already accepted signed-index metadata. It does not download
+every matching package. Results from an expired but previously accepted index
+are marked `stale` and cannot introduce unseen coordinates.
+
+## Inspect or verify a remote coordinate
+
+```bash
+llmwiki template inspect <tap/publisher/template@version> [--json]
+llmwiki template verify <tap/publisher/template@version> [--json]
+```
+
+These commands fetch a missing content-addressed package from the tap's exact
+origin or reuse cached evidence, then re-run digest, signature, revocation,
+coordinate, and template validation. They do not install or update a project.
+Remote installation is intentionally not available in this release.

--- a/docs/cli/template.mdx
+++ b/docs/cli/template.mdx
@@ -71,11 +71,17 @@ llmwiki template tap add <name> <https-index-url> \
 llmwiki template tap list [--json]
 llmwiki template tap refresh <name> [--json]
 llmwiki template tap remove <name>
+llmwiki template tap forget <name> --yes
 ```
 
 `tap add`, `tap list`, and `tap remove` do not access the network. `tap remove`
 disables the source and retains its key, sequence, publisher pins, revocations,
 and coordinate history.
+
+`tap forget` is the destructive recovery path for a lost root key, moved
+infrastructure, or exhausted continuity store. It permanently deletes that
+tap's roots, publisher pins, revocations, and coordinate history, making a
+later add equivalent to trusting the source fresh. It requires `--yes`.
 
 ## Search signed indexes
 
@@ -86,6 +92,10 @@ llmwiki template search <query> [--tap <name>] [--json]
 Search reads only already accepted signed-index metadata. It does not download
 every matching package. Results from an expired but previously accepted index
 are marked `stale` and cannot introduce unseen coordinates.
+
+An unrefreshed or unavailable tap does not hide verified results from healthy
+taps: unscoped search returns those results plus a warning for each skipped
+tap. Search explicitly scoped with `--tap` remains fail closed.
 
 ## Inspect or verify a remote coordinate
 

--- a/docs/configuration/profile-templates.mdx
+++ b/docs/configuration/profile-templates.mdx
@@ -146,3 +146,18 @@ llmwiki template tap remove community
 Removal disables the tap but intentionally retains its trust history. Re-adding
 the same name is allowed only with the exact same URL, origin, and root key. This
 prevents remove-and-readd from becoming an implicit trust reset.
+
+Continuity history is append-only and bounded. `tap list` and `tap refresh`
+warn when a tap approaches its persistence limit so operators can plan a new
+identity or an explicit reset before refresh is refused.
+
+If a tap's root key is lost or its retained history must be discarded, use the
+explicit destructive operation:
+
+```bash
+llmwiki template tap forget community --yes
+```
+
+This deletes only that tap's roots, publisher pins, revocations, and coordinate
+history. It does not delete project profiles. Re-adding the name afterward is a
+fresh trust decision and should use a key verified out of band.

--- a/docs/configuration/profile-templates.mdx
+++ b/docs/configuration/profile-templates.mdx
@@ -24,9 +24,10 @@ The built-in list includes:
 | `autosci` | An AutoSci-derived structured research profile with papers, ideas, experiments, manuscripts, artifacts, workflows, and Crossref binding. |
 | `newsroom` | A newsroom profile with articles, desks, bylines, a filing relation, and a story workflow. |
 
-The public template surface supports built-in templates and local template files.
-Remote marketplaces and paid template distribution are not part of the public
-runtime loader or the `template` command path.
+The public template surface supports built-in templates, local template files,
+and explicitly trusted remote taps. Remote taps are read-only in this release:
+you can refresh, search, inspect, and verify signed releases, but you cannot
+install a remote release into a project yet.
 
 ## Inspect a template
 
@@ -90,3 +91,58 @@ implementations, MCP servers, or out-of-band local or environment trust grants.
 They may declare workflow gates and permission requests that the normal workflow
 authority model evaluates at run time. Connector bindings can only name
 connectors that are both compiled into llmwiki and marked template-installable.
+
+## Configure a signed remote tap
+
+A tap is an HTTPS signed index. Adding one requires its Ed25519 public key
+explicitly; llmwiki does not trust a key merely because a server presents it.
+
+```bash
+llmwiki template tap add community https://templates.example/index.json \
+  --key-id community-root-1 \
+  --key-file ./community-root-key.txt
+```
+
+The key file contains base64-encoded Ed25519 SPKI DER public-key bytes. Use
+`--key-base64` instead of `--key-file` for automation, but never pass both.
+Adding a tap does not perform network I/O.
+
+```bash
+llmwiki template tap refresh community
+llmwiki template search research --tap community
+```
+
+Refresh accepts an index only after its tap signature, expiry, sequence,
+publisher-key continuity, package coordinates, and revocations verify. Fetches
+remain on the exact configured HTTPS origin, including its port. Redirects
+cannot move to another origin, and DNS/private-address and response-size checks
+apply on every hop.
+
+## Inspect and verify a remote release
+
+Remote releases use a fully qualified coordinate:
+
+```text
+tap/publisher/template@version
+```
+
+```bash
+llmwiki template inspect community/acme/research@1.2.0
+llmwiki template verify community/acme/research@1.2.0 --json
+```
+
+Package bytes are addressed by the digest in the signed index, fetched from the
+same origin, and verified with the publisher key before they enter the cache.
+Cached packages are rehashed and reverified on every use. The cache is evidence,
+not authority: deleting it cannot reset accepted sequences, keys, coordinates,
+or revocations.
+
+## Disable a tap
+
+```bash
+llmwiki template tap remove community
+```
+
+Removal disables the tap but intentionally retains its trust history. Re-adding
+the same name is allowed only with the exact same URL, origin, and root key. This
+prevents remove-and-readd from becoming an implicit trust reset.

--- a/docs/configuration/profile-templates.mdx
+++ b/docs/configuration/profile-templates.mdx
@@ -133,9 +133,11 @@ llmwiki template verify community/acme/research@1.2.0 --json
 
 Package bytes are addressed by the digest in the signed index, fetched from the
 same origin, and verified with the publisher key before they enter the cache.
-Cached packages are rehashed and reverified on every use. The cache is evidence,
-not authority: deleting it cannot reset accepted sequences, keys, coordinates,
-or revocations.
+Signed envelopes are cached by coordinate and payload digest so mirrors cannot
+conflict. Cached packages are rehashed and reverified on every use. The cache is
+evidence, not authority: deleting it cannot reset accepted sequences, keys,
+coordinates, or revocations. `tap refresh` can restore missing or malformed
+index evidence only from the exact signed snapshot already recorded in state.
 
 ## Disable a tap
 

--- a/src/cli/template-commands.ts
+++ b/src/cli/template-commands.ts
@@ -16,6 +16,21 @@ import {
   type TemplateUpdateOptions,
 } from "../commands/template.js";
 import { runExitCodeCommand } from "./shared.js";
+import {
+  templateTapAddCommand,
+  templateTapListCommand,
+  templateTapRefreshCommand,
+  templateTapRemoveCommand,
+  type TapAddOptions,
+  type TapOutputOptions,
+} from "../commands/template-tap.js";
+import {
+  templateRemoteInspectCommand,
+  templateSearchCommand,
+  templateVerifyCommand,
+  type RemoteOutputOptions,
+  type TemplateSearchOptions,
+} from "../commands/template-remote.js";
 
 /** Register template list, inspect, and init commands. */
 export function registerTemplateCommands(program: Command): void {
@@ -30,8 +45,24 @@ export function registerTemplateCommands(program: Command): void {
 
   template
     .command("inspect <id>")
-    .description("Inspect one builtin profile template")
-    .action(async (id: string) => runExitCodeCommand(() => templateInspectCommand(id).then(() => 0)));
+    .description("Inspect one builtin id or qualified remote coordinate")
+    .option("--json", "Print stable JSON for a remote coordinate")
+    .action(async (id: string, options: RemoteOutputOptions) => runExitCodeCommand(() =>
+      id.includes("/") ? templateRemoteInspectCommand(id, options) : templateInspectCommand(id).then(() => 0),
+    ));
+
+  template
+    .command("search <query>")
+    .description("Search accepted signed remote template indexes")
+    .option("--tap <name>", "Search one configured tap")
+    .option("--json", "Print stable JSON results")
+    .action(async (query: string, options: TemplateSearchOptions) => runExitCodeCommand(() => templateSearchCommand(query, options)));
+
+  template
+    .command("verify <coordinate>")
+    .description("Verify one qualified remote template package")
+    .option("--json", "Print stable JSON provenance")
+    .action(async (coordinate: string, options: RemoteOutputOptions) => runExitCodeCommand(() => templateVerifyCommand(coordinate, options)));
 
   template
     .command("status")
@@ -56,4 +87,22 @@ export function registerTemplateCommands(program: Command): void {
     .action(async (id: string | undefined, options: TemplateInitOptions) =>
       runExitCodeCommand(() => templateInitCommand(id, options)),
     );
+
+  registerTapCommands(template);
+}
+
+function registerTapCommands(template: Command): void {
+  const tap = template.command("tap").description("Manage explicitly trusted template taps");
+  tap.command("list").option("--json", "Print stable JSON").action(async (options: TapOutputOptions) =>
+    runExitCodeCommand(() => templateTapListCommand(options)));
+  tap.command("add <name> <index-url>")
+    .requiredOption("--key-id <id>", "Trusted Ed25519 key id")
+    .option("--key-file <path>", "Read base64 SPKI DER key from a file")
+    .option("--key-base64 <value>", "Use a base64 SPKI DER key")
+    .action(async (name: string, url: string, options: TapAddOptions) =>
+      runExitCodeCommand(() => templateTapAddCommand(name, url, options)));
+  tap.command("remove <name>").description("Disable a tap and retain trust history").action(async (name: string) =>
+    runExitCodeCommand(() => templateTapRemoveCommand(name)));
+  tap.command("refresh <name>").option("--json", "Print stable JSON").action(async (name: string, options: TapOutputOptions) =>
+    runExitCodeCommand(() => templateTapRefreshCommand(name, options)));
 }

--- a/src/cli/template-commands.ts
+++ b/src/cli/template-commands.ts
@@ -18,10 +18,12 @@ import {
 import { runExitCodeCommand } from "./shared.js";
 import {
   templateTapAddCommand,
+  templateTapForgetCommand,
   templateTapListCommand,
   templateTapRefreshCommand,
   templateTapRemoveCommand,
   type TapAddOptions,
+  type TapForgetOptions,
   type TapOutputOptions,
 } from "../commands/template-tap.js";
 import {
@@ -103,6 +105,10 @@ function registerTapCommands(template: Command): void {
       runExitCodeCommand(() => templateTapAddCommand(name, url, options)));
   tap.command("remove <name>").description("Disable a tap and retain trust history").action(async (name: string) =>
     runExitCodeCommand(() => templateTapRemoveCommand(name)));
+  tap.command("forget <name>").description("Permanently delete a tap and all retained trust history")
+    .option("--yes", "Confirm the irreversible trust reset")
+    .action(async (name: string, options: TapForgetOptions) =>
+      runExitCodeCommand(() => templateTapForgetCommand(name, options)));
   tap.command("refresh <name>").option("--json", "Print stable JSON").action(async (name: string, options: TapOutputOptions) =>
     runExitCodeCommand(() => templateTapRefreshCommand(name, options)));
 }

--- a/src/commands/template-remote.ts
+++ b/src/commands/template-remote.ts
@@ -6,6 +6,8 @@ import * as output from "../utils/output.js";
 import { inspectRemoteTemplate, searchRemoteTemplates } from "../profile/templates/taps/discovery.js";
 import { resolveTapPaths } from "../profile/templates/taps/paths.js";
 
+const TERMINAL_CONTROL = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/gu;
+
 /** Options accepted by remote search. */
 export interface TemplateSearchOptions { tap?: string; json?: boolean }
 /** Stable-output option shared by remote inspect and verify. */
@@ -45,12 +47,16 @@ export async function templateVerifyCommand(coordinate: string, options: RemoteO
 
 function printDetails(details: Awaited<ReturnType<typeof inspectRemoteTemplate>>): void {
   output.header(`Remote template ${details.coordinate}`);
-  console.log(`display:     ${details.displayName}`);
-  console.log(`license:     ${details.license}`);
+  console.log(`display:     ${terminalMetadata(details.displayName)}`);
+  console.log(`license:     ${terminalMetadata(details.license)}`);
   console.log(`digest:      ${details.payloadDigest}`);
   console.log(`publisherKey:${details.publisherKeyId}`);
   console.log(`tapSequence: ${details.sequence}`);
   console.log(`status:      ${details.stale ? "stale accepted evidence" : "current"}`);
+}
+
+function terminalMetadata(value: string): string {
+  return value.replace(TERMINAL_CONTROL, "�");
 }
 
 function printSearch(search: Awaited<ReturnType<typeof searchRemoteTemplates>>): void {

--- a/src/commands/template-remote.ts
+++ b/src/commands/template-remote.ts
@@ -1,0 +1,57 @@
+/**
+ * @file src/commands/template-remote.ts
+ * @description Read-only CLI handlers for signed remote template discovery.
+ */
+import * as output from "../utils/output.js";
+import { inspectRemoteTemplate, searchRemoteTemplates } from "../profile/templates/taps/discovery.js";
+import { resolveTapPaths } from "../profile/templates/taps/paths.js";
+
+/** Options accepted by remote search. */
+export interface TemplateSearchOptions { tap?: string; json?: boolean }
+/** Stable-output option shared by remote inspect and verify. */
+export interface RemoteOutputOptions { json?: boolean }
+
+/** Search accepted signed indexes without downloading package bodies. */
+export async function templateSearchCommand(query: string, options: TemplateSearchOptions): Promise<number> {
+  const results = await searchRemoteTemplates(resolveTapPaths(), query, options.tap);
+  if (options.json) console.log(JSON.stringify(results, null, 2));
+  else {
+    console.log("Coordinate                                      Sequence  Status");
+    for (const item of results) console.log(`${item.coordinate.padEnd(47)} ${String(item.sequence).padEnd(9)} ${item.stale ? "stale" : "current"}`);
+  }
+  return 0;
+}
+
+/** Inspect one fully verified qualified remote template. */
+export async function templateRemoteInspectCommand(coordinate: string, options: RemoteOutputOptions): Promise<number> {
+  const details = await inspectRemoteTemplate(resolveTapPaths(), coordinate);
+  if (options.json) console.log(JSON.stringify(details, null, 2));
+  else printDetails(details);
+  return 0;
+}
+
+/** Verify one package and print only its bounded public provenance. */
+export async function templateVerifyCommand(coordinate: string, options: RemoteOutputOptions): Promise<number> {
+  const details = await inspectRemoteTemplate(resolveTapPaths(), coordinate);
+  const result = {
+    coordinate: details.coordinate,
+    verified: true,
+    payloadDigest: details.payloadDigest,
+    publisherKeyId: details.publisherKeyId,
+    tapSequence: details.sequence,
+    stale: details.stale,
+  };
+  if (options.json) console.log(JSON.stringify(result, null, 2));
+  else output.status("+", output.success(`Verified ${coordinate} at tap sequence ${details.sequence}`));
+  return 0;
+}
+
+function printDetails(details: Awaited<ReturnType<typeof inspectRemoteTemplate>>): void {
+  output.header(`Remote template ${details.coordinate}`);
+  console.log(`display:     ${details.displayName}`);
+  console.log(`license:     ${details.license}`);
+  console.log(`digest:      ${details.payloadDigest}`);
+  console.log(`publisherKey:${details.publisherKeyId}`);
+  console.log(`tapSequence: ${details.sequence}`);
+  console.log(`status:      ${details.stale ? "stale accepted evidence" : "current"}`);
+}

--- a/src/commands/template-remote.ts
+++ b/src/commands/template-remote.ts
@@ -13,12 +13,9 @@ export interface RemoteOutputOptions { json?: boolean }
 
 /** Search accepted signed indexes without downloading package bodies. */
 export async function templateSearchCommand(query: string, options: TemplateSearchOptions): Promise<number> {
-  const results = await searchRemoteTemplates(resolveTapPaths(), query, options.tap);
-  if (options.json) console.log(JSON.stringify(results, null, 2));
-  else {
-    console.log("Coordinate                                      Sequence  Status");
-    for (const item of results) console.log(`${item.coordinate.padEnd(47)} ${String(item.sequence).padEnd(9)} ${item.stale ? "stale" : "current"}`);
-  }
+  const search = await searchRemoteTemplates(resolveTapPaths(), query, options.tap);
+  if (options.json) console.log(JSON.stringify(search, null, 2));
+  else printSearch(search);
   return 0;
 }
 
@@ -54,4 +51,12 @@ function printDetails(details: Awaited<ReturnType<typeof inspectRemoteTemplate>>
   console.log(`publisherKey:${details.publisherKeyId}`);
   console.log(`tapSequence: ${details.sequence}`);
   console.log(`status:      ${details.stale ? "stale accepted evidence" : "current"}`);
+}
+
+function printSearch(search: Awaited<ReturnType<typeof searchRemoteTemplates>>): void {
+  console.log("Coordinate                                      Sequence  Status");
+  for (const item of search.results) {
+    console.log(`${item.coordinate.padEnd(47)} ${String(item.sequence).padEnd(9)} ${item.stale ? "stale" : "current"}`);
+  }
+  for (const warning of search.warnings) output.note(`Warning: tap '${warning.tap}' skipped: ${warning.reason}`);
 }

--- a/src/commands/template-tap.ts
+++ b/src/commands/template-tap.ts
@@ -5,7 +5,7 @@
 import { TextDecoder } from "node:util";
 import { readCappedNoFollowBuffer } from "../utils/confined-read.js";
 import * as output from "../utils/output.js";
-import { addTap, listTaps, removeTap, type TapSummary } from "../profile/templates/taps/manage.js";
+import { addTap, forgetTap, listTaps, removeTap, type TapSummary } from "../profile/templates/taps/manage.js";
 import { resolveTapPaths } from "../profile/templates/taps/paths.js";
 import { refreshTap } from "../profile/templates/taps/refresh.js";
 
@@ -15,6 +15,8 @@ const MAX_KEY_FILE_BYTES = 16 * 1024;
 export interface TapAddOptions { keyId: string; keyFile?: string; keyBase64?: string }
 /** Output options shared by tap list and refresh. */
 export interface TapOutputOptions { json?: boolean }
+/** Explicit confirmation required by irreversible trust reset. */
+export interface TapForgetOptions { yes?: boolean }
 
 /** Add or exactly re-enable one explicitly keyed tap. */
 export async function templateTapAddCommand(name: string, indexUrl: string, options: TapAddOptions): Promise<number> {
@@ -41,11 +43,21 @@ export async function templateTapRemoveCommand(name: string): Promise<number> {
   return 0;
 }
 
+/** Permanently delete one tap's root, pins, revocations, and coordinates. */
+export async function templateTapForgetCommand(name: string, options: TapForgetOptions): Promise<number> {
+  await forgetTap(resolveTapPaths(), name, options.yes === true);
+  output.status("!", output.warn(`Forgot template tap '${name}'; its trust history was permanently deleted`));
+  return 0;
+}
+
 /** Fetch and accept the next signed snapshot for one tap. */
 export async function templateTapRefreshCommand(name: string, options: TapOutputOptions): Promise<number> {
   const result = await refreshTap(resolveTapPaths(), name);
   if (options.json) console.log(JSON.stringify(result, null, 2));
-  else output.status("+", output.success(`Refreshed '${result.tap}' to sequence ${result.sequence} (${result.packages} packages)`));
+  else {
+    output.status("+", output.success(`Refreshed '${result.tap}' to sequence ${result.sequence} (${result.packages} packages)`));
+    result.warnings.forEach((warning) => output.note(`Warning: ${warning}`));
+  }
   return 0;
 }
 
@@ -73,5 +85,8 @@ async function readKeyFile(file: string): Promise<string> {
 
 function printTaps(taps: TapSummary[]): void {
   console.log("Tap          Enabled  Sequence  Origin");
-  for (const tap of taps) console.log(`${tap.name.padEnd(12)} ${String(tap.enabled).padEnd(8)} ${String(tap.highestSequence).padEnd(9)} ${tap.origin}`);
+  for (const tap of taps) {
+    console.log(`${tap.name.padEnd(12)} ${String(tap.enabled).padEnd(8)} ${String(tap.highestSequence).padEnd(9)} ${tap.origin}`);
+    tap.warnings.forEach((warning) => output.note(`Warning: ${warning}`));
+  }
 }

--- a/src/commands/template-tap.ts
+++ b/src/commands/template-tap.ts
@@ -1,0 +1,77 @@
+/**
+ * @file src/commands/template-tap.ts
+ * @description CLI handlers for explicit template-tap lifecycle and refresh.
+ */
+import { TextDecoder } from "node:util";
+import { readCappedNoFollowBuffer } from "../utils/confined-read.js";
+import * as output from "../utils/output.js";
+import { addTap, listTaps, removeTap, type TapSummary } from "../profile/templates/taps/manage.js";
+import { resolveTapPaths } from "../profile/templates/taps/paths.js";
+import { refreshTap } from "../profile/templates/taps/refresh.js";
+
+const MAX_KEY_FILE_BYTES = 16 * 1024;
+
+/** Key-source options accepted by `template tap add`. */
+export interface TapAddOptions { keyId: string; keyFile?: string; keyBase64?: string }
+/** Output options shared by tap list and refresh. */
+export interface TapOutputOptions { json?: boolean }
+
+/** Add or exactly re-enable one explicitly keyed tap. */
+export async function templateTapAddCommand(name: string, indexUrl: string, options: TapAddOptions): Promise<number> {
+  const publicKey = await readKey(options);
+  const summary = await addTap(resolveTapPaths(), { name, indexUrl, key: { keyId: options.keyId, publicKey } });
+  output.status("+", output.success(`Configured template tap '${summary.name}'`));
+  console.log(`origin: ${summary.origin}`);
+  console.log(`key:    ${summary.keyId} (${summary.keyFingerprint})`);
+  return 0;
+}
+
+/** List configured taps without exposing raw key material. */
+export async function templateTapListCommand(options: TapOutputOptions): Promise<number> {
+  const taps = await listTaps(resolveTapPaths());
+  if (options.json) console.log(JSON.stringify(taps, null, 2));
+  else printTaps(taps);
+  return 0;
+}
+
+/** Disable a tap while retaining continuity and trust history. */
+export async function templateTapRemoveCommand(name: string): Promise<number> {
+  const tap = await removeTap(resolveTapPaths(), name);
+  output.status("-", output.warn(`Disabled template tap '${tap.name}' (trust history retained)`));
+  return 0;
+}
+
+/** Fetch and accept the next signed snapshot for one tap. */
+export async function templateTapRefreshCommand(name: string, options: TapOutputOptions): Promise<number> {
+  const result = await refreshTap(resolveTapPaths(), name);
+  if (options.json) console.log(JSON.stringify(result, null, 2));
+  else output.status("+", output.success(`Refreshed '${result.tap}' to sequence ${result.sequence} (${result.packages} packages)`));
+  return 0;
+}
+
+async function readKey(options: TapAddOptions): Promise<string> {
+  const source = selectedKeySource(options);
+  return source.kind === "inline" ? source.value : readKeyFile(source.path);
+}
+
+function selectedKeySource(options: TapAddOptions): { kind: "inline"; value: string } | { kind: "file"; path: string } {
+  const hasInline = options.keyBase64 !== undefined;
+  const hasFile = options.keyFile !== undefined;
+  if (hasInline === hasFile) throw new Error("tap add requires exactly one of --key-file or --key-base64");
+  return hasInline ? { kind: "inline", value: options.keyBase64! } : { kind: "file", path: options.keyFile! };
+}
+
+async function readKeyFile(file: string): Promise<string> {
+  const read = await readCappedNoFollowBuffer(file, MAX_KEY_FILE_BYTES);
+  if (read.kind !== "ok") throw new Error("tap key file is unavailable");
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(read.body).trim();
+  } catch {
+    throw new Error("tap key file is not valid UTF-8");
+  }
+}
+
+function printTaps(taps: TapSummary[]): void {
+  console.log("Tap          Enabled  Sequence  Origin");
+  for (const tap of taps) console.log(`${tap.name.padEnd(12)} ${String(tap.enabled).padEnd(8)} ${String(tap.highestSequence).padEnd(9)} ${tap.origin}`);
+}

--- a/src/connectors/confined-fetch.ts
+++ b/src/connectors/confined-fetch.ts
@@ -8,7 +8,7 @@ import type { LookupAddress } from "node:dns";
 import type { IncomingHttpHeaders } from "node:http";
 import https from "node:https";
 import { isIP } from "node:net";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
 import { createGunzip } from "node:zlib";
 import { isPrivateAddress } from "./private-address.js";
 import type { ConnectorRequest } from "./types.js";
@@ -26,6 +26,8 @@ export const MAX_CONNECTOR_URL_BYTES = 2048;
 export interface FetchLimits {
   timeoutMs: number;
   maxBytes: number;
+  /** Maximum encoded response bytes read from the socket. Defaults to maxBytes. */
+  maxTransportBytes?: number;
   maxRedirects: number;
   contentTypes: readonly string[];
 }
@@ -62,25 +64,31 @@ export interface ConfinedFetchSeams {
   now?: () => number;
 }
 
+/** Host-only connector policy or exact-origin registry policy. */
+export type ConfinedFetchPolicy = readonly string[] | {
+  allowedHosts: readonly string[];
+  allowedOrigins: readonly string[];
+};
+
 /** Fetch one HTTPS connector request through the shared confinement policy. */
 export async function confinedFetch(
   req: ConnectorRequest,
   limits: FetchLimits,
-  allowedHosts: readonly string[],
+  policy: ConfinedFetchPolicy,
   seams: ConfinedFetchSeams = {},
 ): Promise<ConfinedFetchResult> {
-  const parsed = validateUrl(req.url, allowedHosts);
+  const parsed = validateUrl(req.url, policy);
   if (parsed.kind !== "ok") return parsed;
   const headers = validateHeaders(req.headers ?? {});
   if (headers.kind !== "ok") return headers;
   const start = now(seams);
-  return fetchHop(parsed.url, headers.headers, limits, allowedHosts, seams, limits.maxRedirects, start + limits.timeoutMs, start);
+  return fetchHop(parsed.url, headers.headers, limits, policy, seams, limits.maxRedirects, start + limits.timeoutMs, start);
 }
 
 type UrlValidation = { kind: "ok"; url: URL } | { kind: "refused"; reason: string };
 type HeaderValidation = { kind: "ok"; headers: Record<string, string> } | { kind: "refused"; reason: string };
 
-function validateUrl(raw: string, allowedHosts: readonly string[]): UrlValidation {
+function validateUrl(raw: string, policy: ConfinedFetchPolicy): UrlValidation {
   if (Buffer.byteLength(raw, "utf8") > MAX_CONNECTOR_URL_BYTES) {
     return { kind: "refused", reason: "connector URL exceeds the byte cap" };
   }
@@ -90,17 +98,33 @@ function validateUrl(raw: string, allowedHosts: readonly string[]): UrlValidatio
   } catch {
     return { kind: "refused", reason: "invalid connector URL" };
   }
-  // The audit event records the CANONICAL form, which percent-encoding can grow
-  // past the raw byte length — the bound holds only if the canonical form is capped.
-  if (Buffer.byteLength(url.toString(), "utf8") > MAX_CONNECTOR_URL_BYTES) {
-    return { kind: "refused", reason: "connector URL exceeds the byte cap" };
-  }
-  if (url.protocol !== "https:") return { kind: "refused", reason: "connector URL must use https" };
-  if (url.username || url.password) return { kind: "refused", reason: "connector URL cannot include userinfo" };
-  if (!allowedHosts.map((h) => h.toLowerCase()).includes(url.hostname.toLowerCase())) {
-    return { kind: "refused", reason: "connector URL host is not allowlisted" };
-  }
+  return validateParsedUrl(url, policy);
+}
+
+function validateParsedUrl(url: URL, policy: ConfinedFetchPolicy): UrlValidation {
+  if (Buffer.byteLength(url.toString(), "utf8") > MAX_CONNECTOR_URL_BYTES) return urlRefusal("connector URL exceeds the byte cap");
+  if (url.protocol !== "https:") return urlRefusal("connector URL must use https");
+  if (url.username || url.password) return urlRefusal("connector URL cannot include userinfo");
+  if (!allowedHostnames(policy).includes(url.hostname.toLowerCase())) return urlRefusal("connector URL host is not allowlisted");
+  if (isExactOriginPolicy(policy) && !normalizedOrigins(policy).includes(url.origin)) return urlRefusal("connector URL origin is not allowlisted");
   return { kind: "ok", url };
+}
+
+function urlRefusal(reason: string): UrlValidation {
+  return { kind: "refused", reason };
+}
+
+function allowedHostnames(policy: ConfinedFetchPolicy): string[] {
+  const hosts = isExactOriginPolicy(policy) ? policy.allowedHosts : policy;
+  return hosts.map((host) => host.toLowerCase());
+}
+
+function isExactOriginPolicy(policy: ConfinedFetchPolicy): policy is Exclude<ConfinedFetchPolicy, readonly string[]> {
+  return !Array.isArray(policy);
+}
+
+function normalizedOrigins(policy: { allowedOrigins: readonly string[] }): string[] {
+  return policy.allowedOrigins.map((origin) => new URL(origin).origin);
 }
 
 function validateHeaders(headers: Record<string, string>): HeaderValidation {
@@ -122,7 +146,7 @@ async function fetchHop(
   url: URL,
   headers: Record<string, string>,
   limits: FetchLimits,
-  allowedHosts: readonly string[],
+  policy: ConfinedFetchPolicy,
   seams: ConfinedFetchSeams,
   redirectsLeft: number,
   deadlineMs: number,
@@ -135,7 +159,7 @@ async function fetchHop(
   const response = await requestPinned(url, headers, resolved.address, timeoutMs, seams);
   if (response.kind !== "ok") return response;
   if (isRedirect(response.response.statusCode)) {
-    return followRedirect(response.response, url, headers, limits, allowedHosts, seams, redirectsLeft, deadlineMs);
+    return followRedirect(response.response, url, headers, limits, policy, seams, redirectsLeft, deadlineMs);
   }
   return decodeResponse(response.response, url, limits, seams, deadlineMs);
 }
@@ -145,22 +169,34 @@ async function followRedirect(
   baseUrl: URL,
   headers: Record<string, string>,
   limits: FetchLimits,
-  allowedHosts: readonly string[],
+  policy: ConfinedFetchPolicy,
   seams: ConfinedFetchSeams,
   redirectsLeft: number,
   deadlineMs: number,
 ): Promise<ConfinedFetchResult> {
-  if (redirectsLeft <= 0) return { kind: "refused", reason: "connector redirect limit exceeded" };
+  if (redirectsLeft <= 0) return destroyReturning(response.body, { kind: "refused", reason: "connector redirect limit exceeded" });
   const location = firstHeader(response.headers.location);
-  if (!location) return { kind: "unavailable", reason: "connector redirect missing location" };
-  const next = validateUrl(new URL(location, baseUrl).toString(), allowedHosts);
+  if (!location) return destroyReturning(response.body, { kind: "unavailable", reason: "connector redirect missing location" });
+  let target: string;
+  try {
+    target = new URL(location, baseUrl).toString();
+  } catch {
+    return destroyReturning(response.body, { kind: "refused", reason: "connector redirect location is invalid" });
+  }
+  const next = validateUrl(target, policy);
+  response.body.destroy();
   if (next.kind !== "ok") return next;
-  return fetchHop(next.url, headers, limits, allowedHosts, seams, redirectsLeft - 1, deadlineMs, now(seams));
+  return fetchHop(next.url, headers, limits, policy, seams, redirectsLeft - 1, deadlineMs, now(seams));
 }
 
 async function resolvePinnedAddress(hostname: string, seams: ConfinedFetchSeams) {
   const lookup = seams.lookup ?? defaultLookup;
-  const addresses = await lookup(hostname);
+  let addresses: LookupAddress[];
+  try {
+    addresses = await lookup(hostname);
+  } catch {
+    return { kind: "unavailable" as const, reason: "connector host lookup failed" };
+  }
   if (addresses.length === 0) return { kind: "unavailable" as const, reason: "connector host did not resolve" };
   if (addresses.some((entry) => isPrivateAddress(entry.address))) {
     return { kind: "refused" as const, reason: "connector host resolved to a private address" };
@@ -235,26 +271,39 @@ async function decodeResponse(
   deadlineMs: number,
 ): Promise<ConfinedFetchResult> {
   if (response.statusCode < 200 || response.statusCode >= 300) {
-    return { kind: "unavailable", reason: `connector returned HTTP ${response.statusCode}` };
+    return destroyReturning(response.body, { kind: "unavailable", reason: `connector returned HTTP ${response.statusCode}` });
   }
   const contentType = mediaType(firstHeader(response.headers["content-type"]));
-  if (!contentType || !limits.contentTypes.includes(contentType)) return { kind: "refused", reason: "connector response content type is not allowed" };
-  const stream = decodedStream(response);
+  if (!contentType || !limits.contentTypes.includes(contentType)) {
+    return destroyReturning(response.body, { kind: "refused", reason: "connector response content type is not allowed" });
+  }
+  const stream = decodedStream(response, limits.maxTransportBytes ?? limits.maxBytes);
   if (stream.kind !== "ok") return stream;
-  const bytes = await readCapped(stream.body, limits.maxBytes, seams, deadlineMs);
+  const bytes = await readCapped(stream, limits.maxBytes, seams, deadlineMs);
   if (bytes.kind !== "ok") return bytes;
   return { kind: "ok", bytes: bytes.bytes, finalUrl: url.toString(), contentHash: sha256(bytes.bytes) };
 }
 
-function decodedStream(response: ConfinedHttpResponse): { kind: "ok"; body: Readable } | { kind: "refused"; reason: string } {
+type StreamBundle = { kind: "ok"; body: Readable; source: Readable };
+
+function decodedStream(response: ConfinedHttpResponse, maxTransportBytes: number): StreamBundle | { kind: "refused"; reason: string } {
   const encoding = (firstHeader(response.headers["content-encoding"]) ?? "identity").toLowerCase();
-  if (encoding === "identity" || encoding === "") return { kind: "ok", body: response.body };
-  if (encoding !== "gzip") return { kind: "refused", reason: "connector response encoding is not allowed" };
-  return { kind: "ok", body: response.body.pipe(createGunzip()) };
+  if (encoding !== "identity" && encoding !== "" && encoding !== "gzip") {
+    return destroyReturning(response.body, { kind: "refused", reason: "connector response encoding is not allowed" });
+  }
+  const counted = response.body.pipe(new ByteCapTransform(maxTransportBytes, response.body));
+  const body = encoding === "gzip" ? pipeGunzip(counted) : counted;
+  return { kind: "ok", body, source: response.body };
+}
+
+function pipeGunzip(counted: Readable): Readable {
+  const gunzip = createGunzip();
+  counted.on("error", (error) => gunzip.destroy(error));
+  return counted.pipe(gunzip);
 }
 
 async function readCapped(
-  stream: Readable,
+  stream: StreamBundle,
   maxBytes: number,
   seams: ConfinedFetchSeams,
   deadlineMs: number,
@@ -263,15 +312,18 @@ async function readCapped(
   let total = 0;
   try {
     if (deadlineReached(seams, deadlineMs)) return fetchTimedOut(stream);
-    for await (const chunk of stream) {
+    for await (const chunk of stream.body) {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       total += buffer.length;
-      if (total > maxBytes) return { kind: "refused", reason: "connector response exceeds byte cap" };
+      if (total > maxBytes) return destroyReturning(stream, { kind: "refused", reason: "connector response exceeds byte cap" });
       if (deadlineReached(seams, deadlineMs)) return fetchTimedOut(stream);
       chunks.push(buffer);
     }
-  } catch {
-    return { kind: "unavailable", reason: "connector response could not be decoded" };
+  } catch (error) {
+    if (error instanceof TransportCapError) {
+      return destroyReturning(stream, { kind: "refused", reason: "connector response exceeds transport byte cap" });
+    }
+    return destroyReturning(stream, { kind: "unavailable", reason: "connector response could not be decoded" });
   }
   return { kind: "ok", bytes: Buffer.concat(chunks) };
 }
@@ -282,9 +334,30 @@ function deadlineReached(seams: ConfinedFetchSeams, deadlineMs: number): boolean
 }
 
 /** Fail closed and stop reading when the connector fetch deadline expires. */
-function fetchTimedOut(stream: Readable): { kind: "unavailable"; reason: string } {
-  stream.destroy();
-  return { kind: "unavailable", reason: "connector fetch timed out" };
+function fetchTimedOut(stream: StreamBundle): { kind: "unavailable"; reason: string } {
+  return destroyReturning(stream, { kind: "unavailable", reason: "connector fetch timed out" });
+}
+
+class TransportCapError extends Error {}
+
+class ByteCapTransform extends Transform {
+  private total = 0;
+
+  constructor(private readonly maxBytes: number, private readonly source: Readable) { super(); }
+
+  override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null, data?: Buffer) => void): void {
+    this.total += chunk.length;
+    if (this.total > this.maxBytes) this.source.destroy();
+    callback(this.total > this.maxBytes ? new TransportCapError() : null, chunk);
+  }
+}
+
+function destroyReturning<T>(stream: Readable | StreamBundle, result: T): T {
+  if ("source" in stream) {
+    stream.body.destroy();
+    stream.source.destroy();
+  } else stream.destroy();
+  return result;
 }
 
 function isSafeHeaderValue(value: string): boolean {

--- a/src/profile/templates/signing/verify.ts
+++ b/src/profile/templates/signing/verify.ts
@@ -47,6 +47,23 @@ export function verifyTapIndex(
   return index as VerifiedTapIndex;
 }
 
+/** Re-verify an already accepted cached index without requiring current freshness. */
+export function verifyAcceptedTapIndex(
+  index: ParsedTapIndex,
+  expectedTap: string,
+  trustedKey: PublisherKey,
+  state: PublisherPinState,
+): VerifiedTapIndex {
+  if (state.tap !== expectedTap || state.highestSequence !== index.sequence) {
+    refuse("unaccepted-index", "cached tap index is not the authoritative accepted sequence");
+  }
+  if (index.tap !== expectedTap) refuse("wrong-tap", `expected tap ${expectedTap}, received ${index.tap}`);
+  if (index.signature.keyId !== trustedKey.keyId) refuse("wrong-key", "tap signature key does not match the trusted key");
+  const { signature, ...claim } = index;
+  verifySignature(canonicalBytes(claim), signature, trustedKey, "tap-signature");
+  return index as VerifiedTapIndex;
+}
+
 /** Verify one package against the exact signed index entry and publisher key. */
 export function verifySignedPackage(
   envelope: ParsedSignedPackage,

--- a/src/profile/templates/taps/cache.ts
+++ b/src/profile/templates/taps/cache.ts
@@ -3,7 +3,9 @@
  * @description Non-authoritative confined cache for verified indexes and packages.
  */
 import path from "node:path";
-import { unlink } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import type { Dirent } from "node:fs";
+import { readdir, unlink } from "node:fs/promises";
 import { atomicWrite } from "../../../utils/atomic-write.js";
 import { readConfinedLeaf } from "../../../utils/confined-read.js";
 import type { TapPaths } from "./paths.js";
@@ -25,7 +27,7 @@ export async function readIndexCache(paths: TapPaths, tap: string, sequence: num
 }
 
 /** Best-effort removal of superseded non-authoritative index evidence. */
-export async function removeIndexCache(paths: TapPaths, tap: string, sequence: number): Promise<void> {
+async function removeIndexCache(paths: TapPaths, tap: string, sequence: number): Promise<void> {
   const leaf = indexCachePath(paths, tap, sequence);
   const read = await readConfinedLeaf(paths.cacheRoot, leaf, path.dirname(leaf), MAX_CACHED_INDEX_BYTES);
   if (read.kind === "absent") return;
@@ -33,14 +35,25 @@ export async function removeIndexCache(paths: TapPaths, tap: string, sequence: n
   await unlink(leaf);
 }
 
+/** Best-effort removal of every superseded regular index-cache leaf. */
+export async function pruneIndexCaches(paths: TapPaths, tap: string, keepSequence: number): Promise<void> {
+  const directory = path.join(paths.cacheRoot, "indexes", tap);
+  const entries = await readCacheDirectory(directory);
+  const stale = entries.filter((entry) => entry.isFile() && indexSequence(entry.name) !== keepSequence);
+  await Promise.all(stale.map(async (entry) => {
+    const sequence = indexSequence(entry.name);
+    if (sequence !== null) await removeIndexCache(paths, tap, sequence).catch(() => {});
+  }));
+}
+
 /** Write a fully verified package envelope by signed payload digest. */
-export async function writePackageCache(paths: TapPaths, digest: string, text: string): Promise<void> {
-  await writeCache(paths, packageCachePath(paths, digest), text, MAX_CACHED_PACKAGE_BYTES);
+export async function writePackageCache(paths: TapPaths, coordinate: string, digest: string, text: string): Promise<void> {
+  await writeCache(paths, packageCachePath(paths, coordinate, digest), text, MAX_CACHED_PACKAGE_BYTES);
 }
 
 /** Read a cached package envelope for complete re-verification. */
-export async function readPackageCache(paths: TapPaths, digest: string): Promise<string | null> {
-  return readOptionalCache(paths, packageCachePath(paths, digest), MAX_CACHED_PACKAGE_BYTES);
+export async function readPackageCache(paths: TapPaths, coordinate: string, digest: string): Promise<string | null> {
+  return readOptionalCache(paths, packageCachePath(paths, coordinate, digest), MAX_CACHED_PACKAGE_BYTES);
 }
 
 function indexCachePath(paths: TapPaths, tap: string, sequence: number): string {
@@ -48,10 +61,26 @@ function indexCachePath(paths: TapPaths, tap: string, sequence: number): string 
   return path.join(paths.cacheRoot, "indexes", tap, `${sequence}.json`);
 }
 
-function packageCachePath(paths: TapPaths, digest: string): string {
+function packageCachePath(paths: TapPaths, coordinate: string, digest: string): string {
   const hex = /^sha256:([0-9a-f]{64})$/.exec(digest)?.[1];
-  if (!hex) throw new Error("invalid package cache digest");
-  return path.join(paths.cacheRoot, "packages", "sha256", `${hex}.json`);
+  if (!hex || Buffer.byteLength(coordinate) > 4096) throw new Error("invalid package cache identity");
+  const identity = createHash("sha256").update(coordinate).update("\0").update(digest).digest("hex");
+  return path.join(paths.cacheRoot, "packages", "envelopes", `${identity}.json`);
+}
+
+function indexSequence(name: string): number | null {
+  const match = /^(0|[1-9][0-9]*)\.json$/.exec(name);
+  const value = match ? Number(match[1]) : Number.NaN;
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+async function readCacheDirectory(directory: string): Promise<Dirent[]> {
+  try {
+    return await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
 }
 
 async function writeCache(paths: TapPaths, leaf: string, text: string, maxBytes: number): Promise<void> {

--- a/src/profile/templates/taps/cache.ts
+++ b/src/profile/templates/taps/cache.ts
@@ -1,0 +1,65 @@
+/**
+ * @file src/profile/templates/taps/cache.ts
+ * @description Non-authoritative confined cache for verified indexes and packages.
+ */
+import path from "node:path";
+import { atomicWrite } from "../../../utils/atomic-write.js";
+import { readConfinedLeaf } from "../../../utils/confined-read.js";
+import type { TapPaths } from "./paths.js";
+import { ensurePrivateRoot } from "./private-root.js";
+
+const MAX_CACHED_INDEX_BYTES = 4 * 1024 * 1024;
+const MAX_CACHED_PACKAGE_BYTES = 2 * 1024 * 1024;
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Write one verified index snapshot; callers must verify before invoking. */
+export async function writeIndexCache(paths: TapPaths, tap: string, sequence: number, text: string): Promise<void> {
+  const leaf = indexCachePath(paths, tap, sequence);
+  await writeCache(paths, leaf, text, MAX_CACHED_INDEX_BYTES);
+}
+
+/** Read one cached index as evidence, never as authority. */
+export async function readIndexCache(paths: TapPaths, tap: string, sequence: number): Promise<string> {
+  return readCache(paths, indexCachePath(paths, tap, sequence), MAX_CACHED_INDEX_BYTES);
+}
+
+/** Write a fully verified package envelope by signed payload digest. */
+export async function writePackageCache(paths: TapPaths, digest: string, text: string): Promise<void> {
+  await writeCache(paths, packageCachePath(paths, digest), text, MAX_CACHED_PACKAGE_BYTES);
+}
+
+/** Read a cached package envelope for complete re-verification. */
+export async function readPackageCache(paths: TapPaths, digest: string): Promise<string | null> {
+  return readOptionalCache(paths, packageCachePath(paths, digest), MAX_CACHED_PACKAGE_BYTES);
+}
+
+function indexCachePath(paths: TapPaths, tap: string, sequence: number): string {
+  if (!SLUG.test(tap) || !Number.isSafeInteger(sequence) || sequence < 0) throw new Error("invalid index cache identity");
+  return path.join(paths.cacheRoot, "indexes", tap, `${sequence}.json`);
+}
+
+function packageCachePath(paths: TapPaths, digest: string): string {
+  const hex = /^sha256:([0-9a-f]{64})$/.exec(digest)?.[1];
+  if (!hex) throw new Error("invalid package cache digest");
+  return path.join(paths.cacheRoot, "packages", "sha256", `${hex}.json`);
+}
+
+async function writeCache(paths: TapPaths, leaf: string, text: string, maxBytes: number): Promise<void> {
+  if (Buffer.byteLength(text) > maxBytes) throw new Error("template cache entry exceeds its byte cap");
+  await ensurePrivateRoot(paths.cacheRoot);
+  await atomicWrite(leaf, text, { confineRoot: paths.cacheRoot, durable: true, mode: 0o600 });
+}
+
+async function readCache(paths: TapPaths, leaf: string, maxBytes: number): Promise<string> {
+  const expectedDir = path.dirname(leaf);
+  const read = await readConfinedLeaf(paths.cacheRoot, leaf, expectedDir, maxBytes);
+  if (read.kind !== "ok") throw new Error("template cache evidence is unavailable");
+  return read.body;
+}
+
+async function readOptionalCache(paths: TapPaths, leaf: string, maxBytes: number): Promise<string | null> {
+  const read = await readConfinedLeaf(paths.cacheRoot, leaf, path.dirname(leaf), maxBytes);
+  if (read.kind === "absent") return null;
+  if (read.kind !== "ok") throw new Error("template cache evidence is unavailable");
+  return read.body;
+}

--- a/src/profile/templates/taps/cache.ts
+++ b/src/profile/templates/taps/cache.ts
@@ -3,6 +3,7 @@
  * @description Non-authoritative confined cache for verified indexes and packages.
  */
 import path from "node:path";
+import { unlink } from "node:fs/promises";
 import { atomicWrite } from "../../../utils/atomic-write.js";
 import { readConfinedLeaf } from "../../../utils/confined-read.js";
 import type { TapPaths } from "./paths.js";
@@ -21,6 +22,15 @@ export async function writeIndexCache(paths: TapPaths, tap: string, sequence: nu
 /** Read one cached index as evidence, never as authority. */
 export async function readIndexCache(paths: TapPaths, tap: string, sequence: number): Promise<string> {
   return readCache(paths, indexCachePath(paths, tap, sequence), MAX_CACHED_INDEX_BYTES);
+}
+
+/** Best-effort removal of superseded non-authoritative index evidence. */
+export async function removeIndexCache(paths: TapPaths, tap: string, sequence: number): Promise<void> {
+  const leaf = indexCachePath(paths, tap, sequence);
+  const read = await readConfinedLeaf(paths.cacheRoot, leaf, path.dirname(leaf), MAX_CACHED_INDEX_BYTES);
+  if (read.kind === "absent") return;
+  if (read.kind !== "ok") throw new Error("template cache evidence is unavailable");
+  await unlink(leaf);
 }
 
 /** Write a fully verified package envelope by signed payload digest. */

--- a/src/profile/templates/taps/capacity.ts
+++ b/src/profile/templates/taps/capacity.ts
@@ -1,0 +1,59 @@
+/**
+ * @file src/profile/templates/taps/capacity.ts
+ * @description Capacity limits, early warnings, and actionable refusal for
+ * monotonically growing template-tap continuity state.
+ */
+import type { TapOperatorState, TapSourceState } from "./state-types.js";
+
+export const MAX_TAP_STATE_BYTES = 4 * 1024 * 1024;
+export const MAX_TAP_STATE_ITEMS = 10_000;
+export const MAX_TAP_SOURCES = 64;
+const WARNING_RATIO = 0.8;
+
+/** Describe continuity collections approaching their hard persistence bound. */
+export function tapStateCapacityWarnings(state: TapOperatorState): string[] {
+  const warnings = Object.values(state.taps).flatMap(sourceWarnings);
+  const tapCount = Object.keys(state.taps).length;
+  if (tapCount >= MAX_TAP_SOURCES * WARNING_RATIO) warnings.push(capacityMessage("operator configured taps", tapCount, MAX_TAP_SOURCES));
+  const bytes = Buffer.byteLength(JSON.stringify(state, null, 2));
+  if (bytes >= MAX_TAP_STATE_BYTES * WARNING_RATIO) warnings.push(capacityMessage("operator state bytes", bytes, MAX_TAP_STATE_BYTES));
+  return warnings;
+}
+
+/** Refuse a write that cannot be read back, with a scoped recovery command. */
+export function assertTapStateCapacity(state: TapOperatorState, serialized: string): void {
+  const exhausted = Object.values(state.taps).flatMap(sourceExhaustion);
+  if (Object.keys(state.taps).length > MAX_TAP_SOURCES) exhausted.push("configured taps");
+  if (Buffer.byteLength(serialized) > MAX_TAP_STATE_BYTES) exhausted.push("operator state bytes");
+  if (exhausted.length > 0) {
+    throw new Error(`template tap state capacity exhausted (${exhausted.join(", ")}); run 'llmwiki template tap forget <name> --yes' to reset one retained tap explicitly`);
+  }
+}
+
+function sourceWarnings(source: TapSourceState): string[] {
+  return collections(source)
+    .filter(([, count]) => count >= MAX_TAP_STATE_ITEMS * WARNING_RATIO)
+    .map(([label, count]) => capacityMessage(`${source.name} ${label}`, count, MAX_TAP_STATE_ITEMS));
+}
+
+function sourceExhaustion(source: TapSourceState): string[] {
+  return collections(source)
+    .filter(([, count]) => count > MAX_TAP_STATE_ITEMS)
+    .map(([label]) => `${source.name} ${label}`);
+}
+
+function collections(source: TapSourceState): Array<[string, number]> {
+  const pins = source.publisherPins;
+  return [
+    ["retired tap keys", source.retiredTapKeyIds.length],
+    ["publishers", Object.keys(pins.publishers).length],
+    ["key history", Object.keys(pins.keyHistory).length],
+    ["coordinates", Object.keys(pins.coordinates).length],
+    ["package revocations", pins.revokedPackages.length],
+    ["publisher-key revocations", pins.revokedPublisherKeys.length],
+  ];
+}
+
+function capacityMessage(label: string, current: number, limit: number): string {
+  return `${label} is approaching its continuity-state limit (${current}/${limit}); plan an explicit tap trust reset before refresh is refused`;
+}

--- a/src/profile/templates/taps/discovery.ts
+++ b/src/profile/templates/taps/discovery.ts
@@ -8,6 +8,7 @@ import { loadAcceptedIndex } from "./evidence.js";
 import { resolveRemotePackage } from "./package.js";
 import type { TapPaths } from "./paths.js";
 import { readTapState } from "./state-store.js";
+import type { TapSourceState } from "./state-types.js";
 
 /** Index-only search result; no package body or raw key is exposed. */
 export interface RemoteTemplateSearchResult {
@@ -30,27 +31,62 @@ export interface RemoteTemplateDetails extends RemoteTemplateSearchResult {
   capabilities: ReturnType<typeof deriveTemplateCapabilities>;
 }
 
+/** Search envelope preserves healthy results while surfacing degraded taps. */
+export interface RemoteTemplateSearch {
+  results: RemoteTemplateSearchResult[];
+  warnings: Array<{ tap: string; reason: string }>;
+}
+
 /** Search only already accepted index coordinates, never package bodies. */
-export async function searchRemoteTemplates(paths: TapPaths, query: string, tap?: string): Promise<RemoteTemplateSearchResult[]> {
+export async function searchRemoteTemplates(paths: TapPaths, query: string, tap?: string): Promise<RemoteTemplateSearch> {
   const state = await readTapState(paths);
   if (tap && !state.taps[tap]) throw new Error(`unknown template tap: ${tap}`);
   if (tap && !state.taps[tap].enabled) throw new Error(`template tap is disabled: ${tap}`);
   const sources = Object.values(state.taps).filter((source) => source.enabled && (!tap || source.name === tap));
-  const groups = await Promise.all(sources.map(async (source) => {
+  if (tap) return searchOne(paths, sources[0], query);
+  const settled = await Promise.allSettled(sources.map(async (source) => {
     const index = await loadAcceptedIndex(paths, source);
-    return index.packages
-      .filter((entry) => evidenceIsActive(source, entry.publisher, entry.payloadDigest))
-      .map((entry) => searchResult(entry.coordinate, entry.payloadDigest, index.sequence, index.expiresAt));
+    return { source, index };
   }));
-  const needle = query.trim().toLowerCase();
-  return groups.flat().filter((item) => searchable(item).includes(needle)).sort((a, b) => a.coordinate.localeCompare(b.coordinate));
+  const warnings = settled.flatMap((item, index) => item.status === "rejected"
+    ? [{ tap: sources[index].name, reason: errorMessage(item.reason) }]
+    : []);
+  const groups = settled.flatMap((item) => item.status === "fulfilled"
+    ? activeResults(item.value.source, item.value.index)
+    : []);
+  return filterResults(groups, query, warnings);
 }
 
-function evidenceIsActive(source: Awaited<ReturnType<typeof readTapState>>["taps"][string], publisher: string, digest: string): boolean {
+async function searchOne(paths: TapPaths, source: TapSourceState, query: string): Promise<RemoteTemplateSearch> {
+  const index = await loadAcceptedIndex(paths, source);
+  return filterResults(activeResults(source, index), query, []);
+}
+
+function activeResults(source: TapSourceState, index: Awaited<ReturnType<typeof loadAcceptedIndex>>): RemoteTemplateSearchResult[] {
+  return index.packages
+      .filter((entry) => evidenceIsActive(source, entry.publisher, entry.payloadDigest))
+      .map((entry) => searchResult(entry.coordinate, entry.payloadDigest, index.sequence, index.expiresAt));
+}
+
+function filterResults(
+  groups: RemoteTemplateSearchResult[],
+  query: string,
+  warnings: RemoteTemplateSearch["warnings"],
+): RemoteTemplateSearch {
+  const needle = query.trim().toLowerCase();
+  const results = groups.filter((item) => searchable(item).includes(needle)).sort((a, b) => a.coordinate.localeCompare(b.coordinate));
+  return { results, warnings };
+}
+
+function evidenceIsActive(source: TapSourceState, publisher: string, digest: string): boolean {
   const keyId = source.publisherPins.publishers[publisher]?.keyId;
   return !source.publisherPins.revokedPackages.includes(digest)
     && keyId !== undefined
     && !source.publisherPins.revokedPublisherKeys.includes(keyId);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "template tap evidence is unavailable";
 }
 
 /** Fetch or reuse and verify one qualified remote package for display. */

--- a/src/profile/templates/taps/discovery.ts
+++ b/src/profile/templates/taps/discovery.ts
@@ -1,0 +1,84 @@
+/**
+ * @file src/profile/templates/taps/discovery.ts
+ * @description Read-only search and inspect DTOs over accepted signed tap evidence.
+ */
+import { deriveTemplateCapabilities } from "../capabilities.js";
+import { parseTemplateCoordinate } from "../signing/protocol.js";
+import { loadAcceptedIndex } from "./evidence.js";
+import { resolveRemotePackage } from "./package.js";
+import type { TapPaths } from "./paths.js";
+import { readTapState } from "./state-store.js";
+
+/** Index-only search result; no package body or raw key is exposed. */
+export interface RemoteTemplateSearchResult {
+  coordinate: string;
+  tap: string;
+  publisher: string;
+  templateId: string;
+  version: string;
+  payloadDigest: string;
+  sequence: number;
+  stale: boolean;
+}
+
+/** Verified package metadata safe for CLI JSON and human output. */
+export interface RemoteTemplateDetails extends RemoteTemplateSearchResult {
+  displayName: string;
+  license: string;
+  minLlmwikiVersion: string;
+  publisherKeyId: string;
+  capabilities: ReturnType<typeof deriveTemplateCapabilities>;
+}
+
+/** Search only already accepted index coordinates, never package bodies. */
+export async function searchRemoteTemplates(paths: TapPaths, query: string, tap?: string): Promise<RemoteTemplateSearchResult[]> {
+  const state = await readTapState(paths);
+  if (tap && !state.taps[tap]) throw new Error(`unknown template tap: ${tap}`);
+  if (tap && !state.taps[tap].enabled) throw new Error(`template tap is disabled: ${tap}`);
+  const sources = Object.values(state.taps).filter((source) => source.enabled && (!tap || source.name === tap));
+  const groups = await Promise.all(sources.map(async (source) => {
+    const index = await loadAcceptedIndex(paths, source);
+    return index.packages
+      .filter((entry) => evidenceIsActive(source, entry.publisher, entry.payloadDigest))
+      .map((entry) => searchResult(entry.coordinate, entry.payloadDigest, index.sequence, index.expiresAt));
+  }));
+  const needle = query.trim().toLowerCase();
+  return groups.flat().filter((item) => searchable(item).includes(needle)).sort((a, b) => a.coordinate.localeCompare(b.coordinate));
+}
+
+function evidenceIsActive(source: Awaited<ReturnType<typeof readTapState>>["taps"][string], publisher: string, digest: string): boolean {
+  const keyId = source.publisherPins.publishers[publisher]?.keyId;
+  return !source.publisherPins.revokedPackages.includes(digest)
+    && keyId !== undefined
+    && !source.publisherPins.revokedPublisherKeys.includes(keyId);
+}
+
+/** Fetch or reuse and verify one qualified remote package for display. */
+export async function inspectRemoteTemplate(paths: TapPaths, coordinate: string): Promise<RemoteTemplateDetails> {
+  const resolved = await resolveRemotePackage(paths, coordinate);
+  const parsed = parseTemplateCoordinate(coordinate);
+  return {
+    coordinate,
+    tap: parsed.tap,
+    publisher: parsed.publisher,
+    templateId: parsed.templateId,
+    version: parsed.version,
+    payloadDigest: resolved.payloadDigest,
+    sequence: resolved.tapSequence,
+    stale: resolved.indexExpired,
+    displayName: resolved.package.displayName,
+    license: resolved.package.license,
+    minLlmwikiVersion: resolved.package.minLlmwikiVersion,
+    publisherKeyId: resolved.publisherKeyId,
+    capabilities: deriveTemplateCapabilities(resolved.package.profile),
+  };
+}
+
+function searchResult(coordinate: string, payloadDigest: string, sequence: number, expiresAt: string): RemoteTemplateSearchResult {
+  const parsed = parseTemplateCoordinate(coordinate);
+  return { coordinate, ...parsed, payloadDigest, sequence, stale: Date.parse(expiresAt) <= Date.now() };
+}
+
+function searchable(result: RemoteTemplateSearchResult): string {
+  return `${result.coordinate} ${result.tap} ${result.publisher} ${result.templateId}`.toLowerCase();
+}

--- a/src/profile/templates/taps/evidence.ts
+++ b/src/profile/templates/taps/evidence.ts
@@ -3,6 +3,7 @@
  * @description Re-verification of the authoritative tap's accepted cached index.
  */
 import { parseSignedTapIndex } from "../signing/protocol.js";
+import { canonicalDigest } from "../signing/canonical.js";
 import { verifyAcceptedTapIndex, type VerifiedTapIndex } from "../signing/verify.js";
 import { readIndexCache } from "./cache.js";
 import type { TapPaths } from "./paths.js";
@@ -13,12 +14,13 @@ export async function loadAcceptedIndex(paths: TapPaths, source: TapSourceState)
   if (source.publisherPins.highestSequence < 0) throw new Error(`template tap has not been refreshed: ${source.name}`);
   const text = await readIndexCache(paths, source.name, source.publisherPins.highestSequence);
   const parsed = parseSignedTapIndex(text);
+  if (canonicalDigest(parsed) !== source.acceptedIndexDigest) throw new Error("cached tap index differs from the accepted index digest");
   const verified = verifyAcceptedTapIndex(parsed, source.name, source.currentTapKey, source.publisherPins);
   assertContinuityMatchesIndex(verified, source);
   return verified;
 }
 
-function assertContinuityMatchesIndex(index: VerifiedTapIndex, source: TapSourceState): void {
+export function assertContinuityMatchesIndex(index: VerifiedTapIndex, source: TapSourceState): void {
   for (const [publisher, announced] of Object.entries(index.publishers)) {
     const pinned = source.publisherPins.publishers[publisher];
     if (pinned?.keyId !== announced.keyId || pinned.publicKey !== announced.publicKey) {

--- a/src/profile/templates/taps/evidence.ts
+++ b/src/profile/templates/taps/evidence.ts
@@ -1,0 +1,33 @@
+/**
+ * @file src/profile/templates/taps/evidence.ts
+ * @description Re-verification of the authoritative tap's accepted cached index.
+ */
+import { parseSignedTapIndex } from "../signing/protocol.js";
+import { verifyAcceptedTapIndex, type VerifiedTapIndex } from "../signing/verify.js";
+import { readIndexCache } from "./cache.js";
+import type { TapPaths } from "./paths.js";
+import type { TapSourceState } from "./state-types.js";
+
+/** Load and cryptographically re-verify the exact sequence accepted in state. */
+export async function loadAcceptedIndex(paths: TapPaths, source: TapSourceState): Promise<VerifiedTapIndex> {
+  if (source.publisherPins.highestSequence < 0) throw new Error(`template tap has not been refreshed: ${source.name}`);
+  const text = await readIndexCache(paths, source.name, source.publisherPins.highestSequence);
+  const parsed = parseSignedTapIndex(text);
+  const verified = verifyAcceptedTapIndex(parsed, source.name, source.currentTapKey, source.publisherPins);
+  assertContinuityMatchesIndex(verified, source);
+  return verified;
+}
+
+function assertContinuityMatchesIndex(index: VerifiedTapIndex, source: TapSourceState): void {
+  for (const [publisher, announced] of Object.entries(index.publishers)) {
+    const pinned = source.publisherPins.publishers[publisher];
+    if (pinned?.keyId !== announced.keyId || pinned.publicKey !== announced.publicKey) {
+      throw new Error(`template tap publisher continuity does not match accepted index: ${publisher}`);
+    }
+  }
+  for (const entry of index.packages) {
+    if (source.publisherPins.coordinates[entry.coordinate] !== entry.payloadDigest) {
+      throw new Error(`template tap coordinate continuity does not match accepted index: ${entry.coordinate}`);
+    }
+  }
+}

--- a/src/profile/templates/taps/manage.ts
+++ b/src/profile/templates/taps/manage.ts
@@ -84,6 +84,7 @@ function newTapSource(input: { name: string; indexUrl: string; key: PublisherKey
     enabled: true,
     currentTapKey: input.key,
     retiredTapKeyIds: [],
+    acceptedIndexDigest: null,
     publisherPins: emptyPublisherPinState(input.name),
   };
 }

--- a/src/profile/templates/taps/manage.ts
+++ b/src/profile/templates/taps/manage.ts
@@ -1,0 +1,115 @@
+/**
+ * @file src/profile/templates/taps/manage.ts
+ * @description Add, disable, re-enable, and list explicitly trusted taps.
+ */
+import { createHash, createPublicKey } from "node:crypto";
+import { MAX_CONNECTOR_URL_BYTES } from "../../../connectors/confined-fetch.js";
+import { emptyPublisherPinState } from "../signing/continuity.js";
+import type { PublisherKey } from "../signing/types.js";
+import type { TapPaths } from "./paths.js";
+import { withTapStateLock } from "./operator-lock.js";
+import { readTapState, writeTapState } from "./state-store.js";
+import type { TapSourceState } from "./state-types.js";
+
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Public tap metadata suitable for human and JSON output. */
+export interface TapSummary {
+  name: string;
+  indexUrl: string;
+  origin: string;
+  enabled: boolean;
+  keyId: string;
+  keyFingerprint: string;
+  highestSequence: number;
+}
+
+/** Add a fresh tap or re-enable its exact retained trust identity. */
+export async function addTap(paths: TapPaths, input: { name: string; indexUrl: string; key: PublisherKey }): Promise<TapSummary> {
+  const source = newTapSource(input);
+  return withTapStateLock(paths, async () => {
+    const state = await readTapState(paths);
+    const existing = state.taps[source.name];
+    if (existing) assertSameRetainedTap(existing, source);
+    const next = existing ? { ...existing, enabled: true } : source;
+    await writeTapState(paths, { ...state, taps: { ...state.taps, [next.name]: next } });
+    return summarize(next);
+  });
+}
+
+/** Disable a tap while retaining every root, pin, revocation, and coordinate. */
+export async function removeTap(paths: TapPaths, name: string): Promise<TapSummary> {
+  assertSlug(name, "tap name");
+  return withTapStateLock(paths, async () => {
+    const state = await readTapState(paths);
+    const existing = state.taps[name];
+    if (!existing) throw new Error(`unknown template tap: ${name}`);
+    const next = { ...existing, enabled: false };
+    await writeTapState(paths, { ...state, taps: { ...state.taps, [name]: next } });
+    return summarize(next);
+  });
+}
+
+/** List configured taps without exposing raw key bytes. */
+export async function listTaps(paths: TapPaths): Promise<TapSummary[]> {
+  const state = await readTapState(paths);
+  return Object.values(state.taps).map(summarize).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function newTapSource(input: { name: string; indexUrl: string; key: PublisherKey }): TapSourceState {
+  assertSlug(input.name, "tap name");
+  const url = parseIndexUrl(input.indexUrl);
+  assertPublicKey(input.key);
+  return {
+    name: input.name,
+    indexUrl: url.toString(),
+    origin: url.origin,
+    enabled: true,
+    currentTapKey: input.key,
+    retiredTapKeyIds: [],
+    publisherPins: emptyPublisherPinState(input.name),
+  };
+}
+
+function parseIndexUrl(value: string): URL {
+  if (Buffer.byteLength(value) > MAX_CONNECTOR_URL_BYTES) throw new Error("tap index URL exceeds its byte cap");
+  const url = new URL(value);
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) throw new Error("tap index URL must be clean HTTPS");
+  if (!url.pathname.endsWith("/index.json")) throw new Error("tap index URL must end in /index.json");
+  if (Buffer.byteLength(url.toString()) > MAX_CONNECTOR_URL_BYTES) throw new Error("tap index URL exceeds its byte cap");
+  return url;
+}
+
+function assertPublicKey(key: PublisherKey): void {
+  if (!/^[A-Za-z0-9._:-]{1,128}$/.test(key.keyId) || Buffer.byteLength(key.publicKey) > 4096) throw new Error("tap key id or value is invalid");
+  try {
+    const parsed = createPublicKey({ key: Buffer.from(key.publicKey, "base64"), format: "der", type: "spki" });
+    if (parsed.asymmetricKeyType !== "ed25519") throw new Error();
+  } catch {
+    throw new Error("tap public key must be Ed25519 SPKI DER in base64");
+  }
+}
+
+function assertSameRetainedTap(existing: TapSourceState, proposed: TapSourceState): void {
+  const same = existing.indexUrl === proposed.indexUrl
+    && existing.origin === proposed.origin
+    && existing.currentTapKey.keyId === proposed.currentTapKey.keyId
+    && existing.currentTapKey.publicKey === proposed.currentTapKey.publicKey;
+  if (!same) throw new Error("tap trust identity cannot be replaced; use a new tap name");
+}
+
+function summarize(source: TapSourceState): TapSummary {
+  return {
+    name: source.name,
+    indexUrl: source.indexUrl,
+    origin: source.origin,
+    enabled: source.enabled,
+    keyId: source.currentTapKey.keyId,
+    keyFingerprint: createHash("sha256").update(Buffer.from(source.currentTapKey.publicKey, "base64")).digest("hex"),
+    highestSequence: source.publisherPins.highestSequence,
+  };
+}
+
+function assertSlug(value: string, label: string): void {
+  if (!SLUG.test(value)) throw new Error(`${label} must be slug-safe`);
+}

--- a/src/profile/templates/taps/manage.ts
+++ b/src/profile/templates/taps/manage.ts
@@ -6,6 +6,7 @@ import { createHash, createPublicKey } from "node:crypto";
 import { MAX_CONNECTOR_URL_BYTES } from "../../../connectors/confined-fetch.js";
 import { emptyPublisherPinState } from "../signing/continuity.js";
 import type { PublisherKey } from "../signing/types.js";
+import { tapStateCapacityWarnings } from "./capacity.js";
 import type { TapPaths } from "./paths.js";
 import { withTapStateLock } from "./operator-lock.js";
 import { readTapState, writeTapState } from "./state-store.js";
@@ -22,6 +23,7 @@ export interface TapSummary {
   keyId: string;
   keyFingerprint: string;
   highestSequence: number;
+  warnings: string[];
 }
 
 /** Add a fresh tap or re-enable its exact retained trust identity. */
@@ -50,10 +52,25 @@ export async function removeTap(paths: TapPaths, name: string): Promise<TapSumma
   });
 }
 
+/** Permanently delete one tap's roots and continuity after explicit consent. */
+export async function forgetTap(paths: TapPaths, name: string, confirmed: boolean): Promise<void> {
+  assertSlug(name, "tap name");
+  if (!confirmed) throw new Error("tap forget requires --yes because it permanently deletes trust history");
+  await withTapStateLock(paths, async () => {
+    const state = await readTapState(paths);
+    if (!state.taps[name]) throw new Error(`unknown template tap: ${name}`);
+    const taps = { ...state.taps };
+    delete taps[name];
+    await writeTapState(paths, { ...state, taps });
+  });
+}
+
 /** List configured taps without exposing raw key bytes. */
 export async function listTaps(paths: TapPaths): Promise<TapSummary[]> {
   const state = await readTapState(paths);
-  return Object.values(state.taps).map(summarize).sort((a, b) => a.name.localeCompare(b.name));
+  const warnings = tapStateCapacityWarnings(state);
+  return Object.values(state.taps).map((source) => summarize(source, warnings.filter((item) => item.startsWith(source.name) || item.startsWith("operator "))))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function newTapSource(input: { name: string; indexUrl: string; key: PublisherKey }): TapSourceState {
@@ -98,7 +115,7 @@ function assertSameRetainedTap(existing: TapSourceState, proposed: TapSourceStat
   if (!same) throw new Error("tap trust identity cannot be replaced; use a new tap name");
 }
 
-function summarize(source: TapSourceState): TapSummary {
+function summarize(source: TapSourceState, warnings: string[] = []): TapSummary {
   return {
     name: source.name,
     indexUrl: source.indexUrl,
@@ -107,6 +124,7 @@ function summarize(source: TapSourceState): TapSummary {
     keyId: source.currentTapKey.keyId,
     keyFingerprint: createHash("sha256").update(Buffer.from(source.currentTapKey.publicKey, "base64")).digest("hex"),
     highestSequence: source.publisherPins.highestSequence,
+    warnings,
   };
 }
 

--- a/src/profile/templates/taps/operator-lock.ts
+++ b/src/profile/templates/taps/operator-lock.ts
@@ -1,0 +1,101 @@
+/**
+ * @file src/profile/templates/taps/operator-lock.ts
+ * @description Token-owned bounded lock for global template-tap state mutations.
+ */
+import { randomBytes } from "node:crypto";
+import { open, unlink } from "node:fs/promises";
+import { readConfinedLeaf } from "../../../utils/confined-read.js";
+import { isOwnerStale, parseOwner, serializeOwner } from "../../../utils/lock-owner.js";
+import type { TapPaths } from "./paths.js";
+import { ensurePrivateRoot } from "./private-root.js";
+
+const MAX_LOCK_BYTES = 1024;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const POLL_MS = 25;
+
+interface OperatorLockRecord { pid: number; startTime?: string; token: string }
+
+/** Run one authoritative read-modify-write while holding the operator lock. */
+export async function withTapStateLock<T>(paths: TapPaths, operation: () => Promise<T>, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
+  const token = await acquireOperatorLock(paths, timeoutMs);
+  try {
+    return await operation();
+  } finally {
+    await releaseOperatorLock(paths, token);
+  }
+}
+
+async function acquireOperatorLock(paths: TapPaths, timeoutMs: number): Promise<string> {
+  await ensurePrivateRoot(paths.configRoot);
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const token = randomBytes(24).toString("hex");
+    if (await tryCreate(paths.lockFile, token)) return token;
+    await reclaimIfStale(paths);
+    if (Date.now() >= deadline) throw new Error("template tap state is busy");
+    await delay(POLL_MS);
+  }
+}
+
+async function tryCreate(lockFile: string, token: string): Promise<boolean> {
+  const owner = JSON.parse(serializeOwner(process.pid)) as { pid: number; startTime?: string };
+  const record: OperatorLockRecord = { ...owner, token };
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(lockFile, "wx", 0o600);
+    await handle.writeFile(JSON.stringify(record), "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+    await handle?.close().catch(() => {});
+    await unlink(lockFile).catch(() => {});
+    throw error;
+  }
+}
+
+async function reclaimIfStale(paths: TapPaths): Promise<void> {
+  const record = await readRecord(paths, paths.lockFile);
+  if (!record || !isOwnerStale(record)) return;
+  const reclaim = `${paths.lockFile}.reclaim`;
+  const token = randomBytes(24).toString("hex");
+  if (!(await acquireReclaim(paths, reclaim, token))) return;
+  try {
+    const current = await readRecord(paths, paths.lockFile);
+    if (current && isOwnerStale(current)) await unlink(paths.lockFile).catch(() => {});
+  } finally {
+    await unlink(reclaim).catch(() => {});
+  }
+}
+
+async function acquireReclaim(paths: TapPaths, file: string, token: string): Promise<boolean> {
+  if (await tryCreate(file, token)) return true;
+  const existing = await readRecord(paths, file);
+  if (existing && isOwnerStale(existing)) await unlink(file).catch(() => {});
+  return false;
+}
+
+async function readRecord(paths: TapPaths, file: string): Promise<OperatorLockRecord | null> {
+  const read = await readConfinedLeaf(paths.configRoot, file, paths.configRoot, MAX_LOCK_BYTES);
+  if (read.kind !== "ok") return null;
+  try {
+    const value = JSON.parse(read.body) as Record<string, unknown>;
+    const owner = parseOwner(JSON.stringify(value));
+    if (!owner || typeof value.token !== "string" || !/^[0-9a-f]{48}$/.test(value.token)) return null;
+    return { ...owner, token: value.token };
+  } catch {
+    return null;
+  }
+}
+
+async function releaseOperatorLock(paths: TapPaths, token: string): Promise<void> {
+  const record = await readRecord(paths, paths.lockFile);
+  if (record?.token !== token || record.pid !== process.pid) return;
+  await unlink(paths.lockFile).catch(() => {});
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/profile/templates/taps/operator-lock.ts
+++ b/src/profile/templates/taps/operator-lock.ts
@@ -51,7 +51,7 @@ async function tryCreate(lockFile: string, token: string): Promise<boolean> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
     await handle?.close().catch(() => {});
-    await unlink(lockFile).catch(() => {});
+    if (handle !== undefined) await unlink(lockFile).catch(() => {});
     throw error;
   }
 }

--- a/src/profile/templates/taps/package.ts
+++ b/src/profile/templates/taps/package.ts
@@ -1,0 +1,109 @@
+/**
+ * @file src/profile/templates/taps/package.ts
+ * @description Content-addressed package retrieval with full cached-byte re-verification.
+ */
+import { TextDecoder } from "node:util";
+import packageJson from "../../../../package.json" with { type: "json" };
+import { confinedFetch, type ConfinedFetchSeams } from "../../../connectors/confined-fetch.js";
+import type { ProfileTemplatePackage } from "../types.js";
+import { parseSignedPackage, parseTemplateCoordinate } from "../signing/protocol.js";
+import { verifySignedPackage } from "../signing/verify.js";
+import { readPackageCache, writePackageCache } from "./cache.js";
+import { loadAcceptedIndex } from "./evidence.js";
+import type { TapPaths } from "./paths.js";
+import { readTapState } from "./state-store.js";
+import { canonicalDigest } from "../signing/canonical.js";
+
+const PACKAGE_LIMITS = {
+  timeoutMs: 15_000,
+  maxBytes: 2 * 1024 * 1024,
+  maxTransportBytes: 2 * 1024 * 1024,
+  maxRedirects: 3,
+  contentTypes: ["application/json"],
+};
+
+/** Verified remote package plus stable public provenance. */
+export interface ResolvedRemotePackage {
+  package: ProfileTemplatePackage;
+  coordinate: string;
+  payloadDigest: string;
+  publisherKeyId: string;
+  tapSequence: number;
+  indexExpired: boolean;
+}
+
+/** Network/test controls; production fetches by default, offline must be explicit. */
+export interface ResolveRemoteOptions {
+  seams?: ConfinedFetchSeams;
+  offline?: boolean;
+  currentVersion?: string;
+}
+
+/** Resolve one accepted coordinate from verified cache or exact-origin network. */
+export async function resolveRemotePackage(
+  paths: TapPaths,
+  coordinate: string,
+  options: ResolveRemoteOptions = {},
+): Promise<ResolvedRemotePackage> {
+  const parsedCoordinate = parseTemplateCoordinate(coordinate);
+  const state = await readTapState(paths);
+  const source = state.taps[parsedCoordinate.tap];
+  if (!source || !source.enabled) throw new Error("template tap is unavailable or disabled");
+  const index = await loadAcceptedIndex(paths, source);
+  const entry = index.packages.find((candidate) => candidate.coordinate === coordinate);
+  if (!entry) throw new Error(`template coordinate is not accepted: ${coordinate}`);
+  const evidence = await packageEvidence(paths, source.indexUrl, source.origin, entry.payloadDigest, options);
+  const pkg = verifySignedPackage(parseSignedPackage(evidence.text), index, source.publisherPins, options.currentVersion ?? packageJson.version);
+  await assertSourceUnchanged(paths, source);
+  if (!evidence.cached) await writePackageCache(paths, entry.payloadDigest, evidence.text);
+  return {
+    package: pkg,
+    coordinate,
+    payloadDigest: entry.payloadDigest,
+    publisherKeyId: index.publishers[entry.publisher].keyId,
+    tapSequence: index.sequence,
+    indexExpired: Date.parse(index.expiresAt) <= Date.now(),
+  };
+}
+
+async function packageEvidence(
+  paths: TapPaths,
+  indexUrl: string,
+  origin: string,
+  digest: string,
+  options: ResolveRemoteOptions,
+): Promise<{ text: string; cached: boolean }> {
+  const cached = await readPackageCache(paths, digest);
+  if (cached !== null) return { text: cached, cached: true };
+  if (options.offline) throw new Error("template package is not cached; refresh online to inspect it");
+  const result = await confinedFetch(
+    { url: packageUrl(indexUrl, digest) },
+    PACKAGE_LIMITS,
+    { allowedHosts: [new URL(indexUrl).hostname], allowedOrigins: [origin] },
+    options.seams ?? {},
+  );
+  if (result.kind !== "ok") throw new Error(`template package ${result.kind}: ${result.reason}`);
+  return { text: strictUtf8(result.bytes), cached: false };
+}
+
+async function assertSourceUnchanged(paths: TapPaths, expected: Awaited<ReturnType<typeof readTapState>>["taps"][string]): Promise<void> {
+  const current = (await readTapState(paths)).taps[expected.name];
+  if (!current || canonicalDigest(current) !== canonicalDigest(expected)) {
+    throw new Error("tap state changed while verifying the package; retry");
+  }
+}
+
+/** Derive the immutable package endpoint from the signed digest only. */
+export function packageUrl(indexUrl: string, digest: string): string {
+  const hex = /^sha256:([0-9a-f]{64})$/.exec(digest)?.[1];
+  if (!hex) throw new Error("package digest is invalid");
+  return new URL(`packages/sha256/${hex}.json`, new URL(".", indexUrl)).toString();
+}
+
+function strictUtf8(bytes: Buffer): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("signed package is not valid UTF-8");
+  }
+}

--- a/src/profile/templates/taps/package.ts
+++ b/src/profile/templates/taps/package.ts
@@ -52,10 +52,11 @@ export async function resolveRemotePackage(
   const index = await loadAcceptedIndex(paths, source);
   const entry = index.packages.find((candidate) => candidate.coordinate === coordinate);
   if (!entry) throw new Error(`template coordinate is not accepted: ${coordinate}`);
-  const evidence = await packageEvidence(paths, source.indexUrl, source.origin, entry.payloadDigest, options);
-  const pkg = verifySignedPackage(parseSignedPackage(evidence.text), index, source.publisherPins, options.currentVersion ?? packageJson.version);
+  const currentVersion = options.currentVersion ?? packageJson.version;
+  const evidence = await packageEvidence(paths, coordinate, source.indexUrl, source.origin, entry.payloadDigest, index, source.publisherPins, currentVersion, options);
+  const pkg = verifyPackageText(evidence.text, index, source.publisherPins, currentVersion);
   await assertSourceUnchanged(paths, source);
-  if (!evidence.cached) await writePackageCache(paths, entry.payloadDigest, evidence.text);
+  if (!evidence.cached) await writePackageCache(paths, coordinate, entry.payloadDigest, evidence.text);
   return {
     package: pkg,
     coordinate,
@@ -68,13 +69,17 @@ export async function resolveRemotePackage(
 
 async function packageEvidence(
   paths: TapPaths,
+  coordinate: string,
   indexUrl: string,
   origin: string,
   digest: string,
+  index: Parameters<typeof verifySignedPackage>[1],
+  pins: Parameters<typeof verifySignedPackage>[2],
+  currentVersion: string,
   options: ResolveRemoteOptions,
 ): Promise<{ text: string; cached: boolean }> {
-  const cached = await readPackageCache(paths, digest);
-  if (cached !== null) return { text: cached, cached: true };
+  const cached = await readPackageCache(paths, coordinate, digest);
+  if (cached !== null && cacheVerifies(cached, index, pins, currentVersion)) return { text: cached, cached: true };
   if (options.offline) throw new Error("template package is not cached; refresh online to inspect it");
   const result = await confinedFetch(
     { url: packageUrl(indexUrl, digest) },
@@ -84,6 +89,29 @@ async function packageEvidence(
   );
   if (result.kind !== "ok") throw new Error(`template package ${result.kind}: ${result.reason}`);
   return { text: strictUtf8(result.bytes), cached: false };
+}
+
+function cacheVerifies(
+  text: string,
+  index: Parameters<typeof verifySignedPackage>[1],
+  pins: Parameters<typeof verifySignedPackage>[2],
+  currentVersion: string,
+): boolean {
+  try {
+    verifyPackageText(text, index, pins, currentVersion);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function verifyPackageText(
+  text: string,
+  index: Parameters<typeof verifySignedPackage>[1],
+  pins: Parameters<typeof verifySignedPackage>[2],
+  currentVersion: string,
+): ProfileTemplatePackage {
+  return verifySignedPackage(parseSignedPackage(text), index, pins, currentVersion);
 }
 
 async function assertSourceUnchanged(paths: TapPaths, expected: Awaited<ReturnType<typeof readTapState>>["taps"][string]): Promise<void> {

--- a/src/profile/templates/taps/paths.ts
+++ b/src/profile/templates/taps/paths.ts
@@ -1,0 +1,50 @@
+/**
+ * @file src/profile/templates/taps/paths.ts
+ * @description Platform operator config/cache paths with deterministic test overrides.
+ */
+import os from "node:os";
+import path from "node:path";
+
+/** Testable environment and home inputs for platform path resolution. */
+export interface TapPathInputs {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  platform?: NodeJS.Platform;
+  configRoot?: string;
+  cacheRoot?: string;
+}
+
+/** Resolved private roots and authoritative/cache leaves. */
+export interface TapPaths {
+  configRoot: string;
+  cacheRoot: string;
+  stateFile: string;
+  lockFile: string;
+}
+
+/** Resolve platform-conventional roots without reading or writing them. */
+export function resolveTapPaths(inputs: TapPathInputs = {}): TapPaths {
+  const env = inputs.env ?? process.env;
+  const home = inputs.home ?? os.homedir();
+  const platform = inputs.platform ?? process.platform;
+  const configRoot = inputs.configRoot ?? defaultConfigRoot(platform, env, home);
+  const cacheRoot = inputs.cacheRoot ?? defaultCacheRoot(platform, env, home);
+  return {
+    configRoot,
+    cacheRoot,
+    stateFile: path.join(configRoot, "template-taps.json"),
+    lockFile: path.join(configRoot, "template-taps.lock"),
+  };
+}
+
+function defaultConfigRoot(platform: NodeJS.Platform, env: NodeJS.ProcessEnv, home: string): string {
+  if (platform === "win32" && env.APPDATA) return path.join(env.APPDATA, "llmwiki");
+  if (env.XDG_CONFIG_HOME) return path.join(env.XDG_CONFIG_HOME, "llmwiki");
+  return path.join(home, ".config", "llmwiki");
+}
+
+function defaultCacheRoot(platform: NodeJS.Platform, env: NodeJS.ProcessEnv, home: string): string {
+  if (platform === "win32" && env.LOCALAPPDATA) return path.join(env.LOCALAPPDATA, "llmwiki", "cache", "templates");
+  if (env.XDG_CACHE_HOME) return path.join(env.XDG_CACHE_HOME, "llmwiki", "templates");
+  return path.join(home, ".cache", "llmwiki", "templates");
+}

--- a/src/profile/templates/taps/paths.ts
+++ b/src/profile/templates/taps/paths.ts
@@ -38,13 +38,18 @@ export function resolveTapPaths(inputs: TapPathInputs = {}): TapPaths {
 }
 
 function defaultConfigRoot(platform: NodeJS.Platform, env: NodeJS.ProcessEnv, home: string): string {
-  if (platform === "win32" && env.APPDATA) return path.join(env.APPDATA, "llmwiki");
-  if (env.XDG_CONFIG_HOME) return path.join(env.XDG_CONFIG_HOME, "llmwiki");
+  if (platform === "win32" && absolute(platform, env.APPDATA)) return path.join(env.APPDATA!, "llmwiki");
+  if (absolute(platform, env.XDG_CONFIG_HOME)) return path.join(env.XDG_CONFIG_HOME!, "llmwiki");
   return path.join(home, ".config", "llmwiki");
 }
 
 function defaultCacheRoot(platform: NodeJS.Platform, env: NodeJS.ProcessEnv, home: string): string {
-  if (platform === "win32" && env.LOCALAPPDATA) return path.join(env.LOCALAPPDATA, "llmwiki", "cache", "templates");
-  if (env.XDG_CACHE_HOME) return path.join(env.XDG_CACHE_HOME, "llmwiki", "templates");
+  if (platform === "win32" && absolute(platform, env.LOCALAPPDATA)) return path.join(env.LOCALAPPDATA!, "llmwiki", "cache", "templates");
+  if (absolute(platform, env.XDG_CACHE_HOME)) return path.join(env.XDG_CACHE_HOME!, "llmwiki", "templates");
   return path.join(home, ".cache", "llmwiki", "templates");
+}
+
+function absolute(platform: NodeJS.Platform, value: string | undefined): value is string {
+  const paths = platform === "win32" ? path.win32 : path;
+  return value !== undefined && paths.isAbsolute(value);
 }

--- a/src/profile/templates/taps/private-root.ts
+++ b/src/profile/templates/taps/private-root.ts
@@ -1,0 +1,22 @@
+/**
+ * @file src/profile/templates/taps/private-root.ts
+ * @description Safe creation of private operator config and cache roots.
+ */
+import { chmod, lstat, mkdir } from "node:fs/promises";
+
+/** Create a non-symlinked private root and enforce owner-only POSIX permissions. */
+export async function ensurePrivateRoot(root: string): Promise<void> {
+  const existing = await lstat(root).catch((error) => absentOrThrow(error));
+  if (existing && (!existing.isDirectory() || existing.isSymbolicLink())) {
+    throw new Error("template tap root must be a real directory");
+  }
+  await mkdir(root, { recursive: true, mode: 0o700 });
+  const stat = await lstat(root);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("template tap root must be a real directory");
+  if (process.platform !== "win32") await chmod(root, 0o700);
+}
+
+function absentOrThrow(error: unknown): null {
+  if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+  throw error;
+}

--- a/src/profile/templates/taps/refresh.ts
+++ b/src/profile/templates/taps/refresh.ts
@@ -6,11 +6,12 @@ import { TextDecoder } from "node:util";
 import { confinedFetch, type ConfinedFetchSeams } from "../../../connectors/confined-fetch.js";
 import { canonicalDigest } from "../signing/canonical.js";
 import { advancePublisherPins } from "../signing/continuity.js";
-import { parseSignedTapIndex } from "../signing/protocol.js";
+import { parseSignedTapIndex, type ParsedTapIndex } from "../signing/protocol.js";
 import type { PublisherKey } from "../signing/types.js";
-import { verifyTapIndex, verifyTapKeyRotation } from "../signing/verify.js";
-import { removeIndexCache, writeIndexCache } from "./cache.js";
+import { verifyAcceptedTapIndex, verifyTapIndex, verifyTapKeyRotation } from "../signing/verify.js";
+import { pruneIndexCaches, writeIndexCache } from "./cache.js";
 import { tapStateCapacityWarnings } from "./capacity.js";
+import { assertContinuityMatchesIndex, loadAcceptedIndex } from "./evidence.js";
 import { withTapStateLock } from "./operator-lock.js";
 import type { TapPaths } from "./paths.js";
 import { readTapState, writeTapState } from "./state-store.js";
@@ -34,10 +35,13 @@ export async function refreshTap(paths: TapPaths, name: string, seams: ConfinedF
   if (!initial.enabled) throw new Error(`template tap is disabled: ${name}`);
   const fetched = await fetchIndex(initial, seams);
   const parsed = parseSignedTapIndex(fetched.text);
+  if (parsed.sequence === initial.publisherPins.highestSequence) {
+    return repairAcceptedCache(paths, initial, parsed, fetched.text);
+  }
   const key = acceptedTapKey(initial, parsed);
   const verified = verifyTapIndex(parsed, name, key);
   const pins = advancePublisherPins(verified, initial.publisherPins);
-  const successor = nextSource(initial, key, pins);
+  const successor = nextSource(initial, key, pins, canonicalDigest(parsed));
   const warnings = await commitRefresh(paths, initial, successor, fetched.text);
   return { tap: name, sequence: verified.sequence, packages: verified.packages.length, warnings };
 }
@@ -66,14 +70,53 @@ function acceptedTapKey(source: TapSourceState, index: ReturnType<typeof parseSi
   return verifyTapKeyRotation(source.name, rotation, source.currentTapKey);
 }
 
-function nextSource(source: TapSourceState, key: PublisherKey, pins: TapSourceState["publisherPins"]): TapSourceState {
+function nextSource(
+  source: TapSourceState,
+  key: PublisherKey,
+  pins: TapSourceState["publisherPins"],
+  acceptedIndexDigest: string,
+): TapSourceState {
   const rotated = key.keyId !== source.currentTapKey.keyId;
   return {
     ...source,
     currentTapKey: key,
     retiredTapKeyIds: rotated ? [...source.retiredTapKeyIds, source.currentTapKey.keyId] : source.retiredTapKeyIds,
+    acceptedIndexDigest,
     publisherPins: pins,
   };
+}
+
+async function repairAcceptedCache(
+  paths: TapPaths,
+  source: TapSourceState,
+  parsed: ParsedTapIndex,
+  text: string,
+): Promise<TapRefreshResult> {
+  if (await acceptedCacheIsHealthy(paths, source)) throw new Error("tap index sequence rollback or replay");
+  if (canonicalDigest(parsed) !== source.acceptedIndexDigest) throw new Error("fetched index differs from the accepted index digest");
+  const verified = verifyAcceptedTapIndex(parsed, source.name, source.currentTapKey, source.publisherPins);
+  assertContinuityMatchesIndex(verified, source);
+  const warnings = await commitCacheRepair(paths, source, text);
+  return { tap: source.name, sequence: parsed.sequence, packages: parsed.packages.length, warnings };
+}
+
+async function acceptedCacheIsHealthy(paths: TapPaths, source: TapSourceState): Promise<boolean> {
+  try {
+    await loadAcceptedIndex(paths, source);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function commitCacheRepair(paths: TapPaths, expected: TapSourceState, text: string): Promise<string[]> {
+  return withTapStateLock(paths, async () => {
+    const state = await readTapState(paths);
+    const current = state.taps[expected.name];
+    if (!current || canonicalDigest(current) !== canonicalDigest(expected)) throw new Error("tap state changed during refresh; retry");
+    await writeIndexCache(paths, expected.name, expected.publisherPins.highestSequence, text);
+    return tapStateCapacityWarnings(state);
+  });
 }
 
 async function commitRefresh(paths: TapPaths, initial: TapSourceState, next: TapSourceState, indexText: string): Promise<string[]> {
@@ -84,13 +127,7 @@ async function commitRefresh(paths: TapPaths, initial: TapSourceState, next: Tap
     await writeIndexCache(paths, next.name, next.publisherPins.highestSequence, indexText);
     const updated = { ...state, taps: { ...state.taps, [next.name]: next } };
     await writeTapState(paths, updated);
-    await prunePreviousIndex(paths, initial);
+    await pruneIndexCaches(paths, next.name, next.publisherPins.highestSequence).catch(() => {});
     return tapStateCapacityWarnings(updated);
   });
-}
-
-async function prunePreviousIndex(paths: TapPaths, source: TapSourceState): Promise<void> {
-  const sequence = source.publisherPins.highestSequence;
-  if (sequence < 0) return;
-  await removeIndexCache(paths, source.name, sequence).catch(() => {});
 }

--- a/src/profile/templates/taps/refresh.ts
+++ b/src/profile/templates/taps/refresh.ts
@@ -1,0 +1,86 @@
+/**
+ * @file src/profile/templates/taps/refresh.ts
+ * @description Fetch, verify, and atomically accept one signed tap snapshot.
+ */
+import { TextDecoder } from "node:util";
+import { confinedFetch, type ConfinedFetchSeams } from "../../../connectors/confined-fetch.js";
+import { canonicalDigest } from "../signing/canonical.js";
+import { advancePublisherPins } from "../signing/continuity.js";
+import { parseSignedTapIndex } from "../signing/protocol.js";
+import type { PublisherKey } from "../signing/types.js";
+import { verifyTapIndex, verifyTapKeyRotation } from "../signing/verify.js";
+import { writeIndexCache } from "./cache.js";
+import { withTapStateLock } from "./operator-lock.js";
+import type { TapPaths } from "./paths.js";
+import { readTapState, writeTapState } from "./state-store.js";
+import type { TapSourceState } from "./state-types.js";
+
+const INDEX_LIMITS = {
+  timeoutMs: 15_000,
+  maxBytes: 4 * 1024 * 1024,
+  maxTransportBytes: 4 * 1024 * 1024,
+  maxRedirects: 3,
+  contentTypes: ["application/json"],
+};
+
+/** Public refresh result without raw keys or index bytes. */
+export interface TapRefreshResult { tap: string; sequence: number; packages: number }
+
+/** Refresh one enabled tap and commit continuity only if its snapshot is unchanged. */
+export async function refreshTap(paths: TapPaths, name: string, seams: ConfinedFetchSeams = {}): Promise<TapRefreshResult> {
+  const initial = (await readTapState(paths)).taps[name];
+  if (!initial) throw new Error(`unknown template tap: ${name}`);
+  if (!initial.enabled) throw new Error(`template tap is disabled: ${name}`);
+  const fetched = await fetchIndex(initial, seams);
+  const parsed = parseSignedTapIndex(fetched.text);
+  const key = acceptedTapKey(initial, parsed);
+  const verified = verifyTapIndex(parsed, name, key);
+  const pins = advancePublisherPins(verified, initial.publisherPins);
+  const successor = nextSource(initial, key, pins);
+  await commitRefresh(paths, initial, successor, fetched.text);
+  return { tap: name, sequence: verified.sequence, packages: verified.packages.length };
+}
+
+async function fetchIndex(source: TapSourceState, seams: ConfinedFetchSeams): Promise<{ text: string }> {
+  const result = await confinedFetch(
+    { url: source.indexUrl },
+    INDEX_LIMITS,
+    { allowedHosts: [new URL(source.indexUrl).hostname], allowedOrigins: [source.origin] },
+    seams,
+  );
+  if (result.kind !== "ok") throw new Error(`tap refresh ${result.kind}: ${result.reason}`);
+  try {
+    return { text: new TextDecoder("utf-8", { fatal: true }).decode(result.bytes) };
+  } catch {
+    throw new Error("tap index is not valid UTF-8");
+  }
+}
+
+function acceptedTapKey(source: TapSourceState, index: ReturnType<typeof parseSignedTapIndex>): PublisherKey {
+  if (index.signature.keyId === source.currentTapKey.keyId) return source.currentTapKey;
+  const rotation = index.tapKeyRotation;
+  if (!rotation) throw new Error("tap root changed without a signed rotation");
+  if (rotation.effectiveSequence !== index.sequence) throw new Error("tap root rotation sequence differs from its index");
+  if (source.retiredTapKeyIds.includes(rotation.toKey.keyId)) throw new Error("retired tap key cannot be reused");
+  return verifyTapKeyRotation(source.name, rotation, source.currentTapKey);
+}
+
+function nextSource(source: TapSourceState, key: PublisherKey, pins: TapSourceState["publisherPins"]): TapSourceState {
+  const rotated = key.keyId !== source.currentTapKey.keyId;
+  return {
+    ...source,
+    currentTapKey: key,
+    retiredTapKeyIds: rotated ? [...source.retiredTapKeyIds, source.currentTapKey.keyId] : source.retiredTapKeyIds,
+    publisherPins: pins,
+  };
+}
+
+async function commitRefresh(paths: TapPaths, initial: TapSourceState, next: TapSourceState, indexText: string): Promise<void> {
+  await withTapStateLock(paths, async () => {
+    const state = await readTapState(paths);
+    const current = state.taps[initial.name];
+    if (!current || canonicalDigest(current) !== canonicalDigest(initial)) throw new Error("tap state changed during refresh; retry");
+    await writeIndexCache(paths, next.name, next.publisherPins.highestSequence, indexText);
+    await writeTapState(paths, { ...state, taps: { ...state.taps, [next.name]: next } });
+  });
+}

--- a/src/profile/templates/taps/refresh.ts
+++ b/src/profile/templates/taps/refresh.ts
@@ -9,7 +9,8 @@ import { advancePublisherPins } from "../signing/continuity.js";
 import { parseSignedTapIndex } from "../signing/protocol.js";
 import type { PublisherKey } from "../signing/types.js";
 import { verifyTapIndex, verifyTapKeyRotation } from "../signing/verify.js";
-import { writeIndexCache } from "./cache.js";
+import { removeIndexCache, writeIndexCache } from "./cache.js";
+import { tapStateCapacityWarnings } from "./capacity.js";
 import { withTapStateLock } from "./operator-lock.js";
 import type { TapPaths } from "./paths.js";
 import { readTapState, writeTapState } from "./state-store.js";
@@ -24,7 +25,7 @@ const INDEX_LIMITS = {
 };
 
 /** Public refresh result without raw keys or index bytes. */
-export interface TapRefreshResult { tap: string; sequence: number; packages: number }
+export interface TapRefreshResult { tap: string; sequence: number; packages: number; warnings: string[] }
 
 /** Refresh one enabled tap and commit continuity only if its snapshot is unchanged. */
 export async function refreshTap(paths: TapPaths, name: string, seams: ConfinedFetchSeams = {}): Promise<TapRefreshResult> {
@@ -37,8 +38,8 @@ export async function refreshTap(paths: TapPaths, name: string, seams: ConfinedF
   const verified = verifyTapIndex(parsed, name, key);
   const pins = advancePublisherPins(verified, initial.publisherPins);
   const successor = nextSource(initial, key, pins);
-  await commitRefresh(paths, initial, successor, fetched.text);
-  return { tap: name, sequence: verified.sequence, packages: verified.packages.length };
+  const warnings = await commitRefresh(paths, initial, successor, fetched.text);
+  return { tap: name, sequence: verified.sequence, packages: verified.packages.length, warnings };
 }
 
 async function fetchIndex(source: TapSourceState, seams: ConfinedFetchSeams): Promise<{ text: string }> {
@@ -75,12 +76,21 @@ function nextSource(source: TapSourceState, key: PublisherKey, pins: TapSourceSt
   };
 }
 
-async function commitRefresh(paths: TapPaths, initial: TapSourceState, next: TapSourceState, indexText: string): Promise<void> {
-  await withTapStateLock(paths, async () => {
+async function commitRefresh(paths: TapPaths, initial: TapSourceState, next: TapSourceState, indexText: string): Promise<string[]> {
+  return withTapStateLock(paths, async () => {
     const state = await readTapState(paths);
     const current = state.taps[initial.name];
     if (!current || canonicalDigest(current) !== canonicalDigest(initial)) throw new Error("tap state changed during refresh; retry");
     await writeIndexCache(paths, next.name, next.publisherPins.highestSequence, indexText);
-    await writeTapState(paths, { ...state, taps: { ...state.taps, [next.name]: next } });
+    const updated = { ...state, taps: { ...state.taps, [next.name]: next } };
+    await writeTapState(paths, updated);
+    await prunePreviousIndex(paths, initial);
+    return tapStateCapacityWarnings(updated);
   });
+}
+
+async function prunePreviousIndex(paths: TapPaths, source: TapSourceState): Promise<void> {
+  const sequence = source.publisherPins.highestSequence;
+  if (sequence < 0) return;
+  await removeIndexCache(paths, source.name, sequence).catch(() => {});
 }

--- a/src/profile/templates/taps/state-parse.ts
+++ b/src/profile/templates/taps/state-parse.ts
@@ -1,0 +1,163 @@
+/**
+ * @file src/profile/templates/taps/state-parse.ts
+ * @description Exact-shape parser and caps for authoritative template-tap state.
+ */
+import { createPublicKey } from "node:crypto";
+import { parseBoundedUniqueJson } from "../signing/json.js";
+import type { PublisherKey, PublisherPinState } from "../signing/types.js";
+import type { TapOperatorState, TapSourceState } from "./state-types.js";
+
+export const MAX_TAP_STATE_BYTES = 4 * 1024 * 1024;
+const MAX_TAPS = 64;
+const MAX_ITEMS = 10_000;
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+
+/** Parse duplicate-key-free bounded state and reject every unknown field. */
+export function parseTapOperatorState(text: string): TapOperatorState {
+  const root = record(parseBoundedUniqueJson(text, MAX_TAP_STATE_BYTES), "tap state");
+  exact(root, ["schemaVersion", "taps"]);
+  if (root.schemaVersion !== 1) throw new Error("tap state schemaVersion must be 1");
+  const taps = namedMap(root.taps, "taps", parseSource, MAX_TAPS);
+  return { schemaVersion: 1, taps };
+}
+
+function parseSource(value: unknown, name: string): TapSourceState {
+  const obj = record(value, `tap ${name}`);
+  exact(obj, ["name", "indexUrl", "origin", "enabled", "currentTapKey", "retiredTapKeyIds", "publisherPins"]);
+  if (slug(obj.name, "tap name") !== name) throw new Error("tap state name differs from its map key");
+  const indexUrl = httpsUrl(obj.indexUrl, "tap indexUrl");
+  const origin = httpsOrigin(obj.origin, "tap origin");
+  if (new URL(indexUrl).origin !== origin) throw new Error("tap URL differs from its pinned origin");
+  const currentTapKey = publisherKey(obj.currentTapKey);
+  const retiredTapKeyIds = stringList(obj.retiredTapKeyIds, "retired tap keys");
+  if (retiredTapKeyIds.includes(currentTapKey.keyId)) throw new Error("current tap key cannot be retired");
+  return {
+    name,
+    indexUrl,
+    origin,
+    enabled: bool(obj.enabled, "tap enabled"),
+    currentTapKey,
+    retiredTapKeyIds,
+    publisherPins: publisherPins(obj.publisherPins, name),
+  };
+}
+
+function publisherPins(value: unknown, tap: string): PublisherPinState {
+  const obj = record(value, "publisher pins");
+  exact(obj, ["tap", "highestSequence", "publishers", "keyHistory", "coordinates", "revokedPackages", "revokedPublisherKeys"]);
+  if (slug(obj.tap, "pin tap") !== tap) throw new Error("publisher pins belong to another tap");
+  return {
+    tap,
+    highestSequence: integer(obj.highestSequence, "highest sequence", -1),
+    publishers: namedMap(obj.publishers, "publishers", (item) => publisherKey(item)),
+    keyHistory: namedMap(obj.keyHistory, "key history", parseHistory),
+    coordinates: stringMap(obj.coordinates, "coordinates", DIGEST),
+    revokedPackages: stringList(obj.revokedPackages, "revoked packages", DIGEST),
+    revokedPublisherKeys: stringList(obj.revokedPublisherKeys, "revoked publisher keys"),
+  };
+}
+
+function parseHistory(value: unknown): { publisher: string; publicKey: string } {
+  const obj = record(value, "key history entry");
+  exact(obj, ["publisher", "publicKey"]);
+  const publicKey = base64(obj.publicKey, "history publicKey");
+  assertEd25519(publicKey);
+  return { publisher: slug(obj.publisher, "history publisher"), publicKey };
+}
+
+function publisherKey(value: unknown): PublisherKey {
+  const obj = record(value, "publisher key");
+  exact(obj, ["keyId", "publicKey"]);
+  const key = { keyId: boundedText(obj.keyId, "key id"), publicKey: base64(obj.publicKey, "public key") };
+  assertEd25519(key.publicKey);
+  return key;
+}
+
+function assertEd25519(publicKey: string): void {
+  try {
+    const key = createPublicKey({ key: Buffer.from(publicKey, "base64"), format: "der", type: "spki" });
+    if (key.asymmetricKeyType !== "ed25519") throw new Error();
+  } catch {
+    throw new Error("stored public key is not Ed25519 SPKI DER");
+  }
+}
+
+function namedMap<T>(value: unknown, label: string, parse: (item: unknown, name: string) => T, cap = MAX_ITEMS): Record<string, T> {
+  const obj = record(value, label);
+  if (Object.keys(obj).length > cap) throw new Error(`${label} exceeds its item cap`);
+  return Object.fromEntries(Object.entries(obj).map(([name, item]) => [slug(name, `${label} key`), parse(item, name)]));
+}
+
+function stringMap(value: unknown, label: string, pattern?: RegExp): Record<string, string> {
+  const obj = record(value, label);
+  if (Object.keys(obj).length > MAX_ITEMS) throw new Error(`${label} exceeds its item cap`);
+  return Object.fromEntries(Object.entries(obj).map(([key, item]) => [boundedText(key, `${label} key`), matched(item, label, pattern)]));
+}
+
+function stringList(value: unknown, label: string, pattern?: RegExp): string[] {
+  if (!Array.isArray(value) || value.length > MAX_ITEMS) throw new Error(`${label} must be a bounded array`);
+  const values = value.map((item) => matched(item, label, pattern));
+  if (new Set(values).size !== values.length) throw new Error(`${label} contains duplicates`);
+  return values;
+}
+
+function matched(value: unknown, label: string, pattern?: RegExp): string {
+  const text = boundedText(value, label);
+  if (pattern && !pattern.test(text)) throw new Error(`${label} has an invalid value`);
+  return text;
+}
+
+function httpsUrl(value: unknown, label: string): string {
+  const text = boundedText(value, label);
+  const url = new URL(text);
+  if (url.protocol !== "https:" || url.username || url.password || url.hash) throw new Error(`${label} must be a clean HTTPS URL`);
+  return url.toString();
+}
+
+function httpsOrigin(value: unknown, label: string): string {
+  const text = boundedText(value, label);
+  const url = new URL(text);
+  if (url.protocol !== "https:" || url.origin !== text) throw new Error(`${label} must be a normalized HTTPS origin`);
+  return text;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  const isRecord = typeof value === "object" && value !== null && !Array.isArray(value);
+  if (!isRecord) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exact(obj: Record<string, unknown>, keys: string[]): void {
+  const actual = Object.keys(obj).sort().join("\0");
+  const expected = [...keys].sort().join("\0");
+  if (actual !== expected) throw new Error("tap state object has unsupported or missing fields");
+}
+
+function boundedText(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || Buffer.byteLength(value) > 4096) throw new Error(`${label} must be bounded text`);
+  return value;
+}
+
+function slug(value: unknown, label: string): string {
+  const text = boundedText(value, label);
+  if (!SLUG.test(text)) throw new Error(`${label} must be slug-safe`);
+  return text;
+}
+
+function base64(value: unknown, label: string): string {
+  const text = boundedText(value, label);
+  const decoded = Buffer.from(text, "base64");
+  if (decoded.length === 0 || decoded.toString("base64") !== text) throw new Error(`${label} must be base64`);
+  return text;
+}
+
+function bool(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be boolean`);
+  return value;
+}
+
+function integer(value: unknown, label: string, minimum: number): number {
+  if (!Number.isSafeInteger(value) || Number(value) < minimum) throw new Error(`${label} must be an integer`);
+  return Number(value);
+}

--- a/src/profile/templates/taps/state-parse.ts
+++ b/src/profile/templates/taps/state-parse.ts
@@ -5,11 +5,9 @@
 import { createPublicKey } from "node:crypto";
 import { parseBoundedUniqueJson } from "../signing/json.js";
 import type { PublisherKey, PublisherPinState } from "../signing/types.js";
+import { MAX_TAP_SOURCES, MAX_TAP_STATE_BYTES, MAX_TAP_STATE_ITEMS } from "./capacity.js";
 import type { TapOperatorState, TapSourceState } from "./state-types.js";
 
-export const MAX_TAP_STATE_BYTES = 4 * 1024 * 1024;
-const MAX_TAPS = 64;
-const MAX_ITEMS = 10_000;
 const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const DIGEST = /^sha256:[0-9a-f]{64}$/;
 
@@ -18,7 +16,7 @@ export function parseTapOperatorState(text: string): TapOperatorState {
   const root = record(parseBoundedUniqueJson(text, MAX_TAP_STATE_BYTES), "tap state");
   exact(root, ["schemaVersion", "taps"]);
   if (root.schemaVersion !== 1) throw new Error("tap state schemaVersion must be 1");
-  const taps = namedMap(root.taps, "taps", parseSource, MAX_TAPS);
+  const taps = namedMap(root.taps, "taps", parseSource, MAX_TAP_SOURCES);
   return { schemaVersion: 1, taps };
 }
 
@@ -51,7 +49,7 @@ function publisherPins(value: unknown, tap: string): PublisherPinState {
     tap,
     highestSequence: integer(obj.highestSequence, "highest sequence", -1),
     publishers: namedMap(obj.publishers, "publishers", (item) => publisherKey(item)),
-    keyHistory: namedMap(obj.keyHistory, "key history", parseHistory),
+    keyHistory: boundedMap(obj.keyHistory, "key history", parseHistory),
     coordinates: stringMap(obj.coordinates, "coordinates", DIGEST),
     revokedPackages: stringList(obj.revokedPackages, "revoked packages", DIGEST),
     revokedPublisherKeys: stringList(obj.revokedPublisherKeys, "revoked publisher keys"),
@@ -83,7 +81,7 @@ function assertEd25519(publicKey: string): void {
   }
 }
 
-function namedMap<T>(value: unknown, label: string, parse: (item: unknown, name: string) => T, cap = MAX_ITEMS): Record<string, T> {
+function namedMap<T>(value: unknown, label: string, parse: (item: unknown, name: string) => T, cap = MAX_TAP_STATE_ITEMS): Record<string, T> {
   const obj = record(value, label);
   if (Object.keys(obj).length > cap) throw new Error(`${label} exceeds its item cap`);
   return Object.fromEntries(Object.entries(obj).map(([name, item]) => [slug(name, `${label} key`), parse(item, name)]));
@@ -91,12 +89,18 @@ function namedMap<T>(value: unknown, label: string, parse: (item: unknown, name:
 
 function stringMap(value: unknown, label: string, pattern?: RegExp): Record<string, string> {
   const obj = record(value, label);
-  if (Object.keys(obj).length > MAX_ITEMS) throw new Error(`${label} exceeds its item cap`);
+  if (Object.keys(obj).length > MAX_TAP_STATE_ITEMS) throw new Error(`${label} exceeds its item cap`);
   return Object.fromEntries(Object.entries(obj).map(([key, item]) => [boundedText(key, `${label} key`), matched(item, label, pattern)]));
 }
 
+function boundedMap<T>(value: unknown, label: string, parse: (item: unknown) => T): Record<string, T> {
+  const obj = record(value, label);
+  if (Object.keys(obj).length > MAX_TAP_STATE_ITEMS) throw new Error(`${label} exceeds its item cap`);
+  return Object.fromEntries(Object.entries(obj).map(([key, item]) => [boundedText(key, `${label} key`), parse(item)]));
+}
+
 function stringList(value: unknown, label: string, pattern?: RegExp): string[] {
-  if (!Array.isArray(value) || value.length > MAX_ITEMS) throw new Error(`${label} must be a bounded array`);
+  if (!Array.isArray(value) || value.length > MAX_TAP_STATE_ITEMS) throw new Error(`${label} must be a bounded array`);
   const values = value.map((item) => matched(item, label, pattern));
   if (new Set(values).size !== values.length) throw new Error(`${label} contains duplicates`);
   return values;

--- a/src/profile/templates/taps/state-parse.ts
+++ b/src/profile/templates/taps/state-parse.ts
@@ -4,6 +4,7 @@
  */
 import { createPublicKey } from "node:crypto";
 import { parseBoundedUniqueJson } from "../signing/json.js";
+import { parseTemplateCoordinate } from "../signing/protocol.js";
 import type { PublisherKey, PublisherPinState } from "../signing/types.js";
 import { MAX_TAP_SOURCES, MAX_TAP_STATE_BYTES, MAX_TAP_STATE_ITEMS } from "./capacity.js";
 import type { TapOperatorState, TapSourceState } from "./state-types.js";
@@ -22,7 +23,7 @@ export function parseTapOperatorState(text: string): TapOperatorState {
 
 function parseSource(value: unknown, name: string): TapSourceState {
   const obj = record(value, `tap ${name}`);
-  exact(obj, ["name", "indexUrl", "origin", "enabled", "currentTapKey", "retiredTapKeyIds", "publisherPins"]);
+  exact(obj, ["name", "indexUrl", "origin", "enabled", "currentTapKey", "retiredTapKeyIds", "acceptedIndexDigest", "publisherPins"]);
   if (slug(obj.name, "tap name") !== name) throw new Error("tap state name differs from its map key");
   const indexUrl = httpsUrl(obj.indexUrl, "tap indexUrl");
   const origin = httpsOrigin(obj.origin, "tap origin");
@@ -30,6 +31,11 @@ function parseSource(value: unknown, name: string): TapSourceState {
   const currentTapKey = publisherKey(obj.currentTapKey);
   const retiredTapKeyIds = stringList(obj.retiredTapKeyIds, "retired tap keys");
   if (retiredTapKeyIds.includes(currentTapKey.keyId)) throw new Error("current tap key cannot be retired");
+  const publisherPins = parsePublisherPins(obj.publisherPins, name);
+  const acceptedIndexDigest = optionalDigest(obj.acceptedIndexDigest);
+  if ((publisherPins.highestSequence < 0) !== (acceptedIndexDigest === null)) {
+    throw new Error("accepted index digest differs from continuity sequence state");
+  }
   return {
     name,
     indexUrl,
@@ -37,15 +43,16 @@ function parseSource(value: unknown, name: string): TapSourceState {
     enabled: bool(obj.enabled, "tap enabled"),
     currentTapKey,
     retiredTapKeyIds,
-    publisherPins: publisherPins(obj.publisherPins, name),
+    acceptedIndexDigest,
+    publisherPins,
   };
 }
 
-function publisherPins(value: unknown, tap: string): PublisherPinState {
+function parsePublisherPins(value: unknown, tap: string): PublisherPinState {
   const obj = record(value, "publisher pins");
   exact(obj, ["tap", "highestSequence", "publishers", "keyHistory", "coordinates", "revokedPackages", "revokedPublisherKeys"]);
   if (slug(obj.tap, "pin tap") !== tap) throw new Error("publisher pins belong to another tap");
-  return {
+  const pins: PublisherPinState = {
     tap,
     highestSequence: integer(obj.highestSequence, "highest sequence", -1),
     publishers: namedMap(obj.publishers, "publishers", (item) => publisherKey(item)),
@@ -54,6 +61,36 @@ function publisherPins(value: unknown, tap: string): PublisherPinState {
     revokedPackages: stringList(obj.revokedPackages, "revoked packages", DIGEST),
     revokedPublisherKeys: stringList(obj.revokedPublisherKeys, "revoked publisher keys"),
   };
+  assertPinRelationships(pins, tap);
+  return pins;
+}
+
+function assertPinRelationships(pins: PublisherPinState, tap: string): void {
+  assertActivePublisherPins(pins);
+  assertHistoryPublishers(pins);
+  assertCoordinateOwners(pins, tap);
+}
+
+function assertActivePublisherPins(pins: PublisherPinState): void {
+  for (const [publisher, key] of Object.entries(pins.publishers)) {
+    const history = pins.keyHistory[key.keyId];
+    if (history?.publisher !== publisher || history.publicKey !== key.publicKey) {
+      throw new Error(`active publisher key is missing from history: ${publisher}`);
+    }
+    if (pins.revokedPublisherKeys.includes(key.keyId)) throw new Error(`active publisher key is revoked: ${publisher}`);
+  }
+}
+
+function assertHistoryPublishers(pins: PublisherPinState): void {
+  for (const history of Object.values(pins.keyHistory)) {
+    if (!pins.publishers[history.publisher]) throw new Error(`key history names an unknown publisher: ${history.publisher}`);
+  }
+}
+
+function assertCoordinateOwners(pins: PublisherPinState, tap: string): void {
+  for (const coordinate of Object.keys(pins.coordinates)) {
+    if (parseTemplateCoordinate(coordinate).tap !== tap) throw new Error(`coordinate belongs to another tap: ${coordinate}`);
+  }
 }
 
 function parseHistory(value: unknown): { publisher: string; publicKey: string } {
@@ -110,6 +147,11 @@ function matched(value: unknown, label: string, pattern?: RegExp): string {
   const text = boundedText(value, label);
   if (pattern && !pattern.test(text)) throw new Error(`${label} has an invalid value`);
   return text;
+}
+
+function optionalDigest(value: unknown): string | null {
+  if (value === null) return null;
+  return matched(value, "accepted index digest", DIGEST);
 }
 
 function httpsUrl(value: unknown, label: string): string {

--- a/src/profile/templates/taps/state-store.ts
+++ b/src/profile/templates/taps/state-store.ts
@@ -1,0 +1,35 @@
+/**
+ * @file src/profile/templates/taps/state-store.ts
+ * @description Confined, capped, atomic persistence for authoritative tap state.
+ */
+import { lstat } from "node:fs/promises";
+import { atomicWrite } from "../../../utils/atomic-write.js";
+import { readConfinedLeaf } from "../../../utils/confined-read.js";
+import { parseTapOperatorState, MAX_TAP_STATE_BYTES } from "./state-parse.js";
+import { emptyTapOperatorState, type TapOperatorState } from "./state-types.js";
+import type { TapPaths } from "./paths.js";
+import { ensurePrivateRoot } from "./private-root.js";
+
+/** Read authoritative state; only a genuinely absent leaf means empty state. */
+export async function readTapState(paths: TapPaths): Promise<TapOperatorState> {
+  const exists = await lstat(paths.configRoot).catch((error) => absentOrThrow(error));
+  if (exists === null) return emptyTapOperatorState();
+  if (!exists.isDirectory() || exists.isSymbolicLink()) throw new Error("template tap config root is unavailable");
+  const read = await readConfinedLeaf(paths.configRoot, paths.stateFile, paths.configRoot, MAX_TAP_STATE_BYTES);
+  if (read.kind === "absent") return emptyTapOperatorState();
+  if (read.kind !== "ok") throw new Error("template tap state is unavailable");
+  return parseTapOperatorState(read.body);
+}
+
+/** Atomically replace authoritative state under a private confined root. */
+export async function writeTapState(paths: TapPaths, state: TapOperatorState): Promise<void> {
+  await ensurePrivateRoot(paths.configRoot);
+  const text = `${JSON.stringify(state, null, 2)}\n`;
+  parseTapOperatorState(text);
+  await atomicWrite(paths.stateFile, text, { confineRoot: paths.configRoot, durable: true, mode: 0o600 });
+}
+
+function absentOrThrow(error: unknown): null {
+  if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+  throw error;
+}

--- a/src/profile/templates/taps/state-store.ts
+++ b/src/profile/templates/taps/state-store.ts
@@ -5,7 +5,8 @@
 import { lstat } from "node:fs/promises";
 import { atomicWrite } from "../../../utils/atomic-write.js";
 import { readConfinedLeaf } from "../../../utils/confined-read.js";
-import { parseTapOperatorState, MAX_TAP_STATE_BYTES } from "./state-parse.js";
+import { assertTapStateCapacity, MAX_TAP_STATE_BYTES } from "./capacity.js";
+import { parseTapOperatorState } from "./state-parse.js";
 import { emptyTapOperatorState, type TapOperatorState } from "./state-types.js";
 import type { TapPaths } from "./paths.js";
 import { ensurePrivateRoot } from "./private-root.js";
@@ -25,6 +26,7 @@ export async function readTapState(paths: TapPaths): Promise<TapOperatorState> {
 export async function writeTapState(paths: TapPaths, state: TapOperatorState): Promise<void> {
   await ensurePrivateRoot(paths.configRoot);
   const text = `${JSON.stringify(state, null, 2)}\n`;
+  assertTapStateCapacity(state, text);
   parseTapOperatorState(text);
   await atomicWrite(paths.stateFile, text, { confineRoot: paths.configRoot, durable: true, mode: 0o600 });
 }

--- a/src/profile/templates/taps/state-types.ts
+++ b/src/profile/templates/taps/state-types.ts
@@ -12,6 +12,7 @@ export interface TapSourceState {
   enabled: boolean;
   currentTapKey: PublisherKey;
   retiredTapKeyIds: string[];
+  acceptedIndexDigest: string | null;
   publisherPins: PublisherPinState;
 }
 

--- a/src/profile/templates/taps/state-types.ts
+++ b/src/profile/templates/taps/state-types.ts
@@ -1,0 +1,27 @@
+/**
+ * @file src/profile/templates/taps/state-types.ts
+ * @description Authoritative bounded operator state for configured template taps.
+ */
+import type { PublisherKey, PublisherPinState } from "../signing/types.js";
+
+/** One configured source and all continuity needed to prevent trust resets. */
+export interface TapSourceState {
+  name: string;
+  indexUrl: string;
+  origin: string;
+  enabled: boolean;
+  currentTapKey: PublisherKey;
+  retiredTapKeyIds: string[];
+  publisherPins: PublisherPinState;
+}
+
+/** Versioned global tap state; cache files are never authoritative substitutes. */
+export interface TapOperatorState {
+  schemaVersion: 1;
+  taps: Record<string, TapSourceState>;
+}
+
+/** Empty state for an operator who has configured no taps. */
+export function emptyTapOperatorState(): TapOperatorState {
+  return { schemaVersion: 1, taps: {} };
+}

--- a/src/profile/templates/validate.ts
+++ b/src/profile/templates/validate.ts
@@ -23,6 +23,8 @@ const PACKAGE_KEYS = new Set([
   "docs",
   "examples",
 ]);
+const MAX_DISPLAY_NAME_BYTES = 256;
+const MAX_LICENSE_BYTES = 128;
 
 /** Error raised when a template package cannot be installed. */
 export class TemplatePackageError extends Error {
@@ -52,10 +54,10 @@ export function validateTemplatePackage(raw: unknown, options: TemplateValidatio
     schemaVersion: 1,
     templateId,
     version,
-    displayName: nonEmptyString(obj.displayName, "displayName"),
+    displayName: singleLineMetadata(obj.displayName, "displayName", MAX_DISPLAY_NAME_BYTES),
     publisher: nonEmptyString(obj.publisher, "publisher"),
     sourceType: templateSourceType(obj.sourceType, options.sourceType),
-    license: nonEmptyString(obj.license, "license"),
+    license: singleLineMetadata(obj.license, "license", MAX_LICENSE_BYTES),
     minLlmwikiVersion: versionString(obj.minLlmwikiVersion, "template minLlmwikiVersion"),
     profile,
     ...optionalString(obj.description, "description"),
@@ -100,6 +102,20 @@ function nonEmptyString(value: unknown, field: string): string {
     throw new TemplatePackageError(`${field} must be a non-empty string`);
   }
   return value;
+}
+
+function singleLineMetadata(value: unknown, field: string, maxBytes: number): string {
+  const text = nonEmptyString(value, field);
+  if (Buffer.byteLength(text, "utf8") > maxBytes) throw new TemplatePackageError(`${field} exceeds its byte cap`);
+  if (hasTerminalControl(text)) throw new TemplatePackageError(`${field} must be single-line text without control characters`);
+  return text;
+}
+
+function hasTerminalControl(value: string): boolean {
+  return [...value].some((char) => {
+    const code = char.codePointAt(0)!;
+    return code <= 0x1f || (code >= 0x7f && code <= 0x9f) || code === 0x2028 || code === 0x2029;
+  });
 }
 
 function slugString(value: unknown, field: string): string {

--- a/test/connectors/confined-fetch-origin.test.ts
+++ b/test/connectors/confined-fetch-origin.test.ts
@@ -88,6 +88,17 @@ describe("confinedFetch transport byte cap", () => {
     expect(result).toEqual({ kind: "refused", reason: "connector response exceeds transport byte cap" });
   });
 
+  it("refuses a gzip body that expands beyond the decoded byte cap", async () => {
+    const { gzipSync } = await import("node:zlib");
+    const compressed = gzipSync(Buffer.from("x".repeat(128)));
+    const limits = { ...LIMITS, maxTransportBytes: compressed.length + 1 };
+    const result = await confinedFetch(
+      { url: "https://tap.example/index.json" }, limits, POLICY,
+      seams([{ statusCode: 200, headers: { "content-type": "application/json", "content-encoding": "gzip" }, body: Readable.from([compressed]) }]),
+    );
+    expect(result).toEqual({ kind: "refused", reason: "connector response exceeds byte cap" });
+  });
+
   it("destroys a rejected response body", async () => {
     const body = Readable.from(["ignored"]);
     const result = await confinedFetch({ url: "https://tap.example/index.json" }, LIMITS, POLICY, {

--- a/test/connectors/confined-fetch-origin.test.ts
+++ b/test/connectors/confined-fetch-origin.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @file test/connectors/confined-fetch-origin.test.ts
+ * @description Exact-origin and dual-byte-cap regressions for registry fetches.
+ */
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import {
+  confinedFetch,
+  type ConfinedFetchSeams,
+  type ConfinedHttpResponse,
+} from "../../src/connectors/confined-fetch.js";
+
+const LIMITS = {
+  timeoutMs: 100,
+  maxBytes: 64,
+  maxTransportBytes: 8,
+  maxRedirects: 1,
+  contentTypes: ["application/json"],
+};
+const POLICY = { allowedHosts: ["tap.example"], allowedOrigins: ["https://tap.example"] };
+
+function response(statusCode: number, headers: Record<string, string>, body = "{}"): ConfinedHttpResponse {
+  return { statusCode, headers, body: Readable.from([body]) };
+}
+
+function seams(responses: ConfinedHttpResponse[]): ConfinedFetchSeams {
+  return {
+    lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+    request: async () => responses.shift()!,
+  };
+}
+
+describe("confinedFetch exact-origin policy", () => {
+  it("accepts the configured origin and rejects the same host on another port", async () => {
+    const ok = await confinedFetch(
+      { url: "https://tap.example/index.json" }, LIMITS, POLICY,
+      seams([response(200, { "content-type": "application/json" })]),
+    );
+    const refused = await confinedFetch(
+      { url: "https://tap.example:444/index.json" }, LIMITS, POLICY,
+      seams([response(200, { "content-type": "application/json" })]),
+    );
+    expect(ok.kind).toBe("ok");
+    expect(refused).toMatchObject({ kind: "refused" });
+  });
+
+  it("refuses a redirect that changes only the port", async () => {
+    const result = await confinedFetch(
+      { url: "https://tap.example/index.json" }, LIMITS, POLICY,
+      seams([response(302, { location: "https://tap.example:444/index.json" })]),
+    );
+    expect(result).toMatchObject({ kind: "refused" });
+  });
+
+  it("refuses a malformed redirect without throwing or leaving the body open", async () => {
+    const redirect = response(302, { location: "https://[invalid" });
+    const result = await confinedFetch(
+      { url: "https://tap.example/index.json" }, LIMITS, POLICY, seams([redirect]),
+    );
+    expect(result).toMatchObject({ kind: "refused" });
+    expect(redirect.body.destroyed).toBe(true);
+  });
+
+  it("normalizes DNS failures to unavailable", async () => {
+    const result = await confinedFetch({ url: "https://tap.example/index.json" }, LIMITS, POLICY, {
+      lookup: async () => { throw new Error("resolver down"); },
+    });
+    expect(result).toEqual({ kind: "unavailable", reason: "connector host lookup failed" });
+  });
+});
+
+describe("confinedFetch transport byte cap", () => {
+  it("refuses an identity body over the transport cap", async () => {
+    const result = await confinedFetch(
+      { url: "https://tap.example/index.json" }, LIMITS, POLICY,
+      seams([response(200, { "content-type": "application/json" }, "123456789")]),
+    );
+    expect(result).toEqual({ kind: "refused", reason: "connector response exceeds transport byte cap" });
+  });
+
+  it("applies the transport cap before gzip decoding", async () => {
+    const { gzipSync } = await import("node:zlib");
+    const compressed = gzipSync(Buffer.from("{}"));
+    const result = await confinedFetch(
+      { url: "https://tap.example/index.json" }, LIMITS, POLICY,
+      seams([{ statusCode: 200, headers: { "content-type": "application/json", "content-encoding": "gzip" }, body: Readable.from([compressed]) }]),
+    );
+    expect(result).toEqual({ kind: "refused", reason: "connector response exceeds transport byte cap" });
+  });
+
+  it("destroys a rejected response body", async () => {
+    const body = Readable.from(["ignored"]);
+    const result = await confinedFetch({ url: "https://tap.example/index.json" }, LIMITS, POLICY, {
+      lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+      request: async () => ({ statusCode: 200, headers: { "content-type": "text/html" }, body }),
+    });
+    expect(result.kind).toBe("refused");
+    expect(body.destroyed).toBe(true);
+  });
+});

--- a/test/fixtures/template-signing.ts
+++ b/test/fixtures/template-signing.ts
@@ -58,14 +58,14 @@ export function remotePackage(): ProfileTemplatePackage {
   };
 }
 
-export function signedPackage(payload = remotePackage()): SignedPackageEnvelope {
+export function signedPackage(payload = remotePackage(), coordinate = COORDINATE): SignedPackageEnvelope {
   const payloadDigest = canonicalDigest(payload);
   return {
     schemaVersion: 1,
-    coordinate: COORDINATE,
+    coordinate,
     payload,
     payloadDigest,
-    publisherSignature: signClaim(packageClaim(COORDINATE, payloadDigest), "publisher", PUBLISHER_KEY.keyId),
+    publisherSignature: signClaim(packageClaim(coordinate, payloadDigest), "publisher", PUBLISHER_KEY.keyId),
   };
 }
 

--- a/test/fixtures/template-tap-runtime.ts
+++ b/test/fixtures/template-tap-runtime.ts
@@ -1,0 +1,46 @@
+/**
+ * @file test/fixtures/template-tap-runtime.ts
+ * @description Shared offline runtime harness for signed template-tap tests.
+ */
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import type { ConfinedFetchSeams } from "../../src/connectors/confined-fetch.js";
+import { addTap } from "../../src/profile/templates/taps/manage.js";
+import { resolveTapPaths, type TapPaths } from "../../src/profile/templates/taps/paths.js";
+import { refreshTap } from "../../src/profile/templates/taps/refresh.js";
+
+const FIXTURE = path.join(process.cwd(), "test/fixtures/template-registry");
+export const TAP_KEY = {
+  keyId: "tap-key-1",
+  publicKey: "MCowBQYDK2VwAyEA+Zh7GM2+2PTzR+DGzIIMyf9RW3z8iPX+y0ToR7vFF7Q=",
+};
+
+/** Return one deterministic public-network response seam. */
+export function servesTemplateBytes(text: string): ConfinedFetchSeams {
+  return {
+    lookup: async () => [{ address: "93.184.216.34", family: 4 }],
+    request: async () => ({ statusCode: 200, headers: { "content-type": "application/json" }, body: Readable.from([text]) }),
+  };
+}
+
+/** Read one checked-in signing fixture as UTF-8 text. */
+export function templateRegistryFixture(name: "index.json" | "package.json"): Promise<string> {
+  return readFile(path.join(FIXTURE, name), "utf8");
+}
+
+/** Create isolated config/cache paths and register the cleanup root. */
+export async function isolatedTapPaths(prefix: string, roots: string[]): Promise<TapPaths> {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+  roots.push(root);
+  return resolveTapPaths({ configRoot: path.join(root, "config"), cacheRoot: path.join(root, "cache") });
+}
+
+/** Configure and accept the checked-in signed index beneath an isolated root. */
+export async function acceptTemplateTap(root: string, indexUrl = "https://tap.example/index.json"): Promise<TapPaths> {
+  const paths = resolveTapPaths({ configRoot: path.join(root, "config"), cacheRoot: path.join(root, "cache") });
+  await addTap(paths, { name: "official", indexUrl, key: TAP_KEY });
+  await refreshTap(paths, "official", servesTemplateBytes(await templateRegistryFixture("index.json")));
+  return paths;
+}

--- a/test/profile-template-r3-boundary.test.ts
+++ b/test/profile-template-r3-boundary.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @file test/profile-template-r3-boundary.test.ts
+ * @description Structural guard keeping R3 discovery disconnected from project writes.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const R3_FILES = [
+  "cache.ts", "discovery.ts", "evidence.ts", "manage.ts", "operator-lock.ts",
+  "package.ts", "paths.ts", "private-root.ts", "refresh.ts", "state-parse.ts",
+  "state-store.ts", "state-types.ts",
+];
+
+describe("template registry R3 boundary", () => {
+  it("cannot import project installers, profile loaders, or project locks", async () => {
+    const root = path.join(process.cwd(), "src/profile/templates/taps");
+    const text = (await Promise.all(R3_FILES.map((file) => readFile(path.join(root, file), "utf8")))).join("\n");
+    expect(text).not.toMatch(/templates\/install|profile\/load|utils\/lock\.js|writeProfile|installPackage/);
+  });
+});

--- a/test/profile-template-registry.test.ts
+++ b/test/profile-template-registry.test.ts
@@ -66,6 +66,13 @@ describe("validateTemplatePackage", () => {
     expect(() => validate({ ...PACKAGE, version: "next" })).toThrow(/invalid template version/i);
   });
 
+  it("rejects terminal controls and oversized display metadata", () => {
+    for (const displayName of ["Team\nForged", "Team\u001b]8;;https://evil.example\u0007click", "x".repeat(257)]) {
+      expect(() => validate({ ...PACKAGE, displayName })).toThrow(/displayName.*single-line|displayName.*byte cap/i);
+    }
+    expect(() => validate({ ...PACKAGE, license: "MIT\rForged" })).toThrow(/license.*single-line/i);
+  });
+
   it("rejects sourceType self-attestation that does not match the caller context", () => {
     expect(() => validateTemplatePackage({ ...PACKAGE, sourceType: "builtin" }, { currentVersion: "0.11.0", sourceType: "local" })).toThrow(
       /template sourceType must be local for this install source/i,

--- a/test/profile-template-tap-cli.test.ts
+++ b/test/profile-template-tap-cli.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @file test/profile-template-tap-cli.test.ts
+ * @description Compiled CLI proof for tap lifecycle and read-only discovery.
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { addTap } from "../src/profile/templates/taps/manage.js";
+import { resolveRemotePackage } from "../src/profile/templates/taps/package.js";
+import { resolveTapPaths } from "../src/profile/templates/taps/paths.js";
+import { refreshTap } from "../src/profile/templates/taps/refresh.js";
+import { servesTemplateBytes, templateRegistryFixture, TAP_KEY } from "./fixtures/template-tap-runtime.js";
+
+const CLI = path.resolve("dist/cli.js");
+const roots: string[] = [];
+
+async function root(): Promise<string> {
+  const value = await mkdtemp(path.join(os.tmpdir(), "llmwiki-tap-cli-"));
+  roots.push(value);
+  return value;
+}
+
+function run(cwd: string, args: string[]) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, XDG_CONFIG_HOME: path.join(cwd, "operator-config"), XDG_CACHE_HOME: path.join(cwd, "operator-cache") },
+  });
+}
+
+function paths(cwd: string) {
+  return resolveTapPaths({
+    configRoot: path.join(cwd, "operator-config", "llmwiki"),
+    cacheRoot: path.join(cwd, "operator-cache", "llmwiki", "templates"),
+  });
+}
+
+async function seed(cwd: string): Promise<void> {
+  const store = paths(cwd);
+  await addTap(store, { name: "official", indexUrl: "https://tap.example/index.json", key: TAP_KEY });
+  await refreshTap(store, "official", servesTemplateBytes(await templateRegistryFixture("index.json")));
+  await resolveRemotePackage(store, "official/atomicstrata/team@1.0.0", { seams: servesTemplateBytes(await templateRegistryFixture("package.json")) });
+}
+
+afterEach(async () => Promise.all(roots.splice(0).map((item) => rm(item, { recursive: true, force: true }))));
+
+describe("template tap CLI", () => {
+  it("adds, lists, and disables a tap without writing project state", async () => {
+    const cwd = await root();
+    const add = run(cwd, ["template", "tap", "add", "community", "https://tap.example/index.json", "--key-id", TAP_KEY.keyId, "--key-base64", TAP_KEY.publicKey]);
+    expect(add.status).toBe(0);
+    const list = run(cwd, ["template", "tap", "list", "--json"]);
+    expect(JSON.parse(list.stdout)).toMatchObject([{ name: "community", enabled: true }]);
+    expect(list.stdout).not.toContain(TAP_KEY.publicKey);
+    expect(run(cwd, ["template", "tap", "remove", "community"]).status).toBe(0);
+    await expect(stat(path.join(cwd, ".llmwiki"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("searches, inspects, and verifies cached signed evidence", async () => {
+    const cwd = await root();
+    await seed(cwd);
+    const search = run(cwd, ["template", "search", "team", "--json"]);
+    const inspect = run(cwd, ["template", "inspect", "official/atomicstrata/team@1.0.0", "--json"]);
+    const verify = run(cwd, ["template", "verify", "official/atomicstrata/team@1.0.0", "--json"]);
+    expect(JSON.parse(search.stdout)[0]).toMatchObject({ templateId: "team" });
+    expect(JSON.parse(inspect.stdout)).toMatchObject({ displayName: "Team", templateId: "team" });
+    expect(JSON.parse(verify.stdout)).toMatchObject({ verified: true, publisherKeyId: "publisher-key-1" });
+    await expect(stat(path.join(cwd, ".llmwiki"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/profile-template-tap-cli.test.ts
+++ b/test/profile-template-tap-cli.test.ts
@@ -55,6 +55,8 @@ describe("template tap CLI", () => {
     expect(JSON.parse(list.stdout)).toMatchObject([{ name: "community", enabled: true }]);
     expect(list.stdout).not.toContain(TAP_KEY.publicKey);
     expect(run(cwd, ["template", "tap", "remove", "community"]).status).toBe(0);
+    expect(run(cwd, ["template", "tap", "forget", "community"]).status).toBe(1);
+    expect(run(cwd, ["template", "tap", "forget", "community", "--yes"]).status).toBe(0);
     await expect(stat(path.join(cwd, ".llmwiki"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -64,7 +66,7 @@ describe("template tap CLI", () => {
     const search = run(cwd, ["template", "search", "team", "--json"]);
     const inspect = run(cwd, ["template", "inspect", "official/atomicstrata/team@1.0.0", "--json"]);
     const verify = run(cwd, ["template", "verify", "official/atomicstrata/team@1.0.0", "--json"]);
-    expect(JSON.parse(search.stdout)[0]).toMatchObject({ templateId: "team" });
+    expect(JSON.parse(search.stdout).results[0]).toMatchObject({ templateId: "team" });
     expect(JSON.parse(inspect.stdout)).toMatchObject({ displayName: "Team", templateId: "team" });
     expect(JSON.parse(verify.stdout)).toMatchObject({ verified: true, publisherKeyId: "publisher-key-1" });
     await expect(stat(path.join(cwd, ".llmwiki"))).rejects.toMatchObject({ code: "ENOENT" });

--- a/test/profile-template-tap-discovery.test.ts
+++ b/test/profile-template-tap-discovery.test.ts
@@ -55,11 +55,11 @@ describe("remote template discovery", () => {
     }, /coordinate continuity/);
   });
 
-  it("refuses cached evidence when publisher continuity state diverges", async () => {
+  it("refuses persisting publisher continuity that diverges from key history", async () => {
     const paths = await setup();
-    await expectContinuityWarning(paths, (state) => {
-      state.taps.official.publisherPins.publishers.atomicstrata.keyId = "other-key";
-    }, /publisher continuity/);
+    const state = await readTapState(paths);
+    state.taps.official.publisherPins.publishers.atomicstrata.keyId = "other-key";
+    await expect(writeTapState(paths, state)).rejects.toThrow(/active publisher key.*history/);
   });
 
   it("refuses an explicitly selected unknown tap instead of returning an empty result", async () => {

--- a/test/profile-template-tap-discovery.test.ts
+++ b/test/profile-template-tap-discovery.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @file test/profile-template-tap-discovery.test.ts
+ * @description Search and inspect behavior over accepted signed tap evidence.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { searchRemoteTemplates, inspectRemoteTemplate } from "../src/profile/templates/taps/discovery.js";
+import { resolveRemotePackage } from "../src/profile/templates/taps/package.js";
+import type { TapPaths } from "../src/profile/templates/taps/paths.js";
+import { readTapState, writeTapState } from "../src/profile/templates/taps/state-store.js";
+import { acceptTemplateTap, servesTemplateBytes, templateRegistryFixture } from "./fixtures/template-tap-runtime.js";
+
+const roots: string[] = [];
+async function setup(): Promise<TapPaths> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "llmwiki-discovery-"));
+  roots.push(root);
+  return acceptTemplateTap(root);
+}
+
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
+
+describe("remote template discovery", () => {
+  it("searches accepted index metadata without fetching packages", async () => {
+    const results = await searchRemoteTemplates(await setup(), "team");
+    expect(results).toMatchObject([{ coordinate: "official/atomicstrata/team@1.0.0", publisher: "atomicstrata" }]);
+  });
+
+  it("inspects only after package evidence has been verified and cached", async () => {
+    const paths = await setup();
+    const packageText = await templateRegistryFixture("package.json");
+    await resolveRemotePackage(paths, "official/atomicstrata/team@1.0.0", { seams: servesTemplateBytes(packageText) });
+    const details = await inspectRemoteTemplate(paths, "official/atomicstrata/team@1.0.0");
+    expect(details).toMatchObject({ displayName: "Team", templateId: "team", publisherKeyId: "publisher-key-1" });
+    expect(JSON.stringify(details)).not.toContain('"profile"');
+  });
+
+  it("does not advertise a package revoked in authoritative continuity state", async () => {
+    const paths = await setup();
+    const state = await readTapState(paths);
+    const source = state.taps.official;
+    const digest = source.publisherPins.coordinates["official/atomicstrata/team@1.0.0"];
+    source.publisherPins.revokedPackages.push(digest);
+    await writeTapState(paths, state);
+    expect(await searchRemoteTemplates(paths, "team")).toEqual([]);
+  });
+
+  it("refuses cached evidence when coordinate continuity state diverges", async () => {
+    const paths = await setup();
+    const state = await readTapState(paths);
+    state.taps.official.publisherPins.coordinates["official/atomicstrata/team@1.0.0"] = `sha256:${"0".repeat(64)}`;
+    await writeTapState(paths, state);
+    await expect(searchRemoteTemplates(paths, "team")).rejects.toThrow(/coordinate continuity/);
+  });
+
+  it("refuses cached evidence when publisher continuity state diverges", async () => {
+    const paths = await setup();
+    const state = await readTapState(paths);
+    state.taps.official.publisherPins.publishers.atomicstrata.keyId = "other-key";
+    await writeTapState(paths, state);
+    await expect(searchRemoteTemplates(paths, "team")).rejects.toThrow(/publisher continuity/);
+  });
+
+  it("refuses an explicitly selected unknown tap instead of returning an empty result", async () => {
+    const paths = await setup();
+    await expect(searchRemoteTemplates(paths, "team", "missing")).rejects.toThrow(/unknown template tap/);
+  });
+});

--- a/test/profile-template-tap-discovery.test.ts
+++ b/test/profile-template-tap-discovery.test.ts
@@ -7,10 +7,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { searchRemoteTemplates, inspectRemoteTemplate } from "../src/profile/templates/taps/discovery.js";
+import { addTap } from "../src/profile/templates/taps/manage.js";
 import { resolveRemotePackage } from "../src/profile/templates/taps/package.js";
 import type { TapPaths } from "../src/profile/templates/taps/paths.js";
 import { readTapState, writeTapState } from "../src/profile/templates/taps/state-store.js";
-import { acceptTemplateTap, servesTemplateBytes, templateRegistryFixture } from "./fixtures/template-tap-runtime.js";
+import { acceptTemplateTap, servesTemplateBytes, templateRegistryFixture, TAP_KEY } from "./fixtures/template-tap-runtime.js";
 
 const roots: string[] = [];
 async function setup(): Promise<TapPaths> {
@@ -23,8 +24,9 @@ afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recur
 
 describe("remote template discovery", () => {
   it("searches accepted index metadata without fetching packages", async () => {
-    const results = await searchRemoteTemplates(await setup(), "team");
-    expect(results).toMatchObject([{ coordinate: "official/atomicstrata/team@1.0.0", publisher: "atomicstrata" }]);
+    const search = await searchRemoteTemplates(await setup(), "team");
+    expect(search.results).toMatchObject([{ coordinate: "official/atomicstrata/team@1.0.0", publisher: "atomicstrata" }]);
+    expect(search.warnings).toEqual([]);
   });
 
   it("inspects only after package evidence has been verified and cached", async () => {
@@ -43,27 +45,52 @@ describe("remote template discovery", () => {
     const digest = source.publisherPins.coordinates["official/atomicstrata/team@1.0.0"];
     source.publisherPins.revokedPackages.push(digest);
     await writeTapState(paths, state);
-    expect(await searchRemoteTemplates(paths, "team")).toEqual([]);
+    expect((await searchRemoteTemplates(paths, "team")).results).toEqual([]);
   });
 
   it("refuses cached evidence when coordinate continuity state diverges", async () => {
     const paths = await setup();
-    const state = await readTapState(paths);
-    state.taps.official.publisherPins.coordinates["official/atomicstrata/team@1.0.0"] = `sha256:${"0".repeat(64)}`;
-    await writeTapState(paths, state);
-    await expect(searchRemoteTemplates(paths, "team")).rejects.toThrow(/coordinate continuity/);
+    await expectContinuityWarning(paths, (state) => {
+      state.taps.official.publisherPins.coordinates["official/atomicstrata/team@1.0.0"] = `sha256:${"0".repeat(64)}`;
+    }, /coordinate continuity/);
   });
 
   it("refuses cached evidence when publisher continuity state diverges", async () => {
     const paths = await setup();
-    const state = await readTapState(paths);
-    state.taps.official.publisherPins.publishers.atomicstrata.keyId = "other-key";
-    await writeTapState(paths, state);
-    await expect(searchRemoteTemplates(paths, "team")).rejects.toThrow(/publisher continuity/);
+    await expectContinuityWarning(paths, (state) => {
+      state.taps.official.publisherPins.publishers.atomicstrata.keyId = "other-key";
+    }, /publisher continuity/);
   });
 
   it("refuses an explicitly selected unknown tap instead of returning an empty result", async () => {
     const paths = await setup();
     await expect(searchRemoteTemplates(paths, "team", "missing")).rejects.toThrow(/unknown template tap/);
   });
+
+  it("keeps healthy results and warns when another enabled tap is unrefreshed", async () => {
+    const paths = await setup();
+    await addTap(paths, { name: "new", indexUrl: "https://new.example/index.json", key: TAP_KEY });
+    const search = await searchRemoteTemplates(paths, "team");
+    expect(search.results).toHaveLength(1);
+    expect(search.warnings).toEqual([{ tap: "new", reason: "template tap has not been refreshed: new" }]);
+  });
+
+  it("keeps explicitly scoped search fail closed for an unrefreshed tap", async () => {
+    const paths = await setup();
+    await addTap(paths, { name: "new", indexUrl: "https://new.example/index.json", key: TAP_KEY });
+    await expect(searchRemoteTemplates(paths, "team", "new")).rejects.toThrow(/has not been refreshed/);
+  });
 });
+
+async function expectContinuityWarning(
+  paths: TapPaths,
+  mutate: (state: Awaited<ReturnType<typeof readTapState>>) => void,
+  pattern: RegExp,
+): Promise<void> {
+  const state = await readTapState(paths);
+  mutate(state);
+  await writeTapState(paths, state);
+  const search = await searchRemoteTemplates(paths, "team");
+  expect(search.results).toEqual([]);
+  expect(search.warnings[0].reason).toMatch(pattern);
+}

--- a/test/profile-template-tap-package.test.ts
+++ b/test/profile-template-tap-package.test.ts
@@ -2,21 +2,36 @@
  * @file test/profile-template-tap-package.test.ts
  * @description Content-addressed remote package fetch and cache verification tests.
  */
-import { mkdir, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
 import { packageUrl, resolveRemotePackage } from "../src/profile/templates/taps/package.js";
 import type { TapPaths } from "../src/profile/templates/taps/paths.js";
 import { removeTap } from "../src/profile/templates/taps/manage.js";
+import { addTap } from "../src/profile/templates/taps/manage.js";
+import { refreshTap } from "../src/profile/templates/taps/refresh.js";
 import { acceptTemplateTap, isolatedTapPaths, servesTemplateBytes, templateRegistryFixture } from "./fixtures/template-tap-runtime.js";
+import { PUBLISHER_KEY, remotePackage, signedIndex, signedPackage, TAP_KEY } from "./fixtures/template-signing.js";
 
 const roots: string[] = [];
+const COORDINATE = "official/atomicstrata/team@1.0.0";
 async function accepted(): Promise<{ paths: TapPaths; packageText: string }> {
   const isolated = await isolatedTapPaths("llmwiki-package-", roots);
   const root = path.dirname(isolated.configRoot);
   const paths = await acceptTemplateTap(root, "https://tap.example/v1/index.json");
   return { paths, packageText: await templateRegistryFixture("package.json") };
+}
+
+async function packageCacheLeaf(paths: TapPaths): Promise<string> {
+  const root = path.join(paths.cacheRoot, "packages");
+  const files = await readdir(root, { recursive: true });
+  return path.join(root, files.find((file) => file.endsWith(".json"))!);
+}
+
+async function seedPackageCache(fixture: Awaited<ReturnType<typeof accepted>>): Promise<string> {
+  await resolveRemotePackage(fixture.paths, COORDINATE, { seams: servesTemplateBytes(fixture.packageText) });
+  return packageCacheLeaf(fixture.paths);
 }
 
 afterEach(async () => {
@@ -31,17 +46,42 @@ describe("remote package resolution", () => {
 
   it("fetches, verifies, caches, then verifies again offline", async () => {
     const fixture = await accepted();
-    const coordinate = "official/atomicstrata/team@1.0.0";
-    const online = await resolveRemotePackage(fixture.paths, coordinate, { seams: servesTemplateBytes(fixture.packageText) });
-    const offline = await resolveRemotePackage(fixture.paths, coordinate, { offline: true });
+    const online = await resolveRemotePackage(fixture.paths, COORDINATE, { seams: servesTemplateBytes(fixture.packageText) });
+    const offline = await resolveRemotePackage(fixture.paths, COORDINATE, { offline: true });
     expect(online.package.profile.profileId).toBe("team");
     expect(offline).toEqual(online);
+  });
+
+  it("keeps coordinate-specific envelopes separate when taps mirror one payload", async () => {
+    const fixture = await accepted();
+    const mirror = "mirror/atomicstrata/team@1.0.0";
+    const payloadDigest = signedPackage().payloadDigest;
+    await addTap(fixture.paths, { name: "mirror", indexUrl: "https://mirror.example/index.json", key: TAP_KEY });
+    const mirrorIndex = JSON.stringify(signedIndex({
+      tap: "mirror",
+      packages: [{ coordinate: mirror, publisher: "atomicstrata", payloadDigest }],
+      publishers: { atomicstrata: PUBLISHER_KEY },
+    }));
+    await refreshTap(fixture.paths, "mirror", servesTemplateBytes(mirrorIndex));
+    await resolveRemotePackage(fixture.paths, COORDINATE, { seams: servesTemplateBytes(fixture.packageText) });
+    const resolved = await resolveRemotePackage(fixture.paths, mirror, {
+      seams: servesTemplateBytes(JSON.stringify(signedPackage(remotePackage(), mirror))),
+    });
+    expect(resolved.coordinate).toBe(mirror);
+  });
+
+  it("replaces invalid cached evidence from the network when online", async () => {
+    const fixture = await accepted();
+    const leaf = await seedPackageCache(fixture);
+    await writeFile(leaf, "not-json");
+    const resolved = await resolveRemotePackage(fixture.paths, COORDINATE, { seams: servesTemplateBytes(fixture.packageText) });
+    expect(resolved.package.templateId).toBe("team");
   });
 
   it("refuses a tampered package before caching it", async () => {
     const fixture = await accepted();
     const tampered = fixture.packageText.replace('"displayName": "Team"', '"displayName": "Evil"');
-    await expect(resolveRemotePackage(fixture.paths, "official/atomicstrata/team@1.0.0", { seams: servesTemplateBytes(tampered) })).rejects.toThrow(/digest/);
+    await expect(resolveRemotePackage(fixture.paths, COORDINATE, { seams: servesTemplateBytes(tampered) })).rejects.toThrow(/digest/);
   });
 
   it("refuses a package when tap state changes during its fetch", async () => {
@@ -51,20 +91,17 @@ describe("remote package resolution", () => {
       await removeTap(fixture.paths, "official");
       return { statusCode: 200, headers: { "content-type": "application/json" }, body: Readable.from([fixture.packageText]) };
     };
-    await expect(resolveRemotePackage(fixture.paths, "official/atomicstrata/team@1.0.0", { seams: changing })).rejects.toThrow(/changed while verifying/);
+    await expect(resolveRemotePackage(fixture.paths, COORDINATE, { seams: changing })).rejects.toThrow(/changed while verifying/);
   });
 
   it("refuses a symlinked package-cache leaf without reading its target", async () => {
     const fixture = await accepted();
-    const coordinate = "official/atomicstrata/team@1.0.0";
-    await resolveRemotePackage(fixture.paths, coordinate, { seams: servesTemplateBytes(fixture.packageText) });
-    const hex = "4a39b4041e21c92f6a0351624ddfe27ec7bcc924659014909c92418bb06f3416";
-    const leaf = path.join(fixture.paths.cacheRoot, "packages/sha256", `${hex}.json`);
+    const leaf = await seedPackageCache(fixture);
     const victim = path.join(path.dirname(fixture.paths.cacheRoot), "victim.json");
     await writeFile(victim, fixture.packageText);
     await unlink(leaf);
     await mkdir(path.dirname(leaf), { recursive: true });
     await symlink(victim, leaf);
-    await expect(resolveRemotePackage(fixture.paths, coordinate, { offline: true })).rejects.toThrow(/cache evidence is unavailable/);
+    await expect(resolveRemotePackage(fixture.paths, COORDINATE, { offline: true })).rejects.toThrow(/cache evidence is unavailable/);
   });
 });

--- a/test/profile-template-tap-package.test.ts
+++ b/test/profile-template-tap-package.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @file test/profile-template-tap-package.test.ts
+ * @description Content-addressed remote package fetch and cache verification tests.
+ */
+import { mkdir, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { packageUrl, resolveRemotePackage } from "../src/profile/templates/taps/package.js";
+import type { TapPaths } from "../src/profile/templates/taps/paths.js";
+import { removeTap } from "../src/profile/templates/taps/manage.js";
+import { acceptTemplateTap, isolatedTapPaths, servesTemplateBytes, templateRegistryFixture } from "./fixtures/template-tap-runtime.js";
+
+const roots: string[] = [];
+async function accepted(): Promise<{ paths: TapPaths; packageText: string }> {
+  const isolated = await isolatedTapPaths("llmwiki-package-", roots);
+  const root = path.dirname(isolated.configRoot);
+  const paths = await acceptTemplateTap(root, "https://tap.example/v1/index.json");
+  return { paths, packageText: await templateRegistryFixture("package.json") };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("remote package resolution", () => {
+  it("derives an exact-origin content-addressed URL", () => {
+    const digest = `sha256:${"a".repeat(64)}`;
+    expect(packageUrl("https://tap.example/v1/index.json", digest)).toBe(`https://tap.example/v1/packages/sha256/${"a".repeat(64)}.json`);
+  });
+
+  it("fetches, verifies, caches, then verifies again offline", async () => {
+    const fixture = await accepted();
+    const coordinate = "official/atomicstrata/team@1.0.0";
+    const online = await resolveRemotePackage(fixture.paths, coordinate, { seams: servesTemplateBytes(fixture.packageText) });
+    const offline = await resolveRemotePackage(fixture.paths, coordinate, { offline: true });
+    expect(online.package.profile.profileId).toBe("team");
+    expect(offline).toEqual(online);
+  });
+
+  it("refuses a tampered package before caching it", async () => {
+    const fixture = await accepted();
+    const tampered = fixture.packageText.replace('"displayName": "Team"', '"displayName": "Evil"');
+    await expect(resolveRemotePackage(fixture.paths, "official/atomicstrata/team@1.0.0", { seams: servesTemplateBytes(tampered) })).rejects.toThrow(/digest/);
+  });
+
+  it("refuses a package when tap state changes during its fetch", async () => {
+    const fixture = await accepted();
+    const changing = servesTemplateBytes(fixture.packageText);
+    changing.request = async () => {
+      await removeTap(fixture.paths, "official");
+      return { statusCode: 200, headers: { "content-type": "application/json" }, body: Readable.from([fixture.packageText]) };
+    };
+    await expect(resolveRemotePackage(fixture.paths, "official/atomicstrata/team@1.0.0", { seams: changing })).rejects.toThrow(/changed while verifying/);
+  });
+
+  it("refuses a symlinked package-cache leaf without reading its target", async () => {
+    const fixture = await accepted();
+    const coordinate = "official/atomicstrata/team@1.0.0";
+    await resolveRemotePackage(fixture.paths, coordinate, { seams: servesTemplateBytes(fixture.packageText) });
+    const hex = "4a39b4041e21c92f6a0351624ddfe27ec7bcc924659014909c92418bb06f3416";
+    const leaf = path.join(fixture.paths.cacheRoot, "packages/sha256", `${hex}.json`);
+    const victim = path.join(path.dirname(fixture.paths.cacheRoot), "victim.json");
+    await writeFile(victim, fixture.packageText);
+    await unlink(leaf);
+    await mkdir(path.dirname(leaf), { recursive: true });
+    await symlink(victim, leaf);
+    await expect(resolveRemotePackage(fixture.paths, coordinate, { offline: true })).rejects.toThrow(/cache evidence is unavailable/);
+  });
+});

--- a/test/profile-template-tap-refresh.test.ts
+++ b/test/profile-template-tap-refresh.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @file test/profile-template-tap-refresh.test.ts
+ * @description Offline signed-index refresh and continuity commit tests.
+ */
+import { rm } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { addTap } from "../src/profile/templates/taps/manage.js";
+import { removeTap } from "../src/profile/templates/taps/manage.js";
+import type { TapPaths } from "../src/profile/templates/taps/paths.js";
+import { refreshTap } from "../src/profile/templates/taps/refresh.js";
+import { readTapState } from "../src/profile/templates/taps/state-store.js";
+import { isolatedTapPaths, servesTemplateBytes, templateRegistryFixture, TAP_KEY } from "./fixtures/template-tap-runtime.js";
+
+const roots: string[] = [];
+async function setup(): Promise<{ paths: TapPaths; index: string }> {
+  const paths = await isolatedTapPaths("llmwiki-refresh-", roots);
+  await addTap(paths, { name: "official", indexUrl: "https://tap.example/index.json", key: TAP_KEY });
+  return { paths, index: await templateRegistryFixture("index.json") };
+}
+
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
+
+describe("template tap refresh", () => {
+  it("accepts a verified snapshot, caches it, and advances continuity", async () => {
+    const fixture = await setup();
+    expect(await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index))).toEqual({ tap: "official", sequence: 1, packages: 1 });
+    const state = await readTapState(fixture.paths);
+    expect(state.taps.official.publisherPins.highestSequence).toBe(1);
+    expect(state.taps.official.publisherPins.coordinates).toHaveProperty("official/atomicstrata/team@1.0.0");
+  });
+
+  it("refuses tampered signed bytes without advancing state", async () => {
+    const fixture = await setup();
+    const tampered = fixture.index.replace('"sequence": 1', '"sequence": 2');
+    await expect(refreshTap(fixture.paths, "official", servesTemplateBytes(tampered))).rejects.toThrow(/signature/);
+    expect((await readTapState(fixture.paths)).taps.official.publisherPins.highestSequence).toBe(-1);
+  });
+
+  it("refuses replay after accepting a sequence", async () => {
+    const fixture = await setup();
+    await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index));
+    await expect(refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index))).rejects.toThrow(/rollback or replay/);
+  });
+
+  it("does not overwrite a tap disabled while its network fetch is in flight", async () => {
+    const fixture = await setup();
+    const interleaved = servesTemplateBytes(fixture.index);
+    interleaved.request = async () => {
+      await removeTap(fixture.paths, "official");
+      return {
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: (await import("node:stream")).Readable.from([fixture.index]),
+      };
+    };
+    await expect(refreshTap(fixture.paths, "official", interleaved)).rejects.toThrow(/changed during refresh/);
+    expect((await readTapState(fixture.paths)).taps.official.enabled).toBe(false);
+  });
+});

--- a/test/profile-template-tap-refresh.test.ts
+++ b/test/profile-template-tap-refresh.test.ts
@@ -2,11 +2,11 @@
  * @file test/profile-template-tap-refresh.test.ts
  * @description Offline signed-index refresh and continuity commit tests.
  */
-import { rm } from "node:fs/promises";
+import { rm, unlink, writeFile } from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { addTap } from "../src/profile/templates/taps/manage.js";
 import { removeTap } from "../src/profile/templates/taps/manage.js";
-import { readIndexCache } from "../src/profile/templates/taps/cache.js";
+import { readIndexCache, writeIndexCache } from "../src/profile/templates/taps/cache.js";
 import type { TapPaths } from "../src/profile/templates/taps/paths.js";
 import { refreshTap } from "../src/profile/templates/taps/refresh.js";
 import { readTapState } from "../src/profile/templates/taps/state-store.js";
@@ -18,6 +18,17 @@ async function setup(): Promise<{ paths: TapPaths; index: string }> {
   const paths = await isolatedTapPaths("llmwiki-refresh-", roots);
   await addTap(paths, { name: "official", indexUrl: "https://tap.example/index.json", key: TAP_KEY });
   return { paths, index: await templateRegistryFixture("index.json") };
+}
+
+async function expectCacheRepair(
+  fixture: Awaited<ReturnType<typeof setup>>,
+  damage: (leaf: string) => Promise<void>,
+): Promise<void> {
+  await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index));
+  const leaf = `${fixture.paths.cacheRoot}/indexes/official/1.json`;
+  await damage(leaf);
+  await expect(refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index))).resolves.toMatchObject({ sequence: 1 });
+  expect(await readIndexCache(fixture.paths, "official", 1)).toContain('"sequence": 1');
 }
 
 afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
@@ -44,6 +55,22 @@ describe("template tap refresh", () => {
     await expect(refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index))).rejects.toThrow(/rollback or replay/);
   });
 
+  it("repairs missing accepted cache evidence from the exact signed sequence", async () => {
+    await expectCacheRepair(await setup(), unlink);
+  });
+
+  it("repairs malformed accepted cache evidence from the exact signed sequence", async () => {
+    await expectCacheRepair(await setup(), (leaf) => writeFile(leaf, "not-json"));
+  });
+
+  it("refuses a different same-sequence snapshot while repairing evidence", async () => {
+    const fixture = await setup();
+    await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index));
+    await unlink(`${fixture.paths.cacheRoot}/indexes/official/1.json`);
+    const equivocation = JSON.stringify(signedIndex({ packages: [] }));
+    await expect(refreshTap(fixture.paths, "official", servesTemplateBytes(equivocation))).rejects.toThrow(/accepted index digest/);
+  });
+
   it("prunes the superseded index cache after the next sequence commits", async () => {
     const fixture = await setup();
     await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index));
@@ -51,6 +78,17 @@ describe("template tap refresh", () => {
     await refreshTap(fixture.paths, "official", servesTemplateBytes(second));
     await expect(readIndexCache(fixture.paths, "official", 1)).rejects.toThrow(/unavailable/);
     expect(await readIndexCache(fixture.paths, "official", 2)).toContain('"sequence":2');
+  });
+
+  it("retries cleanup of every superseded index on later refreshes", async () => {
+    const fixture = await setup();
+    await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index));
+    await refreshTap(fixture.paths, "official", servesTemplateBytes(JSON.stringify(signedIndex({ sequence: 2 }))));
+    await writeIndexCache(fixture.paths, "official", 1, fixture.index);
+    await refreshTap(fixture.paths, "official", servesTemplateBytes(JSON.stringify(signedIndex({ sequence: 3 }))));
+    await expect(readIndexCache(fixture.paths, "official", 1)).rejects.toThrow(/unavailable/);
+    await expect(readIndexCache(fixture.paths, "official", 2)).rejects.toThrow(/unavailable/);
+    expect(await readIndexCache(fixture.paths, "official", 3)).toContain('"sequence":3');
   });
 
   it("does not overwrite a tap disabled while its network fetch is in flight", async () => {

--- a/test/profile-template-tap-refresh.test.ts
+++ b/test/profile-template-tap-refresh.test.ts
@@ -6,10 +6,12 @@ import { rm } from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { addTap } from "../src/profile/templates/taps/manage.js";
 import { removeTap } from "../src/profile/templates/taps/manage.js";
+import { readIndexCache } from "../src/profile/templates/taps/cache.js";
 import type { TapPaths } from "../src/profile/templates/taps/paths.js";
 import { refreshTap } from "../src/profile/templates/taps/refresh.js";
 import { readTapState } from "../src/profile/templates/taps/state-store.js";
 import { isolatedTapPaths, servesTemplateBytes, templateRegistryFixture, TAP_KEY } from "./fixtures/template-tap-runtime.js";
+import { signedIndex } from "./fixtures/template-signing.js";
 
 const roots: string[] = [];
 async function setup(): Promise<{ paths: TapPaths; index: string }> {
@@ -23,7 +25,7 @@ afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recur
 describe("template tap refresh", () => {
   it("accepts a verified snapshot, caches it, and advances continuity", async () => {
     const fixture = await setup();
-    expect(await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index))).toEqual({ tap: "official", sequence: 1, packages: 1 });
+    expect(await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index))).toEqual({ tap: "official", sequence: 1, packages: 1, warnings: [] });
     const state = await readTapState(fixture.paths);
     expect(state.taps.official.publisherPins.highestSequence).toBe(1);
     expect(state.taps.official.publisherPins.coordinates).toHaveProperty("official/atomicstrata/team@1.0.0");
@@ -40,6 +42,15 @@ describe("template tap refresh", () => {
     const fixture = await setup();
     await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index));
     await expect(refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index))).rejects.toThrow(/rollback or replay/);
+  });
+
+  it("prunes the superseded index cache after the next sequence commits", async () => {
+    const fixture = await setup();
+    await refreshTap(fixture.paths, "official", servesTemplateBytes(fixture.index));
+    const second = JSON.stringify(signedIndex({ sequence: 2 }));
+    await refreshTap(fixture.paths, "official", servesTemplateBytes(second));
+    await expect(readIndexCache(fixture.paths, "official", 1)).rejects.toThrow(/unavailable/);
+    expect(await readIndexCache(fixture.paths, "official", 2)).toContain('"sequence":2');
   });
 
   it("does not overwrite a tap disabled while its network fetch is in flight", async () => {

--- a/test/profile-template-tap-state.test.ts
+++ b/test/profile-template-tap-state.test.ts
@@ -10,6 +10,7 @@ import { addTap, forgetTap, listTaps, removeTap } from "../src/profile/templates
 import { resolveTapPaths, type TapPaths } from "../src/profile/templates/taps/paths.js";
 import { readTapState, writeTapState } from "../src/profile/templates/taps/state-store.js";
 import type { PublisherKey } from "../src/profile/templates/signing/types.js";
+import { acceptTemplateTap } from "./fixtures/template-tap-runtime.js";
 
 const roots: string[] = [];
 const KEY: PublisherKey = {
@@ -95,6 +96,8 @@ function coordinates(count: number): Record<string, string> {
 async function stateWithCoordinates(store: TapPaths, count: number) {
   await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
   const state = await readTapState(store);
+  state.taps.community.publisherPins.highestSequence = 0;
+  state.taps.community.acceptedIndexDigest = `sha256:${"0".repeat(64)}`;
   state.taps.community.publisherPins.coordinates = coordinates(count);
   return state;
 }
@@ -129,9 +132,44 @@ describe("template tap state hardening", () => {
     const store = await paths();
     await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
     const state = await readTapState(store);
-    state.taps.community.publisherPins.keyHistory["publisher:key.v1"] = { publisher: "publisher", publicKey: KEY.publicKey };
+    const source = state.taps.community;
+    source.publisherPins.highestSequence = 0;
+    source.acceptedIndexDigest = `sha256:${"0".repeat(64)}`;
+    source.publisherPins.publishers.publisher = { keyId: "publisher:key.v1", publicKey: KEY.publicKey };
+    source.publisherPins.keyHistory["publisher:key.v1"] = { publisher: "publisher", publicKey: KEY.publicKey };
     await writeTapState(store, state);
     expect((await readTapState(store)).taps.community.publisherPins.keyHistory).toHaveProperty("publisher:key.v1");
+  });
+
+  it("rejects active publisher pins missing from retained key history", async () => {
+    const store = await paths();
+    await acceptTemplateTap(path.dirname(store.configRoot));
+    const state = await readTapState(store);
+    delete state.taps.official.publisherPins.keyHistory["publisher-key-1"];
+    await expect(writeTapState(store, state)).rejects.toThrow(/active publisher key.*history/);
+  });
+
+  it("rejects coordinates belonging to another tap", async () => {
+    const store = await paths();
+    const state = await stateWithCoordinates(store, 0);
+    state.taps.community.publisherPins.coordinates["other/pub/pkg@1.0.0"] = `sha256:${"0".repeat(64)}`;
+    await expect(writeTapState(store, state)).rejects.toThrow(/coordinate belongs to another tap/);
+  });
+
+  it("rejects a revoked key that remains active for a publisher", async () => {
+    const store = await paths();
+    await acceptTemplateTap(path.dirname(store.configRoot));
+    const state = await readTapState(store);
+    state.taps.official.publisherPins.revokedPublisherKeys.push("publisher-key-1");
+    await expect(writeTapState(store, state)).rejects.toThrow(/active publisher key is revoked/);
+  });
+
+  it("rejects key history assigned to an unknown publisher", async () => {
+    const store = await paths();
+    await acceptTemplateTap(path.dirname(store.configRoot));
+    const state = await readTapState(store);
+    state.taps.official.publisherPins.keyHistory["retired-key"] = { publisher: "unknown", publicKey: KEY.publicKey };
+    await expect(writeTapState(store, state)).rejects.toThrow(/key history names an unknown publisher/);
   });
 
   it("refuses a symlinked config root before touching its target", async () => {

--- a/test/profile-template-tap-state.test.ts
+++ b/test/profile-template-tap-state.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @file test/profile-template-tap-state.test.ts
+ * @description Authoritative tap-state parsing, confinement, and lifecycle tests.
+ */
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { addTap, listTaps, removeTap } from "../src/profile/templates/taps/manage.js";
+import { resolveTapPaths, type TapPaths } from "../src/profile/templates/taps/paths.js";
+import { readTapState } from "../src/profile/templates/taps/state-store.js";
+import type { PublisherKey } from "../src/profile/templates/signing/types.js";
+
+const roots: string[] = [];
+const KEY: PublisherKey = {
+  keyId: "tap-key-1",
+  publicKey: "MCowBQYDK2VwAyEA+Zh7GM2+2PTzR+DGzIIMyf9RW3z8iPX+y0ToR7vFF7Q=",
+};
+
+async function paths(): Promise<TapPaths> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "llmwiki-taps-"));
+  roots.push(root);
+  return resolveTapPaths({ configRoot: path.join(root, "config"), cacheRoot: path.join(root, "cache") });
+}
+
+afterEach(async () => {
+  const { rm } = await import("node:fs/promises");
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("template tap lifecycle", () => {
+  it("adds, lists, disables, and exactly re-enables without exposing key bytes", async () => {
+    const store = await paths();
+    await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
+    expect(await removeTap(store, "community")).toMatchObject({ enabled: false });
+    await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
+    const listed = await listTaps(store);
+    expect(listed).toMatchObject([{ name: "community", enabled: true, keyId: "tap-key-1" }]);
+    expect(JSON.stringify(listed)).not.toContain(KEY.publicKey);
+  });
+
+  it("refuses re-adding a retained name with another origin or key", async () => {
+    const store = await paths();
+    await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
+    await removeTap(store, "community");
+    await expect(addTap(store, { name: "community", indexUrl: "https://evil.example/index.json", key: KEY })).rejects.toThrow(/cannot be replaced/);
+  });
+
+  it("serializes concurrent additions without losing either tap", async () => {
+    const store = await paths();
+    await Promise.all([
+      addTap(store, { name: "alpha", indexUrl: "https://alpha.example/index.json", key: KEY }),
+      addTap(store, { name: "beta", indexUrl: "https://beta.example/index.json", key: KEY }),
+    ]);
+    expect((await listTaps(store)).map((tap) => tap.name)).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("template tap state hardening", () => {
+  it("rejects duplicate keys and malformed existing state", async () => {
+    const store = await paths();
+    await mkdir(store.configRoot, { recursive: true });
+    await writeFile(store.stateFile, '{"schemaVersion":1,"schemaVersion":1,"taps":{}}');
+    await expect(readTapState(store)).rejects.toThrow(/duplicate JSON key/);
+  });
+
+  it("refuses a symlinked state leaf without reading its target", async () => {
+    const store = await paths();
+    await mkdir(store.configRoot, { recursive: true });
+    const victim = path.join(path.dirname(store.configRoot), "victim.json");
+    await writeFile(victim, "secret");
+    await symlink(victim, store.stateFile);
+    await expect(readTapState(store)).rejects.toThrow(/unavailable/);
+    expect(await readFile(victim, "utf8")).toBe("secret");
+  });
+
+  it("does not mutate malformed state during add", async () => {
+    const store = await paths();
+    await mkdir(store.configRoot, { recursive: true });
+    await writeFile(store.stateFile, "not-json");
+    await expect(addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY })).rejects.toThrow();
+    expect(await readFile(store.stateFile, "utf8")).toBe("not-json");
+  });
+
+  it("refuses a symlinked config root before touching its target", async () => {
+    const store = await paths();
+    const outside = path.join(path.dirname(store.configRoot), "outside");
+    await mkdir(outside);
+    await symlink(outside, store.configRoot);
+    await expect(addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY })).rejects.toThrow(/real directory/);
+    await expect(readFile(path.join(outside, "template-taps.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/profile-template-tap-state.test.ts
+++ b/test/profile-template-tap-state.test.ts
@@ -6,9 +6,9 @@ import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { addTap, listTaps, removeTap } from "../src/profile/templates/taps/manage.js";
+import { addTap, forgetTap, listTaps, removeTap } from "../src/profile/templates/taps/manage.js";
 import { resolveTapPaths, type TapPaths } from "../src/profile/templates/taps/paths.js";
-import { readTapState } from "../src/profile/templates/taps/state-store.js";
+import { readTapState, writeTapState } from "../src/profile/templates/taps/state-store.js";
 import type { PublisherKey } from "../src/profile/templates/signing/types.js";
 
 const roots: string[] = [];
@@ -54,7 +54,50 @@ describe("template tap lifecycle", () => {
     ]);
     expect((await listTaps(store)).map((tap) => tap.name)).toEqual(["alpha", "beta"]);
   });
+
+  it("requires explicit consent to forget trust, then permits a fresh identity", async () => {
+    const store = await paths();
+    await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
+    await expect(forgetTap(store, "community", false)).rejects.toThrow(/requires --yes/);
+    await forgetTap(store, "community", true);
+    await addTap(store, { name: "community", indexUrl: "https://new.example/index.json", key: KEY });
+    expect(await listTaps(store)).toMatchObject([{ name: "community", origin: "https://new.example" }]);
+  });
+
+  it("warns before monotonic coordinate history reaches its hard cap", async () => {
+    const store = await paths();
+    const state = await stateWithCoordinates(store, 8_000);
+    await writeTapState(store, state);
+    expect((await listTaps(store))[0].warnings.join(" ")).toMatch(/approaching.*8000\/10000/);
+  });
+
+  it("refuses an over-cap write with the scoped recovery command", async () => {
+    const store = await paths();
+    const state = await stateWithCoordinates(store, 10_001);
+    await expect(writeTapState(store, state)).rejects.toThrow(/tap forget <name> --yes/);
+    expect(Object.keys((await readTapState(store)).taps.community.publisherPins.coordinates)).toHaveLength(0);
+  });
 });
+
+describe("template tap path conventions", () => {
+  it("ignores relative XDG roots instead of resolving them under cwd", () => {
+    const resolved = resolveTapPaths({ env: { XDG_CONFIG_HOME: ".config", XDG_CACHE_HOME: ".cache" }, home: "/home/test", platform: "linux" });
+    expect(resolved.configRoot).toBe("/home/test/.config/llmwiki");
+    expect(resolved.cacheRoot).toBe("/home/test/.cache/llmwiki/templates");
+  });
+});
+
+function coordinates(count: number): Record<string, string> {
+  const digest = `sha256:${"0".repeat(64)}`;
+  return Object.fromEntries(Array.from({ length: count }, (_, index) => [`community/pub/pkg-${index}@1.0.0`, digest]));
+}
+
+async function stateWithCoordinates(store: TapPaths, count: number) {
+  await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
+  const state = await readTapState(store);
+  state.taps.community.publisherPins.coordinates = coordinates(count);
+  return state;
+}
 
 describe("template tap state hardening", () => {
   it("rejects duplicate keys and malformed existing state", async () => {
@@ -80,6 +123,15 @@ describe("template tap state hardening", () => {
     await writeFile(store.stateFile, "not-json");
     await expect(addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY })).rejects.toThrow();
     expect(await readFile(store.stateFile, "utf8")).toBe("not-json");
+  });
+
+  it("round-trips signed key-history ids containing non-slug punctuation", async () => {
+    const store = await paths();
+    await addTap(store, { name: "community", indexUrl: "https://tap.example/index.json", key: KEY });
+    const state = await readTapState(store);
+    state.taps.community.publisherPins.keyHistory["publisher:key.v1"] = { publisher: "publisher", publicKey: KEY.publicKey };
+    await writeTapState(store, state);
+    expect((await readTapState(store)).taps.community.publisherPins.keyHistory).toHaveProperty("publisher:key.v1");
   });
 
   it("refuses a symlinked config root before touching its target", async () => {


### PR DESCRIPTION
## Summary

Adds the secure, read-only distribution layer for the profile-template ecosystem. Users can configure explicitly trusted template taps, refresh signed catalogs, search and inspect remote templates, and verify signed package evidence without installing or changing a project profile.

This is the network-facing R3 slice built on the lifecycle and Ed25519 signing foundations from #153. Remote installation and updates remain a separate follow-up so this PR can be reviewed and released as a standalone trust boundary.

## What changes

- Adds `llmwiki template tap` management with explicit root-key trust, enable/disable, refresh, and deliberate `forget --yes` recovery semantics.
- Adds remote template search, inspect, and verify commands backed only by accepted signed evidence.
- Fetches indexes and packages through exact-origin, DNS-pinned HTTPS with redirect revalidation, deadlines, and independent transport/decompression caps.
- Persists bounded publisher, coordinate, revocation, and key-rotation continuity state under a locked, confined operator store; refreshes use an optimistic compare-and-swap commit after network I/O.
- Re-verifies cached indexes and packages on every use. Cache identity binds signed envelopes to their full coordinate, and missing evidence can only be repaired from the exact previously accepted snapshot.
- Makes aggregate search degrade honestly: healthy taps still return results while unavailable taps produce structured warnings; tap-scoped operations remain fail closed.
- Bounds and sanitizes untrusted terminal-facing metadata, and documents the tap workflow and security model.

## Security model

There is no trust-on-first-use. Adding a tap requires an explicit Ed25519 root key. Every remote package is accepted only after strict bounded parsing, tap signature verification, publisher binding and signature verification, immutable coordinate/digest checks, revocation checks, and continuity reconciliation. Disabled taps retain trust history; only the explicit destructive forget command resets one tap's pins.

The v1 protocol deliberately keeps package delivery on the configured tap origin. Remote template installation, marketplace entitlements, transparency logs, and cross-origin package CDNs are not included here.

## Validation

- `npx tsc --noEmit`
- `npm run build`
- `npm test` — 4,162 passed, 3 skipped, 0 failed
- `npx fallow --no-cache`
- `npm run fallow:ci`
- `npm run release:check-docs:current`
- `git diff --check`
