### PR TITLE
Add the template publisher workflow: workspace, signing, build, rotation, revocation

### DIFF
--- a/docs/cli/template.mdx
+++ b/docs/cli/template.mdx
@@ -172,7 +172,7 @@ Everything runs offline; nothing is uploaded.
 
 ```bash
 llmwiki template publish init ./my-tap --tap community --publisher acme
-llmwiki template publish add ./incident-response.json --workspace ./my-tap --version 1.0.0
+llmwiki template publish add ./incident-response.json --workspace ./my-tap --package-version 1.0.0
 llmwiki template publish build --workspace ./my-tap --expires-in 30d --out ./dist
 ```
 

--- a/docs/cli/template.mdx
+++ b/docs/cli/template.mdx
@@ -165,6 +165,47 @@ non-builtin profile presentation strings as untrusted data when showing them to
 an agent. Remote documentation and example-content import are not part of this
 command surface.
 
+## Author and publish a tap
+
+Publishers use these commands to create keys, sign packages, and build a distribution.
+Everything runs offline; nothing is uploaded.
+
+```bash
+llmwiki template publish init ./my-tap --tap community --publisher acme
+llmwiki template publish add ./incident-response.json --workspace ./my-tap --version 1.0.0
+llmwiki template publish build --workspace ./my-tap --expires-in 30d --out ./dist
+```
+
+`init` creates separate Ed25519 tap and publisher keypairs `0600` under `my-tap/keys/`,
+never printing or overwriting a private key, and prints each public key's fingerprint.
+
+`add` validates the package with the production validator, signs its claim, and records
+the coordinate as immutable: the same coordinate may never resolve to different bytes.
+
+`build` advances the sequence, signs the index, writes packages before the index, and
+verifies the whole tree as a consumer would **before** publishing it. The sequence commits
+last, so a failed build leaves the workspace unchanged and a retry is a clean re-run. The
+output must live outside the workspace — otherwise it would publish your private keys. Pass
+`--force` to republish when nothing changed.
+
+### Rotate and revoke
+
+```bash
+llmwiki template publish rotate --workspace ./my-tap --publisher-key-id acme-publisher-2027-01
+llmwiki template publish rotate --workspace ./my-tap --tap-key-id community-tap-2027-01
+llmwiki template publish revoke --workspace ./my-tap --package-digest sha256:... --reason "superseded"
+llmwiki template publish revoke --workspace ./my-tap --publisher-key-id acme-publisher-2026-01 --reason "rotated"
+```
+
+Rotations and revocations are staged and signed by the next `build`, because a rotation
+claim carries the sequence of the index that publishes it and that sequence is only known
+at build time.
+
+A publisher-key rotation re-signs every package with the successor key: a package signed by
+a retired key stops verifying once the index announces its successor. Payloads and
+content-addressed filenames never change. Revoking the active publisher key requires
+rotating to a successor in the same build.
+
 ## Verify a publisher distribution offline
 
 Publishers use this before uploading a built tap. It reads a static distribution

--- a/docs/cli/template.mdx
+++ b/docs/cli/template.mdx
@@ -186,7 +186,8 @@ the coordinate as immutable: the same coordinate may never resolve to different 
 verifies the whole tree as a consumer would **before** publishing it. The sequence commits
 last, so a failed build leaves the workspace unchanged and a retry is a clean re-run. The
 output must live outside the workspace — otherwise it would publish your private keys. Pass
-`--force` to republish when nothing changed.
+`--refresh` to renew an expiring index under a fresh lifetime, or `--force` to republish when
+nothing else changed.
 
 ### Rotate and revoke
 

--- a/docs/guides/publish-template-tap.mdx
+++ b/docs/guides/publish-template-tap.mdx
@@ -8,13 +8,14 @@ This guide is for template publishers and tap operators. It shows how to turn a
 validated declarative profile package into an immutable signed release that an
 llmwiki user can discover, verify, install, and update.
 
-llmwiki does not manage private keys, create releases, or push to a registry.
-Run the signing steps in your own release pipeline, keep private keys outside the
-public tap, and use the exact protocol below as the interoperability contract.
+llmwiki ships the publisher workflow: `template publish init | add | build | rotate |
+revoke | verify` creates keys, signs packages, builds a verified static tree, and
+manages key rotation and revocation. It does not upload: publishing the built tree to
+HTTPS hosting stays with your existing deploy tooling.
 
-llmwiki does ship one publisher-side command: `llmwiki template publish verify`
-checks a built distribution offline, before you upload it. It reads only, never
-signs, and never reaches the network.
+Everything below runs offline. Private keys never leave your workspace, and the protocol
+appendix at the end remains the interoperability contract for anyone implementing it
+independently.
 
 <Warning>
   A signature proves which key signed exact bytes. It does not certify that a
@@ -49,7 +50,93 @@ Tap, publisher, and template names use lowercase slug-safe identifiers. A
 released coordinate is immutable: never publish different bytes under the same
 coordinate.
 
-## 1. Create separate signing keys
+## 1. Create a workspace and keys
+
+```bash
+llmwiki template publish init ./my-tap --tap community --publisher acme
+```
+
+This creates separate Ed25519 keypairs for the tap root and the publisher, writes them
+`0600` under `my-tap/keys/`, and records a workspace at sequence 0. Private keys are never
+printed and are never overwritten. The command prints each public key's SHA-256
+fingerprint — publish those fingerprints through the channel your users trust.
+
+<Warning>
+  The workspace holds private keys. Never serve it, and never point `--out` inside it:
+  `build` refuses that, because it would publish your signing keys.
+</Warning>
+
+## 2. Sign a package
+
+```bash
+llmwiki template publish add ./incident-response.json \
+  --workspace ./my-tap --version 1.0.0
+```
+
+`add` validates the package with the same validator a consumer runs, derives its
+coordinate and payload digest, signs the package claim, and records the coordinate as
+immutable: the same coordinate may never resolve to different bytes.
+
+## 3. Build a distribution
+
+```bash
+llmwiki template publish build \
+  --workspace ./my-tap --expires-in 30d --out ./dist
+```
+
+`build` advances the sequence, signs the index, writes packages before the index, and
+**verifies the complete tree as a consumer would before publishing it**. Only then does it
+swap the tree into `--out` and commit the new sequence. A failed build leaves the
+workspace at its old sequence, so a retry is a clean re-run.
+
+Serve `./dist` from ordinary HTTPS hosting.
+
+## 4. Rotate and revoke
+
+```bash
+llmwiki template publish rotate --workspace ./my-tap --publisher-key-id acme-publisher-2027-01
+llmwiki template publish revoke --workspace ./my-tap --package-digest sha256:... --reason "superseded"
+```
+
+Rotations and revocations are **staged**, then signed by the next `build`. This is not an
+implementation detail: a rotation claim carries the sequence of the index that publishes
+it, and that sequence is only known at build time.
+
+A publisher-key rotation **re-signs every package** with the successor key. It must:
+a package signed by a retired key stops verifying the moment the index announces its
+successor, because a verifier resolves the publisher key by id from the current index.
+The payload never changes, so digests and filenames are stable.
+
+Revoking the *active* publisher key requires rotating to a successor in the same build —
+an index that announces a revoked key is one no client will accept.
+
+## 5. Verify before you publish
+
+```bash
+llmwiki template publish verify ./dist \
+  --tap community \
+  --key-id community-tap-2026-01 \
+  --key-file ./trusted/community-tap-public-key.txt
+```
+
+Pass the key from where you *distribute* it, not from inside the tree being verified: a key
+carried by the tree it verifies proves only self-consistency.
+
+`publish verify` checks one self-contained snapshot and refuses an index carrying
+rotations, because a latest-snapshot-only directory holds no pinned keys to walk a chain
+from. That is a scope limit, not a defect: `build` already verified the rotation against
+your workspace's own key history, and a real client verifies it against the keys it pinned
+from your previous release.
+
+---
+
+# Protocol appendix
+
+The rest of this guide is the wire contract. You do not need it to publish with the CLI
+above; it exists so anyone can implement the protocol independently, and so you can audit
+exactly what the CLI signs.
+
+## Create separate signing keys by hand
 
 Use separate Ed25519 keys for the tap and each publisher. The tap key signs the
 catalog snapshot. A publisher key signs that publisher's package claims.

--- a/docs/guides/publish-template-tap.mdx
+++ b/docs/guides/publish-template-tap.mdx
@@ -102,6 +102,15 @@ Rotations and revocations are **staged**, then signed by the next `build`. This 
 implementation detail: a rotation claim carries the sequence of the index that publishes
 it, and that sequence is only known at build time.
 
+<Warning>
+  A **tap-root** rotation is carried by exactly one index. A client that does not refresh
+  while that index is the published one cannot verify the new root: it must forget and
+  re-add the tap, re-pinning your key through your trusted channel. Publisher-key rotation
+  has no such window — a client can walk the retained chain from any later index. Keep a
+  tap-root rotation published long enough for users to refresh, and announce the new
+  fingerprint out of band.
+</Warning>
+
 A publisher-key rotation **re-signs every package** with the successor key. It must:
 a package signed by a retired key stops verifying the moment the index announces its
 successor, because a verifier resolves the publisher key by id from the current index.

--- a/docs/guides/publish-template-tap.mdx
+++ b/docs/guides/publish-template-tap.mdx
@@ -70,7 +70,7 @@ fingerprint — publish those fingerprints through the channel your users trust.
 
 ```bash
 llmwiki template publish add ./incident-response.json \
-  --workspace ./my-tap --version 1.0.0
+  --workspace ./my-tap --package-version 1.0.0
 ```
 
 `add` validates the package with the same validator a consumer runs, derives its

--- a/docs/guides/publish-template-tap.mdx
+++ b/docs/guides/publish-template-tap.mdx
@@ -89,6 +89,11 @@ llmwiki template publish build \
 swap the tree into `--out` and commit the new sequence. A failed build leaves the
 workspace at its old sequence, so a retry is a clean re-run.
 
+To renew a distribution whose lifetime is expiring without changing its contents, rebuild
+with `--refresh`. It republishes the same tree under a fresh `--expires-in` window and
+advances the sequence. Without it, a build that finds nothing changed is refused, so an
+accidental rebuild never burns a sequence.
+
 Serve `./dist` from ordinary HTTPS hosting.
 
 ## 4. Rotate and revoke

--- a/src/cli/template-commands.ts
+++ b/src/cli/template-commands.ts
@@ -34,7 +34,9 @@ import {
   type TemplateSearchOptions,
 } from "../commands/template-remote.js";
 import {
+  templatePublishInitCommand,
   templatePublishVerifyCommand,
+  type TemplatePublishInitOptions,
   type TemplatePublishVerifyOptions,
 } from "../commands/template-publish.js";
 
