### PR TITLE
feat(cli): add status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The [`examples/basic/`](examples/basic/) directory includes a small pre-generate
 | `llmwiki query "question" [--save]` | Ask questions against the compiled wiki, optionally saving the answer. |
 | `llmwiki context "<prompt>" --json` | Build a citation-aware evidence pack for agents. |
 | `llmwiki view [--open]` | Start the read-only local browser viewer. |
+| `llmwiki status [--json]` | Report page/source counts, stale and orphaned pages, pending work, and state health. |
 | `llmwiki lint` | Validate wiki structure, citations, links, metadata, and freshness. |
 | `llmwiki eval [--suite fast\|full]` | Measure wiki quality and optional citation support. |
 | `llmwiki export --target <format>` | Export the wiki to portable formats, including Open Knowledge Format (`okf`). |

--- a/docs/cli/status.mdx
+++ b/docs/cli/status.mdx
@@ -65,7 +65,7 @@ llmwiki status --json
 }
 ```
 
-`stateStatus` is `ok`, `missing` (no compile has run), or `corrupt` (unreadable `state.json` - run `llmwiki compile` to rebuild it). `stalePages` and `pendingChanges` are capped at 100 entries; `staleCount` and `pendingChangesCount` always carry the true totals. Projects with an active non-default profile additionally include a `profile` block with per-entity-type counts and any validation problems.
+`stateStatus` is `ok`, `missing` (no compile has run), `corrupt` (unreadable `state.json` - run `llmwiki compile` to rebuild it), or `too-new` (written by a newer llmwiki version - upgrade llmwiki rather than recompiling). The `stalePages`, `orphanedPages`, and `pendingChanges` lists are each capped at 100 entries; `staleCount`, `orphanedCount`, and `pendingChangesCount` always carry the true totals. Projects with an active non-default profile additionally include a `profile` block with per-entity-type counts and any validation problems.
 
 <Note>
   For deeper diagnostics than a status summary - broken wikilinks, citation problems, confidence and provenance rules - run [`llmwiki lint`](/cli/lint-eval). To repair the stale pages that status reports, run `llmwiki refresh --stale` (preview with `--dry-run`).

--- a/docs/cli/status.mdx
+++ b/docs/cli/status.mdx
@@ -1,0 +1,72 @@
+---
+title: "llmwiki status - Inspect Project Health at a Glance"
+sidebarTitle: "Status"
+description: "llmwiki status reports page and source counts, stale and orphaned pages, pending changes, the review queue, and state-file health. Add --json for scripts."
+---
+
+`llmwiki status` prints a read-only snapshot of your project: how many pages and sources it has, when it last compiled, which pages are stale or orphaned, what is waiting to be compiled or reviewed, and whether `.llmwiki/state.json` is healthy. It is the same snapshot the MCP `wiki_status` tool and the SDK `status()` method return, surfaced on the command line.
+
+No LLM calls are made and no provider credentials are required - everything is derived from disk. Freshness is computed on demand by re-hashing sources against the recorded compile state, so the command's runtime grows with the size of `sources/`.
+
+## Basic usage
+
+```bash
+llmwiki status
+```
+
+Example output for a healthy project:
+
+```
+llmwiki status
+──────────────────
+i Pages: 12 concept(s), 3 quer(y/ies) — 15 total
+i Sources: 9
+i Last compiled: 2026-07-14T09:12:44.000Z
+✓ Fresh: no stale or orphaned pages
+✓ State: ok
+```
+
+When there is work to do, status says what and points at the next command:
+
+```
+! Stale: 3 page(s): transformer, self-attention, positional-encoding — run `llmwiki refresh --stale`
+~ Pending changes: 2 source(s) awaiting compile — run `llmwiki compile`
+? Pending review: 4 candidate(s) — run `llmwiki review list`
+! State: missing — no compile has run yet — run `llmwiki compile`
+```
+
+The command always exits `0` on a successful inspection; problems are reported in the output, not the exit code.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit the full status snapshot as JSON on stdout instead of the human summary. The shape matches the MCP `wiki_status` tool and the SDK's `status()` return value, so scripts and agents can share one contract across all three surfaces. |
+
+## JSON output
+
+```bash
+llmwiki status --json
+```
+
+```json
+{
+  "pages": { "concepts": 12, "queries": 3, "total": 15 },
+  "sources": 9,
+  "lastCompiledAt": "2026-07-14T09:12:44.000Z",
+  "stalePages": [],
+  "staleCount": 0,
+  "orphanedPages": [],
+  "orphanedCount": 0,
+  "stateStatus": "ok",
+  "pendingCandidates": 0,
+  "pendingChanges": [],
+  "pendingChangesCount": 0
+}
+```
+
+`stateStatus` is `ok`, `missing` (no compile has run), or `corrupt` (unreadable `state.json` - run `llmwiki compile` to rebuild it). `stalePages` and `pendingChanges` are capped at 100 entries; `staleCount` and `pendingChangesCount` always carry the true totals. Projects with an active non-default profile additionally include a `profile` block with per-entity-type counts and any validation problems.
+
+<Note>
+  For deeper diagnostics than a status summary - broken wikilinks, citation problems, confidence and provenance rules - run [`llmwiki lint`](/cli/lint-eval). To repair the stale pages that status reports, run `llmwiki refresh --stale` (preview with `--dry-run`).
+</Note>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,6 +47,7 @@
               "cli/compile",
               "cli/query",
               "cli/view",
+              "cli/status",
               "cli/lint-eval",
               "cli/export",
               "cli/import",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import compileCommand from "./commands/compile.js";
 import queryCommand from "./commands/query.js";
 import watchCommand from "./commands/watch.js";
 import lintCommand from "./commands/lint.js";
+import statusCommand from "./commands/status.js";
 import exportCommand from "./commands/export.js";
 import importCommand from "./commands/import.js";
 import { recoverCommand } from "./commands/recover.js";
@@ -224,6 +225,20 @@ program
   .action(async () => {
     try {
       await lintCommand();
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("status")
+  .description("Report project status: page/source counts, stale and orphaned pages, pending changes, review queue, and state health")
+  .option("--json", "Emit the status snapshot as JSON (same shape as the MCP wiki_status tool)")
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const code = await statusCommand({ json: options.json });
+      process.exit(code);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
       process.exit(1);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,127 @@
+/**
+ * `llmwiki status` — read-only project status snapshot on the CLI.
+ *
+ * Thin wrapper over collectStatus(), the same snapshot the MCP `wiki_status`
+ * tool and the SDK `status()` method return. Default output is a short human
+ * summary (counts, freshness, review queue, state health); `--json` emits the
+ * WikiStatus envelope verbatim for scripts and agents. Credential-free: the
+ * snapshot is derived from disk (state.json, source hashes, page frontmatter)
+ * with no LLM calls.
+ */
+
+import { collectStatus, type WikiStatus } from "../status/collect.js";
+import * as output from "../utils/output.js";
+
+/** CLI-supplied options for `llmwiki status`. */
+export interface StatusCommandOptions {
+  /** Emit the WikiStatus envelope as JSON on stdout instead of the human summary. */
+  json?: boolean;
+}
+
+/**
+ * Run the status command against the current working directory.
+ * Always exits 0 on a successful inspection — problems (stale pages, corrupt
+ * state) are reported in the output, not via the exit code.
+ */
+export default async function statusCommand(
+  options: StatusCommandOptions = {},
+): Promise<number> {
+  // Quiet mode suppresses status()/verbose() so the JSON envelope on stdout
+  // stays machine-parseable; the JSON itself goes through process.stdout.write,
+  // which quiet mode does not intercept. Same pattern as `context --json`.
+  if (options.json) output.setQuiet(true);
+  try {
+    const status = await collectStatus(process.cwd());
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+    } else {
+      renderHumanStatus(status);
+    }
+    return 0;
+  } finally {
+    if (options.json) output.setQuiet(false);
+  }
+}
+
+/** Max slugs shown inline on a stale/orphaned line before "+N more". */
+const MAX_INLINE_SLUGS = 8;
+
+/** Render the human-readable summary. */
+function renderHumanStatus(status: WikiStatus): void {
+  output.header("llmwiki status");
+  output.status("i", output.info(
+    `Pages: ${status.pages.concepts} concept(s), ${status.pages.queries} quer(y/ies) — ${status.pages.total} total`,
+  ));
+  output.status("i", output.info(`Sources: ${status.sources}`));
+  output.status("i", output.dim(`Last compiled: ${status.lastCompiledAt ?? "never"}`));
+  renderFreshness(status);
+  renderQueues(status);
+  renderProfile(status);
+  for (const warning of status.warnings ?? []) {
+    output.status("!", output.warn(warning.message));
+  }
+  renderStateHealth(status);
+}
+
+/** Stale/orphaned page lines; a single success line when everything is fresh. */
+function renderFreshness(status: WikiStatus): void {
+  if (status.staleCount === 0 && status.orphanedCount === 0) {
+    output.status("✓", output.success("Fresh: no stale or orphaned pages"));
+    return;
+  }
+  if (status.staleCount > 0) {
+    output.status("!", output.warn(
+      `Stale: ${status.staleCount} page(s): ${formatSlugList(status.stalePages)} — run \`llmwiki refresh --stale\``,
+    ));
+  }
+  if (status.orphanedCount > 0) {
+    output.status("!", output.warn(
+      `Orphaned: ${status.orphanedCount} page(s): ${formatSlugList(status.orphanedPages)}`,
+    ));
+  }
+}
+
+/** Pending compile work and the review queue; silent when both are empty. */
+function renderQueues(status: WikiStatus): void {
+  if (status.pendingChangesCount > 0) {
+    output.status("~", output.info(
+      `Pending changes: ${status.pendingChangesCount} source(s) awaiting compile — run \`llmwiki compile\``,
+    ));
+  }
+  if (status.pendingCandidates > 0) {
+    output.status("?", output.info(
+      `Pending review: ${status.pendingCandidates} candidate(s) — run \`llmwiki review list\``,
+    ));
+  }
+}
+
+/** One-line active-profile summary; silent for the default profile. */
+function renderProfile(status: WikiStatus): void {
+  if (!status.profile) return;
+  const entityTotal = Object.values(status.profile.entityCounts).reduce((sum, n) => sum + n, 0);
+  const problems = status.profile.problemTotal
+    ? `, ${status.profile.problemTotal} problem(s) — run \`llmwiki profile validate\``
+    : "";
+  output.status("i", output.info(
+    `Profile: ${status.profile.profileId} (${entityTotal} typed page(s)${problems})`,
+  ));
+}
+
+/** State-file health with a recovery hint when it is not ok. */
+function renderStateHealth(status: WikiStatus): void {
+  if (status.stateStatus === "ok") {
+    output.status("✓", output.success("State: ok"));
+    return;
+  }
+  const hint = status.stateStatus === "missing"
+    ? "no compile has run yet — run `llmwiki compile`"
+    : "run `llmwiki compile` to rebuild it";
+  output.status("!", output.warn(`State: ${status.stateStatus} — ${hint}`));
+}
+
+/** Join up to MAX_INLINE_SLUGS slugs, summarizing the remainder as "+N more". */
+function formatSlugList(slugs: string[]): string {
+  const shown = slugs.slice(0, MAX_INLINE_SLUGS).join(", ");
+  const rest = slugs.length - MAX_INLINE_SLUGS;
+  return rest > 0 ? `${shown} (+${rest} more)` : shown;
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -71,12 +71,12 @@ function renderFreshness(status: WikiStatus): void {
   }
   if (status.staleCount > 0) {
     output.status("!", output.warn(
-      `Stale: ${status.staleCount} page(s): ${formatSlugList(status.stalePages)} — run \`llmwiki refresh --stale\``,
+      `Stale: ${status.staleCount} page(s): ${formatSlugList(status.stalePages, status.staleCount)} — run \`llmwiki refresh --stale\``,
     ));
   }
   if (status.orphanedCount > 0) {
     output.status("!", output.warn(
-      `Orphaned: ${status.orphanedCount} page(s): ${formatSlugList(status.orphanedPages)}`,
+      `Orphaned: ${status.orphanedCount} page(s): ${formatSlugList(status.orphanedPages, status.orphanedCount)} — run \`llmwiki refresh --stale\``,
     ));
   }
 }
