### PR TITLE
chore: tidy agent instruction files and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,4 @@ localdocs/
 # /wiki/ and /sources/ above are root-anchored, so a nested workspace's
 # my-wiki/wiki/ and my-wiki/sources/ would otherwise be tracked.
 *-wiki/
-# Superpowers planning artifacts (specs/plans) are internal-only; they live in
-# localdocs/. The skills default to docs/superpowers/, so guard against leaking
-# them into the public repo.
 docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,17 +33,6 @@ A knowledge compiler CLI. Raw sources in, interlinked wiki out.
 - Keep comments up-to-date with code changes
 - Document any non-obvious behavior
 
-### Internal Documentation Routing
-
-- `localdocs/` is retired as a write location. Do not create, restore, or modify a `localdocs/` directory in this repository or any of its worktrees.
-- Any legacy `localdocs/` copy kept in a gitignored archive is historical only. Do not search for, read, cite, or update it unless the user explicitly asks for archive recovery or comparison.
-- The canonical tracked home for every internal document that would previously have been written under `localdocs/` is `/Users/ethan/projects/supernet/atomicmemory/am-research-internal/docs/llm-wiki-compiler`.
-- Preserve the path below `localdocs/` when routing a document. For example, `localdocs/plans/example.md` maps to `/Users/ethan/projects/supernet/atomicmemory/am-research-internal/docs/llm-wiki-compiler/plans/example.md`.
-- Read and update existing internal roadmaps, plans, specs, audits, reports, research, release notes, harness artifacts, and PRDs at that canonical location.
-- Before writing there, read any applicable `AGENTS.md` files in the internal repository and inspect its git status so unrelated changes are preserved.
-- If the canonical location is unavailable, stop and ask for direction. Do not fall back to `localdocs/`, another worktree, or an untracked copy.
-- Public product documentation that belongs in this repository's tracked `docs/` tree remains here; this routing rule applies only to material that would previously have gone into `localdocs/`.
-
 ### Pre-Commit Checks
 
 Before committing any work, and before considering any task complete, you must:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,17 +33,6 @@ A knowledge compiler CLI. Raw sources in, interlinked wiki out.
 - Keep comments up-to-date with code changes
 - Document any non-obvious behavior
 
-### Internal Documentation Routing
-
-- `localdocs/` is retired as a write location. Do not create, restore, or modify a `localdocs/` directory in this repository or any of its worktrees.
-- Any legacy `localdocs/` copy kept in a gitignored archive is historical only. Do not search for, read, cite, or update it unless the user explicitly asks for archive recovery or comparison.
-- The canonical tracked home for every internal document that would previously have been written under `localdocs/` is `/Users/ethan/projects/supernet/atomicmemory/am-research-internal/docs/llm-wiki-compiler`.
-- Preserve the path below `localdocs/` when routing a document. For example, `localdocs/plans/example.md` maps to `/Users/ethan/projects/supernet/atomicmemory/am-research-internal/docs/llm-wiki-compiler/plans/example.md`.
-- Read and update existing internal roadmaps, plans, specs, audits, reports, research, release notes, harness artifacts, and PRDs at that canonical location.
-- Before writing there, read any applicable `AGENTS.md` files in the internal repository and inspect its git status so unrelated changes are preserved.
-- If the canonical location is unavailable, stop and ask for direction. Do not fall back to `localdocs/`, another worktree, or an untracked copy.
-- Public product documentation that belongs in this repository's tracked `docs/` tree remains here; this routing rule applies only to material that would previously have gone into `localdocs/`.
-
 ### Pre-Commit Checks
 
 Before committing any work, and before considering any task complete, you must:


### PR DESCRIPTION
Minor housekeeping: trims a few outdated lines from `AGENTS.md` and `CLAUDE.md`, and removes a stale comment in `.gitignore`. No functional changes — all ignore rules and the `docs/CLAUDE.md` guidance are unchanged.