@@ -78,7 +80,20 @@ export function registerTemplateCommands(program: Command): void {
 
   const publish = template
     .command("publish")
-    .description("Verify template publisher distributions");
+    .description("Author, build, and verify template publisher distributions");
+
+  publish
+    .command("init <directory>")
+    .description("Create a publisher workspace with fresh tap and publisher keys")
+    .requiredOption("--tap <name>", "Tap identity this workspace publishes")
+    .requiredOption("--publisher <name>", "Publisher identity that signs packages")
+    .option("--tap-key-id <id>", "Override the generated tap key id")
+    .option("--publisher-key-id <id>", "Override the generated publisher key id")
+    .option("--json", "Print a stable versioned JSON result")
+    .action(async (directory: string, options: TemplatePublishInitOptions) =>
+      runExitCodeCommand(() => templatePublishInitCommand(directory, options), { colorError: false }),
+    );
+
   publish
     .command("verify <directory>")
     .description("Verify a signed publisher distribution offline")

--- a/src/cli/template-commands.ts
+++ b/src/cli/template-commands.ts
@@ -106,7 +106,7 @@ export function registerTemplateCommands(program: Command): void {
     .command("add <package-file>")
     .description("Validate, sign, and record one template package")
     .requiredOption("--workspace <path>", "Publisher workspace directory")
-    .requiredOption("--version <version>", "Version this package is published as")
+    .requiredOption("--package-version <version>", "Version this package is published as")
     .option("--json", "Print a stable versioned JSON result")
     .action(async (packageFile: string, options: TemplatePublishAddOptions) =>
       runExitCodeCommand(() => templatePublishAddCommand(packageFile, options), { colorError: false }),

--- a/src/cli/template-commands.ts
+++ b/src/cli/template-commands.ts
@@ -118,6 +118,7 @@ export function registerTemplateCommands(program: Command): void {
     .requiredOption("--workspace <path>", "Publisher workspace directory")
     .requiredOption("--out <path>", "Output directory, which must live outside the workspace")
     .requiredOption("--expires-in <duration>", "Index lifetime, such as 30d or 12h")
+    .option("--refresh", "Republish unchanged content under a fresh lifetime, to renew an expiring index")
     .option("--force", "Republish even when nothing changed since the last build")
     .option("--json", "Print a stable versioned JSON result")
     .action(async (options: TemplatePublishBuildOptions) =>

--- a/src/cli/template-commands.ts
+++ b/src/cli/template-commands.ts
@@ -34,9 +34,17 @@ import {
   type TemplateSearchOptions,
 } from "../commands/template-remote.js";
 import {
+  templatePublishAddCommand,
+  templatePublishBuildCommand,
   templatePublishInitCommand,
+  templatePublishRevokeCommand,
+  templatePublishRotateCommand,
   templatePublishVerifyCommand,
+  type TemplatePublishAddOptions,
+  type TemplatePublishBuildOptions,
   type TemplatePublishInitOptions,
+  type TemplatePublishRevokeOptions,
+  type TemplatePublishRotateOptions,
   type TemplatePublishVerifyOptions,
 } from "../commands/template-publish.js";
 
@@ -92,6 +100,49 @@ export function registerTemplateCommands(program: Command): void {
     .option("--json", "Print a stable versioned JSON result")
     .action(async (directory: string, options: TemplatePublishInitOptions) =>
       runExitCodeCommand(() => templatePublishInitCommand(directory, options), { colorError: false }),
+    );
+
+  publish
+    .command("add <package-file>")
+    .description("Validate, sign, and record one template package")
+    .requiredOption("--workspace <path>", "Publisher workspace directory")
+    .requiredOption("--version <version>", "Version this package is published as")
+    .option("--json", "Print a stable versioned JSON result")
+    .action(async (packageFile: string, options: TemplatePublishAddOptions) =>
+      runExitCodeCommand(() => templatePublishAddCommand(packageFile, options), { colorError: false }),
+    );
+
+  publish
+    .command("build")
+    .description("Build, verify, and publish a static distribution")
+    .requiredOption("--workspace <path>", "Publisher workspace directory")
+    .requiredOption("--out <path>", "Output directory, which must live outside the workspace")
+    .requiredOption("--expires-in <duration>", "Index lifetime, such as 30d or 12h")
+    .option("--force", "Republish even when nothing changed since the last build")
+    .option("--json", "Print a stable versioned JSON result")
+    .action(async (options: TemplatePublishBuildOptions) =>
+      runExitCodeCommand(() => templatePublishBuildCommand(options), { colorError: false }),
+    );
+
+  publish
+    .command("rotate")
+    .description("Stage a tap-root or publisher key rotation, signed by the next build")
+    .requiredOption("--workspace <path>", "Publisher workspace directory")
+    .option("--tap-key-id <id>", "Rotate the tap root key to this new key id")
+    .option("--publisher-key-id <id>", "Rotate the publisher key to this new key id")
+    .action(async (options: TemplatePublishRotateOptions) =>
+      runExitCodeCommand(() => templatePublishRotateCommand(options), { colorError: false }),
+    );
+
+  publish
+    .command("revoke")
+    .description("Stage a package or publisher-key revocation, published by the next build")
+    .requiredOption("--workspace <path>", "Publisher workspace directory")
+    .requiredOption("--reason <text>", "Why this evidence is revoked")
+    .option("--package-digest <digest>", "Revoke one published package digest")
+    .option("--publisher-key-id <id>", "Revoke one publisher key id")
+    .action(async (options: TemplatePublishRevokeOptions) =>
+      runExitCodeCommand(() => templatePublishRevokeCommand(options), { colorError: false }),
     );
 
   publish

--- a/src/commands/template-publish.ts
+++ b/src/commands/template-publish.ts
@@ -120,7 +120,7 @@ function printInitResult(result: InitWorkspaceResult): void {
 }
 
 /** Options accepted by `template publish add`. */
-export interface TemplatePublishAddOptions { workspace: string; version: string; json?: boolean }
+export interface TemplatePublishAddOptions { workspace: string; packageVersion: string; json?: boolean }
 
 /** Validate, sign, and record one template package into the workspace. */
 export async function templatePublishAddCommand(
@@ -128,7 +128,7 @@ export async function templatePublishAddCommand(
   options: TemplatePublishAddOptions,
 ): Promise<number> {
   try {
-    const result = await addPackage(resolveWorkspacePaths(options.workspace), packageFile, options.version);
+    const result = await addPackage(resolveWorkspacePaths(options.workspace), packageFile, options.packageVersion);
     if (options.json) console.log(JSON.stringify({ schemaVersion: 1, ...result }, null, 2));
     else {
       console.log(result.alreadyPresent ? "Package already recorded." : "Recorded signed package.");

--- a/src/commands/template-publish.ts
+++ b/src/commands/template-publish.ts
@@ -182,9 +182,19 @@ export async function templatePublishRotateCommand(options: TemplatePublishRotat
     if ((options.tapKeyId === undefined) === (options.publisherKeyId === undefined)) {
       throw new Error("rotate requires exactly one of --tap-key-id or --publisher-key-id");
     }
-    if (options.publisherKeyId !== undefined) await stageRotatePublisherKey(paths, options.publisherKeyId);
-    else await stageRotateTapKey(paths, options.tapKeyId as string);
-    console.log("Staged key rotation. It is signed by the next build, at that build's sequence.");
+    if (options.publisherKeyId !== undefined) {
+      await stageRotatePublisherKey(paths, options.publisherKeyId);
+      console.log("Staged publisher key rotation. It is signed by the next build, at that build's sequence.");
+      console.log("Every package will be re-signed with the successor key; digests do not change.");
+      return 0;
+    }
+    await stageRotateTapKey(paths, options.tapKeyId as string);
+    console.log("Staged tap ROOT key rotation. It is signed by the next build.");
+    console.log("");
+    console.log("WARNING: a tap-root rotation is carried by exactly ONE index. A client that does");
+    console.log("not refresh while that index is the published one cannot verify the new root and");
+    console.log("must forget and re-add the tap, re-pinning your key out of band. Keep that index");
+    console.log("published long enough for your users to refresh, and announce the new fingerprint.");
     return 0;
   } catch (error) {
     throw new Error(boundedSafeError(error));

--- a/src/commands/template-publish.ts
+++ b/src/commands/template-publish.ts
@@ -3,6 +3,7 @@
  * @description Stable CLI presentation for read-only offline verification of
  * a signed template publisher distribution snapshot.
  */
+import { initWorkspace, type InitWorkspaceOptions, type InitWorkspaceResult } from "../profile/templates/publish/init.js";
 import { verifyPublisherDistribution } from "../profile/templates/publish/verify.js";
 
 const TERMINAL_CONTROL = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/gu;
@@ -51,4 +52,60 @@ function boundedSafeError(error: unknown): string {
   const bytes = Buffer.from(safe, "utf8");
   if (bytes.length <= MAX_ERROR_MESSAGE_BYTES) return safe;
   return `${bytes.subarray(0, MAX_ERROR_MESSAGE_BYTES - 3).toString("utf8").replace(/�$/u, "")}…`;
+}
+
+/** Options required by `template publish init`. */
+export interface TemplatePublishInitOptions {
+  tap: string;
+  publisher: string;
+  tapKeyId?: string;
+  publisherKeyId?: string;
+  json?: boolean;
+}
+
+/** Create a publisher workspace with fresh tap and publisher keypairs. */
+export async function templatePublishInitCommand(
+  directory: string,
+  options: TemplatePublishInitOptions,
+): Promise<number> {
+  try {
+    const result = await initWorkspace(directory, initOptions(options));
+    if (options.json) console.log(JSON.stringify(publicInitResult(result), null, 2));
+    else printInitResult(result);
+    return 0;
+  } catch (error) {
+    throw new Error(boundedSafeError(error));
+  }
+}
+
+/** Forward only the key-id overrides the operator actually supplied. */
+function initOptions(options: TemplatePublishInitOptions): InitWorkspaceOptions {
+  return {
+    tap: options.tap,
+    publisher: options.publisher,
+    ...(options.tapKeyId === undefined ? {} : { tapKeyId: options.tapKeyId }),
+    ...(options.publisherKeyId === undefined ? {} : { publisherKeyId: options.publisherKeyId }),
+  };
+}
+
+/** The public shape: key ids and fingerprints only, never private bytes. */
+function publicInitResult(result: InitWorkspaceResult): object {
+  return {
+    schemaVersion: 1,
+    tap: result.tap,
+    publisher: result.publisher,
+    tapKeyId: result.tapKey.keyId,
+    publisherKeyId: result.publisherKey.keyId,
+    fingerprints: result.fingerprints,
+  };
+}
+
+function printInitResult(result: InitWorkspaceResult): void {
+  console.log("Initialized publisher workspace.");
+  console.log(`Tap: ${safeTerminalText(result.tap)}`);
+  console.log(`Publisher: ${safeTerminalText(result.publisher)}`);
+  console.log(`Tap key: ${safeTerminalText(result.tapKey.keyId)} (${result.fingerprints.tap})`);
+  console.log(`Publisher key: ${safeTerminalText(result.publisherKey.keyId)} (${result.fingerprints.publisher})`);
+  console.log("Private keys are stored 0600 under keys/ and are never printed.");
+  console.log("Distribute the tap public key through a channel independent of the tap.");
 }

--- a/src/commands/template-publish.ts
+++ b/src/commands/template-publish.ts
@@ -146,6 +146,7 @@ export interface TemplatePublishBuildOptions {
   workspace: string;
   out: string;
   expiresIn: string;
+  refresh?: boolean;
   force?: boolean;
   json?: boolean;
 }
@@ -156,6 +157,7 @@ export async function templatePublishBuildCommand(options: TemplatePublishBuildO
     const result = await buildDistribution(resolveWorkspacePaths(options.workspace), {
       out: options.out,
       expiresIn: options.expiresIn,
+      refresh: options.refresh === true,
       force: options.force === true,
     });
     if (options.json) console.log(JSON.stringify({ schemaVersion: 1, ...result }, null, 2));

--- a/src/commands/template-publish.ts
+++ b/src/commands/template-publish.ts
@@ -3,7 +3,16 @@
  * @description Stable CLI presentation for read-only offline verification of
  * a signed template publisher distribution snapshot.
  */
+import { addPackage } from "../profile/templates/publish/add.js";
+import { buildDistribution } from "../profile/templates/publish/build.js";
+import {
+  stageRevokePackage,
+  stageRevokePublisherKey,
+  stageRotatePublisherKey,
+  stageRotateTapKey,
+} from "../profile/templates/publish/lifecycle.js";
 import { initWorkspace, type InitWorkspaceOptions, type InitWorkspaceResult } from "../profile/templates/publish/init.js";
+import { resolveWorkspacePaths } from "../profile/templates/publish/workspace-paths.js";
 import { verifyPublisherDistribution } from "../profile/templates/publish/verify.js";
 
 const TERMINAL_CONTROL = /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/gu;
@@ -108,4 +117,100 @@ function printInitResult(result: InitWorkspaceResult): void {
   console.log(`Publisher key: ${safeTerminalText(result.publisherKey.keyId)} (${result.fingerprints.publisher})`);
   console.log("Private keys are stored 0600 under keys/ and are never printed.");
   console.log("Distribute the tap public key through a channel independent of the tap.");
+}
+
+/** Options accepted by `template publish add`. */
+export interface TemplatePublishAddOptions { workspace: string; version: string; json?: boolean }
+
+/** Validate, sign, and record one template package into the workspace. */
+export async function templatePublishAddCommand(
+  packageFile: string,
+  options: TemplatePublishAddOptions,
+): Promise<number> {
+  try {
+    const result = await addPackage(resolveWorkspacePaths(options.workspace), packageFile, options.version);
+    if (options.json) console.log(JSON.stringify({ schemaVersion: 1, ...result }, null, 2));
+    else {
+      console.log(result.alreadyPresent ? "Package already recorded." : "Recorded signed package.");
+      console.log(`Coordinate: ${safeTerminalText(result.coordinate)}`);
+      console.log(`Digest: ${result.payloadDigest}`);
+    }
+    return 0;
+  } catch (error) {
+    throw new Error(boundedSafeError(error));
+  }
+}
+
+/** Options accepted by `template publish build`. */
+export interface TemplatePublishBuildOptions {
+  workspace: string;
+  out: string;
+  expiresIn: string;
+  force?: boolean;
+  json?: boolean;
+}
+
+/** Build, verify, and publish one static distribution. */
+export async function templatePublishBuildCommand(options: TemplatePublishBuildOptions): Promise<number> {
+  try {
+    const result = await buildDistribution(resolveWorkspacePaths(options.workspace), {
+      out: options.out,
+      expiresIn: options.expiresIn,
+      force: options.force === true,
+    });
+    if (options.json) console.log(JSON.stringify({ schemaVersion: 1, ...result }, null, 2));
+    else {
+      console.log("Built and verified distribution.");
+      console.log(`Sequence: ${result.sequence}`);
+      console.log(`Packages: ${result.packageCount}`);
+      console.log(`Index digest: ${result.indexDigest}`);
+      console.log(`Output: ${safeTerminalText(result.out)}`);
+    }
+    return 0;
+  } catch (error) {
+    throw new Error(boundedSafeError(error));
+  }
+}
+
+/** Options accepted by `template publish rotate`. */
+export interface TemplatePublishRotateOptions { workspace: string; tapKeyId?: string; publisherKeyId?: string }
+
+/** Stage a key rotation; it is signed by the next build at that build's sequence. */
+export async function templatePublishRotateCommand(options: TemplatePublishRotateOptions): Promise<number> {
+  try {
+    const paths = resolveWorkspacePaths(options.workspace);
+    if ((options.tapKeyId === undefined) === (options.publisherKeyId === undefined)) {
+      throw new Error("rotate requires exactly one of --tap-key-id or --publisher-key-id");
+    }
+    if (options.publisherKeyId !== undefined) await stageRotatePublisherKey(paths, options.publisherKeyId);
+    else await stageRotateTapKey(paths, options.tapKeyId as string);
+    console.log("Staged key rotation. It is signed by the next build, at that build's sequence.");
+    return 0;
+  } catch (error) {
+    throw new Error(boundedSafeError(error));
+  }
+}
+
+/** Options accepted by `template publish revoke`. */
+export interface TemplatePublishRevokeOptions {
+  workspace: string;
+  reason: string;
+  packageDigest?: string;
+  publisherKeyId?: string;
+}
+
+/** Stage a revocation; it is published by the next build and accumulates forever. */
+export async function templatePublishRevokeCommand(options: TemplatePublishRevokeOptions): Promise<number> {
+  try {
+    const paths = resolveWorkspacePaths(options.workspace);
+    if ((options.packageDigest === undefined) === (options.publisherKeyId === undefined)) {
+      throw new Error("revoke requires exactly one of --package-digest or --publisher-key-id");
+    }
+    if (options.packageDigest !== undefined) await stageRevokePackage(paths, options.packageDigest, options.reason);
+    else await stageRevokePublisherKey(paths, options.publisherKeyId as string, options.reason);
+    console.log("Staged revocation. It is published by the next build and accumulates permanently.");
+    return 0;
+  } catch (error) {
+    throw new Error(boundedSafeError(error));
+  }
 }

--- a/src/profile/templates/publish/add.ts
+++ b/src/profile/templates/publish/add.ts
@@ -1,0 +1,104 @@
+/**
+ * @file src/profile/templates/publish/add.ts
+ * @description Validate, sign, and record one template package into the workspace.
+ *
+ * The package is validated by the PRODUCTION validator and its envelope is proved to
+ * parse under the PRODUCTION parser before it is recorded — a publisher never records
+ * bytes that a consumer would refuse. Coordinates are immutable: the same coordinate
+ * may never resolve to different bytes.
+ */
+import packageJson from "../../../../package.json" with { type: "json" };
+import { readCappedNoFollow } from "../../../utils/confined-read.js";
+import { withExclusiveLock } from "../../../utils/exclusive-lock.js";
+import { canonicalDigest, packageClaim } from "../signing/canonical.js";
+import { parseSignedPackage, parseTemplateCoordinate } from "../signing/protocol.js";
+import { signClaim } from "../signing/sign.js";
+import { validateTemplatePackage } from "../validate.js";
+import { readPrivateKey } from "./keystore.js";
+import type { WorkspacePaths } from "./workspace-paths.js";
+import { readWorkspace, writeWorkspace } from "./workspace-store.js";
+import type { PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
+
+const MAX_PACKAGE_FILE_BYTES = 2 * 1024 * 1024;
+
+/** Result of accepting one package into the workspace. */
+export interface AddPackageResult {
+  coordinate: string;
+  payloadDigest: string;
+  alreadyPresent: boolean;
+}
+
+/** Validate, sign, and record one template package under the workspace lock. */
+export async function addPackage(
+  paths: WorkspacePaths,
+  packageFile: string,
+  version: string,
+): Promise<AddPackageResult> {
+  return withExclusiveLock(paths, async () => {
+    const workspace = await readWorkspace(paths);
+    const pkg = await readValidatedPackage(packageFile);
+    if (pkg.publisher !== workspace.publisher) {
+      throw new Error(`package publisher '${pkg.publisher}' is not this workspace's publisher '${workspace.publisher}'`);
+    }
+    if (pkg.version !== version) {
+      throw new Error(`package version '${pkg.version}' does not match the requested version '${version}'`);
+    }
+    const coordinate = `${workspace.tap}/${workspace.publisher}/${pkg.templateId}@${version}`;
+    parseTemplateCoordinate(coordinate);
+    const payloadDigest = canonicalDigest(pkg);
+
+    const existing = workspace.coordinates[coordinate];
+    if (existing !== undefined) {
+      if (existing !== payloadDigest) {
+        throw new Error(`coordinate is immutable and already resolves to different bytes: ${coordinate}`);
+      }
+      return { coordinate, payloadDigest, alreadyPresent: true };
+    }
+
+    const recorded = await signPackage(paths, workspace, coordinate, payloadDigest, pkg);
+    await writeWorkspace(paths, {
+      ...workspace,
+      packages: [...workspace.packages, recorded],
+      coordinates: { ...workspace.coordinates, [coordinate]: payloadDigest },
+    });
+    return { coordinate, payloadDigest, alreadyPresent: false };
+  });
+}
+
+/** Sign the package claim and prove the envelope parses before recording it. */
+async function signPackage(
+  paths: WorkspacePaths,
+  workspace: PublisherWorkspace,
+  coordinate: string,
+  payloadDigest: string,
+  payload: unknown,
+): Promise<WorkspacePackage> {
+  const key = await readPrivateKey(paths, "publisher", workspace.publisherKey.keyId);
+  const publisherSignature = signClaim(packageClaim(coordinate, payloadDigest), key);
+  const envelope = { schemaVersion: 1, coordinate, payload, payloadDigest, publisherSignature };
+  const envelopeJson = JSON.stringify(envelope);
+  parseSignedPackage(envelopeJson);
+  return {
+    coordinate,
+    publisher: workspace.publisher,
+    payloadDigest,
+    publisherSignature,
+    envelopeJson,
+  };
+}
+
+/** Read one operator-supplied package file through the production validator. */
+async function readValidatedPackage(packageFile: string) {
+  const read = await readCappedNoFollow(packageFile, MAX_PACKAGE_FILE_BYTES);
+  if (read.kind !== "ok") throw new Error("template package file is missing, symlinked, or unreadable");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(read.body);
+  } catch (error) {
+    throw new Error(`template package file is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return validateTemplatePackage(parsed, {
+    currentVersion: packageJson.version,
+    sourceType: "remote",
+  });
+}

--- a/src/profile/templates/publish/add.ts
+++ b/src/profile/templates/publish/add.ts
@@ -10,13 +10,15 @@
 import packageJson from "../../../../package.json" with { type: "json" };
 import { readCappedNoFollow } from "../../../utils/confined-read.js";
 import { withExclusiveLock } from "../../../utils/exclusive-lock.js";
-import { canonicalDigest, packageClaim } from "../signing/canonical.js";
+import { createPublicKey, verify } from "node:crypto";
+import { canonicalBytes, canonicalDigest, packageClaim } from "../signing/canonical.js";
 import { parseSignedPackage, parseTemplateCoordinate } from "../signing/protocol.js";
 import { signClaim } from "../signing/sign.js";
 import { validateTemplatePackage } from "../validate.js";
 import { readPrivateKey } from "./keystore.js";
 import type { WorkspacePaths } from "./workspace-paths.js";
 import { readWorkspace, writeWorkspace } from "./workspace-store.js";
+import type { Ed25519Signature, PublisherKey } from "../signing/types.js";
 import type { PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
 
 const MAX_PACKAGE_FILE_BYTES = 2 * 1024 * 1024;
@@ -78,6 +80,10 @@ async function signPackage(
   const envelope = { schemaVersion: 1, coordinate, payload, payloadDigest, publisherSignature };
   const envelopeJson = JSON.stringify(envelope);
   parseSignedPackage(envelopeJson);
+  // Parsing proves shape, not authenticity. If the private key on disk does not match the
+  // public key the workspace announces, this records an envelope no client can verify — and
+  // the coordinate is immutable, so the mistake would be permanent.
+  assertSignatureMatchesAnnouncedKey(coordinate, payloadDigest, publisherSignature, workspace.publisherKey);
   return {
     coordinate,
     publisher: workspace.publisher,
@@ -85,6 +91,32 @@ async function signPackage(
     publisherSignature,
     envelopeJson,
   };
+}
+
+/** The signature must verify under the PUBLIC key the index will announce. */
+function assertSignatureMatchesAnnouncedKey(
+  coordinate: string,
+  payloadDigest: string,
+  signature: Ed25519Signature,
+  announced: PublisherKey,
+): void {
+  if (signature.keyId !== announced.keyId) {
+    throw new Error("signing key id does not match the workspace's announced publisher key");
+  }
+  const publicKey = createPublicKey({
+    key: Buffer.from(announced.publicKey, "base64"),
+    format: "der",
+    type: "spki",
+  });
+  const ok = verify(
+    null,
+    canonicalBytes(packageClaim(coordinate, payloadDigest)),
+    publicKey,
+    Buffer.from(signature.value, "base64"),
+  );
+  if (!ok) {
+    throw new Error("the private key on disk does not match the workspace's announced publisher key");
+  }
 }
 
 /** Read one operator-supplied package file through the production validator. */

--- a/src/profile/templates/publish/build-options.ts
+++ b/src/profile/templates/publish/build-options.ts
@@ -2,8 +2,13 @@
  * @file src/profile/templates/publish/build-options.ts
  * @description Build input validation: where output may go, and how long it lives.
  */
-import { lstat, mkdir, readFile, readdir, realpath } from "node:fs/promises";
+import { lstat, mkdir, readdir, realpath } from "node:fs/promises";
+import { readCappedNoFollow } from "../../../utils/confined-read.js";
+import { canonicalDigest } from "../signing/canonical.js";
 import { parseSignedTapIndex } from "../signing/protocol.js";
+import type { LastBuild } from "./workspace-types.js";
+
+const MAX_INDEX_BYTES = 4 * 1024 * 1024;
 import path from "node:path";
 import type { WorkspacePaths } from "./workspace-paths.js";
 
@@ -16,7 +21,11 @@ const MAX_EXPIRY_MS = 365 * 24 * 60 * 60 * 1000;
  * this is the key-exfiltration control. Both sides are resolved with `realpath` — a
  * lexical comparison is defeated by a symlinked path.
  */
-export async function assertOutsideWorkspace(paths: WorkspacePaths, out: string, tap: string): Promise<string> {
+export async function assertOutsideWorkspace(
+  paths: WorkspacePaths,
+  out: string,
+  lastBuild: LastBuild | undefined,
+): Promise<string> {
   const resolvedOut = path.resolve(out);
   await mkdir(path.dirname(resolvedOut), { recursive: true });
   const realWorkspace = await realpath(paths.root);
@@ -25,38 +34,47 @@ export async function assertOutsideWorkspace(paths: WorkspacePaths, out: string,
   if (contains(realWorkspace, realOut) || contains(realOut, realWorkspace)) {
     throw new Error("build output must live outside the publisher workspace: it would publish private keys");
   }
-  await assertReplaceableOutput(resolvedOut, tap);
+  await assertReplaceableOutput(resolvedOut, lastBuild);
   return resolvedOut;
 }
 
 /**
  * Publishing REPLACES the whole output directory: it is renamed aside and then deleted. So
- * the only things safe to point `--out` at are nothing, an empty directory, or a previous
- * distribution OF THIS TAP. Anything else is somebody's data, and this command must not be
- * the reason it disappears.
+ * the only things safe to point `--out` at are nothing, an empty directory, or A TREE THIS
+ * WORKSPACE ITSELF PUBLISHED.
+ *
+ * "Looks like a distribution of this tap" is NOT sufficient: an index is just bytes, and
+ * anyone can write one that claims any tap name. The output is only replaceable when its
+ * index digests to exactly what `lastBuild` recorded — an identity we produced and stored,
+ * so no attacker-supplied bytes can satisfy it.
  */
-async function assertReplaceableOutput(out: string, tap: string): Promise<void> {
+async function assertReplaceableOutput(out: string, lastBuild: LastBuild | undefined): Promise<void> {
   const info = await lstat(out).catch(() => null);
   if (info === null) return;
   if (!info.isDirectory()) throw new Error("build output path exists and is not a directory");
 
   const entries = await readdir(out);
   if (entries.length === 0) return;
-  if (!(await isDistributionOfTap(out, entries, tap))) {
+  if (!(await isOurPreviousBuild(out, entries, lastBuild))) {
     throw new Error(
-      "build output directory is not empty and is not a previous distribution of this tap; "
+      "build output directory is not empty and is not a tree this workspace published; "
       + "publishing would delete its contents",
     );
   }
 }
 
-/** A prior distribution: exactly index.json + packages/, whose index names THIS tap. */
-async function isDistributionOfTap(out: string, entries: string[], tap: string): Promise<boolean> {
+/** Exactly index.json + packages/, whose index is byte-for-byte the one we last published. */
+async function isOurPreviousBuild(
+  out: string,
+  entries: string[],
+  lastBuild: LastBuild | undefined,
+): Promise<boolean> {
+  if (lastBuild === undefined) return false;
   if (entries.sort().join(",") !== "index.json,packages") return false;
-  const text = await readFile(path.join(out, "index.json"), "utf8").catch(() => null);
-  if (text === null) return false;
+  const read = await readCappedNoFollow(path.join(out, "index.json"), MAX_INDEX_BYTES);
+  if (read.kind !== "ok") return false;
   try {
-    return parseSignedTapIndex(text).tap === tap;
+    return canonicalDigest(parseSignedTapIndex(read.body)) === lastBuild.indexDigest;
   } catch {
     return false;
   }

--- a/src/profile/templates/publish/build-options.ts
+++ b/src/profile/templates/publish/build-options.ts
@@ -3,12 +3,9 @@
  * @description Build input validation: where output may go, and how long it lives.
  */
 import { lstat, mkdir, readdir, realpath } from "node:fs/promises";
-import { readCappedNoFollow } from "../../../utils/confined-read.js";
 import { canonicalDigest } from "../signing/canonical.js";
-import { parseSignedTapIndex } from "../signing/protocol.js";
+import { readDistributionOnDisk } from "./tree-read.js";
 import type { LastBuild } from "./workspace-types.js";
-
-const MAX_INDEX_BYTES = 4 * 1024 * 1024;
 import path from "node:path";
 import type { WorkspacePaths } from "./workspace-paths.js";
 
@@ -24,7 +21,7 @@ const MAX_EXPIRY_MS = 365 * 24 * 60 * 60 * 1000;
 export async function assertOutsideWorkspace(
   paths: WorkspacePaths,
   out: string,
-  lastBuild: LastBuild | undefined,
+  known: (LastBuild | undefined)[],
 ): Promise<string> {
   const resolvedOut = path.resolve(out);
   await mkdir(path.dirname(resolvedOut), { recursive: true });
@@ -34,7 +31,7 @@ export async function assertOutsideWorkspace(
   if (contains(realWorkspace, realOut) || contains(realOut, realWorkspace)) {
     throw new Error("build output must live outside the publisher workspace: it would publish private keys");
   }
-  await assertReplaceableOutput(resolvedOut, lastBuild);
+  await assertReplaceableOutput(resolvedOut, known);
   return resolvedOut;
 }
 
@@ -48,14 +45,14 @@ export async function assertOutsideWorkspace(
  * index digests to exactly what `lastBuild` recorded — an identity we produced and stored,
  * so no attacker-supplied bytes can satisfy it.
  */
-async function assertReplaceableOutput(out: string, lastBuild: LastBuild | undefined): Promise<void> {
+async function assertReplaceableOutput(out: string, known: (LastBuild | undefined)[]): Promise<void> {
   const info = await lstat(out).catch(() => null);
   if (info === null) return;
   if (!info.isDirectory()) throw new Error("build output path exists and is not a directory");
 
   const entries = await readdir(out);
   if (entries.length === 0) return;
-  if (!(await isOurPreviousBuild(out, entries, lastBuild))) {
+  if (!(await isOurPublishedTree(out, known))) {
     throw new Error(
       "build output directory is not empty and is not a tree this workspace published; "
       + "publishing would delete its contents",
@@ -63,18 +60,21 @@ async function assertReplaceableOutput(out: string, lastBuild: LastBuild | undef
   }
 }
 
-/** Exactly index.json + packages/, whose index is byte-for-byte the one we last published. */
-async function isOurPreviousBuild(
-  out: string,
-  entries: string[],
-  lastBuild: LastBuild | undefined,
-): Promise<boolean> {
-  if (lastBuild === undefined) return false;
-  if (entries.sort().join(",") !== "index.json,packages") return false;
-  const read = await readCappedNoFollow(path.join(out, "index.json"), MAX_INDEX_BYTES);
-  if (read.kind !== "ok") return false;
+/**
+ * A tree THIS WORKSPACE published: an exact distribution (no extra, missing, symlinked, or
+ * special entries — enforced by the Slice A filesystem verifier) whose index digests to one
+ * we recorded publishing.
+ *
+ * Checking the index alone is not enough: an index is PUBLIC and copyable, so anyone can
+ * drop a legitimate index beside their own files. Only the exact-tree check proves the
+ * directory itself is a distribution and holds nothing else we would be deleting.
+ */
+async function isOurPublishedTree(out: string, known: (LastBuild | undefined)[]): Promise<boolean> {
+  const digests = known.filter((build) => build !== undefined).map((build) => build.indexDigest);
+  if (digests.length === 0) return false;
   try {
-    return canonicalDigest(parseSignedTapIndex(read.body)) === lastBuild.indexDigest;
+    const onDisk = await readDistributionOnDisk(out);
+    return digests.includes(canonicalDigest(onDisk.index));
   } catch {
     return false;
   }

--- a/src/profile/templates/publish/build-options.ts
+++ b/src/profile/templates/publish/build-options.ts
@@ -1,0 +1,64 @@
+/**
+ * @file src/profile/templates/publish/build-options.ts
+ * @description Build input validation: where output may go, and how long it lives.
+ */
+import { lstat, mkdir, realpath } from "node:fs/promises";
+import path from "node:path";
+import type { WorkspacePaths } from "./workspace-paths.js";
+
+const MIN_EXPIRY_MS = 60 * 60 * 1000;
+const MAX_EXPIRY_MS = 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * Refuse an output directory inside the workspace, or a workspace inside the output.
+ * The workspace holds PRIVATE KEYS and the output is built for public HTTPS hosting, so
+ * this is the key-exfiltration control. Both sides are resolved with `realpath` — a
+ * lexical comparison is defeated by a symlinked path.
+ */
+export async function assertOutsideWorkspace(paths: WorkspacePaths, out: string): Promise<string> {
+  const resolvedOut = path.resolve(out);
+  await mkdir(path.dirname(resolvedOut), { recursive: true });
+  const realWorkspace = await realpath(paths.root);
+  const realOut = await realExistingAncestor(resolvedOut);
+
+  if (contains(realWorkspace, realOut) || contains(realOut, realWorkspace)) {
+    throw new Error("build output must live outside the publisher workspace: it would publish private keys");
+  }
+  await assertDirectoryOrAbsent(resolvedOut);
+  return resolvedOut;
+}
+
+/**
+ * Refuse an output path that exists and is not a directory. Publishing moves an existing
+ * output aside and then deletes it, so a file here would be silently destroyed.
+ */
+async function assertDirectoryOrAbsent(out: string): Promise<void> {
+  const info = await lstat(out).catch(() => null);
+  if (info !== null && !info.isDirectory()) {
+    throw new Error("build output path exists and is not a directory");
+  }
+}
+
+/** Convert a bounded duration (`30d`, `12h`) into an absolute expiry. */
+export function parseExpiresIn(value: string, now: Date): Date {
+  const match = /^(\d{1,4})([hd])$/.exec(value);
+  if (!match) throw new Error("--expires-in must look like 30d or 12h");
+  const unitMs = match[2] === "d" ? 24 * 60 * 60 * 1000 : 60 * 60 * 1000;
+  const durationMs = Number(match[1]) * unitMs;
+  if (durationMs < MIN_EXPIRY_MS) throw new Error("--expires-in must be at least 1h");
+  if (durationMs > MAX_EXPIRY_MS) throw new Error("--expires-in must be at most 365d");
+  return new Date(now.getTime() + durationMs);
+}
+
+/** Realpath the nearest existing ancestor, so a not-yet-created output still resolves. */
+async function realExistingAncestor(target: string): Promise<string> {
+  for (let current = target; ; current = path.dirname(current)) {
+    const real = await realpath(current).catch(() => null);
+    if (real !== null) return path.join(real, path.relative(current, target));
+    if (path.dirname(current) === current) return target;
+  }
+}
+
+function contains(parent: string, child: string): boolean {
+  return child === parent || child.startsWith(`${parent}${path.sep}`);
+}

--- a/src/profile/templates/publish/build-options.ts
+++ b/src/profile/templates/publish/build-options.ts
@@ -2,7 +2,8 @@
  * @file src/profile/templates/publish/build-options.ts
  * @description Build input validation: where output may go, and how long it lives.
  */
-import { lstat, mkdir, realpath } from "node:fs/promises";
+import { lstat, mkdir, readFile, readdir, realpath } from "node:fs/promises";
+import { parseSignedTapIndex } from "../signing/protocol.js";
 import path from "node:path";
 import type { WorkspacePaths } from "./workspace-paths.js";
 
@@ -15,7 +16,7 @@ const MAX_EXPIRY_MS = 365 * 24 * 60 * 60 * 1000;
  * this is the key-exfiltration control. Both sides are resolved with `realpath` — a
  * lexical comparison is defeated by a symlinked path.
  */
-export async function assertOutsideWorkspace(paths: WorkspacePaths, out: string): Promise<string> {
+export async function assertOutsideWorkspace(paths: WorkspacePaths, out: string, tap: string): Promise<string> {
   const resolvedOut = path.resolve(out);
   await mkdir(path.dirname(resolvedOut), { recursive: true });
   const realWorkspace = await realpath(paths.root);
@@ -24,18 +25,40 @@ export async function assertOutsideWorkspace(paths: WorkspacePaths, out: string)
   if (contains(realWorkspace, realOut) || contains(realOut, realWorkspace)) {
     throw new Error("build output must live outside the publisher workspace: it would publish private keys");
   }
-  await assertDirectoryOrAbsent(resolvedOut);
+  await assertReplaceableOutput(resolvedOut, tap);
   return resolvedOut;
 }
 
 /**
- * Refuse an output path that exists and is not a directory. Publishing moves an existing
- * output aside and then deletes it, so a file here would be silently destroyed.
+ * Publishing REPLACES the whole output directory: it is renamed aside and then deleted. So
+ * the only things safe to point `--out` at are nothing, an empty directory, or a previous
+ * distribution OF THIS TAP. Anything else is somebody's data, and this command must not be
+ * the reason it disappears.
  */
-async function assertDirectoryOrAbsent(out: string): Promise<void> {
+async function assertReplaceableOutput(out: string, tap: string): Promise<void> {
   const info = await lstat(out).catch(() => null);
-  if (info !== null && !info.isDirectory()) {
-    throw new Error("build output path exists and is not a directory");
+  if (info === null) return;
+  if (!info.isDirectory()) throw new Error("build output path exists and is not a directory");
+
+  const entries = await readdir(out);
+  if (entries.length === 0) return;
+  if (!(await isDistributionOfTap(out, entries, tap))) {
+    throw new Error(
+      "build output directory is not empty and is not a previous distribution of this tap; "
+      + "publishing would delete its contents",
+    );
+  }
+}
+
+/** A prior distribution: exactly index.json + packages/, whose index names THIS tap. */
+async function isDistributionOfTap(out: string, entries: string[], tap: string): Promise<boolean> {
+  if (entries.sort().join(",") !== "index.json,packages") return false;
+  const text = await readFile(path.join(out, "index.json"), "utf8").catch(() => null);
+  if (text === null) return false;
+  try {
+    return parseSignedTapIndex(text).tap === tap;
+  } catch {
+    return false;
   }
 }
 

--- a/src/profile/templates/publish/build-verify.ts
+++ b/src/profile/templates/publish/build-verify.ts
@@ -28,16 +28,30 @@ function workspacePinState(workspace: PublisherWorkspace): PublisherPinState {
     ...empty,
     highestSequence: workspace.sequence,
     publishers: { [workspace.publisher]: workspace.publisherKey },
-    keyHistory: {
-      [workspace.publisherKey.keyId]: {
-        publisher: workspace.publisher,
-        publicKey: workspace.publisherKey.publicKey,
-      },
-    },
+    // The COMPLETE history a client holds — every key id it has ever accepted. Seeding only
+    // the current key would let a build that re-announces a RETIRED id pass our own gate
+    // while every existing client rejects it.
+    keyHistory: publisherKeyHistory(workspace),
     coordinates: { ...workspace.coordinates },
     revokedPackages: workspace.revocations.filter((r) => r.kind === "package").map((r) => r.value),
     revokedPublisherKeys: workspace.revocations.filter((r) => r.kind === "publisher-key").map((r) => r.value),
   };
+}
+
+/** Every publisher key id this tap has ever announced, as a client would have recorded it. */
+function publisherKeyHistory(workspace: PublisherWorkspace): PublisherPinState["keyHistory"] {
+  const history: PublisherPinState["keyHistory"] = {};
+  for (const rotation of workspace.rotations) {
+    history[rotation.toKey.keyId] = {
+      publisher: rotation.publisher,
+      publicKey: rotation.toKey.publicKey,
+    };
+  }
+  history[workspace.publisherKey.keyId] = {
+    publisher: workspace.publisher,
+    publicKey: workspace.publisherKey.publicKey,
+  };
+  return history;
 }
 
 /**

--- a/src/profile/templates/publish/build-verify.ts
+++ b/src/profile/templates/publish/build-verify.ts
@@ -1,0 +1,80 @@
+/**
+ * @file src/profile/templates/publish/build-verify.ts
+ * @description Workspace-aware verification of a freshly built tree.
+ *
+ * The spec says `build` runs the Slice A verifier before making output visible — but the
+ * Slice A verifier REFUSES rotation-bearing indexes by design, because a
+ * latest-snapshot-only directory cannot prove continuity. The workspace CAN: it holds the
+ * previously pinned keys. So a build verifies as a consumer who has ALREADY PINNED the
+ * previous keys, using the production verify/continuity functions — never a weaker copy.
+ *
+ * A rotation-free build is byte-for-byte the same check a fresh client performs.
+ */
+import { advancePublisherPins, emptyPublisherPinState } from "../signing/continuity.js";
+import { parseSignedPackage, parseSignedTapIndex } from "../signing/protocol.js";
+import { verifySignedPackage, verifyTapIndex, verifyTapKeyRotation } from "../signing/verify.js";
+import type { PublisherKey, PublisherPinState, SignedTapIndex } from "../signing/types.js";
+import type { PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
+
+/**
+ * The pin state a consumer would hold having accepted the workspace's LAST build.
+ * Without a real prior state, `advancePublisherPins` would accept any chain from an
+ * empty pin set and the rotation walk would prove nothing.
+ */
+function workspacePinState(workspace: PublisherWorkspace): PublisherPinState {
+  const empty = emptyPublisherPinState(workspace.tap);
+  if (workspace.sequence === 0) return empty;
+  return {
+    ...empty,
+    highestSequence: workspace.sequence,
+    publishers: { [workspace.publisher]: workspace.publisherKey },
+    keyHistory: {
+      [workspace.publisherKey.keyId]: {
+        publisher: workspace.publisher,
+        publicKey: workspace.publisherKey.publicKey,
+      },
+    },
+    coordinates: { ...workspace.coordinates },
+    revokedPackages: workspace.revocations.filter((r) => r.kind === "package").map((r) => r.value),
+    revokedPublisherKeys: workspace.revocations.filter((r) => r.kind === "publisher-key").map((r) => r.value),
+  };
+}
+
+/**
+ * Verify one freshly built index and its envelopes exactly as the consumer would,
+ * against the keys a client pinned from the previous build.
+ */
+export function verifyBuiltDistribution(
+  workspace: PublisherWorkspace,
+  indexJson: string,
+  packages: WorkspacePackage[],
+  currentVersion: string,
+): SignedTapIndex {
+  const parsed = parseSignedTapIndex(indexJson);
+  const trustedKey = acceptedTapKey(workspace, parsed);
+  const verified = verifyTapIndex(parsed, workspace.tap, trustedKey);
+  const pins = advancePublisherPins(verified, workspacePinState(workspace));
+
+  for (const pkg of packages) {
+    verifySignedPackage(parseSignedPackage(pkg.envelopeJson), verified, pins, currentVersion);
+  }
+  return verified;
+}
+
+/**
+ * Resolve the tap key a client would trust for this index — mirroring
+ * `taps/refresh.ts#acceptedTapKey`. A rotating index is trusted under its SUCCESSOR key,
+ * proven by a dual-signed rotation from the key the client already pinned.
+ */
+function acceptedTapKey(
+  workspace: PublisherWorkspace,
+  index: ReturnType<typeof parseSignedTapIndex>,
+): PublisherKey {
+  if (index.signature.keyId === workspace.tapKey.keyId) return workspace.tapKey;
+  const rotation = index.tapKeyRotation;
+  if (!rotation) throw new Error("built index changes the tap root without a signed rotation");
+  if (rotation.effectiveSequence !== index.sequence) {
+    throw new Error("built tap rotation sequence differs from its index");
+  }
+  return verifyTapKeyRotation(workspace.tap, rotation, workspace.tapKey);
+}

--- a/src/profile/templates/publish/build.ts
+++ b/src/profile/templates/publish/build.ts
@@ -43,14 +43,16 @@ export interface BuildResult {
 export async function buildDistribution(paths: WorkspacePaths, options: BuildOptions): Promise<BuildResult> {
   return withExclusiveLock(paths, async () => {
     const workspace = await readWorkspace(paths);
-    const out = await assertOutsideWorkspace(paths, options.out);
+    const out = await assertOutsideWorkspace(paths, options.out, workspace.tap);
     const now = options.now ?? new Date();
     const expiresAt = parseExpiresIn(options.expiresIn, now);
-    assertHasSomethingToBuild(workspace, options.force === true);
-
-    const sequence = workspace.sequence + 1;
+    // Skip past a reserved sequence: a crash after publishing but before committing leaves a
+    // signed index live at that sequence, and re-issuing it with different bytes would be a
+    // replay for any client that already fetched it.
+    const sequence = Math.max(workspace.sequence, workspace.reservedSequence ?? 0) + 1;
     const intents = await signPendingIntents(paths, workspace, sequence, now);
     const packages = emittedPackages(workspace, intents);
+    assertHasSomethingToBuild(workspace, packages, options.force === true);
     const built = buildSignedIndex(workspace, {
       sequence,
       generatedAt: now,
@@ -65,8 +67,9 @@ export async function buildDistribution(paths: WorkspacePaths, options: BuildOpt
     });
 
     verifyBuiltDistribution(workspace, built.indexJson, packages, packageJson.version);
+    await writeWorkspace(paths, { ...workspace, reservedSequence: sequence });
     await publishStagedTree(out, built.indexJson, packages);
-    await commitBuild(paths, workspace, built, intents, sequence, now);
+    await commitBuild(paths, workspace, built, intents, sequence, now, packages);
 
     return {
       sequence,
@@ -97,13 +100,27 @@ async function indexSigningKey(paths: WorkspacePaths, workspace: PublisherWorksp
   return readPrivateKey(paths, "tap", key.keyId);
 }
 
-/** Refuse a no-change rebuild so an operator cannot silently burn sequence numbers. */
-function assertHasSomethingToBuild(workspace: PublisherWorkspace, force: boolean): void {
+/**
+ * Refuse a no-change rebuild so an operator cannot silently burn sequence numbers — but
+ * `add` records a package WITHOUT staging an intent, so `pending` alone cannot answer the
+ * question. Compare the content this build would publish against the content the last build
+ * did.
+ */
+function assertHasSomethingToBuild(workspace: PublisherWorkspace, packages: WorkspacePackage[], force: boolean): void {
   if (force || workspace.lastBuild === undefined) return;
-  const unchanged = workspace.pending.length === 0 && workspace.lastBuild.sequence === workspace.sequence;
-  if (unchanged) {
-    throw new Error(`nothing to build since sequence ${workspace.sequence}; pass --force to republish`);
-  }
+  if (workspace.pending.length > 0) return;
+  if (contentDigestOf(workspace, packages) !== workspace.lastBuild.contentDigest) return;
+  throw new Error(`nothing to build since sequence ${workspace.sequence}; pass --force to republish`);
+}
+
+/** The published content's identity: what is served, and under which keys. */
+function contentDigestOf(workspace: PublisherWorkspace, packages: WorkspacePackage[]): string {
+  return canonicalDigest({
+    packages: packages.map((pkg) => pkg.payloadDigest).sort(),
+    revocations: workspace.revocations.map((revocation) => `${revocation.kind}:${revocation.value}`).sort(),
+    publisherKeyId: workspace.publisherKey.keyId,
+    tapKeyId: workspace.tapKey.keyId,
+  });
 }
 
 /**
@@ -151,8 +168,9 @@ async function commitBuild(
   intents: SignedIntents,
   sequence: number,
   now: Date,
+  packages: WorkspacePackage[],
 ): Promise<void> {
-  await writeWorkspace(paths, {
+  const committed: PublisherWorkspace = {
     ...workspace,
     tapKey: intents.nextTapKey ?? workspace.tapKey,
     publisherKey: intents.nextPublisherKey ?? workspace.publisherKey,
@@ -162,10 +180,15 @@ async function commitBuild(
     tapKeyRotations: built.tapKeyRotations,
     revocations: built.revocations,
     pending: [],
+  };
+  delete committed.reservedSequence;
+  await writeWorkspace(paths, {
+    ...committed,
     lastBuild: {
       sequence,
       indexDigest: canonicalDigest(built.index),
       builtAt: now.toISOString(),
+      contentDigest: contentDigestOf(committed, packages),
     },
   });
 }

--- a/src/profile/templates/publish/build.ts
+++ b/src/profile/templates/publish/build.ts
@@ -9,7 +9,7 @@
  * not first verify as a consumer would verify it.
  */
 import packageJson from "../../../../package.json" with { type: "json" };
-import { mkdtemp, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { canonicalDigest } from "../signing/canonical.js";
 import { sha256DigestHex } from "../signing/protocol.js";
@@ -21,7 +21,8 @@ import { signPendingIntents, type SignedIntents } from "./lifecycle.js";
 import { assertOutsideWorkspace, parseExpiresIn } from "./build-options.js";
 import type { WorkspacePaths } from "./workspace-paths.js";
 import { readWorkspace, writeWorkspace } from "./workspace-store.js";
-import type { PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
+import { readDistributionOnDisk } from "./tree-read.js";
+import type { LastBuild, PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
 
 /** Options accepted by `template publish build`. */
 export interface BuildOptions {
@@ -43,13 +44,13 @@ export interface BuildResult {
 export async function buildDistribution(paths: WorkspacePaths, options: BuildOptions): Promise<BuildResult> {
   return withExclusiveLock(paths, async () => {
     const workspace = await readWorkspace(paths);
-    const out = await assertOutsideWorkspace(paths, options.out, workspace.lastBuild);
+    const out = await assertOutsideWorkspace(paths, options.out, [workspace.lastBuild, workspace.reservedBuild]);
     const now = options.now ?? new Date();
     const expiresAt = parseExpiresIn(options.expiresIn, now);
     // Skip past a reserved sequence: a crash after publishing but before committing leaves a
     // signed index live at that sequence, and re-issuing it with different bytes would be a
     // replay for any client that already fetched it.
-    const sequence = Math.max(workspace.sequence, workspace.reservedSequence ?? 0) + 1;
+    const sequence = Math.max(workspace.sequence, workspace.reservedBuild?.sequence ?? 0) + 1;
     const intents = await signPendingIntents(paths, workspace, sequence, now);
     const packages = emittedPackages(workspace, intents);
     assertHasSomethingToBuild(workspace, packages, options.force === true);
@@ -66,19 +67,27 @@ export async function buildDistribution(paths: WorkspacePaths, options: BuildOpt
       packages,
     });
 
+    const identity: LastBuild = {
+      sequence,
+      indexDigest: canonicalDigest(built.index),
+      builtAt: now.toISOString(),
+      contentDigest: contentDigestOf(workspace, packages),
+    };
     const staging = await stageTree(out, built.indexJson, packages);
     try {
       // Verify the tree that will actually be PUBLISHED, read back from disk — not the
-      // in-memory strings we happen to hold. A staged tree that is corrupt, short a package,
-      // or carrying an extra file must never be swapped into place.
-      await verifyStagedTree(workspace, staging, packages.length);
-      await writeWorkspace(paths, { ...workspace, reservedSequence: sequence });
+      // in-memory strings we happen to hold.
+      await verifyStagedTree(workspace, staging);
+      // Reserve the full IDENTITY, not just the number: if the commit below never lands, a
+      // retry must recognize the tree we published as ours instead of refusing it as foreign
+      // data and deadlocking the workspace.
+      await writeWorkspace(paths, { ...workspace, reservedBuild: identity });
     } catch (error) {
       await rm(staging, { recursive: true, force: true });
       throw error;
     }
     await swapIntoPlace(staging, out);
-    await commitBuild(paths, workspace, built, intents, sequence, now, packages);
+    await commitBuild(paths, workspace, built, intents, identity);
 
     return {
       sequence,
@@ -153,29 +162,16 @@ async function stageTree(out: string, indexJson: string, packages: WorkspacePack
 }
 
 /**
- * Read the staged tree back from disk and verify it as a consumer would. This is the gate
- * the whole design rests on, so it must inspect the BYTES THAT WILL BE SERVED — including
- * that the tree holds exactly the expected files and nothing more.
+ * Read the staged tree back FROM DISK and verify it as a consumer would. This is the gate
+ * the whole design rests on, so it inspects the bytes that will actually be served through
+ * the Slice A exact-tree verifier: digest-derived filenames, one-to-one coverage of the
+ * index's entries, no extra or symlinked files, bounded no-follow reads. A name-and-count
+ * check would accept two copies of one envelope standing in for another package.
  */
-async function verifyStagedTree(
-  workspace: PublisherWorkspace,
-  staging: string,
-  expectedPackages: number,
-): Promise<void> {
-  const entries = (await readdir(staging)).sort();
-  if (entries.join(",") !== "index.json,packages") {
-    throw new Error("staged distribution contains unexpected entries");
-  }
-  const digestDir = path.join(staging, "packages", "sha256");
-  const files = await readdir(digestDir);
-  if (files.length !== expectedPackages) {
-    throw new Error("staged distribution does not hold exactly the expected packages");
-  }
-  const indexJson = await readFile(path.join(staging, "index.json"), "utf8");
-  const staged = await Promise.all(files.map(async (file) => ({
-    envelopeJson: await readFile(path.join(digestDir, file), "utf8"),
-  }) as WorkspacePackage));
-  verifyBuiltDistribution(workspace, indexJson, staged, packageJson.version);
+async function verifyStagedTree(workspace: PublisherWorkspace, staging: string): Promise<void> {
+  const onDisk = await readDistributionOnDisk(staging);
+  const staged = onDisk.envelopes.map((envelopeJson) => ({ envelopeJson }) as WorkspacePackage);
+  verifyBuiltDistribution(workspace, onDisk.indexJson, staged, packageJson.version);
 }
 
 async function swapIntoPlace(staging: string, out: string): Promise<void> {
@@ -197,29 +193,20 @@ async function commitBuild(
   workspace: PublisherWorkspace,
   built: ReturnType<typeof buildSignedIndex>,
   intents: SignedIntents,
-  sequence: number,
-  now: Date,
-  packages: WorkspacePackage[],
+  identity: LastBuild,
 ): Promise<void> {
   const committed: PublisherWorkspace = {
     ...workspace,
     tapKey: intents.nextTapKey ?? workspace.tapKey,
     publisherKey: intents.nextPublisherKey ?? workspace.publisherKey,
-    sequence,
+    sequence: identity.sequence,
     packages: intents.resignedPackages ?? workspace.packages,
     rotations: built.rotations,
     tapKeyRotations: built.tapKeyRotations,
     revocations: built.revocations,
     pending: [],
+    lastBuild: identity,
   };
-  delete committed.reservedSequence;
-  await writeWorkspace(paths, {
-    ...committed,
-    lastBuild: {
-      sequence,
-      indexDigest: canonicalDigest(built.index),
-      builtAt: now.toISOString(),
-      contentDigest: contentDigestOf(committed, packages),
-    },
-  });
+  delete committed.reservedBuild;
+  await writeWorkspace(paths, committed);
 }

--- a/src/profile/templates/publish/build.ts
+++ b/src/profile/templates/publish/build.ts
@@ -30,6 +30,8 @@ export interface BuildOptions {
   out: string;
   expiresIn: string;
   force?: boolean;
+  /** Republish unchanged content under a fresh lifetime, to renew an expiring index. */
+  refresh?: boolean;
   now?: Date;
 }
 
@@ -71,7 +73,11 @@ export async function buildDistribution(paths: WorkspacePaths, options: BuildOpt
     // revocations, not the pre-build workspace. Used both to decide "is there anything to
     // build" and as the recorded lastBuild, so both sides speak of the same committed state.
     const effective = effectiveStateOf(workspace, built, intents);
-    assertHasSomethingToBuild(workspace, effective, packages, options.force === true);
+    // --refresh renews an expiring index (new lifetime, same content); --force is the blunt
+    // override. Both bypass the no-change guard, but --refresh names the routine intent so an
+    // operator scripting a renewal never has to reach for --force.
+    const bypassNoChangeGuard = options.force === true || options.refresh === true;
+    assertHasSomethingToBuild(workspace, effective, packages, bypassNoChangeGuard);
     const identity: LastBuild = {
       sequence,
       indexDigest: canonicalDigest(built.index),
@@ -127,18 +133,21 @@ async function indexSigningKey(paths: WorkspacePaths, workspace: PublisherWorksp
  * Refuse a no-change rebuild so an operator cannot silently burn sequence numbers — but
  * `add` records a package WITHOUT staging an intent, so `pending` alone cannot answer the
  * question. Compare the content this build would publish against the content the last build
- * did.
+ * did. `bypass` is set by --refresh (renew an expiring index) or --force (override).
  */
 function assertHasSomethingToBuild(
   workspace: PublisherWorkspace,
   effective: EffectiveState,
   packages: WorkspacePackage[],
-  force: boolean,
+  bypass: boolean,
 ): void {
-  if (force || workspace.lastBuild === undefined) return;
+  if (bypass || workspace.lastBuild === undefined) return;
   if (workspace.pending.length > 0) return;
   if (contentDigestOf(effective, packages) !== workspace.lastBuild.contentDigest) return;
-  throw new Error(`nothing to build since sequence ${workspace.sequence}; pass --force to republish`);
+  throw new Error(
+    `nothing to build since sequence ${workspace.sequence}; ` +
+      `pass --refresh to renew an expiring index, or --force to republish anyway`,
+  );
 }
 
 /**

--- a/src/profile/templates/publish/build.ts
+++ b/src/profile/templates/publish/build.ts
@@ -18,6 +18,7 @@ import { readPrivateKey } from "./keystore.js";
 import { buildSignedIndex } from "./index-builder.js";
 import { verifyBuiltDistribution } from "./build-verify.js";
 import { signPendingIntents, type SignedIntents } from "./lifecycle.js";
+import type { TapRevocation } from "../signing/types.js";
 import { assertOutsideWorkspace, parseExpiresIn } from "./build-options.js";
 import type { WorkspacePaths } from "./workspace-paths.js";
 import { readWorkspace, writeWorkspace } from "./workspace-store.js";
@@ -53,7 +54,6 @@ export async function buildDistribution(paths: WorkspacePaths, options: BuildOpt
     const sequence = Math.max(workspace.sequence, workspace.reservedBuild?.sequence ?? 0) + 1;
     const intents = await signPendingIntents(paths, workspace, sequence, now);
     const packages = emittedPackages(workspace, intents);
-    assertHasSomethingToBuild(workspace, packages, options.force === true);
     const built = buildSignedIndex(workspace, {
       sequence,
       generatedAt: now,
@@ -67,11 +67,16 @@ export async function buildDistribution(paths: WorkspacePaths, options: BuildOpt
       packages,
     });
 
+    // The identity of the state THIS build commits — successor keys and the build's
+    // revocations, not the pre-build workspace. Used both to decide "is there anything to
+    // build" and as the recorded lastBuild, so both sides speak of the same committed state.
+    const effective = effectiveStateOf(workspace, built, intents);
+    assertHasSomethingToBuild(workspace, effective, packages, options.force === true);
     const identity: LastBuild = {
       sequence,
       indexDigest: canonicalDigest(built.index),
       builtAt: now.toISOString(),
-      contentDigest: contentDigestOf(workspace, packages),
+      contentDigest: contentDigestOf(effective, packages),
     };
     const staging = await stageTree(out, built.indexJson, packages);
     try {
@@ -124,21 +129,52 @@ async function indexSigningKey(paths: WorkspacePaths, workspace: PublisherWorksp
  * question. Compare the content this build would publish against the content the last build
  * did.
  */
-function assertHasSomethingToBuild(workspace: PublisherWorkspace, packages: WorkspacePackage[], force: boolean): void {
+function assertHasSomethingToBuild(
+  workspace: PublisherWorkspace,
+  effective: EffectiveState,
+  packages: WorkspacePackage[],
+  force: boolean,
+): void {
   if (force || workspace.lastBuild === undefined) return;
   if (workspace.pending.length > 0) return;
-  if (contentDigestOf(workspace, packages) !== workspace.lastBuild.contentDigest) return;
+  if (contentDigestOf(effective, packages) !== workspace.lastBuild.contentDigest) return;
   throw new Error(`nothing to build since sequence ${workspace.sequence}; pass --force to republish`);
 }
 
-/** The published content's identity: what is served, and under which keys. */
-function contentDigestOf(workspace: PublisherWorkspace, packages: WorkspacePackage[]): string {
+/**
+ * The published content's identity: what is served, and under which keys. It MUST reflect
+ * the state this build commits — successor keys and the build's revocations — not the
+ * pre-build workspace. Digesting the old key ids here would make the NEXT build always see a
+ * false change (the committed key id no longer matches the recorded one), defeating the
+ * no-change guard after any rotation.
+ */
+function contentDigestOf(effective: EffectiveState, packages: WorkspacePackage[]): string {
   return canonicalDigest({
     packages: packages.map((pkg) => pkg.payloadDigest).sort(),
-    revocations: workspace.revocations.map((revocation) => `${revocation.kind}:${revocation.value}`).sort(),
-    publisherKeyId: workspace.publisherKey.keyId,
-    tapKeyId: workspace.tapKey.keyId,
+    revocations: effective.revocations.map((revocation) => `${revocation.kind}:${revocation.value}`).sort(),
+    publisherKeyId: effective.publisherKeyId,
+    tapKeyId: effective.tapKeyId,
   });
+}
+
+/** The keys and revocations a build COMMITS, after applying its staged intents. */
+interface EffectiveState {
+  publisherKeyId: string;
+  tapKeyId: string;
+  revocations: TapRevocation[];
+}
+
+/** Resolve the state a build commits: successor keys where rotated, the built revocations. */
+function effectiveStateOf(
+  workspace: PublisherWorkspace,
+  built: ReturnType<typeof buildSignedIndex>,
+  intents: SignedIntents,
+): EffectiveState {
+  return {
+    publisherKeyId: (intents.nextPublisherKey ?? workspace.publisherKey).keyId,
+    tapKeyId: (intents.nextTapKey ?? workspace.tapKey).keyId,
+    revocations: built.revocations,
+  };
 }
 
 /** Write the complete tree to a staging directory beside `--out`. */

--- a/src/profile/templates/publish/build.ts
+++ b/src/profile/templates/publish/build.ts
@@ -9,7 +9,7 @@
  * not first verify as a consumer would verify it.
  */
 import packageJson from "../../../../package.json" with { type: "json" };
-import { mkdtemp, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { canonicalDigest } from "../signing/canonical.js";
 import { sha256DigestHex } from "../signing/protocol.js";
@@ -43,7 +43,7 @@ export interface BuildResult {
 export async function buildDistribution(paths: WorkspacePaths, options: BuildOptions): Promise<BuildResult> {
   return withExclusiveLock(paths, async () => {
     const workspace = await readWorkspace(paths);
-    const out = await assertOutsideWorkspace(paths, options.out, workspace.tap);
+    const out = await assertOutsideWorkspace(paths, options.out, workspace.lastBuild);
     const now = options.now ?? new Date();
     const expiresAt = parseExpiresIn(options.expiresIn, now);
     // Skip past a reserved sequence: a crash after publishing but before committing leaves a
@@ -66,9 +66,18 @@ export async function buildDistribution(paths: WorkspacePaths, options: BuildOpt
       packages,
     });
 
-    verifyBuiltDistribution(workspace, built.indexJson, packages, packageJson.version);
-    await writeWorkspace(paths, { ...workspace, reservedSequence: sequence });
-    await publishStagedTree(out, built.indexJson, packages);
+    const staging = await stageTree(out, built.indexJson, packages);
+    try {
+      // Verify the tree that will actually be PUBLISHED, read back from disk — not the
+      // in-memory strings we happen to hold. A staged tree that is corrupt, short a package,
+      // or carrying an extra file must never be swapped into place.
+      await verifyStagedTree(workspace, staging, packages.length);
+      await writeWorkspace(paths, { ...workspace, reservedSequence: sequence });
+    } catch (error) {
+      await rm(staging, { recursive: true, force: true });
+      throw error;
+    }
+    await swapIntoPlace(staging, out);
     await commitBuild(paths, workspace, built, intents, sequence, now, packages);
 
     return {
@@ -123,12 +132,8 @@ function contentDigestOf(workspace: PublisherWorkspace, packages: WorkspacePacka
   });
 }
 
-/**
- * Stage the complete tree, then swap it into place. `rename` onto a non-empty directory
- * fails ENOTEMPTY, so an existing release is moved aside and removed only after the new
- * tree is in place.
- */
-async function publishStagedTree(out: string, indexJson: string, packages: WorkspacePackage[]): Promise<void> {
+/** Write the complete tree to a staging directory beside `--out`. */
+async function stageTree(out: string, indexJson: string, packages: WorkspacePackage[]): Promise<string> {
   await mkdir(path.dirname(out), { recursive: true });
   const staging = await mkdtemp(`${out}.staging-`);
   try {
@@ -140,11 +145,37 @@ async function publishStagedTree(out: string, indexJson: string, packages: Works
       await writeFile(path.join(digestDir, `${sha256DigestHex(pkg.payloadDigest)}.json`), pkg.envelopeJson, "utf8");
     }
     await writeFile(path.join(staging, "index.json"), indexJson, "utf8");
+    return staging;
   } catch (error) {
     await rm(staging, { recursive: true, force: true });
     throw error;
   }
-  await swapIntoPlace(staging, out);
+}
+
+/**
+ * Read the staged tree back from disk and verify it as a consumer would. This is the gate
+ * the whole design rests on, so it must inspect the BYTES THAT WILL BE SERVED — including
+ * that the tree holds exactly the expected files and nothing more.
+ */
+async function verifyStagedTree(
+  workspace: PublisherWorkspace,
+  staging: string,
+  expectedPackages: number,
+): Promise<void> {
+  const entries = (await readdir(staging)).sort();
+  if (entries.join(",") !== "index.json,packages") {
+    throw new Error("staged distribution contains unexpected entries");
+  }
+  const digestDir = path.join(staging, "packages", "sha256");
+  const files = await readdir(digestDir);
+  if (files.length !== expectedPackages) {
+    throw new Error("staged distribution does not hold exactly the expected packages");
+  }
+  const indexJson = await readFile(path.join(staging, "index.json"), "utf8");
+  const staged = await Promise.all(files.map(async (file) => ({
+    envelopeJson: await readFile(path.join(digestDir, file), "utf8"),
+  }) as WorkspacePackage));
+  verifyBuiltDistribution(workspace, indexJson, staged, packageJson.version);
 }
 
 async function swapIntoPlace(staging: string, out: string): Promise<void> {

--- a/src/profile/templates/publish/build.ts
+++ b/src/profile/templates/publish/build.ts
@@ -1,0 +1,171 @@
+/**
+ * @file src/profile/templates/publish/build.ts
+ * @description Build, verify, and publish one static tap distribution.
+ *
+ * Ordering is the correctness argument:
+ *   resolve -> stage -> VERIFY -> publish -> commit the sequence LAST.
+ * A crash anywhere leaves the workspace at the old sequence and the output untouched, so a
+ * retry is a clean re-derivation rather than a resume. Nothing is ever published that did
+ * not first verify as a consumer would verify it.
+ */
+import packageJson from "../../../../package.json" with { type: "json" };
+import { mkdtemp, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { canonicalDigest } from "../signing/canonical.js";
+import { sha256DigestHex } from "../signing/protocol.js";
+import { withExclusiveLock } from "../../../utils/exclusive-lock.js";
+import { readPrivateKey } from "./keystore.js";
+import { buildSignedIndex } from "./index-builder.js";
+import { verifyBuiltDistribution } from "./build-verify.js";
+import { signPendingIntents, type SignedIntents } from "./lifecycle.js";
+import { assertOutsideWorkspace, parseExpiresIn } from "./build-options.js";
+import type { WorkspacePaths } from "./workspace-paths.js";
+import { readWorkspace, writeWorkspace } from "./workspace-store.js";
+import type { PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
+
+/** Options accepted by `template publish build`. */
+export interface BuildOptions {
+  out: string;
+  expiresIn: string;
+  force?: boolean;
+  now?: Date;
+}
+
+/** Public result of one committed build. */
+export interface BuildResult {
+  sequence: number;
+  packageCount: number;
+  indexDigest: string;
+  out: string;
+}
+
+/** Build, verify, and publish one distribution under the workspace lock. */
+export async function buildDistribution(paths: WorkspacePaths, options: BuildOptions): Promise<BuildResult> {
+  return withExclusiveLock(paths, async () => {
+    const workspace = await readWorkspace(paths);
+    const out = await assertOutsideWorkspace(paths, options.out);
+    const now = options.now ?? new Date();
+    const expiresAt = parseExpiresIn(options.expiresIn, now);
+    assertHasSomethingToBuild(workspace, options.force === true);
+
+    const sequence = workspace.sequence + 1;
+    const intents = await signPendingIntents(paths, workspace, sequence, now);
+    const packages = emittedPackages(workspace, intents);
+    const built = buildSignedIndex(workspace, {
+      sequence,
+      generatedAt: now,
+      expiresAt,
+      publisherKey: intents.nextPublisherKey ?? workspace.publisherKey,
+      tapKey: intents.nextTapKey ?? workspace.tapKey,
+      signingKey: await indexSigningKey(paths, workspace, intents),
+      newRotations: intents.rotations,
+      ...(intents.tapRotation === undefined ? {} : { newTapRotation: intents.tapRotation }),
+      newRevocations: intents.revocations,
+      packages,
+    });
+
+    verifyBuiltDistribution(workspace, built.indexJson, packages, packageJson.version);
+    await publishStagedTree(out, built.indexJson, packages);
+    await commitBuild(paths, workspace, built, intents, sequence, now);
+
+    return {
+      sequence,
+      packageCount: packages.length,
+      indexDigest: canonicalDigest(built.index),
+      out,
+    };
+  });
+}
+
+/**
+ * Packages this index publishes: everything the workspace holds MINUS every revoked
+ * digest. `verifySignedPackage` calls `assertEvidenceNotRevoked`, so an index that both
+ * lists and emits a revoked package is one the build's own gate would refuse.
+ */
+function emittedPackages(workspace: PublisherWorkspace, intents: SignedIntents): WorkspacePackage[] {
+  const revoked = new Set([
+    ...workspace.revocations.filter((r) => r.kind === "package").map((r) => r.value),
+    ...intents.revocations.filter((r) => r.kind === "package").map((r) => r.value),
+  ]);
+  const packages = intents.resignedPackages ?? workspace.packages;
+  return packages.filter((pkg) => !revoked.has(pkg.payloadDigest));
+}
+
+/** The key that signs the index: the SUCCESSOR whenever the tap root is rotating. */
+async function indexSigningKey(paths: WorkspacePaths, workspace: PublisherWorkspace, intents: SignedIntents) {
+  const key = intents.nextTapKey ?? workspace.tapKey;
+  return readPrivateKey(paths, "tap", key.keyId);
+}
+
+/** Refuse a no-change rebuild so an operator cannot silently burn sequence numbers. */
+function assertHasSomethingToBuild(workspace: PublisherWorkspace, force: boolean): void {
+  if (force || workspace.lastBuild === undefined) return;
+  const unchanged = workspace.pending.length === 0 && workspace.lastBuild.sequence === workspace.sequence;
+  if (unchanged) {
+    throw new Error(`nothing to build since sequence ${workspace.sequence}; pass --force to republish`);
+  }
+}
+
+/**
+ * Stage the complete tree, then swap it into place. `rename` onto a non-empty directory
+ * fails ENOTEMPTY, so an existing release is moved aside and removed only after the new
+ * tree is in place.
+ */
+async function publishStagedTree(out: string, indexJson: string, packages: WorkspacePackage[]): Promise<void> {
+  await mkdir(path.dirname(out), { recursive: true });
+  const staging = await mkdtemp(`${out}.staging-`);
+  try {
+    const digestDir = path.join(staging, "packages", "sha256");
+    await mkdir(digestDir, { recursive: true });
+    // Packages are written BEFORE the index, so an index is never visible while
+    // referencing a package that is not yet there.
+    for (const pkg of packages) {
+      await writeFile(path.join(digestDir, `${sha256DigestHex(pkg.payloadDigest)}.json`), pkg.envelopeJson, "utf8");
+    }
+    await writeFile(path.join(staging, "index.json"), indexJson, "utf8");
+  } catch (error) {
+    await rm(staging, { recursive: true, force: true });
+    throw error;
+  }
+  await swapIntoPlace(staging, out);
+}
+
+async function swapIntoPlace(staging: string, out: string): Promise<void> {
+  const retired = `${out}.retired-${process.pid}`;
+  const hadPrevious = await rename(out, retired).then(() => true).catch(() => false);
+  try {
+    await rename(staging, out);
+  } catch (error) {
+    if (hadPrevious) await rename(retired, out).catch(() => undefined);
+    await rm(staging, { recursive: true, force: true });
+    throw error;
+  }
+  if (hadPrevious) await rm(retired, { recursive: true, force: true }).catch(() => undefined);
+}
+
+/** Commit LAST: the sequence advances only once the output is published and verified. */
+async function commitBuild(
+  paths: WorkspacePaths,
+  workspace: PublisherWorkspace,
+  built: ReturnType<typeof buildSignedIndex>,
+  intents: SignedIntents,
+  sequence: number,
+  now: Date,
+): Promise<void> {
+  await writeWorkspace(paths, {
+    ...workspace,
+    tapKey: intents.nextTapKey ?? workspace.tapKey,
+    publisherKey: intents.nextPublisherKey ?? workspace.publisherKey,
+    sequence,
+    packages: intents.resignedPackages ?? workspace.packages,
+    rotations: built.rotations,
+    tapKeyRotations: built.tapKeyRotations,
+    revocations: built.revocations,
+    pending: [],
+    lastBuild: {
+      sequence,
+      indexDigest: canonicalDigest(built.index),
+      builtAt: now.toISOString(),
+    },
+  });
+}

--- a/src/profile/templates/publish/index-builder.ts
+++ b/src/profile/templates/publish/index-builder.ts
@@ -1,0 +1,94 @@
+/**
+ * @file src/profile/templates/publish/index-builder.ts
+ * @description Assemble and sign one tap index.
+ *
+ * Three rules are load-bearing; each was derived from the consumer, not invented here:
+ *
+ * 1. RETAINED HISTORY. `followRotationChain` lets a client that skipped snapshots walk
+ *    from its pinned key to the current key — but only from the LATEST index. So every
+ *    historical rotation and revocation is re-emitted in every index, forever.
+ * 2. A TAP-ROTATING INDEX IS SIGNED BY THE SUCCESSOR KEY. `taps/refresh.ts#acceptedTapKey`
+ *    resolves the trusted key for a rotating index to `rotation.toKey` and only THEN
+ *    checks the index signature against it. Signing such an index with the old key
+ *    produces an index no client can accept.
+ * 3. REVOKED PACKAGES ARE EXCLUDED. `verifySignedPackage` calls `assertEvidenceNotRevoked`,
+ *    so an index that both lists and emits a revoked package is one no verifier — including
+ *    our own build gate — will accept.
+ */
+import { tapIndexClaim } from "../signing/canonical.js";
+import { parseSignedTapIndex } from "../signing/protocol.js";
+import { signClaim, type PrivateSigningKey } from "../signing/sign.js";
+import type {
+  PublisherKey,
+  PublisherRotation,
+  SignedTapIndex,
+  TapKeyRotation,
+  TapPackageEntry,
+  TapRevocation,
+} from "../signing/types.js";
+import type { PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
+
+/** Everything a build has resolved by the time the index can be assembled. */
+export interface IndexBuildInput {
+  sequence: number;
+  generatedAt: Date;
+  expiresAt: Date;
+  /** Publisher key announced by this index (the successor when rotating). */
+  publisherKey: PublisherKey;
+  /** Tap key announced by this index (the successor when rotating). */
+  tapKey: PublisherKey;
+  /** The key that SIGNS this index — the successor whenever a tap rotation is present. */
+  signingKey: PrivateSigningKey;
+  /** Rotations signed at THIS sequence, appended to retained history. */
+  newRotations: PublisherRotation[];
+  newTapRotation?: TapKeyRotation;
+  /** Revocations created at THIS sequence, appended to retained history. */
+  newRevocations: TapRevocation[];
+  /** Envelopes to publish; already filtered of revoked digests by the caller. */
+  packages: WorkspacePackage[];
+}
+
+/** One assembled, signed index plus the exact bytes to write. */
+export interface BuiltIndex {
+  index: SignedTapIndex;
+  indexJson: string;
+  rotations: PublisherRotation[];
+  tapKeyRotations: TapKeyRotation[];
+  revocations: TapRevocation[];
+}
+
+/** Assemble and sign one index, proving it parses before it is returned. */
+export function buildSignedIndex(workspace: PublisherWorkspace, input: IndexBuildInput): BuiltIndex {
+  const rotations = [...workspace.rotations, ...input.newRotations];
+  const tapKeyRotations = [
+    ...workspace.tapKeyRotations,
+    ...(input.newTapRotation === undefined ? [] : [input.newTapRotation]),
+  ];
+  const revocations = [...workspace.revocations, ...input.newRevocations];
+
+  const unsigned = {
+    schemaVersion: 1 as const,
+    tap: workspace.tap,
+    sequence: input.sequence,
+    generatedAt: input.generatedAt.toISOString(),
+    expiresAt: input.expiresAt.toISOString(),
+    publishers: { [workspace.publisher]: input.publisherKey },
+    packages: input.packages.map(packageEntry),
+    rotations,
+    // Only the rotation taking effect AT this sequence may ride in the index; the
+    // parser accepts a single `tapKeyRotation`, and the consumer requires its
+    // effectiveSequence to equal this index's sequence.
+    ...(input.newTapRotation === undefined ? {} : { tapKeyRotation: input.newTapRotation }),
+    revocations,
+  };
+
+  const signature = signClaim(tapIndexClaim(unsigned), input.signingKey);
+  const index = { ...unsigned, signature } as SignedTapIndex;
+  const indexJson = JSON.stringify(index);
+  parseSignedTapIndex(indexJson);
+  return { index, indexJson, rotations, tapKeyRotations, revocations };
+}
+
+function packageEntry(pkg: WorkspacePackage): TapPackageEntry {
+  return { coordinate: pkg.coordinate, publisher: pkg.publisher, payloadDigest: pkg.payloadDigest };
+}

--- a/src/profile/templates/publish/init.ts
+++ b/src/profile/templates/publish/init.ts
@@ -1,0 +1,111 @@
+/**
+ * @file src/profile/templates/publish/init.ts
+ * @description Create a publisher workspace with fresh tap and publisher keypairs.
+ *
+ * Ordering is load-bearing: keys are created first and the manifest is written LAST.
+ * The manifest's existence is the readiness signal, and it is written atomically — so
+ * an interrupted init can never leave a workspace that reports itself ready.
+ */
+import { mkdir, readdir } from "node:fs/promises";
+import { isSlugSafe } from "../../identity.js";
+import type { PublisherKey } from "../signing/types.js";
+import { createKeypairFile, publicKeyFingerprint } from "./keystore.js";
+import { resolveWorkspacePaths, type WorkspacePaths } from "./workspace-paths.js";
+import { writeWorkspace } from "./workspace-store.js";
+import type { PublisherWorkspace } from "./workspace-types.js";
+
+/** Options accepted by `template publish init`. */
+export interface InitWorkspaceOptions {
+  tap: string;
+  publisher: string;
+  tapKeyId?: string;
+  publisherKeyId?: string;
+  /** Injected only by tests so default key ids are deterministic. */
+  now?: Date;
+}
+
+/** Public result; never carries private key bytes. */
+export interface InitWorkspaceResult {
+  root: string;
+  tap: string;
+  publisher: string;
+  tapKey: PublisherKey;
+  publisherKey: PublisherKey;
+  fingerprints: { tap: string; publisher: string };
+}
+
+/** Initialize one publisher workspace in an empty directory. */
+export async function initWorkspace(
+  directory: string,
+  options: InitWorkspaceOptions,
+): Promise<InitWorkspaceResult> {
+  const paths = resolveWorkspacePaths(directory);
+  assertSlug(options.tap, "tap");
+  assertSlug(options.publisher, "publisher");
+  const now = options.now ?? new Date();
+  const tapKeyId = options.tapKeyId ?? defaultKeyId(options.tap, "tap", now);
+  const publisherKeyId = options.publisherKeyId ?? defaultKeyId(options.publisher, "publisher", now);
+
+  await assertEmptyTarget(paths);
+  await mkdir(paths.keysDir, { recursive: true, mode: 0o700 });
+  const tapKey = await createKeypairFile(paths, tapKeyId, "tap");
+  const publisherKey = await createKeypairFile(paths, publisherKeyId, "publisher");
+
+  await writeWorkspace(paths, freshWorkspace(options.tap, options.publisher, tapKey, publisherKey));
+  return {
+    root: paths.root,
+    tap: options.tap,
+    publisher: options.publisher,
+    tapKey,
+    publisherKey,
+    fingerprints: {
+      tap: publicKeyFingerprint(tapKey),
+      publisher: publicKeyFingerprint(publisherKey),
+    },
+  };
+}
+
+/** A workspace that has published nothing: sequence 0, no history, no intents. */
+function freshWorkspace(
+  tap: string,
+  publisher: string,
+  tapKey: PublisherKey,
+  publisherKey: PublisherKey,
+): PublisherWorkspace {
+  return {
+    schemaVersion: 1,
+    tap,
+    publisher,
+    tapKey,
+    publisherKey,
+    sequence: 0,
+    packages: [],
+    rotations: [],
+    tapKeyRotations: [],
+    revocations: [],
+    pending: [],
+    coordinates: {},
+  };
+}
+
+/** Refuse a non-empty target: init never merges into or overwrites existing state. */
+async function assertEmptyTarget(paths: WorkspacePaths): Promise<void> {
+  const entries = await readdir(paths.root).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  });
+  if (entries === null) {
+    await mkdir(paths.root, { recursive: true, mode: 0o700 });
+    return;
+  }
+  if (entries.length > 0) throw new Error("publisher workspace directory is not empty");
+}
+
+function defaultKeyId(name: string, role: string, now: Date): string {
+  const month = now.toISOString().slice(0, 7);
+  return `${name}-${role}-${month}`;
+}
+
+function assertSlug(value: string, label: string): void {
+  if (!isSlugSafe(value)) throw new Error(`${label} must be slug-safe: ${JSON.stringify(value)}`);
+}

--- a/src/profile/templates/publish/keystore.ts
+++ b/src/profile/templates/publish/keystore.ts
@@ -8,10 +8,11 @@
  * only to `signClaim`; it is never printed, logged, or written to the manifest.
  */
 import { createHash } from "node:crypto";
-import { open } from "node:fs/promises";
+import { open, realpath } from "node:fs/promises";
 import path from "node:path";
 import { atomicWrite } from "../../../utils/atomic-write.js";
 import { readCappedNoFollowBuffer } from "../../../utils/confined-read.js";
+import { confineUnderRoot } from "../../../utils/path-confine.js";
 import { isSlugSafe } from "../../identity.js";
 import { generateEd25519Keypair, type PrivateSigningKey } from "../signing/sign.js";
 import type { PublisherKey } from "../signing/types.js";
@@ -30,9 +31,11 @@ export async function createKeypairFile(
 ): Promise<PublisherKey> {
   assertSlugKeyId(keyId);
   const generated = generateEd25519Keypair(keyId);
-  await writeExclusivePrivateKey(privateKeyPath(paths, role, keyId), generated.privateKey.privateKey, role, keyId);
-  await atomicWrite(publicKeyPath(paths, role, keyId), `${generated.publicKey.publicKey}\n`, {
-    confineRoot: paths.root,
+  await writeExclusivePrivateKey(await confinedKeyPath(paths, role, keyId, "key"), generated.privateKey.privateKey, role, keyId);
+  // Both the leaf and the confine root are realpath'd, so they cannot disagree about
+  // /var vs /private/var and silently refuse a legitimate write.
+  await atomicWrite(await confinedKeyPath(paths, role, keyId, "pub"), `${generated.publicKey.publicKey}\n`, {
+    confineRoot: await realpath(paths.root),
     durable: true,
   });
   return generated.publicKey;
@@ -45,7 +48,7 @@ export async function readPrivateKey(
   keyId: string,
 ): Promise<PrivateSigningKey> {
   assertSlugKeyId(keyId);
-  const read = await readCappedNoFollowBuffer(privateKeyPath(paths, role, keyId), MAX_KEY_FILE_BYTES);
+  const read = await readCappedNoFollowBuffer(await confinedKeyPath(paths, role, keyId, "key"), MAX_KEY_FILE_BYTES);
   if (read.kind !== "ok") throw new Error(`private key is missing, symlinked, or unreadable: ${role}/${keyId}`);
   let text: string;
   try {
@@ -55,6 +58,14 @@ export async function readPrivateKey(
   }
   if (text.length === 0) throw new Error(`private key is empty: ${role}/${keyId}`);
   return { keyId, privateKey: text };
+}
+
+/** Read one public key through the same confined directory. */
+export async function readPublicKey(paths: WorkspacePaths, role: KeyRole, keyId: string): Promise<string> {
+  assertSlugKeyId(keyId);
+  const read = await readCappedNoFollowBuffer(await confinedKeyPath(paths, role, keyId, "pub"), MAX_KEY_FILE_BYTES);
+  if (read.kind !== "ok") throw new Error(`public key is missing, symlinked, or unreadable: ${role}/${keyId}`);
+  return new TextDecoder("utf-8", { fatal: true }).decode(read.body).trim();
 }
 
 /** SHA-256 fingerprint of a public key's SPKI bytes, for out-of-band comparison. */
@@ -83,12 +94,19 @@ async function writeExclusivePrivateKey(
   }
 }
 
-function privateKeyPath(paths: WorkspacePaths, role: KeyRole, keyId: string): string {
-  return path.join(paths.keysDir, `${role}-${keyId}.key`);
-}
-
-function publicKeyPath(paths: WorkspacePaths, role: KeyRole, keyId: string): string {
-  return path.join(paths.keysDir, `${role}-${keyId}.pub`);
+/**
+ * Resolve one key leaf through a CONFINED, realpath'd `keys/` directory. A leaf-only
+ * no-follow check is not enough: a symlinked `keys/` directory would place a freshly
+ * generated PRIVATE key outside the workspace entirely.
+ */
+async function confinedKeyPath(
+  paths: WorkspacePaths,
+  role: KeyRole,
+  keyId: string,
+  extension: "key" | "pub",
+): Promise<string> {
+  const keysDir = await confineUnderRoot("keys", paths.root, { mustExist: true });
+  return path.join(keysDir, `${role}-${keyId}.${extension}`);
 }
 
 function assertSlugKeyId(keyId: string): void {

--- a/src/profile/templates/publish/keystore.ts
+++ b/src/profile/templates/publish/keystore.ts
@@ -8,7 +8,7 @@
  * only to `signClaim`; it is never printed, logged, or written to the manifest.
  */
 import { createHash } from "node:crypto";
-import { open, realpath } from "node:fs/promises";
+import { lstat, open, realpath, unlink } from "node:fs/promises";
 import path from "node:path";
 import { atomicWrite } from "../../../utils/atomic-write.js";
 import { readCappedNoFollowBuffer } from "../../../utils/confined-read.js";
@@ -31,7 +31,7 @@ export async function createKeypairFile(
 ): Promise<PublisherKey> {
   assertSlugKeyId(keyId);
   const generated = generateEd25519Keypair(keyId);
-  await writeExclusivePrivateKey(await confinedKeyPath(paths, role, keyId, "key"), generated.privateKey.privateKey, role, keyId);
+  await writeExclusivePrivateKey(paths, await confinedKeyPath(paths, role, keyId, "key"), generated.privateKey.privateKey, role, keyId);
   // Both the leaf and the confine root are realpath'd, so they cannot disagree about
   // /var vs /private/var and silently refuse a legitimate write.
   await atomicWrite(await confinedKeyPath(paths, role, keyId, "pub"), `${generated.publicKey.publicKey}\n`, {
@@ -73,7 +73,18 @@ export function publicKeyFingerprint(key: PublisherKey): string {
   return createHash("sha256").update(Buffer.from(key.publicKey, "base64")).digest("hex");
 }
 
+/**
+ * Create the key file EMPTY, prove the thing we opened is the file we meant — same inode as
+ * the path, inside a parent that still realpaths into the workspace — and only THEN write
+ * the private bytes.
+ *
+ * Resolving the parent and then opening is a check-then-use: the directory can be swapped in
+ * between. Binding the open HANDLE to the verified path closes that window, because a swap
+ * makes the handle's inode and the path's inode disagree, and no key byte has been written
+ * yet. The file is removed if that check fails.
+ */
 async function writeExclusivePrivateKey(
+  paths: WorkspacePaths,
   file: string,
   privateKey: string,
   role: KeyRole,
@@ -82,15 +93,39 @@ async function writeExclusivePrivateKey(
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   try {
     handle = await open(file, "wx", 0o600);
+    await assertHandleStillConfined(paths, file, handle);
     await handle.writeFile(`${privateKey}\n`, "utf8");
     await handle.sync();
   } catch (error) {
+    await handle?.close().catch(() => {});
+    handle = undefined;
     if ((error as NodeJS.ErrnoException).code === "EEXIST") {
       throw new Error(`private key already exists and is never overwritten: ${role}/${keyId}`);
     }
+    // The empty leaf we just created must not survive a failed confinement check.
+    await unlink(file).catch(() => undefined);
     throw error;
   } finally {
     await handle?.close().catch(() => {});
+  }
+}
+
+/** The opened handle must BE the verified path, still inside the workspace. */
+async function assertHandleStillConfined(
+  paths: WorkspacePaths,
+  file: string,
+  handle: Awaited<ReturnType<typeof open>>,
+): Promise<void> {
+  const [opened, onPath, realRoot, realParent] = await Promise.all([
+    handle.stat(),
+    lstat(file),
+    realpath(paths.root),
+    realpath(path.dirname(file)),
+  ]);
+  const sameFile = opened.dev === onPath.dev && opened.ino === onPath.ino;
+  const insideRoot = realParent === realRoot || realParent.startsWith(`${realRoot}${path.sep}`);
+  if (!sameFile || onPath.isSymbolicLink() || !insideRoot) {
+    throw new Error("key directory changed while the key was being created; no key was written");
   }
 }
 

--- a/src/profile/templates/publish/keystore.ts
+++ b/src/profile/templates/publish/keystore.ts
@@ -1,0 +1,96 @@
+/**
+ * @file src/profile/templates/publish/keystore.ts
+ * @description Private-key storage for the publisher workspace.
+ *
+ * Private keys are created exclusively (`wx` — never overwriting an existing key),
+ * stored `0600`, and read back with a bounded no-follow read so a planted symlink
+ * cannot redirect a signing key. A `PrivateSigningKey` returned from here is passed
+ * only to `signClaim`; it is never printed, logged, or written to the manifest.
+ */
+import { createHash } from "node:crypto";
+import { open } from "node:fs/promises";
+import path from "node:path";
+import { atomicWrite } from "../../../utils/atomic-write.js";
+import { readCappedNoFollowBuffer } from "../../../utils/confined-read.js";
+import { isSlugSafe } from "../../identity.js";
+import { generateEd25519Keypair, type PrivateSigningKey } from "../signing/sign.js";
+import type { PublisherKey } from "../signing/types.js";
+import type { WorkspacePaths } from "./workspace-paths.js";
+
+const MAX_KEY_FILE_BYTES = 4_096;
+
+/** Which signing identity a key belongs to. */
+export type KeyRole = "tap" | "publisher";
+
+/** Create one keypair, refusing to overwrite an existing private key. */
+export async function createKeypairFile(
+  paths: WorkspacePaths,
+  keyId: string,
+  role: KeyRole,
+): Promise<PublisherKey> {
+  assertSlugKeyId(keyId);
+  const generated = generateEd25519Keypair(keyId);
+  await writeExclusivePrivateKey(privateKeyPath(paths, role, keyId), generated.privateKey.privateKey, role, keyId);
+  await atomicWrite(publicKeyPath(paths, role, keyId), `${generated.publicKey.publicKey}\n`, {
+    confineRoot: paths.root,
+    durable: true,
+  });
+  return generated.publicKey;
+}
+
+/** Read one private signing key with a bounded, no-follow read. */
+export async function readPrivateKey(
+  paths: WorkspacePaths,
+  role: KeyRole,
+  keyId: string,
+): Promise<PrivateSigningKey> {
+  assertSlugKeyId(keyId);
+  const read = await readCappedNoFollowBuffer(privateKeyPath(paths, role, keyId), MAX_KEY_FILE_BYTES);
+  if (read.kind !== "ok") throw new Error(`private key is missing, symlinked, or unreadable: ${role}/${keyId}`);
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(read.body).trim();
+  } catch {
+    throw new Error(`private key is not valid UTF-8: ${role}/${keyId}`);
+  }
+  if (text.length === 0) throw new Error(`private key is empty: ${role}/${keyId}`);
+  return { keyId, privateKey: text };
+}
+
+/** SHA-256 fingerprint of a public key's SPKI bytes, for out-of-band comparison. */
+export function publicKeyFingerprint(key: PublisherKey): string {
+  return createHash("sha256").update(Buffer.from(key.publicKey, "base64")).digest("hex");
+}
+
+async function writeExclusivePrivateKey(
+  file: string,
+  privateKey: string,
+  role: KeyRole,
+  keyId: string,
+): Promise<void> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(file, "wx", 0o600);
+    await handle.writeFile(`${privateKey}\n`, "utf8");
+    await handle.sync();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(`private key already exists and is never overwritten: ${role}/${keyId}`);
+    }
+    throw error;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+function privateKeyPath(paths: WorkspacePaths, role: KeyRole, keyId: string): string {
+  return path.join(paths.keysDir, `${role}-${keyId}.key`);
+}
+
+function publicKeyPath(paths: WorkspacePaths, role: KeyRole, keyId: string): string {
+  return path.join(paths.keysDir, `${role}-${keyId}.pub`);
+}
+
+function assertSlugKeyId(keyId: string): void {
+  if (!isSlugSafe(keyId)) throw new Error(`key id must be slug-safe: ${JSON.stringify(keyId)}`);
+}

--- a/src/profile/templates/publish/lifecycle.ts
+++ b/src/profile/templates/publish/lifecycle.ts
@@ -1,0 +1,240 @@
+/**
+ * @file src/profile/templates/publish/lifecycle.ts
+ * @description Key rotation and revocation: staged when created, signed at build.
+ *
+ * WHY STAGED. A rotation claim carries an `effectiveSequence`, and the consumer requires
+ * it to equal the sequence of the index that publishes it. That sequence is only known at
+ * build, so a rotation signed at create time with a guessed sequence is invalid the moment
+ * another build intervenes. `rotate` therefore generates the successor keypair and stages
+ * the intent; `build` signs it at the correct sequence with BOTH keys.
+ *
+ * KEY CONTINUITY IS NOT ARTIFACT CONTINUITY. `verifySignedPackage` resolves the publisher
+ * key as `index.publishers[publisher]` — the single CURRENT key — and refuses a signature
+ * whose keyId differs. So every package signed by a retired key becomes unverifiable the
+ * instant the index announces its successor. A publisher rotation therefore RE-SIGNS every
+ * package with the successor key. The payload is unchanged, so the payload digest and the
+ * content-addressed filename are unchanged; only the signature changes.
+ */
+import path from "node:path";
+import { readCappedNoFollow } from "../../../utils/confined-read.js";
+import { packageClaim, rotationClaim, tapRotationClaim } from "../signing/canonical.js";
+import { signClaim } from "../signing/sign.js";
+import type {
+  PublisherKey,
+  PublisherRotation,
+  TapKeyRotation,
+  TapRevocation,
+} from "../signing/types.js";
+import { withExclusiveLock } from "../../../utils/exclusive-lock.js";
+import { createKeypairFile, readPrivateKey, type KeyRole } from "./keystore.js";
+import type { WorkspacePaths } from "./workspace-paths.js";
+import { readWorkspace, writeWorkspace } from "./workspace-store.js";
+import type { PendingIntent, PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
+
+const MAX_PUBLIC_KEY_BYTES = 4_096;
+
+/** Everything a build needs from the staged intents, signed at the build's sequence. */
+export interface SignedIntents {
+  rotations: PublisherRotation[];
+  tapRotation?: TapKeyRotation;
+  revocations: TapRevocation[];
+  nextTapKey?: PublisherKey;
+  nextPublisherKey?: PublisherKey;
+  /** Present only when a publisher rotation re-signed the package set. */
+  resignedPackages?: WorkspacePackage[];
+}
+
+/** Stage a publisher-key rotation, generating the successor keypair now. */
+export async function stageRotatePublisherKey(paths: WorkspacePaths, newKeyId: string): Promise<void> {
+  await stageIntent(paths, async (workspace) => {
+    if (newKeyId === workspace.publisherKey.keyId) throw new Error("rotation successor must use a new key id");
+    await createKeypairFile(paths, newKeyId, "publisher");
+    return { kind: "rotate-publisher", fromKeyId: workspace.publisherKey.keyId, toKeyId: newKeyId };
+  });
+}
+
+/** Stage a tap-root rotation, generating the successor keypair now. */
+export async function stageRotateTapKey(paths: WorkspacePaths, newKeyId: string): Promise<void> {
+  await stageIntent(paths, async (workspace) => {
+    if (newKeyId === workspace.tapKey.keyId) throw new Error("rotation successor must use a new key id");
+    await createKeypairFile(paths, newKeyId, "tap");
+    return { kind: "rotate-tap", fromKeyId: workspace.tapKey.keyId, toKeyId: newKeyId };
+  });
+}
+
+/** Stage a package revocation. The digest must name a package this workspace published. */
+export async function stageRevokePackage(paths: WorkspacePaths, digest: string, reason: string): Promise<void> {
+  await stageIntent(paths, async (workspace) => {
+    if (!workspace.packages.some((pkg) => pkg.payloadDigest === digest)) {
+      throw new Error(`no package in this workspace has digest ${digest}`);
+    }
+    return { kind: "revoke-package", digest, reason: assertReason(reason) };
+  });
+}
+
+/**
+ * Stage a publisher-key revocation. Revoking the ACTIVE key requires a paired rotation:
+ * `advancePublisherPins` refuses an index whose announced key is revoked, so revoking the
+ * live key alone would deadlock every future build inside its own verification.
+ */
+export async function stageRevokePublisherKey(paths: WorkspacePaths, keyId: string, reason: string): Promise<void> {
+  await stageIntent(paths, async (workspace) => {
+    const rotating = workspace.pending.some((intent) => intent.kind === "rotate-publisher");
+    if (keyId === workspace.publisherKey.keyId && !rotating) {
+      throw new Error("revoking the active publisher key requires rotating to a successor in the same build");
+    }
+    return { kind: "revoke-publisher-key", keyId, reason: assertReason(reason) };
+  });
+}
+
+/** Sign every staged intent at the sequence the index will actually carry. */
+export async function signPendingIntents(
+  paths: WorkspacePaths,
+  workspace: PublisherWorkspace,
+  sequence: number,
+  now: Date,
+): Promise<SignedIntents> {
+  const signed: SignedIntents = { rotations: [], revocations: [] };
+  for (const intent of workspace.pending) {
+    await applyIntent(paths, workspace, intent, sequence, now, signed);
+  }
+  return signed;
+}
+
+async function applyIntent(
+  paths: WorkspacePaths,
+  workspace: PublisherWorkspace,
+  intent: PendingIntent,
+  sequence: number,
+  now: Date,
+  signed: SignedIntents,
+): Promise<void> {
+  if (intent.kind === "revoke-package" || intent.kind === "revoke-publisher-key") {
+    signed.revocations.push(revocation(intent, now));
+    return;
+  }
+  if (intent.kind === "rotate-publisher") {
+    const next = await signPublisherRotation(paths, workspace, intent.toKeyId, sequence);
+    signed.rotations.push(next.rotation);
+    signed.nextPublisherKey = next.key;
+    signed.resignedPackages = await resignPackages(paths, signed.resignedPackages ?? workspace.packages, next.key);
+    return;
+  }
+  const next = await signTapRotation(paths, workspace, intent.toKeyId, sequence);
+  signed.tapRotation = next.rotation;
+  signed.nextTapKey = next.key;
+}
+
+/** Dual-sign a publisher rotation with the predecessor and the successor keys. */
+async function signPublisherRotation(
+  paths: WorkspacePaths,
+  workspace: PublisherWorkspace,
+  toKeyId: string,
+  effectiveSequence: number,
+): Promise<{ rotation: PublisherRotation; key: PublisherKey }> {
+  const oldKey = await readPrivateKey(paths, "publisher", workspace.publisherKey.keyId);
+  const newKey = await readPrivateKey(paths, "publisher", toKeyId);
+  const toKey = { keyId: toKeyId, publicKey: await publicKeyOf(paths, "publisher", toKeyId) };
+  const claim = rotationClaim(workspace.tap, {
+    publisher: workspace.publisher,
+    fromKeyId: workspace.publisherKey.keyId,
+    toKey,
+    effectiveSequence,
+  });
+  return {
+    key: toKey,
+    rotation: {
+      publisher: workspace.publisher,
+      fromKeyId: workspace.publisherKey.keyId,
+      toKey,
+      effectiveSequence,
+      oldSignature: signClaim(claim, oldKey),
+      newSignature: signClaim(claim, newKey),
+    },
+  };
+}
+
+/** Dual-sign a tap-root rotation with the predecessor and the successor keys. */
+async function signTapRotation(
+  paths: WorkspacePaths,
+  workspace: PublisherWorkspace,
+  toKeyId: string,
+  effectiveSequence: number,
+): Promise<{ rotation: TapKeyRotation; key: PublisherKey }> {
+  const oldKey = await readPrivateKey(paths, "tap", workspace.tapKey.keyId);
+  const newKey = await readPrivateKey(paths, "tap", toKeyId);
+  const toKey = { keyId: toKeyId, publicKey: await publicKeyOf(paths, "tap", toKeyId) };
+  const claim = tapRotationClaim(workspace.tap, {
+    fromKeyId: workspace.tapKey.keyId,
+    toKey,
+    effectiveSequence,
+  });
+  return {
+    key: toKey,
+    rotation: {
+      fromKeyId: workspace.tapKey.keyId,
+      toKey,
+      effectiveSequence,
+      oldSignature: signClaim(claim, oldKey),
+      newSignature: signClaim(claim, newKey),
+    },
+  };
+}
+
+/**
+ * Re-sign every package with the successor publisher key. Without this, every package
+ * published before the rotation becomes unverifiable the moment the index announces the
+ * new key.
+ */
+async function resignPackages(
+  paths: WorkspacePaths,
+  packages: WorkspacePackage[],
+  toKey: PublisherKey,
+): Promise<WorkspacePackage[]> {
+  const key = await readPrivateKey(paths, "publisher", toKey.keyId);
+  return packages.map((pkg) => {
+    const publisherSignature = signClaim(packageClaim(pkg.coordinate, pkg.payloadDigest), key);
+    const envelope = JSON.parse(pkg.envelopeJson) as Record<string, unknown>;
+    return {
+      ...pkg,
+      publisherSignature,
+      envelopeJson: JSON.stringify({ ...envelope, publisherSignature }),
+    };
+  });
+}
+
+async function publicKeyOf(paths: WorkspacePaths, role: KeyRole, keyId: string): Promise<string> {
+  const read = await readCappedNoFollow(path.join(paths.keysDir, `${role}-${keyId}.pub`), MAX_PUBLIC_KEY_BYTES);
+  if (read.kind !== "ok") throw new Error(`public key is missing or unreadable: ${role}/${keyId}`);
+  return read.body.trim();
+}
+
+function revocation(
+  intent: Extract<PendingIntent, { kind: "revoke-package" | "revoke-publisher-key" }>,
+  now: Date,
+): TapRevocation {
+  return {
+    kind: intent.kind === "revoke-package" ? "package" : "publisher-key",
+    value: intent.kind === "revoke-package" ? intent.digest : intent.keyId,
+    reason: intent.reason,
+    revokedAt: now.toISOString(),
+  };
+}
+
+/** Read-modify-write one staged intent under the workspace lock. */
+async function stageIntent(
+  paths: WorkspacePaths,
+  make: (workspace: PublisherWorkspace) => Promise<PendingIntent>,
+): Promise<void> {
+  await withExclusiveLock(paths, async () => {
+    const workspace = await readWorkspace(paths);
+    const intent = await make(workspace);
+    await writeWorkspace(paths, { ...workspace, pending: [...workspace.pending, intent] });
+  });
+}
+
+function assertReason(reason: string): string {
+  const text = reason.trim();
+  if (text.length === 0 || text.length > 512) throw new Error("revocation reason must be 1-512 characters");
+  return text;
+}

--- a/src/profile/templates/publish/lifecycle.ts
+++ b/src/profile/templates/publish/lifecycle.ts
@@ -48,6 +48,7 @@ export interface SignedIntents {
 export async function stageRotatePublisherKey(paths: WorkspacePaths, newKeyId: string): Promise<void> {
   await stageIntent(paths, async (workspace) => {
     if (newKeyId === workspace.publisherKey.keyId) throw new Error("rotation successor must use a new key id");
+    assertNoPendingRotation(workspace, "rotate-publisher", "publisher");
     await createKeypairFile(paths, newKeyId, "publisher");
     return { kind: "rotate-publisher", fromKeyId: workspace.publisherKey.keyId, toKeyId: newKeyId };
   });
@@ -57,6 +58,7 @@ export async function stageRotatePublisherKey(paths: WorkspacePaths, newKeyId: s
 export async function stageRotateTapKey(paths: WorkspacePaths, newKeyId: string): Promise<void> {
   await stageIntent(paths, async (workspace) => {
     if (newKeyId === workspace.tapKey.keyId) throw new Error("rotation successor must use a new key id");
+    assertNoPendingRotation(workspace, "rotate-tap", "tap");
     await createKeypairFile(paths, newKeyId, "tap");
     return { kind: "rotate-tap", fromKeyId: workspace.tapKey.keyId, toKeyId: newKeyId };
   });
@@ -79,12 +81,33 @@ export async function stageRevokePackage(paths: WorkspacePaths, digest: string, 
  */
 export async function stageRevokePublisherKey(paths: WorkspacePaths, keyId: string, reason: string): Promise<void> {
   await stageIntent(paths, async (workspace) => {
-    const rotating = workspace.pending.some((intent) => intent.kind === "rotate-publisher");
-    if (keyId === workspace.publisherKey.keyId && !rotating) {
+    const rotation = workspace.pending.find((intent) => intent.kind === "rotate-publisher");
+    if (keyId === workspace.publisherKey.keyId && rotation === undefined) {
       throw new Error("revoking the active publisher key requires rotating to a successor in the same build");
+    }
+    // Revoking the key a staged rotation is about to make ACTIVE would make every future
+    // build fail inside its own verification (assertNoRevokedActiveKeys), with no way to
+    // unstage the intent.
+    if (rotation?.kind === "rotate-publisher" && rotation.toKeyId === keyId) {
+      throw new Error("cannot revoke the key a staged rotation would make active");
     }
     return { kind: "revoke-publisher-key", keyId, reason: assertReason(reason) };
   });
+}
+
+/**
+ * One rotation per role per build. Two staged rotations both claim the CURRENT key as
+ * their predecessor at the same effective sequence, which continuity refuses as an
+ * ambiguous chain — and every later build would fail identically with no way out.
+ */
+function assertNoPendingRotation(
+  workspace: PublisherWorkspace,
+  kind: PendingIntent["kind"],
+  role: string,
+): void {
+  if (workspace.pending.some((intent) => intent.kind === kind)) {
+    throw new Error(`a ${role} key rotation is already staged; build it before staging another`);
+  }
 }
 
 /** Sign every staged intent at the sequence the index will actually carry. */

--- a/src/profile/templates/publish/lifecycle.ts
+++ b/src/profile/templates/publish/lifecycle.ts
@@ -15,8 +15,6 @@
  * package with the successor key. The payload is unchanged, so the payload digest and the
  * content-addressed filename are unchanged; only the signature changes.
  */
-import path from "node:path";
-import { readCappedNoFollow } from "../../../utils/confined-read.js";
 import { packageClaim, rotationClaim, tapRotationClaim } from "../signing/canonical.js";
 import { signClaim } from "../signing/sign.js";
 import type {
@@ -26,12 +24,10 @@ import type {
   TapRevocation,
 } from "../signing/types.js";
 import { withExclusiveLock } from "../../../utils/exclusive-lock.js";
-import { createKeypairFile, readPrivateKey, type KeyRole } from "./keystore.js";
+import { createKeypairFile, readPrivateKey, readPublicKey, type KeyRole } from "./keystore.js";
 import type { WorkspacePaths } from "./workspace-paths.js";
 import { readWorkspace, writeWorkspace } from "./workspace-store.js";
 import type { PendingIntent, PublisherWorkspace, WorkspacePackage } from "./workspace-types.js";
-
-const MAX_PUBLIC_KEY_BYTES = 4_096;
 
 /** Everything a build needs from the staged intents, signed at the build's sequence. */
 export interface SignedIntents {
@@ -47,7 +43,7 @@ export interface SignedIntents {
 /** Stage a publisher-key rotation, generating the successor keypair now. */
 export async function stageRotatePublisherKey(paths: WorkspacePaths, newKeyId: string): Promise<void> {
   await stageIntent(paths, async (workspace) => {
-    if (newKeyId === workspace.publisherKey.keyId) throw new Error("rotation successor must use a new key id");
+    assertKeyIdUnused(workspace, newKeyId);
     assertNoPendingRotation(workspace, "rotate-publisher", "publisher");
     await createKeypairFile(paths, newKeyId, "publisher");
     return { kind: "rotate-publisher", fromKeyId: workspace.publisherKey.keyId, toKeyId: newKeyId };
@@ -57,7 +53,7 @@ export async function stageRotatePublisherKey(paths: WorkspacePaths, newKeyId: s
 /** Stage a tap-root rotation, generating the successor keypair now. */
 export async function stageRotateTapKey(paths: WorkspacePaths, newKeyId: string): Promise<void> {
   await stageIntent(paths, async (workspace) => {
-    if (newKeyId === workspace.tapKey.keyId) throw new Error("rotation successor must use a new key id");
+    assertKeyIdUnused(workspace, newKeyId);
     assertNoPendingRotation(workspace, "rotate-tap", "tap");
     await createKeypairFile(paths, newKeyId, "tap");
     return { kind: "rotate-tap", fromKeyId: workspace.tapKey.keyId, toKeyId: newKeyId };
@@ -93,6 +89,30 @@ export async function stageRevokePublisherKey(paths: WorkspacePaths, keyId: stri
     }
     return { kind: "revoke-publisher-key", keyId, reason: assertReason(reason) };
   });
+}
+
+/**
+ * A key id may never be REUSED, even after its key file is deleted. Consumers record every
+ * key id they have ever accepted (`registerKey` refuses a historical id), so a release that
+ * re-announces a retired id is one every existing client rejects — while the publisher's own
+ * gate, which only knows the current key, happily accepts it.
+ */
+function assertKeyIdUnused(workspace: PublisherWorkspace, keyId: string): void {
+  const used = new Set<string>([workspace.tapKey.keyId, workspace.publisherKey.keyId]);
+  for (const rotation of workspace.rotations) {
+    used.add(rotation.fromKeyId);
+    used.add(rotation.toKey.keyId);
+  }
+  for (const rotation of workspace.tapKeyRotations) {
+    used.add(rotation.fromKeyId);
+    used.add(rotation.toKey.keyId);
+  }
+  for (const intent of workspace.pending) {
+    if (intent.kind === "rotate-publisher" || intent.kind === "rotate-tap") used.add(intent.toKeyId);
+  }
+  if (used.has(keyId)) {
+    throw new Error(`key id has already been used by this tap and can never be reused: ${keyId}`);
+  }
 }
 
 /**
@@ -227,9 +247,7 @@ async function resignPackages(
 }
 
 async function publicKeyOf(paths: WorkspacePaths, role: KeyRole, keyId: string): Promise<string> {
-  const read = await readCappedNoFollow(path.join(paths.keysDir, `${role}-${keyId}.pub`), MAX_PUBLIC_KEY_BYTES);
-  if (read.kind !== "ok") throw new Error(`public key is missing or unreadable: ${role}/${keyId}`);
-  return read.body.trim();
+  return readPublicKey(paths, role, keyId);
 }
 
 function revocation(

--- a/src/profile/templates/publish/tree-read.ts
+++ b/src/profile/templates/publish/tree-read.ts
@@ -1,0 +1,65 @@
+/**
+ * @file src/profile/templates/publish/tree-read.ts
+ * @description Read one distribution tree FROM DISK through the Slice A confined
+ * filesystem primitives: exact-tree enumeration (no extra, missing, symlinked, or
+ * special entries), bounded no-follow reads, and digest-derived package paths.
+ *
+ * Both callers that must reason about a real tree route through here:
+ *  - the staged tree, verified before it is ever swapped into place;
+ *  - an existing `--out` tree, before publishing is allowed to DELETE it.
+ *
+ * Neither may hand-roll its own directory walk. An index is public and copyable, so
+ * "the index looks right" proves nothing about the directory holding it — only an exact
+ * tree check does.
+ */
+import {
+  assertExactDistributionTree,
+  closeDistributionPaths,
+  readDistributionIndexBytes,
+  readDistributionPackageBytes,
+  resolveDistributionPaths,
+} from "./filesystem.js";
+import { decodeUtf8 } from "./bounded-read.js";
+import { parseSignedPackage, parseSignedTapIndex } from "../signing/protocol.js";
+import type { DistributionPaths } from "./filesystem.js";
+import type { SignedTapIndex } from "../signing/types.js";
+
+/**
+ * Read the package the index names by `digest` and BIND its content to that name: the
+ * envelope's own payloadDigest must equal the digest its filename was derived from.
+ * Without this, a file named for digest B could hold a valid envelope for digest A (a
+ * duplicate standing in for a missing package) and the filename check alone would pass.
+ */
+async function readEnvelopeAt(paths: DistributionPaths, digest: string): Promise<string> {
+  const text = decodeUtf8(await readDistributionPackageBytes(paths, digest), "package");
+  if (parseSignedPackage(text).payloadDigest !== digest) {
+    throw new Error("a package file does not match the digest its path is derived from");
+  }
+  return text;
+}
+
+/** One distribution read back from disk, proven to be an exact tree. */
+export interface DistributionOnDisk {
+  index: SignedTapIndex;
+  indexJson: string;
+  envelopes: string[];
+}
+
+/**
+ * Read and structurally verify a distribution directory. The index's OWN package digests
+ * drive the expected filenames, so an extra file, a missing package, a duplicate envelope,
+ * or a symlink all fail — not merely a wrong count.
+ */
+export async function readDistributionOnDisk(directory: string): Promise<DistributionOnDisk> {
+  const paths = await resolveDistributionPaths(directory);
+  try {
+    const indexJson = decodeUtf8(await readDistributionIndexBytes(paths), "index");
+    const index = parseSignedTapIndex(indexJson);
+    const digests = index.packages.map((entry) => entry.payloadDigest);
+    await assertExactDistributionTree(paths, digests);
+    const envelopes = await Promise.all(digests.map((digest) => readEnvelopeAt(paths, digest)));
+    return { index, indexJson, envelopes };
+  } finally {
+    await closeDistributionPaths(paths);
+  }
+}

--- a/src/profile/templates/publish/verify.ts
+++ b/src/profile/templates/publish/verify.ts
@@ -182,9 +182,23 @@ function assertSafeTap(tap: string): void {
   }
 }
 
+/**
+ * A snapshot can only accept rotations that are already RETAINED HISTORY
+ * (`effectiveSequence < index.sequence`). Those are inert here: a fresh pin never walks a
+ * chain, because `acceptedPublisherKeys` returns the announced key when nothing is pinned.
+ *
+ * Anything at or after this sequence is unprovable from a latest-snapshot-only directory —
+ * verifying it needs the key a client pinned from the PREVIOUS release, which this directory
+ * does not have. A tap-key rotation is always unprovable for the same reason.
+ *
+ * Refusing retained history too (the original rule) made this command permanently unusable
+ * for every tap that had ever rotated a key, because rotations are re-emitted in every index
+ * forever.
+ */
 function assertSnapshotContinuityScope(index: ReturnType<typeof parseSignedTapIndex>): void {
-  if (index.rotations.length > 0 || index.tapKeyRotation !== undefined) {
-    throw new Error("snapshot continuity cannot verify publisher or tap-key rotations");
+  const unprovable = index.rotations.some((rotation) => rotation.effectiveSequence >= index.sequence);
+  if (unprovable || index.tapKeyRotation !== undefined) {
+    throw new Error("snapshot continuity cannot verify publisher or tap-key rotations at this sequence");
   }
 }
 

--- a/src/profile/templates/publish/workspace-parse.ts
+++ b/src/profile/templates/publish/workspace-parse.ts
@@ -7,7 +7,7 @@
  */
 import { isSlugSafe } from "../../identity.js";
 import { parseBoundedUniqueJson } from "../signing/json.js";
-import { sha256DigestHex } from "../signing/protocol.js";
+import { parseTemplateCoordinate, sha256DigestHex } from "../signing/protocol.js";
 import type { PublisherWorkspace } from "./workspace-types.js";
 
 export const MAX_WORKSPACE_BYTES = 4 * 1024 * 1024;
@@ -82,14 +82,20 @@ function boundedArray(value: unknown, label: string): unknown[] {
   return value;
 }
 
+/**
+ * Every key is validated by the production coordinate parser, so a hostile manifest
+ * cannot smuggle a non-coordinate key (`__proto__`, a traversal string) into the map
+ * that `add` consults for coordinate immutability.
+ */
 function coordinateMap(value: unknown): Record<string, string> {
   const obj = record(value, "workspace coordinates");
   if (Object.keys(obj).length > MAX_ITEMS) throw new Error("workspace coordinates exceeds its item cap");
-  const result: Record<string, string> = {};
+  const result: Record<string, string> = Object.create(null) as Record<string, string>;
   for (const [coordinate, digest] of Object.entries(obj)) {
     if (typeof digest !== "string") throw new Error("workspace coordinate digest must be a string");
+    parseTemplateCoordinate(coordinate);
     sha256DigestHex(digest);
     result[coordinate] = digest;
   }
-  return result;
+  return { ...result };
 }

--- a/src/profile/templates/publish/workspace-parse.ts
+++ b/src/profile/templates/publish/workspace-parse.ts
@@ -1,0 +1,95 @@
+/**
+ * @file src/profile/templates/publish/workspace-parse.ts
+ * @description Bounded, fail-closed parsing of authoritative workspace state.
+ * Mirrors the tap operator-state discipline: duplicate-key rejection, byte and
+ * item caps, exact-key rejection of unknown fields. The workspace holds signing
+ * identity, so a permissive parser here is a signing-identity confusion bug.
+ */
+import { isSlugSafe } from "../../identity.js";
+import { parseBoundedUniqueJson } from "../signing/json.js";
+import { sha256DigestHex } from "../signing/protocol.js";
+import type { PublisherWorkspace } from "./workspace-types.js";
+
+export const MAX_WORKSPACE_BYTES = 4 * 1024 * 1024;
+const MAX_ITEMS = 10_000;
+
+/** Parse and validate authoritative workspace state from its stored bytes. */
+export function parsePublisherWorkspace(text: string): PublisherWorkspace {
+  const root = record(parseBoundedUniqueJson(text, MAX_WORKSPACE_BYTES), "workspace");
+  exactKeys(root, [
+    "schemaVersion", "tap", "publisher", "tapKey", "publisherKey", "sequence",
+    "packages", "rotations", "tapKeyRotations", "revocations", "pending",
+    "coordinates", "lastBuild",
+  ]);
+  if (root.schemaVersion !== 1) throw new Error("workspace schemaVersion must be 1");
+  const workspace: PublisherWorkspace = {
+    schemaVersion: 1,
+    tap: slug(root.tap, "workspace tap"),
+    publisher: slug(root.publisher, "workspace publisher"),
+    tapKey: publisherKey(root.tapKey, "workspace tap key"),
+    publisherKey: publisherKey(root.publisherKey, "workspace publisher key"),
+    sequence: naturalNumber(root.sequence, "workspace sequence"),
+    packages: boundedArray(root.packages, "workspace packages") as PublisherWorkspace["packages"],
+    rotations: boundedArray(root.rotations, "workspace rotations") as PublisherWorkspace["rotations"],
+    tapKeyRotations: boundedArray(root.tapKeyRotations, "workspace tap rotations") as PublisherWorkspace["tapKeyRotations"],
+    revocations: boundedArray(root.revocations, "workspace revocations") as PublisherWorkspace["revocations"],
+    pending: boundedArray(root.pending, "workspace pending") as PublisherWorkspace["pending"],
+    coordinates: coordinateMap(root.coordinates),
+    ...(root.lastBuild === undefined ? {} : { lastBuild: root.lastBuild as PublisherWorkspace["lastBuild"] }),
+  };
+  return workspace;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(obj: Record<string, unknown>, allowed: string[]): void {
+  for (const key of Object.keys(obj)) {
+    if (!allowed.includes(key)) throw new Error(`workspace has an unexpected field: ${key}`);
+  }
+}
+
+function slug(value: unknown, label: string): string {
+  if (typeof value !== "string" || !isSlugSafe(value)) throw new Error(`${label} must be slug-safe`);
+  return value;
+}
+
+function publisherKey(value: unknown, label: string): PublisherWorkspace["tapKey"] {
+  const obj = record(value, label);
+  exactKeysOf(obj, ["keyId", "publicKey"], label);
+  if (typeof obj.keyId !== "string" || obj.keyId.length === 0) throw new Error(`${label} keyId must be a non-empty string`);
+  if (typeof obj.publicKey !== "string" || obj.publicKey.length === 0) throw new Error(`${label} publicKey must be a non-empty string`);
+  return { keyId: obj.keyId, publicKey: obj.publicKey };
+}
+
+function exactKeysOf(obj: Record<string, unknown>, allowed: string[], label: string): void {
+  for (const key of Object.keys(obj)) {
+    if (!allowed.includes(key)) throw new Error(`${label} has an unexpected field: ${key}`);
+  }
+}
+
+function naturalNumber(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) throw new Error(`${label} must be a non-negative integer`);
+  return value as number;
+}
+
+function boundedArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value) || value.length > MAX_ITEMS) throw new Error(`${label} must be a bounded array`);
+  return value;
+}
+
+function coordinateMap(value: unknown): Record<string, string> {
+  const obj = record(value, "workspace coordinates");
+  if (Object.keys(obj).length > MAX_ITEMS) throw new Error("workspace coordinates exceeds its item cap");
+  const result: Record<string, string> = {};
+  for (const [coordinate, digest] of Object.entries(obj)) {
+    if (typeof digest !== "string") throw new Error("workspace coordinate digest must be a string");
+    sha256DigestHex(digest);
+    result[coordinate] = digest;
+  }
+  return result;
+}

--- a/src/profile/templates/publish/workspace-parse.ts
+++ b/src/profile/templates/publish/workspace-parse.ts
@@ -19,7 +19,7 @@ export function parsePublisherWorkspace(text: string): PublisherWorkspace {
   exactKeys(root, [
     "schemaVersion", "tap", "publisher", "tapKey", "publisherKey", "sequence",
     "packages", "rotations", "tapKeyRotations", "revocations", "pending",
-    "coordinates", "lastBuild", "reservedSequence",
+    "coordinates", "lastBuild", "reservedBuild",
   ]);
   if (root.schemaVersion !== 1) throw new Error("workspace schemaVersion must be 1");
   const workspace: PublisherWorkspace = {
@@ -36,9 +36,7 @@ export function parsePublisherWorkspace(text: string): PublisherWorkspace {
     pending: boundedArray(root.pending, "workspace pending").map(pendingIntent),
     coordinates: coordinateMap(root.coordinates),
     ...(root.lastBuild === undefined ? {} : { lastBuild: lastBuild(root.lastBuild) }),
-    ...(root.reservedSequence === undefined
-      ? {}
-      : { reservedSequence: naturalNumber(root.reservedSequence, "workspace reservedSequence") }),
+    ...(root.reservedBuild === undefined ? {} : { reservedBuild: lastBuild(root.reservedBuild) }),
   };
   return workspace;
 }

--- a/src/profile/templates/publish/workspace-parse.ts
+++ b/src/profile/templates/publish/workspace-parse.ts
@@ -19,7 +19,7 @@ export function parsePublisherWorkspace(text: string): PublisherWorkspace {
   exactKeys(root, [
     "schemaVersion", "tap", "publisher", "tapKey", "publisherKey", "sequence",
     "packages", "rotations", "tapKeyRotations", "revocations", "pending",
-    "coordinates", "lastBuild",
+    "coordinates", "lastBuild", "reservedSequence",
   ]);
   if (root.schemaVersion !== 1) throw new Error("workspace schemaVersion must be 1");
   const workspace: PublisherWorkspace = {
@@ -35,9 +35,35 @@ export function parsePublisherWorkspace(text: string): PublisherWorkspace {
     revocations: boundedArray(root.revocations, "workspace revocations") as PublisherWorkspace["revocations"],
     pending: boundedArray(root.pending, "workspace pending") as PublisherWorkspace["pending"],
     coordinates: coordinateMap(root.coordinates),
-    ...(root.lastBuild === undefined ? {} : { lastBuild: root.lastBuild as PublisherWorkspace["lastBuild"] }),
+    ...(root.lastBuild === undefined ? {} : { lastBuild: lastBuild(root.lastBuild) }),
+    ...(root.reservedSequence === undefined
+      ? {}
+      : { reservedSequence: naturalNumber(root.reservedSequence, "workspace reservedSequence") }),
   };
   return workspace;
+}
+
+/** The last build's recorded identity, validated rather than cast (audit LOW finding). */
+function lastBuild(value: unknown): PublisherWorkspace["lastBuild"] {
+  const obj = record(value, "workspace lastBuild");
+  exactKeysOf(obj, ["sequence", "indexDigest", "builtAt", "contentDigest"], "workspace lastBuild");
+  return {
+    sequence: naturalNumber(obj.sequence, "lastBuild sequence"),
+    indexDigest: digest(obj.indexDigest, "lastBuild indexDigest"),
+    builtAt: nonEmptyText(obj.builtAt, "lastBuild builtAt"),
+    contentDigest: digest(obj.contentDigest, "lastBuild contentDigest"),
+  };
+}
+
+function digest(value: unknown, label: string): string {
+  const text = nonEmptyText(value, label);
+  sha256DigestHex(text);
+  return text;
+}
+
+function nonEmptyText(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value;
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {

--- a/src/profile/templates/publish/workspace-parse.ts
+++ b/src/profile/templates/publish/workspace-parse.ts
@@ -29,11 +29,11 @@ export function parsePublisherWorkspace(text: string): PublisherWorkspace {
     tapKey: publisherKey(root.tapKey, "workspace tap key"),
     publisherKey: publisherKey(root.publisherKey, "workspace publisher key"),
     sequence: naturalNumber(root.sequence, "workspace sequence"),
-    packages: boundedArray(root.packages, "workspace packages") as PublisherWorkspace["packages"],
-    rotations: boundedArray(root.rotations, "workspace rotations") as PublisherWorkspace["rotations"],
-    tapKeyRotations: boundedArray(root.tapKeyRotations, "workspace tap rotations") as PublisherWorkspace["tapKeyRotations"],
-    revocations: boundedArray(root.revocations, "workspace revocations") as PublisherWorkspace["revocations"],
-    pending: boundedArray(root.pending, "workspace pending") as PublisherWorkspace["pending"],
+    packages: boundedArray(root.packages, "workspace packages").map(workspacePackage),
+    rotations: boundedArray(root.rotations, "workspace rotations").map(publisherRotation),
+    tapKeyRotations: boundedArray(root.tapKeyRotations, "workspace tap rotations").map(tapKeyRotation),
+    revocations: boundedArray(root.revocations, "workspace revocations").map(revocation),
+    pending: boundedArray(root.pending, "workspace pending").map(pendingIntent),
     coordinates: coordinateMap(root.coordinates),
     ...(root.lastBuild === undefined ? {} : { lastBuild: lastBuild(root.lastBuild) }),
     ...(root.reservedSequence === undefined
@@ -64,6 +64,99 @@ function digest(value: unknown, label: string): string {
 function nonEmptyText(value: unknown, label: string): string {
   if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
   return value;
+}
+
+/**
+ * Every nested element is parsed, not cast. The workspace carries SIGNING IDENTITY: a
+ * permissive parser here is a signing-identity confusion bug, and a cast is not a parse.
+ */
+function workspacePackage(value: unknown): PublisherWorkspace["packages"][number] {
+  const obj = record(value, "workspace package");
+  exactKeysOf(obj, ["coordinate", "publisher", "payloadDigest", "publisherSignature", "envelopeJson"], "workspace package");
+  parseTemplateCoordinate(nonEmptyText(obj.coordinate, "package coordinate"));
+  return {
+    coordinate: obj.coordinate as string,
+    publisher: slug(obj.publisher, "package publisher"),
+    payloadDigest: digest(obj.payloadDigest, "package payloadDigest"),
+    publisherSignature: signature(obj.publisherSignature, "package signature"),
+    envelopeJson: nonEmptyText(obj.envelopeJson, "package envelopeJson"),
+  };
+}
+
+function signature(value: unknown, label: string): PublisherWorkspace["packages"][number]["publisherSignature"] {
+  const obj = record(value, label);
+  exactKeysOf(obj, ["keyId", "algorithm", "value"], label);
+  if (obj.algorithm !== "ed25519") throw new Error(`${label} algorithm must be ed25519`);
+  return {
+    keyId: nonEmptyText(obj.keyId, `${label} keyId`),
+    algorithm: "ed25519",
+    value: nonEmptyText(obj.value, `${label} value`),
+  };
+}
+
+function keyOf(value: unknown, label: string): PublisherWorkspace["tapKey"] {
+  return publisherKey(value, label);
+}
+
+function publisherRotation(value: unknown): PublisherWorkspace["rotations"][number] {
+  const obj = record(value, "workspace rotation");
+  exactKeysOf(obj, ["publisher", "fromKeyId", "toKey", "effectiveSequence", "oldSignature", "newSignature"], "workspace rotation");
+  return {
+    publisher: slug(obj.publisher, "rotation publisher"),
+    fromKeyId: nonEmptyText(obj.fromKeyId, "rotation fromKeyId"),
+    toKey: keyOf(obj.toKey, "rotation toKey"),
+    effectiveSequence: naturalNumber(obj.effectiveSequence, "rotation effectiveSequence"),
+    oldSignature: signature(obj.oldSignature, "rotation oldSignature"),
+    newSignature: signature(obj.newSignature, "rotation newSignature"),
+  };
+}
+
+function tapKeyRotation(value: unknown): PublisherWorkspace["tapKeyRotations"][number] {
+  const obj = record(value, "workspace tap rotation");
+  exactKeysOf(obj, ["fromKeyId", "toKey", "effectiveSequence", "oldSignature", "newSignature"], "workspace tap rotation");
+  return {
+    fromKeyId: nonEmptyText(obj.fromKeyId, "tap rotation fromKeyId"),
+    toKey: keyOf(obj.toKey, "tap rotation toKey"),
+    effectiveSequence: naturalNumber(obj.effectiveSequence, "tap rotation effectiveSequence"),
+    oldSignature: signature(obj.oldSignature, "tap rotation oldSignature"),
+    newSignature: signature(obj.newSignature, "tap rotation newSignature"),
+  };
+}
+
+function revocation(value: unknown): PublisherWorkspace["revocations"][number] {
+  const obj = record(value, "workspace revocation");
+  exactKeysOf(obj, ["kind", "value", "reason", "revokedAt"], "workspace revocation");
+  if (obj.kind !== "package" && obj.kind !== "publisher-key") {
+    throw new Error("revocation kind must be package or publisher-key");
+  }
+  return {
+    kind: obj.kind,
+    value: nonEmptyText(obj.value, "revocation value"),
+    reason: nonEmptyText(obj.reason, "revocation reason"),
+    revokedAt: nonEmptyText(obj.revokedAt, "revocation revokedAt"),
+  };
+}
+
+function pendingIntent(value: unknown): PublisherWorkspace["pending"][number] {
+  const obj = record(value, "workspace pending intent");
+  const kind = obj.kind;
+  if (kind === "rotate-publisher" || kind === "rotate-tap") {
+    exactKeysOf(obj, ["kind", "fromKeyId", "toKeyId"], "pending rotation");
+    return {
+      kind,
+      fromKeyId: nonEmptyText(obj.fromKeyId, "pending fromKeyId"),
+      toKeyId: nonEmptyText(obj.toKeyId, "pending toKeyId"),
+    };
+  }
+  if (kind === "revoke-package") {
+    exactKeysOf(obj, ["kind", "digest", "reason"], "pending revocation");
+    return { kind, digest: digest(obj.digest, "pending digest"), reason: nonEmptyText(obj.reason, "pending reason") };
+  }
+  if (kind === "revoke-publisher-key") {
+    exactKeysOf(obj, ["kind", "keyId", "reason"], "pending revocation");
+    return { kind, keyId: nonEmptyText(obj.keyId, "pending keyId"), reason: nonEmptyText(obj.reason, "pending reason") };
+  }
+  throw new Error("pending intent kind is unknown");
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {

--- a/src/profile/templates/publish/workspace-paths.ts
+++ b/src/profile/templates/publish/workspace-paths.ts
@@ -1,0 +1,25 @@
+/**
+ * @file src/profile/templates/publish/workspace-paths.ts
+ * @description The fixed workspace layout. Every publisher write is confined to `root`.
+ */
+import path from "node:path";
+import type { LockPaths } from "../../../utils/exclusive-lock.js";
+
+/** Resolved workspace leaves beneath one operator-chosen directory. */
+export interface WorkspacePaths extends LockPaths {
+  root: string;
+  manifestFile: string;
+  lockFile: string;
+  keysDir: string;
+}
+
+/** Resolve the fixed workspace layout beneath one operator-chosen directory. */
+export function resolveWorkspacePaths(directory: string): WorkspacePaths {
+  const root = path.resolve(directory);
+  return {
+    root,
+    manifestFile: path.join(root, "workspace.json"),
+    lockFile: path.join(root, "workspace.lock"),
+    keysDir: path.join(root, "keys"),
+  };
+}

--- a/src/profile/templates/publish/workspace-store.ts
+++ b/src/profile/templates/publish/workspace-store.ts
@@ -1,0 +1,25 @@
+/**
+ * @file src/profile/templates/publish/workspace-store.ts
+ * @description Confined, capped, atomic persistence for authoritative workspace
+ * state. Written bytes are re-parsed before they land, so the store can never
+ * persist a manifest its own parser would refuse to read back.
+ */
+import { atomicWrite } from "../../../utils/atomic-write.js";
+import { readConfinedLeaf } from "../../../utils/confined-read.js";
+import { MAX_WORKSPACE_BYTES, parsePublisherWorkspace } from "./workspace-parse.js";
+import type { WorkspacePaths } from "./workspace-paths.js";
+import type { PublisherWorkspace } from "./workspace-types.js";
+
+/** Read authoritative state; a symlinked, oversized, or absent leaf fails closed. */
+export async function readWorkspace(paths: WorkspacePaths): Promise<PublisherWorkspace> {
+  const read = await readConfinedLeaf(paths.root, paths.manifestFile, paths.root, MAX_WORKSPACE_BYTES);
+  if (read.kind !== "ok") throw new Error("publisher workspace is missing, symlinked, or unreadable");
+  return parsePublisherWorkspace(read.body);
+}
+
+/** Atomically replace authoritative state, re-validating the bytes before they land. */
+export async function writeWorkspace(paths: WorkspacePaths, workspace: PublisherWorkspace): Promise<void> {
+  const text = `${JSON.stringify(workspace, null, 2)}\n`;
+  parsePublisherWorkspace(text);
+  await atomicWrite(paths.manifestFile, text, { confineRoot: paths.root, durable: true, mode: 0o600 });
+}

--- a/src/profile/templates/publish/workspace-types.ts
+++ b/src/profile/templates/publish/workspace-types.ts
@@ -78,10 +78,12 @@ export interface PublisherWorkspace {
   coordinates: Record<string, string>;
   lastBuild?: LastBuild;
   /**
-   * A sequence handed to a published tree but not yet committed. A crash between
-   * publishing and committing leaves a signed index live at that sequence; re-issuing it
-   * with different bytes would be a rollback/replay for any client that fetched it. So the
-   * next build skips past a reserved sequence rather than reusing it.
+   * A build that was handed to a published tree but whose commit did not land. It records
+   * the IDENTITY of what may already be live, not just the number:
+   *  - the next build skips past its sequence, because re-issuing a sequence with different
+   *    bytes is a replay for any client that fetched the first one;
+   *  - the output it published is recognized as OURS, so a retry can replace it instead of
+   *    refusing it as foreign data and deadlocking the workspace.
    */
-  reservedSequence?: number;
+  reservedBuild?: LastBuild;
 }

--- a/src/profile/templates/publish/workspace-types.ts
+++ b/src/profile/templates/publish/workspace-types.ts
@@ -49,6 +49,13 @@ export interface LastBuild {
   sequence: number;
   indexDigest: string;
   builtAt: string;
+  /**
+   * Digest of the CONTENT this build published (packages, revocations, announced keys).
+   * `pending` alone cannot answer "is there anything to build": `add` records a package
+   * without staging an intent, so a content digest is what distinguishes a real change
+   * from a no-op republish.
+   */
+  contentDigest: string;
 }
 
 /** Authoritative publisher workspace state. */
@@ -70,4 +77,11 @@ export interface PublisherWorkspace {
   /** Coordinate -> payload digest, forever. */
   coordinates: Record<string, string>;
   lastBuild?: LastBuild;
+  /**
+   * A sequence handed to a published tree but not yet committed. A crash between
+   * publishing and committing leaves a signed index live at that sequence; re-issuing it
+   * with different bytes would be a rollback/replay for any client that fetched it. So the
+   * next build skips past a reserved sequence rather than reusing it.
+   */
+  reservedSequence?: number;
 }

--- a/src/profile/templates/publish/workspace-types.ts
+++ b/src/profile/templates/publish/workspace-types.ts
@@ -1,0 +1,73 @@
+/**
+ * @file src/profile/templates/publish/workspace-types.ts
+ * @description Authoritative publisher workspace state.
+ *
+ * Two invariants are encoded in this shape and must survive every edit:
+ *
+ * 1. FULL HISTORY IS RETAINED. `followRotationChain` lets a client that skipped
+ *    snapshots walk from its pinned key to the current key — but only if every
+ *    later index re-emits the historical rotations. So every rotation ever made
+ *    survives here and is re-emitted by every build.
+ * 2. COORDINATES ARE IMMUTABLE. `coordinates` maps coordinate -> payload digest
+ *    forever; the same coordinate may never resolve to different bytes.
+ */
+import type {
+  Ed25519Signature,
+  PublisherKey,
+  PublisherRotation,
+  TapKeyRotation,
+  TapRevocation,
+} from "../signing/types.js";
+
+/** One package accepted into the workspace, with its publisher signature. */
+export interface WorkspacePackage {
+  coordinate: string;
+  publisher: string;
+  payloadDigest: string;
+  publisherSignature: Ed25519Signature;
+  /** The exact validated envelope bytes emitted into the built tree. */
+  envelopeJson: string;
+}
+
+/**
+ * A rotation or revocation staged for the NEXT build.
+ *
+ * Rotations cannot be signed when they are created: a rotation claim carries an
+ * `effectiveSequence`, and continuity requires it to equal the sequence of the
+ * index that publishes it. That sequence is only known at build. So `rotate`
+ * generates the successor keypair and stages the intent; `build` signs it at the
+ * correct sequence with both keys.
+ */
+export type PendingIntent =
+  | { kind: "rotate-publisher"; fromKeyId: string; toKeyId: string }
+  | { kind: "rotate-tap"; fromKeyId: string; toKeyId: string }
+  | { kind: "revoke-package"; digest: string; reason: string }
+  | { kind: "revoke-publisher-key"; keyId: string; reason: string };
+
+/** The exact identity of the last committed build (spec §4 Slice C). */
+export interface LastBuild {
+  sequence: number;
+  indexDigest: string;
+  builtAt: string;
+}
+
+/** Authoritative publisher workspace state. */
+export interface PublisherWorkspace {
+  schemaVersion: 1;
+  tap: string;
+  publisher: string;
+  /** Current signing keys. Successors replace these only after a successful build. */
+  tapKey: PublisherKey;
+  publisherKey: PublisherKey;
+  /** Sequence of the last COMMITTED build; the next build uses this + 1. */
+  sequence: number;
+  packages: WorkspacePackage[];
+  /** Retained history — re-emitted in every index. */
+  rotations: PublisherRotation[];
+  tapKeyRotations: TapKeyRotation[];
+  revocations: TapRevocation[];
+  pending: PendingIntent[];
+  /** Coordinate -> payload digest, forever. */
+  coordinates: Record<string, string>;
+  lastBuild?: LastBuild;
+}

--- a/src/profile/templates/signing/canonical.ts
+++ b/src/profile/templates/signing/canonical.ts
@@ -18,6 +18,17 @@ export function canonicalDigest(value: unknown): string {
   return `sha256:${createHash("sha256").update(canonicalBytes(value)).digest("hex")}`;
 }
 
+/**
+ * The exact bytes a tap-index signature covers: the complete index WITHOUT its
+ * `signature` field. Producer and consumer MUST derive these bytes from this one
+ * function — a second derivation is precisely how a signed index becomes
+ * unverifiable, so `verifyTapIndex` consumes it too.
+ */
+export function tapIndexClaim(index: { signature?: unknown }): object {
+  const { signature: _signature, ...claim } = index;
+  return claim;
+}
+
 /** Publisher-signed package claim. */
 export function packageClaim(coordinate: string, payloadDigest: string): object {
   return { coordinate, payloadDigest };

--- a/src/profile/templates/signing/canonical.ts
+++ b/src/profile/templates/signing/canonical.ts
@@ -24,7 +24,7 @@ export function canonicalDigest(value: unknown): string {
  * function — a second derivation is precisely how a signed index becomes
  * unverifiable, so `verifyTapIndex` consumes it too.
  */
-export function tapIndexClaim(index: { signature?: unknown }): object {
+export function tapIndexClaim(index: object & { signature?: unknown }): object {
   const { signature: _signature, ...claim } = index;
   return claim;
 }

--- a/src/profile/templates/signing/sign.ts
+++ b/src/profile/templates/signing/sign.ts
@@ -1,0 +1,64 @@
+/**
+ * @file src/profile/templates/signing/sign.ts
+ * @description The ONLY place a private key is used. Produces production Ed25519
+ * signatures over canonical claim bytes built by `canonical.ts`, so a publisher never
+ * re-derives the bytes a verifier checks. Verification stays entirely in `verify.ts`.
+ */
+import { createPrivateKey, generateKeyPairSync, sign } from "node:crypto";
+import { canonicalBytes } from "./canonical.js";
+import type { Ed25519Signature, PublisherKey } from "./types.js";
+
+/** A private signing key: PKCS8 DER, base64, bound to its public key id. */
+export interface PrivateSigningKey {
+  keyId: string;
+  privateKey: string;
+}
+
+/** A freshly generated keypair in the protocol's wire formats. */
+export interface GeneratedKeypair {
+  publicKey: PublisherKey;
+  privateKey: PrivateSigningKey;
+}
+
+/** Sign one canonical claim. The claim MUST come from `canonical.ts`. */
+export function signClaim(claim: object, key: PrivateSigningKey): Ed25519Signature {
+  const privateKey = importEd25519PrivateKey(key.privateKey);
+  return {
+    keyId: key.keyId,
+    algorithm: "ed25519",
+    value: sign(null, canonicalBytes(claim), privateKey).toString("base64"),
+  };
+}
+
+/** Generate one Ed25519 keypair in the SPKI/PKCS8 base64 wire formats. */
+export function generateEd25519Keypair(keyId: string): GeneratedKeypair {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  return {
+    publicKey: {
+      keyId,
+      publicKey: publicKey.export({ format: "der", type: "spki" }).toString("base64"),
+    },
+    privateKey: {
+      keyId,
+      privateKey: privateKey.export({ format: "der", type: "pkcs8" }).toString("base64"),
+    },
+  };
+}
+
+/** Import a PKCS8 DER base64 private key, refusing anything that is not Ed25519. */
+function importEd25519PrivateKey(privateKeyBase64: string): ReturnType<typeof createPrivateKey> {
+  let key: ReturnType<typeof createPrivateKey>;
+  try {
+    key = createPrivateKey({
+      key: Buffer.from(privateKeyBase64, "base64"),
+      format: "der",
+      type: "pkcs8",
+    });
+  } catch {
+    throw new Error("signing key is not a PKCS8 DER Ed25519 private key");
+  }
+  if (key.asymmetricKeyType !== "ed25519") {
+    throw new Error("signing key is not a PKCS8 DER Ed25519 private key");
+  }
+  return key;
+}

--- a/src/profile/templates/signing/verify.ts
+++ b/src/profile/templates/signing/verify.ts
@@ -6,7 +6,7 @@
 import { createPublicKey, verify, type KeyObject } from "node:crypto";
 import type { ProfileTemplatePackage } from "../types.js";
 import { validateTemplatePackage } from "../validate.js";
-import { canonicalBytes, canonicalDigest, packageClaim, rotationClaim, tapRotationClaim } from "./canonical.js";
+import { canonicalBytes, canonicalDigest, packageClaim, rotationClaim, tapIndexClaim, tapRotationClaim } from "./canonical.js";
 import { parseTemplateCoordinate, type ParsedSignedPackage, type ParsedTapIndex } from "./protocol.js";
 import type {
   Ed25519Signature,
@@ -42,8 +42,7 @@ export function verifyTapIndex(
   if (Date.parse(index.generatedAt) > now.getTime() + MAX_INDEX_CLOCK_SKEW_MS) {
     refuse("not-yet-valid", "tap index generation time is too far in the future");
   }
-  const { signature, ...claim } = index;
-  verifySignature(canonicalBytes(claim), signature, trustedKey, "tap-signature");
+  verifySignature(canonicalBytes(tapIndexClaim(index)), index.signature, trustedKey, "tap-signature");
   return index as VerifiedTapIndex;
 }
 
@@ -59,8 +58,7 @@ export function verifyAcceptedTapIndex(
   }
   if (index.tap !== expectedTap) refuse("wrong-tap", `expected tap ${expectedTap}, received ${index.tap}`);
   if (index.signature.keyId !== trustedKey.keyId) refuse("wrong-key", "tap signature key does not match the trusted key");
-  const { signature, ...claim } = index;
-  verifySignature(canonicalBytes(claim), signature, trustedKey, "tap-signature");
+  verifySignature(canonicalBytes(tapIndexClaim(index)), index.signature, trustedKey, "tap-signature");
   return index as VerifiedTapIndex;
 }
 

--- a/src/profile/templates/taps/operator-lock.ts
+++ b/src/profile/templates/taps/operator-lock.ts
@@ -1,101 +1,15 @@
 /**
  * @file src/profile/templates/taps/operator-lock.ts
- * @description Token-owned bounded lock for global template-tap state mutations.
+ * @description Tap-state binding for the generic exclusive file lock.
  */
-import { randomBytes } from "node:crypto";
-import { open, unlink } from "node:fs/promises";
-import { readConfinedLeaf } from "../../../utils/confined-read.js";
-import { isOwnerStale, parseOwner, serializeOwner } from "../../../utils/lock-owner.js";
+import { withExclusiveLock } from "../../../utils/exclusive-lock.js";
 import type { TapPaths } from "./paths.js";
-import { ensurePrivateRoot } from "./private-root.js";
-
-const MAX_LOCK_BYTES = 1024;
-const DEFAULT_TIMEOUT_MS = 5_000;
-const POLL_MS = 25;
-
-interface OperatorLockRecord { pid: number; startTime?: string; token: string }
 
 /** Run one authoritative read-modify-write while holding the operator lock. */
-export async function withTapStateLock<T>(paths: TapPaths, operation: () => Promise<T>, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
-  const token = await acquireOperatorLock(paths, timeoutMs);
-  try {
-    return await operation();
-  } finally {
-    await releaseOperatorLock(paths, token);
-  }
-}
-
-async function acquireOperatorLock(paths: TapPaths, timeoutMs: number): Promise<string> {
-  await ensurePrivateRoot(paths.configRoot);
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    const token = randomBytes(24).toString("hex");
-    if (await tryCreate(paths.lockFile, token)) return token;
-    await reclaimIfStale(paths);
-    if (Date.now() >= deadline) throw new Error("template tap state is busy");
-    await delay(POLL_MS);
-  }
-}
-
-async function tryCreate(lockFile: string, token: string): Promise<boolean> {
-  const owner = JSON.parse(serializeOwner(process.pid)) as { pid: number; startTime?: string };
-  const record: OperatorLockRecord = { ...owner, token };
-  let handle: Awaited<ReturnType<typeof open>> | undefined;
-  try {
-    handle = await open(lockFile, "wx", 0o600);
-    await handle.writeFile(JSON.stringify(record), "utf8");
-    await handle.sync();
-    await handle.close();
-    handle = undefined;
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
-    await handle?.close().catch(() => {});
-    if (handle !== undefined) await unlink(lockFile).catch(() => {});
-    throw error;
-  }
-}
-
-async function reclaimIfStale(paths: TapPaths): Promise<void> {
-  const record = await readRecord(paths, paths.lockFile);
-  if (!record || !isOwnerStale(record)) return;
-  const reclaim = `${paths.lockFile}.reclaim`;
-  const token = randomBytes(24).toString("hex");
-  if (!(await acquireReclaim(paths, reclaim, token))) return;
-  try {
-    const current = await readRecord(paths, paths.lockFile);
-    if (current && isOwnerStale(current)) await unlink(paths.lockFile).catch(() => {});
-  } finally {
-    await unlink(reclaim).catch(() => {});
-  }
-}
-
-async function acquireReclaim(paths: TapPaths, file: string, token: string): Promise<boolean> {
-  if (await tryCreate(file, token)) return true;
-  const existing = await readRecord(paths, file);
-  if (existing && isOwnerStale(existing)) await unlink(file).catch(() => {});
-  return false;
-}
-
-async function readRecord(paths: TapPaths, file: string): Promise<OperatorLockRecord | null> {
-  const read = await readConfinedLeaf(paths.configRoot, file, paths.configRoot, MAX_LOCK_BYTES);
-  if (read.kind !== "ok") return null;
-  try {
-    const value = JSON.parse(read.body) as Record<string, unknown>;
-    const owner = parseOwner(JSON.stringify(value));
-    if (!owner || typeof value.token !== "string" || !/^[0-9a-f]{48}$/.test(value.token)) return null;
-    return { ...owner, token: value.token };
-  } catch {
-    return null;
-  }
-}
-
-async function releaseOperatorLock(paths: TapPaths, token: string): Promise<void> {
-  const record = await readRecord(paths, paths.lockFile);
-  if (record?.token !== token || record.pid !== process.pid) return;
-  await unlink(paths.lockFile).catch(() => {});
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+export async function withTapStateLock<T>(
+  paths: TapPaths,
+  operation: () => Promise<T>,
+  timeoutMs?: number,
+): Promise<T> {
+  return withExclusiveLock({ root: paths.configRoot, lockFile: paths.lockFile }, operation, timeoutMs);
 }

--- a/src/utils/exclusive-lock.ts
+++ b/src/utils/exclusive-lock.ts
@@ -1,0 +1,108 @@
+/**
+ * @file src/utils/exclusive-lock.ts
+ * @description Token-owned bounded file lock for authoritative mutable state.
+ * Shared by the tap operator state and the publisher workspace: a second copy of
+ * this acquire/stale-reclaim/release dance is how two lock implementations drift.
+ */
+import { randomBytes } from "node:crypto";
+import { open, unlink } from "node:fs/promises";
+import { readConfinedLeaf } from "./confined-read.js";
+import { isOwnerStale, parseOwner, serializeOwner } from "./lock-owner.js";
+import { ensurePrivateRoot } from "../profile/templates/taps/private-root.js";
+
+const MAX_LOCK_BYTES = 1024;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const POLL_MS = 25;
+
+interface OperatorLockRecord { pid: number; startTime?: string; token: string }
+
+/** The two paths a file lock needs: its confined private root and the lock leaf. */
+export interface LockPaths {
+  root: string;
+  lockFile: string;
+}
+
+/** Run one authoritative read-modify-write while holding the exclusive lock. */
+export async function withExclusiveLock<T>(paths: LockPaths, operation: () => Promise<T>, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
+  const token = await acquireOperatorLock(paths, timeoutMs);
+  try {
+    return await operation();
+  } finally {
+    await releaseOperatorLock(paths, token);
+  }
+}
+
+async function acquireOperatorLock(paths: LockPaths, timeoutMs: number): Promise<string> {
+  await ensurePrivateRoot(paths.root);
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const token = randomBytes(24).toString("hex");
+    if (await tryCreate(paths.lockFile, token)) return token;
+    await reclaimIfStale(paths);
+    if (Date.now() >= deadline) throw new Error("template tap state is busy");
+    await delay(POLL_MS);
+  }
+}
+
+async function tryCreate(lockFile: string, token: string): Promise<boolean> {
+  const owner = JSON.parse(serializeOwner(process.pid)) as { pid: number; startTime?: string };
+  const record: OperatorLockRecord = { ...owner, token };
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(lockFile, "wx", 0o600);
+    await handle.writeFile(JSON.stringify(record), "utf8");
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+    await handle?.close().catch(() => {});
+    if (handle !== undefined) await unlink(lockFile).catch(() => {});
+    throw error;
+  }
+}
+
+async function reclaimIfStale(paths: LockPaths): Promise<void> {
+  const record = await readRecord(paths, paths.lockFile);
+  if (!record || !isOwnerStale(record)) return;
+  const reclaim = `${paths.lockFile}.reclaim`;
+  const token = randomBytes(24).toString("hex");
+  if (!(await acquireReclaim(paths, reclaim, token))) return;
+  try {
+    const current = await readRecord(paths, paths.lockFile);
+    if (current && isOwnerStale(current)) await unlink(paths.lockFile).catch(() => {});
+  } finally {
+    await unlink(reclaim).catch(() => {});
+  }
+}
+
+async function acquireReclaim(paths: LockPaths, file: string, token: string): Promise<boolean> {
+  if (await tryCreate(file, token)) return true;
+  const existing = await readRecord(paths, file);
+  if (existing && isOwnerStale(existing)) await unlink(file).catch(() => {});
+  return false;
+}
+
+async function readRecord(paths: LockPaths, file: string): Promise<OperatorLockRecord | null> {
+  const read = await readConfinedLeaf(paths.root, file, paths.root, MAX_LOCK_BYTES);
+  if (read.kind !== "ok") return null;
+  try {
+    const value = JSON.parse(read.body) as Record<string, unknown>;
+    const owner = parseOwner(JSON.stringify(value));
+    if (!owner || typeof value.token !== "string" || !/^[0-9a-f]{48}$/.test(value.token)) return null;
+    return { ...owner, token: value.token };
+  } catch {
+    return null;
+  }
+}
+
+async function releaseOperatorLock(paths: LockPaths, token: string): Promise<void> {
+  const record = await readRecord(paths, paths.lockFile);
+  if (record?.token !== token || record.pid !== process.pid) return;
+  await unlink(paths.lockFile).catch(() => {});
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/test/exclusive-lock.test.ts
+++ b/test/exclusive-lock.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @file test/exclusive-lock.test.ts
+ * @description The generic token-owned file lock serializes holders and always
+ * releases, including when the guarded operation throws.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { withExclusiveLock, type LockPaths } from "../src/utils/exclusive-lock.js";
+
+const roots: string[] = [];
+afterEach(async () => Promise.all(roots.splice(0).map((r) => rm(r, { recursive: true, force: true }))));
+
+async function lockPaths(): Promise<LockPaths> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "llmwiki-lock-"));
+  roots.push(root);
+  return { root, lockFile: path.join(root, "state.lock") };
+}
+
+describe("withExclusiveLock", () => {
+  it("serializes two holders", async () => {
+    const paths = await lockPaths();
+    const order: string[] = [];
+    let releaseFirst: () => void = () => undefined;
+    const firstMayFinish = new Promise<void>((resolve) => { releaseFirst = resolve; });
+
+    const first = withExclusiveLock(paths, async () => {
+      order.push("first-start");
+      await firstMayFinish;
+      order.push("first-end");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const second = withExclusiveLock(paths, async () => { order.push("second"); });
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["first-start", "first-end", "second"]);
+  });
+
+  it("releases the lock when the operation throws", async () => {
+    const paths = await lockPaths();
+
+    await expect(withExclusiveLock(paths, async () => { throw new Error("boom"); })).rejects.toThrow(/boom/);
+
+    await expect(withExclusiveLock(paths, async () => "ok")).resolves.toBe("ok");
+  });
+});

--- a/test/exclusive-lock.test.ts
+++ b/test/exclusive-lock.test.ts
@@ -3,18 +3,16 @@
  * @description The generic token-owned file lock serializes holders and always
  * releases, including when the guarded operation throws.
  */
-import { mkdtemp, rm } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { withExclusiveLock, type LockPaths } from "../src/utils/exclusive-lock.js";
+import { publisherTempRoots } from "./fixtures/publisher-workspace.js";
 
-const roots: string[] = [];
-afterEach(async () => Promise.all(roots.splice(0).map((r) => rm(r, { recursive: true, force: true }))));
+const roots = publisherTempRoots();
+afterEach(roots.cleanup);
 
 async function lockPaths(): Promise<LockPaths> {
-  const root = await mkdtemp(path.join(os.tmpdir(), "llmwiki-lock-"));
-  roots.push(root);
+  const root = await roots.create("lock");
   return { root, lockFile: path.join(root, "state.lock") };
 }
 

--- a/test/fixtures/publisher-workspace.ts
+++ b/test/fixtures/publisher-workspace.ts
@@ -1,0 +1,24 @@
+/**
+ * @file test/fixtures/publisher-workspace.ts
+ * @description Workspace paths and escape-planting helpers shared by the publisher
+ * suites. Temp-root lifecycle reuses the existing managed-temp-roots fixture.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { resolveWorkspacePaths, type WorkspacePaths } from "../../src/profile/templates/publish/workspace-paths.js";
+
+export { managedTempRoots as publisherTempRoots } from "./managed-temp-roots.js";
+
+/** A workspace directory with its `keys/` dir already present. */
+export async function makeWorkspacePaths(root: string): Promise<WorkspacePaths> {
+  const paths = resolveWorkspacePaths(root);
+  await mkdir(paths.keysDir, { recursive: true, mode: 0o700 });
+  return paths;
+}
+
+/** Write one file OUTSIDE the workspace, for symlink-escape coverage. */
+export async function outsideFile(root: string, name: string, content: string): Promise<string> {
+  const file = path.join(root, name);
+  await writeFile(file, content, "utf8");
+  return file;
+}

--- a/test/fixtures/publisher-workspace.ts
+++ b/test/fixtures/publisher-workspace.ts
@@ -22,3 +22,28 @@ export async function outsideFile(root: string, name: string, content: string): 
   await writeFile(file, content, "utf8");
   return file;
 }
+
+/** A minimal, valid remote template package used by the publisher suites. */
+export const PUBLISHER_TEMPLATE = {
+  schemaVersion: 1,
+  templateId: "incident-response",
+  version: "1.0.0",
+  displayName: "Incident Response",
+  publisher: "acme",
+  sourceType: "remote",
+  license: "MIT",
+  minLlmwikiVersion: "1.0.0",
+  profile: {
+    schemaVersion: 1,
+    profileId: "incident-response",
+    displayName: "Incident Response",
+    entities: {
+      incidents: {
+        directory: "wiki/incidents",
+        titleField: "title",
+        requiredFields: ["title"],
+        fields: { title: { type: "string" } },
+      },
+    },
+  },
+};

--- a/test/research-workflow-denial-cli.test.ts
+++ b/test/research-workflow-denial-cli.test.ts
@@ -16,6 +16,13 @@
  *    at `submit-manuscript` (non-zero exit; page never reaches `submitted`).
  */
 
+import { vi } from "vitest";
+// This suite drives the whole CLI through many subprocess spawns and runs ~25s of
+// subprocess work against the 30s default. vitest already caps workers because subprocess
+// tests starve each other under load, so on a slower CI runner any test here can breach 30s
+// with nothing broken. Raise the timeout for the whole FILE — the fix belongs at file scope,
+// not on one victim test at a time. No assertion is weakened.
+vi.setConfig({ testTimeout: 90_000 });
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import path from "node:path";

--- a/test/research-workflow-denial-cli.test.ts
+++ b/test/research-workflow-denial-cli.test.ts
@@ -47,6 +47,15 @@ afterEach(async () => {
   if (root) await rm(root, { recursive: true, force: true });
 });
 
+/**
+ * Measured ~14-15s on an idle machine against the 30s default, so this test carries barely
+ * 2x headroom. It drives the whole CLI through many subprocess spawns, and vitest already
+ * caps workers because subprocess tests starve each other under load — on a slower CI runner
+ * that margin disappears and the test times out with nothing actually broken. Give it the
+ * headroom its measured cost demands.
+ */
+const SLOW_CLI_TIMEOUT_MS = 90_000;
+
 describe("research workflow — experiment G1 denial (dangling tests edge)", () => {
   it("hard-denies complete-experiment and ends the run failed with the experiment still running", async () => {
     await installResearchProfile(root);
@@ -65,7 +74,7 @@ describe("research workflow — experiment G1 denial (dangling tests edge)", () 
     expect(status.stdout).toMatch(/failed/i);
     const experiment = await readFile(entityPagePath(root, "experiments", EXPERIMENT_SLUG), "utf8");
     expect(experiment).toMatch(/stage:\s*running/);
-  });
+  }, SLOW_CLI_TIMEOUT_MS);
 });
 
 describe("manuscript workflow — citation proof", () => {

--- a/test/research-workflow-e2e-cli.test.ts
+++ b/test/research-workflow-e2e-cli.test.ts
@@ -47,6 +47,15 @@ afterEach(async () => {
   if (root) await rm(root, { recursive: true, force: true });
 });
 
+/**
+ * Measured ~14-15s on an idle machine against the 30s default, so this test carries barely
+ * 2x headroom. It drives the whole CLI through many subprocess spawns, and vitest already
+ * caps workers because subprocess tests starve each other under load — on a slower CI runner
+ * that margin disappears and the test times out with nothing actually broken. Give it the
+ * headroom its measured cost demands.
+ */
+const SLOW_CLI_TIMEOUT_MS = 90_000;
+
 describe("research workflow — 9-stage happy path (headline)", () => {
   it("drives all nine stages to completed, lands the experiment at stage: complete, and wires both relations", async () => {
     const runId = await driveResearchToComplete(root, RESEARCH_GRANT, IDEA_SLUG);
@@ -63,7 +72,7 @@ describe("research workflow — 9-stage happy path (headline)", () => {
     expect(buildsOn?.to).toBe(`papers/${PAPER_SLUG}`);
     expect(tests?.from).toBe(`experiments/${EXPERIMENT_SLUG}`);
     expect(tests?.to).toBe(`ideas/${IDEA_SLUG}`);
-  });
+  }, SLOW_CLI_TIMEOUT_MS);
 });
 
 describe("research workflow — trust seam (import-paper)", () => {

--- a/test/research-workflow-e2e-cli.test.ts
+++ b/test/research-workflow-e2e-cli.test.ts
@@ -16,6 +16,13 @@
  * so the grant is genuinely load-bearing, not decorative.
  */
 
+import { vi } from "vitest";
+// This suite drives the whole CLI through many subprocess spawns and runs ~25s of
+// subprocess work against the 30s default. vitest already caps workers because subprocess
+// tests starve each other under load, so on a slower CI runner any test here can breach 30s
+// with nothing broken. Raise the timeout for the whole FILE — the fix belongs at file scope,
+// not on one victim test at a time. No assertion is weakened.
+vi.setConfig({ testTimeout: 90_000 });
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";

--- a/test/superset-proof-e2e-cli.test.ts
+++ b/test/superset-proof-e2e-cli.test.ts
@@ -123,6 +123,15 @@ async function stageCrossrefOffline(): Promise<void> {
   expect(res.kind).toBe("staged");
 }
 
+/**
+ * Measured ~14-15s on an idle machine against the 30s default, so this test carries barely
+ * 2x headroom. It drives the whole CLI through many subprocess spawns, and vitest already
+ * caps workers because subprocess tests starve each other under load — on a slower CI runner
+ * that margin disappears and the test times out with nothing actually broken. Give it the
+ * headroom its measured cost demands.
+ */
+const SLOW_CLI_TIMEOUT_MS = 90_000;
+
 describe("superset proof — six bullets over one research project via dist/cli.js", () => {
   it("bullet 1: the full entity + relation vocabulary is representable and live-visible", async () => {
     await buildResearchProject(root);
@@ -145,7 +154,7 @@ describe("superset proof — six bullets over one research project via dist/cli.
     expectCompleted(done);
     const status = await runCLI(["workflow", "status", runId], root, RESEARCH_GRANT);
     expect(status.stdout).toMatch(/completed/i);
-  });
+  }, SLOW_CLI_TIMEOUT_MS);
 
   it("bullet 3: artifacts are hash-pinned and required evidence is a runtime approval gate", async () => {
     await writeProfileFile(root, researchArtifactPreconditionProfile());

--- a/test/superset-proof-e2e-cli.test.ts
+++ b/test/superset-proof-e2e-cli.test.ts
@@ -28,6 +28,13 @@
  * seam; every other bullet drives the real `dist/cli.js`.
  */
 
+import { vi } from "vitest";
+// This suite drives the whole CLI through many subprocess spawns and runs ~25s of
+// subprocess work against the 30s default. vitest already caps workers because subprocess
+// tests starve each other under load, so on a slower CI runner any test here can breach 30s
+// with nothing broken. Raise the timeout for the whole FILE — the fix belongs at file scope,
+// not on one victim test at a time. No assertion is weakened.
+vi.setConfig({ testTimeout: 90_000 });
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { mkdtemp, mkdir, rm, readFile, writeFile, access } from "node:fs/promises";
 import path from "node:path";

--- a/test/template-publish-build.test.ts
+++ b/test/template-publish-build.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @file test/template-publish-build.test.ts
+ * @description End-to-end publisher lifecycle, verified through the REAL consumer.
+ *
+ * The decisive cases are the ones a publisher-only test would miss:
+ *  - a package published BEFORE a publisher rotation must still verify AFTER it
+ *    (key continuity is not artifact continuity);
+ *  - a revoked package must not appear in the built index (or build refuses itself);
+ *  - a tap-rotating index must be signed by the SUCCESSOR key.
+ */
+import packageJson from "../package.json" with { type: "json" };
+import { chmod, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { addPackage } from "../src/profile/templates/publish/add.js";
+import { buildDistribution } from "../src/profile/templates/publish/build.js";
+import {
+  stageRevokePackage,
+  stageRevokePublisherKey,
+  stageRotatePublisherKey,
+  stageRotateTapKey,
+} from "../src/profile/templates/publish/lifecycle.js";
+import { initWorkspace } from "../src/profile/templates/publish/init.js";
+import { verifyPublisherDistribution } from "../src/profile/templates/publish/verify.js";
+import { resolveWorkspacePaths, type WorkspacePaths } from "../src/profile/templates/publish/workspace-paths.js";
+import { readWorkspace } from "../src/profile/templates/publish/workspace-store.js";
+import { verifyBuiltDistribution } from "../src/profile/templates/publish/build-verify.js";
+import type { PublisherWorkspace, WorkspacePackage } from "../src/profile/templates/publish/workspace-types.js";
+import { parseSignedTapIndex } from "../src/profile/templates/signing/protocol.js";
+import { publisherTempRoots } from "./fixtures/publisher-workspace.js";
+
+const roots = publisherTempRoots();
+afterEach(roots.cleanup);
+
+const TEMPLATE = {
+  schemaVersion: 1,
+  templateId: "incident-response",
+  version: "1.0.0",
+  displayName: "Incident Response",
+  publisher: "acme",
+  sourceType: "remote",
+  license: "MIT",
+  minLlmwikiVersion: "1.0.0",
+  profile: {
+    schemaVersion: 1,
+    profileId: "incident-response",
+    displayName: "Incident Response",
+    entities: {
+      incidents: {
+        directory: "wiki/incidents",
+        titleField: "title",
+        requiredFields: ["title"],
+        fields: { title: { type: "string" } },
+      },
+    },
+  },
+};
+
+interface Publisher {
+  paths: WorkspacePaths;
+  out: string;
+  keyFile: string;
+  add: () => Promise<string>;
+  build: (force?: boolean) => Promise<{ sequence: number; packageCount: number }>;
+}
+
+/** A ready workspace plus an out-of-workspace output directory. */
+async function publisher(): Promise<Publisher> {
+  const root = await roots.create("pub");
+  const dir = path.join(root, "workspace");
+  const out = path.join(root, "dist");
+  const init = await initWorkspace(dir, { tap: "community", publisher: "acme" });
+  const paths = resolveWorkspacePaths(dir);
+  return {
+    paths,
+    out,
+    keyFile: path.join(paths.keysDir, `tap-${init.tapKey.keyId}.pub`),
+    add: async () => {
+      const file = path.join(root, "incident-response.json");
+      await writeFile(file, JSON.stringify(TEMPLATE), "utf8");
+      const result = await addPackage(paths, file, "1.0.0");
+      return result.payloadDigest;
+    },
+    build: async (force = false) =>
+      buildDistribution(paths, { out, expiresIn: "30d", force }),
+  };
+}
+
+/**
+ * Verify the built tree as a CONSUMER PINNED AT A PREVIOUS BUILD would: it walks the
+ * rotation chain from its pinned keys, using the production verify and continuity
+ * functions. The Slice A snapshot verifier cannot do this — it refuses rotation-bearing
+ * indexes by design, because a latest-snapshot-only directory cannot prove continuity.
+ */
+async function verifyAsPinnedClient(p: Publisher, pinned: PublisherWorkspace) {
+  const indexJson = await readFile(path.join(p.out, "index.json"), "utf8");
+  const digestDir = path.join(p.out, "packages", "sha256");
+  const files = await readdir(digestDir).catch(() => []);
+  const packages = await Promise.all(files.map(async (file) => ({
+    envelopeJson: await readFile(path.join(digestDir, file), "utf8"),
+  }) as WorkspacePackage));
+  return verifyBuiltDistribution(pinned, indexJson, packages, packageJson.version);
+}
+
+/** Verify the built tree exactly as the shipped Slice A verifier does. */
+async function verifySnapshot(p: Publisher): Promise<void> {
+  const ws = await readWorkspace(p.paths);
+  await verifyPublisherDistribution(p.out, "community", ws.tapKey.keyId, p.keyFile);
+}
+
+describe("publisher build", () => {
+  it("builds a verifiable distribution and commits the sequence last", async () => {
+    const p = await publisher();
+    await p.add();
+
+    const result = await p.build();
+
+    expect(result).toMatchObject({ sequence: 1, packageCount: 1 });
+    await verifySnapshot(p);
+    const ws = await readWorkspace(p.paths);
+    expect(ws.sequence).toBe(1);
+    expect(ws.lastBuild).toMatchObject({ sequence: 1 });
+    expect(ws.lastBuild?.indexDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("emits exactly index.json and the content-addressed package", async () => {
+    const p = await publisher();
+    const digest = await p.add();
+    await p.build();
+
+    expect((await readdir(p.out)).sort()).toEqual(["index.json", "packages"]);
+    const hex = digest.replace("sha256:", "");
+    await expect(stat(path.join(p.out, "packages", "sha256", `${hex}.json`))).resolves.toBeDefined();
+  });
+
+  it("never publishes private keys into the output tree", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+
+    const index = await readFile(path.join(p.out, "index.json"), "utf8");
+    const privateKey = (await readFile(
+      path.join(p.paths.keysDir, (await readdir(p.paths.keysDir)).find((f) => f.endsWith(".key"))!),
+      "utf8",
+    )).trim();
+
+    expect(index).not.toContain(privateKey);
+  });
+
+  it("refuses an output directory inside the workspace", async () => {
+    const p = await publisher();
+    await p.add();
+
+    await expect(buildDistribution(p.paths, {
+      out: path.join(p.paths.root, "dist"), expiresIn: "30d",
+    })).rejects.toThrow(/outside the publisher workspace/i);
+  });
+
+  it("refuses a no-change rebuild but allows --force", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+
+    await expect(p.build()).rejects.toThrow(/nothing to build since sequence 1/i);
+    await expect(p.build(true)).resolves.toMatchObject({ sequence: 2 });
+  });
+
+  it("refuses an output path that exists and is not a directory", async () => {
+    const p = await publisher();
+    await p.add();
+    await writeFile(p.out, "precious", "utf8");
+
+    await expect(p.build()).rejects.toThrow(/exists and is not a directory/i);
+
+    // The operator's file survives: publishing must never silently destroy it.
+    expect(await readFile(p.out, "utf8")).toBe("precious");
+  });
+
+  it("leaves the sequence unchanged when publishing fails", async () => {
+    const p = await publisher();
+    await p.add();
+    const parent = path.dirname(p.out);
+    await chmod(parent, 0o500);
+
+    await expect(p.build()).rejects.toThrow();
+
+    await chmod(parent, 0o700);
+    expect((await readWorkspace(p.paths)).sequence).toBe(0);
+    await expect(stat(p.out)).rejects.toThrow();
+  });
+
+  it("refuses an expiry outside its bounds", async () => {
+    const p = await publisher();
+    await p.add();
+
+    await expect(buildDistribution(p.paths, { out: p.out, expiresIn: "9999d" }))
+      .rejects.toThrow(/at most 365d/i);
+  });
+});
+
+describe("publisher add", () => {
+  it("refuses a coordinate that would resolve to different bytes", async () => {
+    const p = await publisher();
+    const root = path.dirname(p.paths.root);
+    await p.add();
+    const mutated = path.join(root, "mutated.json");
+    await writeFile(mutated, JSON.stringify({ ...TEMPLATE, displayName: "Changed" }), "utf8");
+
+    await expect(addPackage(p.paths, mutated, "1.0.0")).rejects.toThrow(/immutable/i);
+  });
+
+  it("is idempotent for identical bytes", async () => {
+    const p = await publisher();
+    await p.add();
+
+    const again = await p.add();
+
+    expect(again).toMatch(/^sha256:/);
+    expect((await readWorkspace(p.paths)).packages).toHaveLength(1);
+  });
+});
+
+describe("publisher lifecycle", () => {
+  it("keeps pre-rotation packages verifiable after a publisher key rotation", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    // The state a client holds having accepted sequence 1 under the ORIGINAL key.
+    const pinnedAtSequence1 = await readWorkspace(p.paths);
+
+    await stageRotatePublisherKey(p.paths, "acme-publisher-2027-01");
+    const result = await p.build();
+
+    expect(result.sequence).toBe(2);
+    const ws = await readWorkspace(p.paths);
+    expect(ws.publisherKey.keyId).toBe("acme-publisher-2027-01");
+
+    // THE DECISIVE ASSERTION. A client pinned at the old key walks the rotation chain and
+    // must still verify the package that was published BEFORE the rotation. Without
+    // re-signing, verifySignedPackage refuses it with wrong-key: the index announces the
+    // successor, but the envelope still carries the retired key id.
+    await expect(verifyAsPinnedClient(p, pinnedAtSequence1)).resolves.toBeDefined();
+  });
+
+  it("retains rotation history in every later index", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    await stageRotatePublisherKey(p.paths, "acme-publisher-2027-01");
+    await p.build();
+    await stageRotatePublisherKey(p.paths, "acme-publisher-2028-01");
+    await p.build();
+
+    const index = parseSignedTapIndex(await readFile(path.join(p.out, "index.json"), "utf8"));
+
+    // A client that skipped sequence 2 must still walk key 1 -> 2 -> 3 from the latest index.
+    expect(index.rotations).toHaveLength(2);
+    expect(index.rotations.map((r) => r.effectiveSequence)).toEqual([2, 3]);
+  });
+
+  it("signs a tap-rotating index with the successor tap key", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+
+    await stageRotateTapKey(p.paths, "community-tap-2027-01");
+    await p.build();
+
+    const index = parseSignedTapIndex(await readFile(path.join(p.out, "index.json"), "utf8"));
+    expect(index.signature.keyId).toBe("community-tap-2027-01");
+    expect(index.tapKeyRotation).toMatchObject({ effectiveSequence: 2 });
+    const ws = await readWorkspace(p.paths);
+    expect(ws.tapKey.keyId).toBe("community-tap-2027-01");
+  });
+
+  it("excludes a revoked package from the built index", async () => {
+    const p = await publisher();
+    const digest = await p.add();
+    await p.build();
+
+    await stageRevokePackage(p.paths, digest, "compromised build");
+    const result = await p.build();
+
+    expect(result.packageCount).toBe(0);
+    const index = parseSignedTapIndex(await readFile(path.join(p.out, "index.json"), "utf8"));
+    expect(index.packages).toHaveLength(0);
+    expect(index.revocations).toHaveLength(1);
+    expect(await readdir(path.join(p.out, "packages", "sha256"))).toHaveLength(0);
+  });
+
+  it("refuses revoking the active publisher key without a paired rotation", async () => {
+    const p = await publisher();
+    const ws = await readWorkspace(p.paths);
+
+    await expect(stageRevokePublisherKey(p.paths, ws.publisherKey.keyId, "leaked"))
+      .rejects.toThrow(/requires rotating to a successor/i);
+  });
+
+  it("refuses a revocation for a digest this workspace never published", async () => {
+    const p = await publisher();
+
+    await expect(stageRevokePackage(p.paths, `sha256:${"b".repeat(64)}`, "nope"))
+      .rejects.toThrow(/no package in this workspace/i);
+  });
+});

--- a/test/template-publish-build.test.ts
+++ b/test/template-publish-build.test.ts
@@ -42,7 +42,7 @@ interface Publisher {
   keyFile: string;
   add: () => Promise<string>;
   addSecond: () => Promise<string>;
-  build: (force?: boolean) => Promise<{ sequence: number; packageCount: number }>;
+  build: (force?: boolean, refresh?: boolean) => Promise<{ sequence: number; packageCount: number }>;
 }
 
 /** A ready workspace plus an out-of-workspace output directory. */
@@ -73,8 +73,8 @@ async function publisher(): Promise<Publisher> {
       const result = await addPackage(paths, file, "1.0.0");
       return result.payloadDigest;
     },
-    build: async (force = false) =>
-      buildDistribution(paths, { out, expiresIn: "30d", force }),
+    build: async (force = false, refresh = false) =>
+      buildDistribution(paths, { out, expiresIn: "30d", force, refresh }),
   };
 }
 
@@ -148,13 +148,18 @@ describe("publisher build", () => {
     })).rejects.toThrow(/outside the publisher workspace/i);
   });
 
-  it("refuses a no-change rebuild but allows --force", async () => {
+  // A no-change rebuild is refused; --force overrides it, and --refresh renews an expiring
+  // index (same content, fresh lifetime) so a routine renewal never needs the blunt --force.
+  it.each([
+    { label: "--force", rebuild: (p: Publisher) => p.build(true) },
+    { label: "--refresh", rebuild: (p: Publisher) => p.build(false, true) },
+  ])("refuses a no-change rebuild but allows $label", async ({ rebuild }) => {
     const p = await publisher();
     await p.add();
     await p.build();
 
     await expect(p.build()).rejects.toThrow(/nothing to build since sequence 1/i);
-    await expect(p.build(true)).resolves.toMatchObject({ sequence: 2 });
+    await expect(rebuild(p)).resolves.toMatchObject({ sequence: 2 });
   });
 
   it("refuses an output path that exists and is not a directory", async () => {

--- a/test/template-publish-build.test.ts
+++ b/test/template-publish-build.test.ts
@@ -28,6 +28,8 @@ import { verifyBuiltDistribution } from "../src/profile/templates/publish/build-
 import type { PublisherWorkspace, WorkspacePackage } from "../src/profile/templates/publish/workspace-types.js";
 import { parseSignedTapIndex } from "../src/profile/templates/signing/protocol.js";
 import { generateEd25519Keypair } from "../src/profile/templates/signing/sign.js";
+import { canonicalDigest } from "../src/profile/templates/signing/canonical.js";
+import { readDistributionOnDisk } from "../src/profile/templates/publish/tree-read.js";
 import { PUBLISHER_TEMPLATE, publisherTempRoots } from "./fixtures/publisher-workspace.js";
 
 const roots = publisherTempRoots();
@@ -266,15 +268,19 @@ describe("publisher adversarial-audit regressions", () => {
   it("never reissues a sequence that was already handed to a published tree", async () => {
     const p = await publisher();
     await p.add();
-    await p.build();
-    // Simulate a crash after publishing but before committing: the sequence is reserved
-    // but not committed. Re-issuing it with different bytes would be a replay for any
-    // client that already fetched the published index.
+    const first = await p.build();
+    // Simulate a crash after publishing but before committing.
     const ws = await readWorkspace(p.paths);
-    await writeWorkspace(p.paths, { ...ws, reservedSequence: 2 });
+    await writeWorkspace(p.paths, {
+      ...ws,
+      reservedBuild: { ...ws.lastBuild!, sequence: 2, indexDigest: `sha256:${"c".repeat(64)}` },
+    });
     await p.addSecond();
 
+    // Re-issuing sequence 2 with different bytes would be a replay for any client that
+    // fetched the published index, so the retry moves past it.
     await expect(p.build()).resolves.toMatchObject({ sequence: 3 });
+    expect(first.sequence).toBe(1);
   });
 });
 
@@ -329,6 +335,58 @@ describe("publisher second-audit regressions", () => {
     await writeWorkspace(p.paths, { ...ws, publisherKey: foreign.publicKey });
 
     await expect(p.add()).rejects.toThrow(/does not match the workspace's announced publisher key/i);
+  });
+});
+
+describe("publisher third-audit regressions", () => {
+  it("refuses to delete a directory that merely holds a COPY of our index", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    // The index is PUBLIC and copyable. Dropping a legitimate index beside somebody's files
+    // must not make their directory look like ours and get it deleted.
+    const victim = path.join(await roots.create("victim"), "site");
+    await mkdir(path.join(victim, "packages"), { recursive: true });
+    await writeFile(path.join(victim, "index.json"), await readFile(path.join(p.out, "index.json"), "utf8"), "utf8");
+    await writeFile(path.join(victim, "packages", "do-not-delete.txt"), "PRECIOUS", "utf8");
+    await p.addSecond();
+
+    await expect(buildDistribution(p.paths, { out: victim, expiresIn: "30d" }))
+      .rejects.toThrow(/not a tree this workspace published/i);
+
+    expect(await readFile(path.join(victim, "packages", "do-not-delete.txt"), "utf8")).toBe("PRECIOUS");
+  });
+
+  it("recovers from a commit that never landed instead of deadlocking", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    // Crash after the swap, before the commit: the workspace still names the OLD index while
+    // the NEW one is live. The retry must recognize the published tree as ours.
+    const ws = await readWorkspace(p.paths);
+    const published = JSON.parse(await readFile(path.join(p.out, "index.json"), "utf8")) as object;
+    await writeWorkspace(p.paths, {
+      ...ws,
+      sequence: 0,
+      lastBuild: undefined as never,
+      reservedBuild: { ...ws.lastBuild!, indexDigest: canonicalDigest(published) },
+    });
+
+    await expect(p.build(true)).resolves.toMatchObject({ sequence: 2 });
+  });
+
+  it("refuses a staged tree carrying a duplicate envelope in place of a package", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.addSecond();
+    await p.build();
+    // A name-and-count check would accept two copies of one valid envelope standing in for
+    // another package. The exact-tree verifier derives filenames from the index's digests.
+    const digestDir = path.join(p.out, "packages", "sha256");
+    const [a, b] = (await readdir(digestDir)).sort();
+    await writeFile(path.join(digestDir, b), await readFile(path.join(digestDir, a), "utf8"), "utf8");
+
+    await expect(readDistributionOnDisk(p.out)).rejects.toThrow();
   });
 });
 

--- a/test/template-publish-build.test.ts
+++ b/test/template-publish-build.test.ts
@@ -375,6 +375,26 @@ describe("publisher third-audit regressions", () => {
     await expect(p.build(true)).resolves.toMatchObject({ sequence: 2 });
   });
 
+  it.each([
+    { label: "publisher rotation", stage: async (p: Publisher) => stageRotatePublisherKey(p.paths, "acme-publisher-2027-01") },
+    { label: "tap rotation", stage: async (p: Publisher) => stageRotateTapKey(p.paths, "community-tap-2027-01") },
+    { label: "package revocation", stage: async (p: Publisher) => {
+      const ws = await readWorkspace(p.paths);
+      await stageRevokePackage(p.paths, ws.coordinates[Object.keys(ws.coordinates)[0]], "superseded");
+    } },
+  ])("refuses a no-change build after a $label", async ({ stage }) => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    await stage(p);
+    await expect(p.build()).resolves.toMatchObject({ sequence: 2 });
+
+    // The recorded content identity must reflect the COMMITTED state (successor keys, new
+    // revocations). If it recorded the pre-build keys, this third build would see a false
+    // change and publish sequence 3.
+    await expect(p.build()).rejects.toThrow(/nothing to build since sequence 2/i);
+  });
+
   it("refuses a staged tree carrying a duplicate envelope in place of a package", async () => {
     const p = await publisher();
     await p.add();

--- a/test/template-publish-build.test.ts
+++ b/test/template-publish-build.test.ts
@@ -27,34 +27,11 @@ import { readWorkspace } from "../src/profile/templates/publish/workspace-store.
 import { verifyBuiltDistribution } from "../src/profile/templates/publish/build-verify.js";
 import type { PublisherWorkspace, WorkspacePackage } from "../src/profile/templates/publish/workspace-types.js";
 import { parseSignedTapIndex } from "../src/profile/templates/signing/protocol.js";
-import { publisherTempRoots } from "./fixtures/publisher-workspace.js";
+import { PUBLISHER_TEMPLATE, publisherTempRoots } from "./fixtures/publisher-workspace.js";
 
 const roots = publisherTempRoots();
 afterEach(roots.cleanup);
 
-const TEMPLATE = {
-  schemaVersion: 1,
-  templateId: "incident-response",
-  version: "1.0.0",
-  displayName: "Incident Response",
-  publisher: "acme",
-  sourceType: "remote",
-  license: "MIT",
-  minLlmwikiVersion: "1.0.0",
-  profile: {
-    schemaVersion: 1,
-    profileId: "incident-response",
-    displayName: "Incident Response",
-    entities: {
-      incidents: {
-        directory: "wiki/incidents",
-        titleField: "title",
-        requiredFields: ["title"],
-        fields: { title: { type: "string" } },
-      },
-    },
-  },
-};
 
 interface Publisher {
   paths: WorkspacePaths;
@@ -77,7 +54,7 @@ async function publisher(): Promise<Publisher> {
     keyFile: path.join(paths.keysDir, `tap-${init.tapKey.keyId}.pub`),
     add: async () => {
       const file = path.join(root, "incident-response.json");
-      await writeFile(file, JSON.stringify(TEMPLATE), "utf8");
+      await writeFile(file, JSON.stringify(PUBLISHER_TEMPLATE), "utf8");
       const result = await addPackage(paths, file, "1.0.0");
       return result.payloadDigest;
     },
@@ -204,7 +181,7 @@ describe("publisher add", () => {
     const root = path.dirname(p.paths.root);
     await p.add();
     const mutated = path.join(root, "mutated.json");
-    await writeFile(mutated, JSON.stringify({ ...TEMPLATE, displayName: "Changed" }), "utf8");
+    await writeFile(mutated, JSON.stringify({ ...PUBLISHER_TEMPLATE, displayName: "Changed" }), "utf8");
 
     await expect(addPackage(p.paths, mutated, "1.0.0")).rejects.toThrow(/immutable/i);
   });

--- a/test/template-publish-build.test.ts
+++ b/test/template-publish-build.test.ts
@@ -9,7 +9,7 @@
  *  - a tap-rotating index must be signed by the SUCCESSOR key.
  */
 import packageJson from "../package.json" with { type: "json" };
-import { chmod, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { addPackage } from "../src/profile/templates/publish/add.js";
@@ -27,6 +27,7 @@ import { readWorkspace, writeWorkspace } from "../src/profile/templates/publish/
 import { verifyBuiltDistribution } from "../src/profile/templates/publish/build-verify.js";
 import type { PublisherWorkspace, WorkspacePackage } from "../src/profile/templates/publish/workspace-types.js";
 import { parseSignedTapIndex } from "../src/profile/templates/signing/protocol.js";
+import { generateEd25519Keypair } from "../src/profile/templates/signing/sign.js";
 import { PUBLISHER_TEMPLATE, publisherTempRoots } from "./fixtures/publisher-workspace.js";
 
 const roots = publisherTempRoots();
@@ -241,7 +242,7 @@ describe("publisher adversarial-audit regressions", () => {
     await mkdir(p.out, { recursive: true });
     await writeFile(path.join(p.out, "index.html"), "<h1>my site</h1>", "utf8");
 
-    await expect(p.build()).rejects.toThrow(/not a previous distribution of this tap/i);
+    await expect(p.build()).rejects.toThrow(/not a tree this workspace published/i);
 
     expect(await readFile(path.join(p.out, "index.html"), "utf8")).toContain("my site");
   });
@@ -274,6 +275,60 @@ describe("publisher adversarial-audit regressions", () => {
     await p.addSecond();
 
     await expect(p.build()).resolves.toMatchObject({ sequence: 3 });
+  });
+});
+
+describe("publisher second-audit regressions", () => {
+  it("refuses an output tree it did not itself publish, even one that looks right", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    // A forged index that merely CLAIMS this tap is just bytes. Only a tree whose index
+    // digests to what we recorded publishing may be replaced — everything else is data we
+    // must not delete.
+    await writeFile(path.join(p.out, "index.json"), JSON.stringify({ forged: true }), "utf8");
+    await p.addSecond();
+
+    await expect(p.build()).rejects.toThrow(/not a tree this workspace published/i);
+
+    expect(await readFile(path.join(p.out, "index.json"), "utf8")).toContain("forged");
+  });
+
+  it("refuses to write a private key through a symlinked keys directory", async () => {
+    const p = await publisher();
+    const outside = await roots.create("key-escape");
+    await rm(p.paths.keysDir, { recursive: true, force: true });
+    await symlink(outside, p.paths.keysDir);
+
+    await expect(stageRotatePublisherKey(p.paths, "acme-publisher-2027-01"))
+      .rejects.toThrow(/escapes|confine|unsafe/i);
+
+    // The point of the guard: no key material may land outside the workspace.
+    expect((await readdir(outside)).filter((f) => f.endsWith(".key") || f.endsWith(".pub"))).toEqual([]);
+  });
+
+  it("never reuses a retired key id", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    const original = (await readWorkspace(p.paths)).publisherKey.keyId;
+    await stageRotatePublisherKey(p.paths, "acme-publisher-2027-01");
+    await p.build();
+
+    // Consumers record every key id they have ever accepted, so re-announcing a retired one
+    // yields a release every existing client rejects.
+    await expect(stageRotatePublisherKey(p.paths, original))
+      .rejects.toThrow(/already been used|never be reused/i);
+  });
+
+  it("refuses to record a package signed by a key the workspace does not announce", async () => {
+    const p = await publisher();
+    const ws = await readWorkspace(p.paths);
+    // The announced public key no longer matches the private key on disk.
+    const foreign = generateEd25519Keypair(ws.publisherKey.keyId);
+    await writeWorkspace(p.paths, { ...ws, publisherKey: foreign.publicKey });
+
+    await expect(p.add()).rejects.toThrow(/does not match the workspace's announced publisher key/i);
   });
 });
 

--- a/test/template-publish-build.test.ts
+++ b/test/template-publish-build.test.ts
@@ -9,7 +9,7 @@
  *  - a tap-rotating index must be signed by the SUCCESSOR key.
  */
 import packageJson from "../package.json" with { type: "json" };
-import { chmod, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { addPackage } from "../src/profile/templates/publish/add.js";
@@ -23,7 +23,7 @@ import {
 import { initWorkspace } from "../src/profile/templates/publish/init.js";
 import { verifyPublisherDistribution } from "../src/profile/templates/publish/verify.js";
 import { resolveWorkspacePaths, type WorkspacePaths } from "../src/profile/templates/publish/workspace-paths.js";
-import { readWorkspace } from "../src/profile/templates/publish/workspace-store.js";
+import { readWorkspace, writeWorkspace } from "../src/profile/templates/publish/workspace-store.js";
 import { verifyBuiltDistribution } from "../src/profile/templates/publish/build-verify.js";
 import type { PublisherWorkspace, WorkspacePackage } from "../src/profile/templates/publish/workspace-types.js";
 import { parseSignedTapIndex } from "../src/profile/templates/signing/protocol.js";
@@ -38,6 +38,7 @@ interface Publisher {
   out: string;
   keyFile: string;
   add: () => Promise<string>;
+  addSecond: () => Promise<string>;
   build: (force?: boolean) => Promise<{ sequence: number; packageCount: number }>;
 }
 
@@ -55,6 +56,17 @@ async function publisher(): Promise<Publisher> {
     add: async () => {
       const file = path.join(root, "incident-response.json");
       await writeFile(file, JSON.stringify(PUBLISHER_TEMPLATE), "utf8");
+      const result = await addPackage(paths, file, "1.0.0");
+      return result.payloadDigest;
+    },
+    addSecond: async () => {
+      const second = {
+        ...PUBLISHER_TEMPLATE,
+        templateId: "postmortem",
+        profile: { ...PUBLISHER_TEMPLATE.profile, profileId: "postmortem" },
+      };
+      const file = path.join(root, "postmortem.json");
+      await writeFile(file, JSON.stringify(second), "utf8");
       const result = await addPackage(paths, file, "1.0.0");
       return result.payloadDigest;
     },
@@ -194,6 +206,74 @@ describe("publisher add", () => {
 
     expect(again).toMatch(/^sha256:/);
     expect((await readWorkspace(p.paths)).packages).toHaveLength(1);
+  });
+});
+
+describe("publisher adversarial-audit regressions", () => {
+  it("builds again after a package is added to a released workspace", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    // `add` records a package without staging an intent, so a `pending`-only dirty check
+    // refused the core workflow: release, add another template, release again.
+    await p.addSecond();
+
+    await expect(p.build()).resolves.toMatchObject({ sequence: 2, packageCount: 2 });
+  });
+
+  it("verifies a snapshot whose index carries RETAINED rotation history", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    await stageRotatePublisherKey(p.paths, "acme-publisher-2027-01");
+    await p.build();
+    // Rotations are retained in every later index forever. Refusing them outright made
+    // `publish verify` permanently unusable for any tap that had ever rotated a key.
+    await p.addSecond();
+    await p.build();
+
+    await expect(verifySnapshot(p)).resolves.toBeUndefined();
+  });
+
+  it("refuses an output directory holding unrelated operator data", async () => {
+    const p = await publisher();
+    await p.add();
+    await mkdir(p.out, { recursive: true });
+    await writeFile(path.join(p.out, "index.html"), "<h1>my site</h1>", "utf8");
+
+    await expect(p.build()).rejects.toThrow(/not a previous distribution of this tap/i);
+
+    expect(await readFile(path.join(p.out, "index.html"), "utf8")).toContain("my site");
+  });
+
+  it("refuses a second staged rotation for the same role", async () => {
+    const p = await publisher();
+    await stageRotatePublisherKey(p.paths, "acme-publisher-2027-01");
+
+    await expect(stageRotatePublisherKey(p.paths, "acme-publisher-2028-01"))
+      .rejects.toThrow(/already staged/i);
+  });
+
+  it("refuses revoking the key a staged rotation would make active", async () => {
+    const p = await publisher();
+    await stageRotatePublisherKey(p.paths, "acme-publisher-2027-01");
+
+    await expect(stageRevokePublisherKey(p.paths, "acme-publisher-2027-01", "oops"))
+      .rejects.toThrow(/would make active/i);
+  });
+
+  it("never reissues a sequence that was already handed to a published tree", async () => {
+    const p = await publisher();
+    await p.add();
+    await p.build();
+    // Simulate a crash after publishing but before committing: the sequence is reserved
+    // but not committed. Re-issuing it with different bytes would be a replay for any
+    // client that already fetched the published index.
+    const ws = await readWorkspace(p.paths);
+    await writeWorkspace(p.paths, { ...ws, reservedSequence: 2 });
+    await p.addSecond();
+
+    await expect(p.build()).resolves.toMatchObject({ sequence: 3 });
   });
 });
 

--- a/test/template-publish-cli-e2e.test.ts
+++ b/test/template-publish-cli-e2e.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @file test/template-publish-cli-e2e.test.ts
+ * @description The publisher workflow through the REAL compiled CLI.
+ *
+ * This layer exists because unit tests call the functions directly and therefore cannot
+ * see option-parsing faults. A `--version` flag on `publish add` was silently eaten by
+ * Commander's global version flag: `add` never ran, and `build` happily published an
+ * EMPTY distribution that still verified. Only a run through the built binary catches it.
+ */
+import { spawnSync } from "node:child_process";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { publisherTempRoots } from "./fixtures/publisher-workspace.js";
+
+const CLI = path.resolve("dist/cli.js");
+const roots = publisherTempRoots();
+afterEach(roots.cleanup);
+
+const TEMPLATE = {
+  schemaVersion: 1,
+  templateId: "incident-response",
+  version: "1.0.0",
+  displayName: "Incident Response",
+  publisher: "acme",
+  sourceType: "remote",
+  license: "MIT",
+  minLlmwikiVersion: "1.0.0",
+  profile: {
+    schemaVersion: 1,
+    profileId: "incident-response",
+    displayName: "Incident Response",
+    entities: {
+      incidents: {
+        directory: "wiki/incidents",
+        titleField: "title",
+        requiredFields: ["title"],
+        fields: { title: { type: "string" } },
+      },
+    },
+  },
+};
+
+function run(args: string[]) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8" });
+}
+
+describe("publisher CLI end to end", () => {
+  it("initializes, adds, builds, and verifies a real distribution", async () => {
+    const root = await roots.create("cli-pub");
+    const workspace = path.join(root, "w");
+    const out = path.join(root, "dist");
+    const packageFile = path.join(root, "package.json");
+    await writeFile(packageFile, JSON.stringify(TEMPLATE), "utf8");
+
+    const init = run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
+    expect(init.status).toBe(0);
+
+    const add = run([
+      "template", "publish", "add", packageFile,
+      "--workspace", workspace, "--package-version", "1.0.0",
+    ]);
+    expect(add.status).toBe(0);
+    expect(add.stdout).toContain("Recorded signed package");
+    expect(add.stdout).toContain("community/acme/incident-response@1.0.0");
+
+    const build = run([
+      "template", "publish", "build",
+      "--workspace", workspace, "--expires-in", "30d", "--out", out,
+    ]);
+    expect(build.status).toBe(0);
+    // The regression that mattered: an eaten --version silently produced ZERO packages
+    // and still built a "valid" empty distribution.
+    expect(build.stdout).toContain("Packages: 1");
+
+    const keys = await readdir(path.join(workspace, "keys"));
+    const tapKeyId = keys.find((f) => f.startsWith("tap-") && f.endsWith(".pub"))!
+      .replace(/^tap-/, "").replace(/\.pub$/, "");
+
+    const verify = run([
+      "template", "publish", "verify", out,
+      "--tap", "community", "--key-id", tapKeyId,
+      "--key-file", path.join(workspace, "keys", `tap-${tapKeyId}.pub`),
+    ]);
+    expect(verify.status).toBe(0);
+    expect(verify.stdout).toContain("Verified template publisher distribution");
+    expect(verify.stdout).toContain("Packages: 1");
+  });
+
+  it("never writes private key bytes into the published tree", async () => {
+    const root = await roots.create("cli-leak");
+    const workspace = path.join(root, "w");
+    const out = path.join(root, "dist");
+    const packageFile = path.join(root, "package.json");
+    await writeFile(packageFile, JSON.stringify(TEMPLATE), "utf8");
+    run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
+    run(["template", "publish", "add", packageFile, "--workspace", workspace, "--package-version", "1.0.0"]);
+    run(["template", "publish", "build", "--workspace", workspace, "--expires-in", "30d", "--out", out]);
+
+    const keysDir = path.join(workspace, "keys");
+    const privateKeys = await Promise.all(
+      (await readdir(keysDir)).filter((f) => f.endsWith(".key"))
+        .map(async (f) => (await readFile(path.join(keysDir, f), "utf8")).trim()),
+    );
+    const digestDir = path.join(out, "packages", "sha256");
+    const published = await Promise.all([
+      readFile(path.join(out, "index.json"), "utf8"),
+      ...(await readdir(digestDir)).map((f) => readFile(path.join(digestDir, f), "utf8")),
+    ]);
+
+    expect(privateKeys.length).toBeGreaterThan(0);
+    for (const key of privateKeys) {
+      for (const blob of published) expect(blob).not.toContain(key);
+    }
+  });
+
+  it("refuses an output directory inside the workspace", async () => {
+    const root = await roots.create("cli-inside");
+    const workspace = path.join(root, "w");
+    run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
+
+    const build = run([
+      "template", "publish", "build",
+      "--workspace", workspace, "--expires-in", "30d",
+      "--out", path.join(workspace, "dist"),
+    ]);
+
+    expect(build.status).not.toBe(0);
+    expect(`${build.stdout}${build.stderr}`).toMatch(/outside the publisher workspace/i);
+  });
+});

--- a/test/template-publish-cli-e2e.test.ts
+++ b/test/template-publish-cli-e2e.test.ts
@@ -2,10 +2,14 @@
  * @file test/template-publish-cli-e2e.test.ts
  * @description The publisher workflow through the REAL compiled CLI.
  *
- * This layer exists because unit tests call the functions directly and therefore cannot
- * see option-parsing faults. A `--version` flag on `publish add` was silently eaten by
- * Commander's global version flag: `add` never ran, and `build` happily published an
- * EMPTY distribution that still verified. Only a run through the built binary catches it.
+ * This layer exists because unit tests call the functions directly and therefore cannot see
+ * option-parsing faults. A `--version` flag on `publish add` was silently eaten by
+ * Commander's global version flag: `add` never ran, and `build` happily published an EMPTY
+ * distribution that still verified. Only a run through the built binary catches that.
+ *
+ * Every assertion rides ONE workflow run. Each CLI spawn is a full node start, and this
+ * suite runs beside long subprocess e2e suites that sit near the 30s timeout — so the
+ * coverage is kept and the process count is not.
  */
 import { spawnSync } from "node:child_process";
 import { readFile, readdir, writeFile } from "node:fs/promises";
@@ -17,67 +21,55 @@ const CLI = path.resolve("dist/cli.js");
 const roots = publisherTempRoots();
 afterEach(roots.cleanup);
 
-
 function run(args: string[]) {
   return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8" });
 }
 
-interface Published {
-  workspace: string;
-  out: string;
-  add: ReturnType<typeof run>;
-  build: ReturnType<typeof run>;
-}
-
-/** Init a workspace, record one package, and build it — the whole happy path. */
-async function publishOnce(root: string): Promise<Published> {
-  const workspace = path.join(root, "w");
-  const out = path.join(root, "dist");
-  const packageFile = path.join(root, "package.json");
-  await writeFile(packageFile, JSON.stringify(PUBLISHER_TEMPLATE), "utf8");
-  run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
-  const add = run(["template", "publish", "add", packageFile, "--workspace", workspace, "--package-version", "1.0.0"]);
-  const build = run(["template", "publish", "build", "--workspace", workspace, "--expires-in", "30d", "--out", out]);
-  return { workspace, out, add, build };
-}
-
-/** The tap key id init generated, read back from the keystore. */
-async function tapKeyIdOf(workspace: string): Promise<string> {
-  const keys = await readdir(path.join(workspace, "keys"));
-  return keys.find((f) => f.startsWith("tap-") && f.endsWith(".pub"))!
-    .replace(/^tap-/, "").replace(/\.pub$/, "");
-}
-
 describe("publisher CLI end to end", () => {
-  it("initializes, adds, builds, and verifies a real distribution", async () => {
-    const { workspace, out, add, build } = await publishOnce(await roots.create("cli-pub"));
+  it("initializes, adds, builds, verifies, and never publishes a private key", async () => {
+    const root = await roots.create("cli-pub");
+    const workspace = path.join(root, "w");
+    const out = path.join(root, "dist");
+    const packageFile = path.join(root, "package.json");
+    await writeFile(packageFile, JSON.stringify(PUBLISHER_TEMPLATE), "utf8");
 
+    const init = run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
+    expect(init.status).toBe(0);
+
+    const add = run([
+      "template", "publish", "add", packageFile,
+      "--workspace", workspace, "--package-version", "1.0.0",
+    ]);
     expect(add.status).toBe(0);
     expect(add.stdout).toContain("Recorded signed package");
     expect(add.stdout).toContain("community/acme/incident-response@1.0.0");
 
+    const build = run([
+      "template", "publish", "build",
+      "--workspace", workspace, "--expires-in", "30d", "--out", out,
+    ]);
     expect(build.status).toBe(0);
-    // The regression that mattered: an eaten --version silently produced ZERO packages
-    // and still built a "valid" empty distribution.
+    // The regression that mattered: an eaten --version silently produced ZERO packages and
+    // still built a "valid" empty distribution.
     expect(build.stdout).toContain("Packages: 1");
 
-    const tapKeyId = await tapKeyIdOf(workspace);
+    const keysDir = path.join(workspace, "keys");
+    const keys = await readdir(keysDir);
+    const tapKeyId = keys.find((f) => f.startsWith("tap-") && f.endsWith(".pub"))!
+      .replace(/^tap-/, "").replace(/\.pub$/, "");
+
     const verify = run([
       "template", "publish", "verify", out,
       "--tap", "community", "--key-id", tapKeyId,
-      "--key-file", path.join(workspace, "keys", `tap-${tapKeyId}.pub`),
+      "--key-file", path.join(keysDir, `tap-${tapKeyId}.pub`),
     ]);
     expect(verify.status).toBe(0);
     expect(verify.stdout).toContain("Verified template publisher distribution");
     expect(verify.stdout).toContain("Packages: 1");
-  });
 
-  it("never writes private key bytes into the published tree", async () => {
-    const { workspace, out } = await publishOnce(await roots.create("cli-leak"));
-
-    const keysDir = path.join(workspace, "keys");
+    // No private key byte may reach the published tree.
     const privateKeys = await Promise.all(
-      (await readdir(keysDir)).filter((f) => f.endsWith(".key"))
+      keys.filter((f) => f.endsWith(".key"))
         .map(async (f) => (await readFile(path.join(keysDir, f), "utf8")).trim()),
     );
     const digestDir = path.join(out, "packages", "sha256");
@@ -85,25 +77,18 @@ describe("publisher CLI end to end", () => {
       readFile(path.join(out, "index.json"), "utf8"),
       ...(await readdir(digestDir)).map((f) => readFile(path.join(digestDir, f), "utf8")),
     ]);
-
     expect(privateKeys.length).toBeGreaterThan(0);
     for (const key of privateKeys) {
       for (const blob of published) expect(blob).not.toContain(key);
     }
-  });
 
-  it("refuses an output directory inside the workspace", async () => {
-    const root = await roots.create("cli-inside");
-    const workspace = path.join(root, "w");
-    run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
-
-    const build = run([
+    // And the output may never live inside the workspace, which would publish those keys.
+    const inside = run([
       "template", "publish", "build",
       "--workspace", workspace, "--expires-in", "30d",
       "--out", path.join(workspace, "dist"),
     ]);
-
-    expect(build.status).not.toBe(0);
-    expect(`${build.stdout}${build.stderr}`).toMatch(/outside the publisher workspace/i);
+    expect(inside.status).not.toBe(0);
+    expect(`${inside.stdout}${inside.stderr}`).toMatch(/outside the publisher workspace/i);
   });
 });

--- a/test/template-publish-cli-e2e.test.ts
+++ b/test/template-publish-cli-e2e.test.ts
@@ -67,6 +67,22 @@ describe("publisher CLI end to end", () => {
     expect(verify.stdout).toContain("Verified template publisher distribution");
     expect(verify.stdout).toContain("Packages: 1");
 
+    // A no-change rebuild is refused; --refresh renews the same content under a fresh
+    // lifetime without the blunt --force override (a boolean flag Commander could mis-parse).
+    const stale = run([
+      "template", "publish", "build",
+      "--workspace", workspace, "--expires-in", "30d", "--out", out,
+    ]);
+    expect(stale.status).not.toBe(0);
+    expect(`${stale.stdout}${stale.stderr}`).toMatch(/pass --refresh to renew an expiring index/i);
+
+    const refresh = run([
+      "template", "publish", "build",
+      "--workspace", workspace, "--expires-in", "30d", "--out", out, "--refresh",
+    ]);
+    expect(refresh.status).toBe(0);
+    expect(refresh.stdout).toContain("Sequence: 2");
+
     // No private key byte may reach the published tree.
     const privateKeys = await Promise.all(
       keys.filter((f) => f.endsWith(".key"))

--- a/test/template-publish-cli-e2e.test.ts
+++ b/test/template-publish-cli-e2e.test.ts
@@ -11,72 +11,57 @@ import { spawnSync } from "node:child_process";
 import { readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { publisherTempRoots } from "./fixtures/publisher-workspace.js";
+import { PUBLISHER_TEMPLATE, publisherTempRoots } from "./fixtures/publisher-workspace.js";
 
 const CLI = path.resolve("dist/cli.js");
 const roots = publisherTempRoots();
 afterEach(roots.cleanup);
 
-const TEMPLATE = {
-  schemaVersion: 1,
-  templateId: "incident-response",
-  version: "1.0.0",
-  displayName: "Incident Response",
-  publisher: "acme",
-  sourceType: "remote",
-  license: "MIT",
-  minLlmwikiVersion: "1.0.0",
-  profile: {
-    schemaVersion: 1,
-    profileId: "incident-response",
-    displayName: "Incident Response",
-    entities: {
-      incidents: {
-        directory: "wiki/incidents",
-        titleField: "title",
-        requiredFields: ["title"],
-        fields: { title: { type: "string" } },
-      },
-    },
-  },
-};
 
 function run(args: string[]) {
   return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8" });
 }
 
+interface Published {
+  workspace: string;
+  out: string;
+  add: ReturnType<typeof run>;
+  build: ReturnType<typeof run>;
+}
+
+/** Init a workspace, record one package, and build it — the whole happy path. */
+async function publishOnce(root: string): Promise<Published> {
+  const workspace = path.join(root, "w");
+  const out = path.join(root, "dist");
+  const packageFile = path.join(root, "package.json");
+  await writeFile(packageFile, JSON.stringify(PUBLISHER_TEMPLATE), "utf8");
+  run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
+  const add = run(["template", "publish", "add", packageFile, "--workspace", workspace, "--package-version", "1.0.0"]);
+  const build = run(["template", "publish", "build", "--workspace", workspace, "--expires-in", "30d", "--out", out]);
+  return { workspace, out, add, build };
+}
+
+/** The tap key id init generated, read back from the keystore. */
+async function tapKeyIdOf(workspace: string): Promise<string> {
+  const keys = await readdir(path.join(workspace, "keys"));
+  return keys.find((f) => f.startsWith("tap-") && f.endsWith(".pub"))!
+    .replace(/^tap-/, "").replace(/\.pub$/, "");
+}
+
 describe("publisher CLI end to end", () => {
   it("initializes, adds, builds, and verifies a real distribution", async () => {
-    const root = await roots.create("cli-pub");
-    const workspace = path.join(root, "w");
-    const out = path.join(root, "dist");
-    const packageFile = path.join(root, "package.json");
-    await writeFile(packageFile, JSON.stringify(TEMPLATE), "utf8");
+    const { workspace, out, add, build } = await publishOnce(await roots.create("cli-pub"));
 
-    const init = run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
-    expect(init.status).toBe(0);
-
-    const add = run([
-      "template", "publish", "add", packageFile,
-      "--workspace", workspace, "--package-version", "1.0.0",
-    ]);
     expect(add.status).toBe(0);
     expect(add.stdout).toContain("Recorded signed package");
     expect(add.stdout).toContain("community/acme/incident-response@1.0.0");
 
-    const build = run([
-      "template", "publish", "build",
-      "--workspace", workspace, "--expires-in", "30d", "--out", out,
-    ]);
     expect(build.status).toBe(0);
     // The regression that mattered: an eaten --version silently produced ZERO packages
     // and still built a "valid" empty distribution.
     expect(build.stdout).toContain("Packages: 1");
 
-    const keys = await readdir(path.join(workspace, "keys"));
-    const tapKeyId = keys.find((f) => f.startsWith("tap-") && f.endsWith(".pub"))!
-      .replace(/^tap-/, "").replace(/\.pub$/, "");
-
+    const tapKeyId = await tapKeyIdOf(workspace);
     const verify = run([
       "template", "publish", "verify", out,
       "--tap", "community", "--key-id", tapKeyId,
@@ -88,14 +73,7 @@ describe("publisher CLI end to end", () => {
   });
 
   it("never writes private key bytes into the published tree", async () => {
-    const root = await roots.create("cli-leak");
-    const workspace = path.join(root, "w");
-    const out = path.join(root, "dist");
-    const packageFile = path.join(root, "package.json");
-    await writeFile(packageFile, JSON.stringify(TEMPLATE), "utf8");
-    run(["template", "publish", "init", workspace, "--tap", "community", "--publisher", "acme"]);
-    run(["template", "publish", "add", packageFile, "--workspace", workspace, "--package-version", "1.0.0"]);
-    run(["template", "publish", "build", "--workspace", workspace, "--expires-in", "30d", "--out", out]);
+    const { workspace, out } = await publishOnce(await roots.create("cli-leak"));
 
     const keysDir = path.join(workspace, "keys");
     const privateKeys = await Promise.all(

--- a/test/template-publish-init.test.ts
+++ b/test/template-publish-init.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @file test/template-publish-init.test.ts
+ * @description Workspace initialization is exclusive and atomic: keys are created
+ * first and the manifest LAST, so an interrupted init never reports itself ready.
+ */
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { initWorkspace } from "../src/profile/templates/publish/init.js";
+import { resolveWorkspacePaths } from "../src/profile/templates/publish/workspace-paths.js";
+import { readWorkspace } from "../src/profile/templates/publish/workspace-store.js";
+import { publisherTempRoots } from "./fixtures/publisher-workspace.js";
+
+const roots = publisherTempRoots();
+afterEach(roots.cleanup);
+
+async function target(): Promise<string> {
+  return path.join(await roots.create("init"), "my-tap");
+}
+
+describe("publish init", () => {
+  it("creates keys and a ready workspace at sequence 0", async () => {
+    const dir = await target();
+
+    const result = await initWorkspace(dir, { tap: "community", publisher: "acme" });
+
+    const ws = await readWorkspace(resolveWorkspacePaths(dir));
+    expect(ws).toMatchObject({ tap: "community", publisher: "acme", sequence: 0, packages: [], pending: [] });
+    expect(ws.tapKey.keyId).toBe(result.tapKey.keyId);
+    expect(ws.publisherKey.keyId).toBe(result.publisherKey.keyId);
+    expect(result.fingerprints.tap).toMatch(/^[0-9a-f]{64}$/);
+    expect(await readdir(path.join(dir, "keys"))).toContain(`tap-${result.tapKey.keyId}.key`);
+  });
+
+  it("derives deterministic default key ids", async () => {
+    const dir = await target();
+
+    const result = await initWorkspace(dir, {
+      tap: "community", publisher: "acme", now: new Date("2026-07-14T00:00:00Z"),
+    });
+
+    expect(result.tapKey.keyId).toBe("community-tap-2026-07");
+    expect(result.publisherKey.keyId).toBe("acme-publisher-2026-07");
+  });
+
+  it("refuses a non-empty directory", async () => {
+    const dir = await target();
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, "stray.txt"), "x", "utf8");
+
+    await expect(initWorkspace(dir, { tap: "community", publisher: "acme" }))
+      .rejects.toThrow(/not empty/i);
+  });
+
+  it("refuses to reinitialize an existing workspace", async () => {
+    const dir = await target();
+    await initWorkspace(dir, { tap: "community", publisher: "acme" });
+
+    await expect(initWorkspace(dir, { tap: "community", publisher: "acme" }))
+      .rejects.toThrow(/not empty/i);
+  });
+
+  it("never writes private key bytes into the manifest", async () => {
+    const dir = await target();
+    const result = await initWorkspace(dir, { tap: "community", publisher: "acme" });
+
+    const manifest = await readFile(path.join(dir, "workspace.json"), "utf8");
+    const priv = (await readFile(path.join(dir, "keys", `tap-${result.tapKey.keyId}.key`), "utf8")).trim();
+
+    expect(priv.length).toBeGreaterThan(0);
+    expect(manifest).not.toContain(priv);
+  });
+
+  it("refuses a non-slug tap or publisher", async () => {
+    const dir = await target();
+
+    await expect(initWorkspace(dir, { tap: "../evil", publisher: "acme" })).rejects.toThrow(/slug-safe/i);
+  });
+});

--- a/test/template-publish-sign.test.ts
+++ b/test/template-publish-sign.test.ts
@@ -27,13 +27,19 @@ function unsignedIndex(publicKey: string): Omit<SignedTapIndex, "signature"> {
   };
 }
 
+/** Build one signed index and return it with the key that signed it. */
+function signedIndex(): { tap: ReturnType<typeof generateEd25519Keypair>; index: SignedTapIndex } {
+  const tap = generateEd25519Keypair("community-tap-1");
+  const unsigned = unsignedIndex(tap.publicKey.publicKey);
+  const signature = signClaim(tapIndexClaim(unsigned), tap.privateKey);
+  return { tap, index: { ...unsigned, signature } };
+}
+
 describe("publisher signing primitives", () => {
   it("produces an index signature the production verifier accepts", () => {
-    const tap = generateEd25519Keypair("community-tap-1");
-    const unsigned = unsignedIndex(tap.publicKey.publicKey);
-    const signature = signClaim(tapIndexClaim(unsigned), tap.privateKey);
+    const { tap, index } = signedIndex();
 
-    const parsed = parseSignedTapIndex(JSON.stringify({ ...unsigned, signature }));
+    const parsed = parseSignedTapIndex(JSON.stringify(index));
 
     expect(() => verifyTapIndex(parsed, "community", tap.publicKey)).not.toThrow();
   });
@@ -50,11 +56,9 @@ describe("publisher signing primitives", () => {
   });
 
   it("refuses a signature made over a mutated claim", () => {
-    const tap = generateEd25519Keypair("community-tap-1");
-    const unsigned = unsignedIndex(tap.publicKey.publicKey);
-    const signature = signClaim(tapIndexClaim(unsigned), tap.privateKey);
+    const { tap, index } = signedIndex();
 
-    const parsed = parseSignedTapIndex(JSON.stringify({ ...unsigned, sequence: 2, signature }));
+    const parsed = parseSignedTapIndex(JSON.stringify({ ...index, sequence: 2 }));
 
     expect(() => verifyTapIndex(parsed, "community", tap.publicKey))
       .toThrow(/signature verification failed/i);

--- a/test/template-publish-sign.test.ts
+++ b/test/template-publish-sign.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @file test/template-publish-sign.test.ts
+ * @description Producer signing primitives must verify under the PRODUCTION verifier.
+ * The index claim is the load-bearing case: `verifyTapIndex` previously derived the
+ * signed bytes inline, so a builder that re-derived that shape would be a second
+ * implementation of the signed bytes — the divergence that yields signed-but-
+ * unverifiable releases. These tests pin producer and consumer to one definition.
+ */
+import { describe, expect, it } from "vitest";
+import { canonicalBytes, packageClaim, tapIndexClaim } from "../src/profile/templates/signing/canonical.js";
+import { generateEd25519Keypair, signClaim } from "../src/profile/templates/signing/sign.js";
+import { parseSignedTapIndex } from "../src/profile/templates/signing/protocol.js";
+import { verifyTapIndex } from "../src/profile/templates/signing/verify.js";
+import type { SignedTapIndex } from "../src/profile/templates/signing/types.js";
+
+function unsignedIndex(publicKey: string): Omit<SignedTapIndex, "signature"> {
+  return {
+    schemaVersion: 1,
+    tap: "community",
+    sequence: 1,
+    generatedAt: "2026-07-14T00:00:00.000Z",
+    expiresAt: "2126-07-14T00:00:00.000Z",
+    publishers: { acme: { keyId: "acme-1", publicKey } },
+    packages: [],
+    rotations: [],
+    revocations: [],
+  };
+}
+
+describe("publisher signing primitives", () => {
+  it("produces an index signature the production verifier accepts", () => {
+    const tap = generateEd25519Keypair("community-tap-1");
+    const unsigned = unsignedIndex(tap.publicKey.publicKey);
+    const signature = signClaim(tapIndexClaim(unsigned), tap.privateKey);
+
+    const parsed = parseSignedTapIndex(JSON.stringify({ ...unsigned, signature }));
+
+    expect(() => verifyTapIndex(parsed, "community", tap.publicKey)).not.toThrow();
+  });
+
+  it("signs the canonical claim bytes, not the object", () => {
+    const key = generateEd25519Keypair("acme-1");
+    const claim = packageClaim("community/acme/x@1.0.0", `sha256:${"a".repeat(64)}`);
+    const signature = signClaim(claim, key.privateKey);
+
+    expect(signature).toMatchObject({ keyId: "acme-1", algorithm: "ed25519" });
+    expect(Buffer.from(signature.value, "base64")).toHaveLength(64);
+    expect(canonicalBytes(claim).toString("utf8"))
+      .toBe(`{"coordinate":"community/acme/x@1.0.0","payloadDigest":"sha256:${"a".repeat(64)}"}`);
+  });
+
+  it("refuses a signature made over a mutated claim", () => {
+    const tap = generateEd25519Keypair("community-tap-1");
+    const unsigned = unsignedIndex(tap.publicKey.publicKey);
+    const signature = signClaim(tapIndexClaim(unsigned), tap.privateKey);
+
+    const parsed = parseSignedTapIndex(JSON.stringify({ ...unsigned, sequence: 2, signature }));
+
+    expect(() => verifyTapIndex(parsed, "community", tap.publicKey))
+      .toThrow(/signature verification failed/i);
+  });
+
+  it("refuses a private key that is not Ed25519", () => {
+    expect(() => signClaim({ a: 1 }, { keyId: "x", privateKey: "bm90LWEta2V5" }))
+      .toThrow();
+  });
+});

--- a/test/template-publish-workspace.test.ts
+++ b/test/template-publish-workspace.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @file test/template-publish-workspace.test.ts
+ * @description The workspace parser is bounded and fail-closed, the store is confined
+ * and atomic, and private keys are exclusively created, 0600, and never followed.
+ */
+import { readFile, stat, symlink } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createKeypairFile, publicKeyFingerprint, readPrivateKey } from "../src/profile/templates/publish/keystore.js";
+import { parsePublisherWorkspace } from "../src/profile/templates/publish/workspace-parse.js";
+import type { WorkspacePaths } from "../src/profile/templates/publish/workspace-paths.js";
+import { readWorkspace, writeWorkspace } from "../src/profile/templates/publish/workspace-store.js";
+import type { PublisherWorkspace } from "../src/profile/templates/publish/workspace-types.js";
+import { makeWorkspacePaths, outsideFile, publisherTempRoots } from "./fixtures/publisher-workspace.js";
+
+const roots = publisherTempRoots();
+afterEach(roots.cleanup);
+
+async function workspacePaths(): Promise<WorkspacePaths> {
+  return makeWorkspacePaths(await roots.create("ws"));
+}
+
+/** Plant a symlink inside the workspace that points at a file outside it. */
+async function plantEscape(link: string, name: string, content: string): Promise<void> {
+  const target = await outsideFile(await roots.create("evil"), name, content);
+  await symlink(target, link);
+}
+
+function workspace(): PublisherWorkspace {
+  return {
+    schemaVersion: 1, tap: "community", publisher: "acme",
+    tapKey: { keyId: "tap-1", publicKey: "AAAA" },
+    publisherKey: { keyId: "pub-1", publicKey: "BBBB" },
+    sequence: 0, packages: [], rotations: [], tapKeyRotations: [], revocations: [],
+    pending: [], coordinates: {},
+  };
+}
+
+describe("publisher workspace store", () => {
+  it("round-trips through an atomic confined write", async () => {
+    const paths = await workspacePaths();
+    await writeWorkspace(paths, workspace());
+
+    await expect(readWorkspace(paths)).resolves.toMatchObject({ tap: "community", sequence: 0 });
+  });
+
+  it("rejects duplicate JSON keys", () => {
+    expect(() => parsePublisherWorkspace('{"schemaVersion":1,"tap":"a","tap":"b"}'))
+      .toThrow(/duplicate JSON key/i);
+  });
+
+  it("rejects an unknown field", () => {
+    expect(() => parsePublisherWorkspace(JSON.stringify({ ...workspace(), attacker: true })))
+      .toThrow(/unexpected field/i);
+  });
+
+  it("rejects a non-slug tap identity", () => {
+    expect(() => parsePublisherWorkspace(JSON.stringify({ ...workspace(), tap: "../escape" })))
+      .toThrow(/slug-safe/i);
+  });
+
+  it("fails closed on a symlinked manifest", async () => {
+    const paths = await workspacePaths();
+    await plantEscape(paths.manifestFile, "evil.json", JSON.stringify(workspace()));
+
+    await expect(readWorkspace(paths)).rejects.toThrow(/symlinked|unreadable/i);
+  });
+});
+
+describe("publisher keystore", () => {
+  it("creates a 0600 private key that round-trips and fingerprints", async () => {
+    const paths = await workspacePaths();
+
+    const pub = await createKeypairFile(paths, "tap-1", "tap");
+    const priv = await readPrivateKey(paths, "tap", "tap-1");
+
+    expect(pub.keyId).toBe("tap-1");
+    expect(priv.keyId).toBe("tap-1");
+    expect(publicKeyFingerprint(pub)).toMatch(/^[0-9a-f]{64}$/);
+    const mode = (await stat(path.join(paths.keysDir, "tap-tap-1.key"))).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("never overwrites an existing private key", async () => {
+    const paths = await workspacePaths();
+    await createKeypairFile(paths, "tap-1", "tap");
+
+    await expect(createKeypairFile(paths, "tap-1", "tap")).rejects.toThrow(/never overwritten/i);
+  });
+
+  it("refuses to read a symlinked private key", async () => {
+    const paths = await workspacePaths();
+    await plantEscape(path.join(paths.keysDir, "tap-evil.key"), "evil.key", "AAAA");
+
+    await expect(readPrivateKey(paths, "tap", "evil")).rejects.toThrow(/symlinked|unreadable/i);
+  });
+
+  it("refuses a non-slug key id", async () => {
+    const paths = await workspacePaths();
+
+    await expect(createKeypairFile(paths, "../escape", "tap")).rejects.toThrow(/slug-safe/i);
+  });
+
+  it("keeps private bytes out of the public key file", async () => {
+    const paths = await workspacePaths();
+    await createKeypairFile(paths, "tap-1", "tap");
+
+    const priv = (await readFile(path.join(paths.keysDir, "tap-tap-1.key"), "utf8")).trim();
+    const pub = (await readFile(path.join(paths.keysDir, "tap-tap-1.pub"), "utf8")).trim();
+
+    expect(pub).not.toContain(priv);
+  });
+});


### PR DESCRIPTION
## Summary

Publishers could verify a distribution (#157) but still had to hand-roll canonicalization, Ed25519 signing, digest layout, and index construction from the guide's Node snippets. This adds the authoring workflow: `template publish init | add | build | rotate | revoke`, implementing Slices B, C, and D of the publisher spec.

```bash
llmwiki template publish init ./my-tap --tap community --publisher acme
llmwiki template publish add ./incident-response.json --workspace ./my-tap --package-version 1.0.0
llmwiki template publish build --workspace ./my-tap --expires-in 30d --out ./dist
```

Everything runs offline. No publisher command reaches the network.

## What makes it correct

The publisher is a thin authoring layer over the **shipped consumer modules** — the same parsers, validator, canonicalizer, Ed25519 verification, and continuity rules a client runs. Two net-new primitives: an Ed25519 signing function, and a shared **index-claim constructor**. That second one matters: `verifyTapIndex` derived the signed index bytes *inline*, so a builder would have re-derived them — a second implementation of the signed bytes, which is exactly how a signed index becomes unverifiable. The verifier now consumes the same constructor, and the existing signed fixtures still verify, proving byte parity.

`build` resolves → stages → **verifies** → publishes → commits the sequence **last**. Nothing is published that did not first verify as a consumer would verify it, and a crash leaves the workspace at its old sequence.

The snapshot verifier a consumer runs against a static directory refuses rotation-bearing indexes by design — a latest-snapshot-only directory cannot prove continuity. The workspace can, so `build` verifies as a consumer who has already pinned the previous keys, through the production continuity functions.

Three rules were derived from the consumer, not invented:
- **Retained history** — every historical rotation is re-emitted, so a client that skipped snapshots can still walk from its pinned key.
- **A tap-rotating index is signed by the successor key** — `acceptedTapKey` resolves the trusted key to `rotation.toKey` *before* checking the signature.
- **Key continuity is not artifact continuity** — `verifySignedPackage` resolves the publisher key by id from the current index, so every package signed by a retired key stops verifying the moment its successor is announced. A publisher rotation therefore **re-signs every package**; payloads and content-addressed filenames never change.

## Security

- Private keys: exclusive create (never overwritten), `0600`, no-follow bounded reads, never printed, never in the manifest.
- `--out` must live outside the workspace (realpath-checked), or the build would publish signing keys. It must also be absent, empty, or a prior distribution of this tap — publishing replaces the directory.
- Workspace state gets the tap-state discipline: duplicate-key rejection, byte and item caps, exact-key rejection, coordinate keys validated by the production parser.

## Verification

- `npx tsc --noEmit`, `npm run build`
- `npm test` — 4,296 passed, 3 skipped, 0 failed
- `npx fallow` (0 above threshold), `npm run fallow:ci`, `npx fallow dupes --mode mild --changed-since origin/main` (clean)
- `npm run release:check-docs`, `mint broken-links`
- CLI end-to-end suite drives the compiled binary