@@ -107,21 +107,32 @@ function renderProfile(status: WikiStatus): void {
   ));
 }
 
+/** Per-state recovery hints; each names the command that actually fixes that state. */
+const STATE_HINTS: Record<Exclude<WikiStatus["stateStatus"], "ok">, string> = {
+  missing: "no compile has run yet — run `llmwiki compile`",
+  corrupt: "run `llmwiki compile` to rebuild it",
+  // Compile refuses a newer-versioned state, so recompiling is NOT the fix here.
+  "too-new": "written by a newer version — upgrade llmwiki (`npm install -g llm-wiki-compiler`)",
+};
+
 /** State-file health with a recovery hint when it is not ok. */
 function renderStateHealth(status: WikiStatus): void {
   if (status.stateStatus === "ok") {
     output.status("✓", output.success("State: ok"));
     return;
   }
-  const hint = status.stateStatus === "missing"
-    ? "no compile has run yet — run `llmwiki compile`"
-    : "run `llmwiki compile` to rebuild it";
-  output.status("!", output.warn(`State: ${status.stateStatus} — ${hint}`));
+  output.status("!", output.warn(
+    `State: ${status.stateStatus} — ${STATE_HINTS[status.stateStatus]}`,
+  ));
 }
 
-/** Join up to MAX_INLINE_SLUGS slugs, summarizing the remainder as "+N more". */
-function formatSlugList(slugs: string[]): string {
+/**
+ * Join up to MAX_INLINE_SLUGS slugs, summarizing the remainder as "+N more".
+ * The remainder is computed from `total` — the true count — because the slug
+ * array itself is capped at MAX_STATUS_LIST and may undercount.
+ */
+function formatSlugList(slugs: string[], total: number): string {
   const shown = slugs.slice(0, MAX_INLINE_SLUGS).join(", ");
-  const rest = slugs.length - MAX_INLINE_SLUGS;
+  const rest = total - Math.min(slugs.length, MAX_INLINE_SLUGS);
   return rest > 0 ? `${shown} (+${rest} more)` : shown;
 }

--- a/src/profile/reserved-verbs.ts
+++ b/src/profile/reserved-verbs.ts
@@ -19,5 +19,5 @@ export const RESERVED_CORE_VERBS: ReadonlySet<string> = new Set([
   "artifact", "cache", "compile", "connector", "context", "eval", "export", "import",
   "ingest", "ingest-session", "lint", "next", "profile", "query",
   "quickstart", "recover", "refresh", "review", "rules", "schema", "serve",
-  "state", "template", "view", "watch", "workflow",
+  "state", "status", "template", "view", "watch", "workflow",
 ]);

--- a/test/status/cli-integration.test.ts
+++ b/test/status/cli-integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Subprocess integration tests for `llmwiki status`.
+ *
+ * Exercises the built CLI end-to-end so the documented surface is pinned at
+ * the level real users hit: the command exists, needs no provider
+ * credentials, prints a human summary by default, and emits the WikiStatus
+ * JSON envelope with --json.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runCLI, expectCLIExit } from "../fixtures/run-cli.js";
+
+/** Env that guarantees no provider credentials leak in from the host. */
+const NO_CREDS = {
+  ANTHROPIC_API_KEY: "",
+  ANTHROPIC_AUTH_TOKEN: "",
+  OPENAI_API_KEY: "",
+  LLMWIKI_PROVIDER: "",
+};
+
+describe("llmwiki status (CLI)", () => {
+  let cwd = "";
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-status-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it("status --help shows the command and the --json flag", async () => {
+    const result = await runCLI(["status", "--help"], cwd);
+    expectCLIExit(result, 0);
+    expect(result.stdout).toContain("--json");
+    expect(result.stdout).toContain("state health");
+  });
+
+  it("runs credential-free on an empty project and reports missing state", async () => {
+    const result = await runCLI(["status"], cwd, NO_CREDS);
+    expectCLIExit(result, 0);
+    expect(result.stdout).toMatch(/State: missing/);
+  });
+
+  it("--json emits a parseable WikiStatus envelope for a compiled project", async () => {
+    await mkdir(path.join(cwd, "sources"), { recursive: true });
+    await mkdir(path.join(cwd, "wiki", "concepts"), { recursive: true });
+    await mkdir(path.join(cwd, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(cwd, "sources", "a.md"), "# A\n\nBody.", "utf-8");
+    await writeFile(
+      path.join(cwd, "wiki", "concepts", "topic.md"),
+      "---\ntitle: Topic\nsummary: S.\nsources: [a.md]\n---\n\nBody.\n",
+      "utf-8",
+    );
+    await writeFile(
+      path.join(cwd, ".llmwiki", "state.json"),
+      JSON.stringify({ version: 1, indexHash: "", sources: {} }),
+      "utf-8",
+    );
+
+    const result = await runCLI(["status", "--json"], cwd, NO_CREDS);
+
+    expectCLIExit(result, 0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.pages.concepts).toBe(1);
+    expect(parsed.stateStatus).toBe("ok");
+    expect(typeof parsed.pendingChangesCount).toBe("number");
+  });
+});

--- a/test/status/command.test.ts
+++ b/test/status/command.test.ts
@@ -101,6 +101,72 @@ describe("statusCommand", () => {
     expect(Array.isArray(parsed.pendingChanges)).toBe(true);
   });
 
+  it("too-new state recommends upgrading llmwiki, not recompiling", async () => {
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    await writeFile(
+      path.join(root, ".llmwiki", "state.json"),
+      JSON.stringify({ version: 3 }),
+      "utf-8",
+    );
+
+    const code = await statusCommand();
+
+    expect(code).toBe(0);
+    const out = logLines.join("\n");
+    expect(out).toMatch(/State: too-new/);
+    expect(out).toContain("upgrade llmwiki");
+    // Compile refuses a too-new state, so it must NOT be the recovery hint.
+    expect(out).not.toContain("`llmwiki compile`");
+  });
+
+  it("counts truncated stale pages from the true total, not the capped list", async () => {
+    await seedProject(root);
+    // Make a.md stale (hash mismatch) and give it 101 pages so staleCount
+    // exceeds the MAX_STATUS_LIST=100 cap on the stalePages array.
+    const state = { version: 1, indexHash: "", sources: {
+      "a.md": { hash: "stale-hash", concepts: [] as string[], compiledAt: "t" },
+    } };
+    for (let i = 0; i < 101; i++) {
+      const slug = `page-${String(i).padStart(3, "0")}`;
+      state.sources["a.md"].concepts.push(slug);
+      await writeFile(
+        path.join(root, "wiki", "concepts", `${slug}.md`),
+        `---\ntitle: Page ${i}\nsummary: S.\nsources: [a.md]\n---\n\nBody.\n`,
+        "utf-8",
+      );
+    }
+    await writeFile(path.join(root, ".llmwiki", "state.json"), JSON.stringify(state), "utf-8");
+
+    await statusCommand();
+
+    const staleLine = logLines.find((line) => line.includes("Stale:")) ?? "";
+    expect(staleLine).toContain("Stale: 101 page(s)");
+    // 101 stale total, 8 shown inline ⇒ remainder must come from staleCount
+    // (101-8=93), not from the capped 100-entry array (100-8=92).
+    expect(staleLine).toContain("(+93 more)");
+  });
+
+  it("gives orphaned pages a repair hint", async () => {
+    await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    await writeFile(
+      path.join(root, ".llmwiki", "state.json"),
+      JSON.stringify({ version: 1, indexHash: "", sources: {} }),
+      "utf-8",
+    );
+    await writeFile(
+      path.join(root, "wiki", "concepts", "widowed.md"),
+      "---\ntitle: Widowed\nsummary: S.\nsources: [gone.md]\norphaned: true\n---\n\nBody.\n",
+      "utf-8",
+    );
+
+    await statusCommand();
+
+    const orphanLine = logLines.find((line) => line.includes("Orphaned:")) ?? "";
+    expect(orphanLine).toContain("widowed");
+    expect(orphanLine).toContain("llmwiki refresh --stale");
+  });
+
   it("--json stays pure when verbose mode is enabled", async () => {
     await seedProject(root);
     setVerbose(true);

--- a/test/status/command.test.ts
+++ b/test/status/command.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the `llmwiki status` command wrapper.
+ *
+ * The heavy lifting (freshness, page scan, candidates) is collectStatus's and
+ * is covered by collect.test.ts. These tests pin the CLI contract: readable
+ * human summary by default, a pure machine-readable JSON envelope with --json
+ * (immune to verbose/status pollution), exit code 0 on successful inspection,
+ * and no provider credentials required.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import statusCommand from "../../src/commands/status.js";
+import { setVerbose } from "../../src/utils/output.js";
+
+/** Seed a minimal compiled project: one source, one concept page, valid state. */
+async function seedProject(root: string): Promise<void> {
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  const sourceContent = "# Topic\n\nAbout the topic.";
+  await writeFile(path.join(root, "sources", "a.md"), sourceContent, "utf-8");
+  const { createHash } = await import("node:crypto");
+  const hash = createHash("sha256").update(sourceContent).digest("hex");
+  await writeFile(
+    path.join(root, ".llmwiki", "state.json"),
+    JSON.stringify({
+      version: 1,
+      indexHash: "",
+      sources: { "a.md": { hash, concepts: ["topic"], compiledAt: "2026-07-14T00:00:00.000Z" } },
+    }),
+    "utf-8",
+  );
+  await writeFile(
+    path.join(root, "wiki", "concepts", "topic.md"),
+    "---\ntitle: Topic\nsummary: The topic.\nsources: [a.md]\n---\n\nBody.\n",
+    "utf-8",
+  );
+}
+
+describe("statusCommand", () => {
+  let root = "";
+  let savedCwd = "";
+  let logLines: string[];
+  let stdoutChunks: string[];
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "llmwiki-status-cmd-"));
+    savedCwd = process.cwd();
+    process.chdir(root);
+    logLines = [];
+    stdoutChunks = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logLines.push(args.map(String).join(" "));
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+  });
+
+  afterEach(async () => {
+    process.chdir(savedCwd);
+    vi.restoreAllMocks();
+    setVerbose(false);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("prints a human summary with page/source counts and state status", async () => {
+    await seedProject(root);
+
+    const code = await statusCommand();
+
+    expect(code).toBe(0);
+    const out = logLines.join("\n");
+    expect(out).toContain("1 concept");
+    expect(out).toContain("Sources: 1");
+    expect(out).toMatch(/State: ok/);
+  });
+
+  it("reports missing state on an uncompiled project without failing", async () => {
+    const code = await statusCommand();
+
+    expect(code).toBe(0);
+    expect(logLines.join("\n")).toMatch(/State: missing/);
+  });
+
+  it("--json emits the collectStatus envelope as parseable JSON on stdout", async () => {
+    await seedProject(root);
+
+    const code = await statusCommand({ json: true });
+
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdoutChunks.join(""));
+    expect(parsed.pages.concepts).toBe(1);
+    expect(parsed.sources).toBe(1);
+    expect(parsed.stateStatus).toBe("ok");
+    expect(parsed.staleCount).toBe(0);
+    expect(Array.isArray(parsed.pendingChanges)).toBe(true);
+  });
+
+  it("--json stays pure when verbose mode is enabled", async () => {
+    await seedProject(root);
+    setVerbose(true);
+
+    await statusCommand({ json: true });
+
+    expect(() => JSON.parse(stdoutChunks.join(""))).not.toThrow();
+    // Quiet mode must suppress all human/verbose lines in JSON mode.
+    expect(logLines).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
The docs have referenced `llmwiki status` since 0.10.0 — including the 1.0 upgrade guide's copy-paste verification block — but the command never existed; the status snapshot was only reachable over MCP (`wiki_status`) and the SDK (`status()`).

## What changed
- New `llmwiki status` command: a readable summary of page/source counts, last compile time, stale and orphaned pages, pending changes, the review queue, active profile, and state-file health — with a next-command hint on each problem line
- `--json` emits the same `WikiStatus` envelope as the MCP tool and SDK, quiet-gated so stdout stays machine-parseable
- Credential-free and read-only; always exits 0 on a successful inspection
- `status` added to the reserved core verbs so profile workflows can't shadow it
- CLI reference page (`docs/cli/status`), navigation entry, and README row; the existing doc mentions are now accurate as written

## Tests
In-process command tests (human output, JSON envelope, JSON purity under verbose) plus subprocess integration tests (`--help`, credential-free run on an empty project, `--json` on a compiled project).