### PR TITLE
fix(citations): align line-list parsing

### DIFF
--- a/src/linter/rules-citations.ts
+++ b/src/linter/rules-citations.ts
@@ -4,16 +4,18 @@
  * This family validates the `^[file.md]` citation markers that anchor wiki
  * prose to its sources: broken citations (source file missing or claim-level
  * line span out of bounds) and malformed claim citations (entries that don't
- * parse against the documented `file.md` / `file.md:N-N` / `file.md#LN-LN`
- * grammar). Each on-disk walker has a pure per-page variant so the in-memory
- * candidate-lint path (`compile --review`) surfaces the same findings before a
- * reviewer approves a candidate. Re-exported through {@link file://./rules.ts}.
+ * parse against the documented `file.md` / `file.md:N-N` / `file.md:N,N-M`
+ * / `file.md#LN-LN` grammar). Each on-disk walker has a pure per-page variant
+ * so the in-memory candidate-lint path (`compile --review`) surfaces the same
+ * findings before a reviewer approves a candidate. Re-exported through
+ * {@link file://./rules.ts}.
  */
 
 import { existsSync } from "fs";
 import path from "path";
 import {
   isMalformedCitationEntry,
+  parseCitationLineRanges,
   parseFrontmatter,
   safeReadFile,
   splitCitationMarker,
@@ -26,42 +28,9 @@ import {
   findMatchesInContent,
 } from "./rules-shared.js";
 
-/** Regex matching the `:start-end` span suffix on a citation entry. */
-const COLON_SPAN_PATTERN = /^[^:#]+:(\d+)(?:[,-]\s*(\d+))?$/;
-
-/** Regex matching the `#Lstart-Lend` span suffix on a citation entry. */
-const HASH_SPAN_PATTERN = /^[^:#]+#L(\d+)(?:-L(\d+))?$/;
-
-/** Parsed line range from a citation entry, or null if no range is present. */
-interface ParsedLineRange {
-  start: number;
-  end: number;
-}
-
 /** Strip an optional `:start-end` or `#Lstart-Lend` span suffix from a citation entry. */
 function stripSpanSuffix(entry: string): string {
-  const colonIdx = entry.indexOf(":");
-  const hashIdx = entry.indexOf("#");
-  const cuts = [colonIdx, hashIdx].filter((i) => i >= 0);
-  if (cuts.length === 0) return entry;
-  return entry.slice(0, Math.min(...cuts));
-}
-
-/** Extract the line range from a citation entry string, or return null if there is none. */
-function parseLineRange(entry: string): ParsedLineRange | null {
-  const colonMatch = COLON_SPAN_PATTERN.exec(entry);
-  if (colonMatch) {
-    const start = Number(colonMatch[1]);
-    const end = colonMatch[2] !== undefined ? Number(colonMatch[2]) : start;
-    return { start, end };
-  }
-  const hashMatch = HASH_SPAN_PATTERN.exec(entry);
-  if (hashMatch) {
-    const start = Number(hashMatch[1]);
-    const end = hashMatch[2] !== undefined ? Number(hashMatch[2]) : start;
-    return { start, end };
-  }
-  return null;
+  return entry.split(/[:#]/, 1)[0];
 }
 
 /** Count the number of lines in a file's text content. */
@@ -74,8 +43,9 @@ function countLines(content: string): number {
  * Find ^[filename.md] citations referencing source files that don't exist, and
  * flag claim-level spans whose line ranges exceed the source file's actual length.
  * Handles both single-source ^[file.md] and multi-source ^[a.md, b.md] forms,
- * plus the claim-level extension `^[file.md:42-58]` / `^[file.md#L42-L58]`.
- * Line counts are cached per source file to avoid redundant reads.
+ * plus claim-level spans such as `^[file.md:42-58]`, `^[file.md:1, 4-6]`,
+ * and `^[file.md#L42-L58]`. Line counts are cached per source file to avoid
+ * redundant reads.
  */
 export async function checkBrokenCitations(root: string): Promise<LintResult[]> {
   const pages = await collectAllPages(root);
@@ -150,10 +120,10 @@ async function collectBrokenForMarker(
       });
       continue;
     }
-    const range = parseLineRange(trimmed);
-    if (range === null) continue;
+    const ranges = parseCitationLineRanges(trimmed);
+    if (ranges === null || ranges.length === 0) continue;
     const lineCount = await resolveLineCount(citedPath, filename, lineCountCache);
-    if (range.end <= lineCount) continue;
+    if (ranges.every((range) => range.end <= lineCount)) continue;
     out.push({
       rule: "broken-citation",
       severity: "error",
@@ -207,7 +177,7 @@ export function checkPageMalformedCitations(content: string, filePath: string): 
         rule: "malformed-claim-citation",
         severity: "error",
         file: filePath,
-        message: `Malformed claim citation ^[${captured}] — expected file.md, file.md:N-N, file.md:N,N,…, or file.md#LN-LN`,
+        message: `Malformed claim citation ^[${captured}] — expected file.md, file.md:N-N, file.md:N,N-M,…, or file.md#LN-LN`,
         line,
       });
     }

--- a/src/linter/rules-citations.ts
+++ b/src/linter/rules-citations.ts
@@ -207,7 +207,7 @@ export function checkPageMalformedCitations(content: string, filePath: string): 
         rule: "malformed-claim-citation",
         severity: "error",
         file: filePath,
-        message: `Malformed claim citation ^[${captured}] — expected file.md, file.md:N-N, or file.md#LN-LN`,
+        message: `Malformed claim citation ^[${captured}] — expected file.md, file.md:N-N, file.md:N,N,…, or file.md#LN-LN`,
         line,
       });
     }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -175,12 +175,12 @@ export function extractClaimCitations(body: string): ClaimCitation[] {
  * individual source-entry strings, without separating comma-separated line
  * numbers like the `12` in `source.md:1, 12`.
  *
- * The rule: split on every comma EXCEPT those followed by a purely-digit token
- * (which must be a line-number continuation). This correctly handles
- * digit-leading filenames such as `2024-notes.md`, `99problems.md`, and `1.md`.
+ * The rule: split on every comma EXCEPT those followed by a line-number token
+ * (`12` or `12-15`). This correctly handles digit-leading filenames such as
+ * `2024-notes.md`, `99problems.md`, and `1.md`.
  */
 export function splitCitationMarker(inner: string): string[] {
-  return inner.split(/,(?!\s*\d+\s*(?:,|$))/);
+  return inner.split(/,(?!\s*\d+(?:-\d+)?\s*(?:,|$))/);
 }
 
 /**
@@ -200,27 +200,18 @@ function parseCitationEntries(inner: string): SourceSpan[] {
 }
 
 /**
- * Dispatch a single trimmed citation entry to the right span parser.
- * Comma-separated line numbers (e.g. `file.md:1, 12`) expand into one
- * SourceSpan per line; everything else delegates to parseSpanEntry.
+ * Parse a single trimmed citation entry into SourceSpans: one per line range,
+ * or a single file-only span for paragraph-form citations. Returns an empty
+ * array when the span syntax or range semantics are invalid.
  */
 function parseSpanEntries(entry: string): SourceSpan[] {
-  const multi = COLON_MULTILINE_PATTERN.exec(entry);
-  if (multi?.groups) return parseCommaLines(multi.groups.file, multi.groups.lines);
-  const single = parseSpanEntry(entry);
-  return single !== undefined ? [single] : [];
-}
-
-/** Expand a comma-separated line-token string (numbers or hyphen ranges) into spans. */
-function parseCommaLines(file: string, linesStr: string): SourceSpan[] {
-  const spans: SourceSpan[] = [];
-  for (const token of linesStr.split(/,\s*/)) {
-    const { start, end } = parseLineToken(token);
-    if (isValidLineRange(start, end)) {
-      spans.push({ file, lines: { start, end } });
-    }
-  }
-  return spans;
+  const match = COLON_MULTILINE_PATTERN.exec(entry) ?? SPAN_SUFFIX_PATTERN.exec(entry);
+  // Unparseable entries, such as malformed spans like file.md:abc, are preserved as file-only spans so the malformed-citation linter can report them.
+  if (!match?.groups) return [{ file: entry }];
+  const file = match.groups.file;
+  const ranges = parseCitationLineRanges(entry);
+  if (ranges === null) return [];
+  return ranges.length > 0 ? ranges.map((lines) => ({ file, lines })) : [{ file }];
 }
 
 /** Parse a single line token (`12` or `1-5`) into a start/end pair. */
@@ -231,24 +222,27 @@ function parseLineToken(token: string): { start: number; end: number } {
   return { start, end };
 }
 
+/** Parse comma-separated line tokens, returning null if any token is invalid. */
+function parseLineTokens(linesStr: string): Array<{ start: number; end: number }> | null {
+  const ranges = linesStr.split(/,\s*/).map(parseLineToken);
+  return ranges.every(({ start, end }) => isValidLineRange(start, end)) ? ranges : null;
+}
+
 /**
- * Parse a single citation entry (`file.md` / `file.md:1-3` / `file.md#L1-L3`).
- * Returns undefined when the parsed line range is semantically invalid (line
- * numbers must be >= 1 and end must be >= start).
+ * Parse every line range from a citation entry. Returns an empty array for
+ * paragraph-form citations, or null when span syntax/range semantics are invalid.
  */
-function parseSpanEntry(entry: string): SourceSpan | undefined {
-  const match = SPAN_SUFFIX_PATTERN.exec(entry);
-  if (!match || !match.groups) {
-    return { file: entry };
-  }
-  const { file, colonStart, colonEnd, hashStart, hashEnd } = match.groups;
+export function parseCitationLineRanges(entry: string): Array<{ start: number; end: number }> | null {
+  const trimmed = entry.trim();
+  const multi = COLON_MULTILINE_PATTERN.exec(trimmed);
+  if (multi?.groups) return parseLineTokens(multi.groups.lines);
+  const match = SPAN_SUFFIX_PATTERN.exec(trimmed);
+  if (!match?.groups) return null;
+  const { colonStart, colonEnd, hashStart, hashEnd } = match.groups;
   const start = colonStart ?? hashStart;
   const end = colonEnd ?? hashEnd;
-  if (start === undefined) return { file };
-  const startLine = Number(start);
-  const endLine = end === undefined ? startLine : Number(end);
-  if (!isValidLineRange(startLine, endLine)) return undefined;
-  return { file, lines: { start: startLine, end: endLine } };
+  if (start === undefined) return [];
+  return parseLineTokens(end === undefined ? start : `${start}-${end}`);
 }
 
 /** Returns true when both lines are >= 1 and end is not before start. */
@@ -266,22 +260,7 @@ export function isMalformedCitationEntry(entry: string): boolean {
   const trimmed = entry.trim();
   if (trimmed.length === 0) return true;
   if (!trimmed.includes(":") && !trimmed.includes("#")) return false;
-  const multi = COLON_MULTILINE_PATTERN.exec(trimmed);
-  if (multi?.groups) {
-    return multi.groups.lines.split(",").some((token) => {
-      const { start, end } = parseLineToken(token);
-      return !isValidLineRange(start, end);
-    });
-  }
-  const match = SPAN_SUFFIX_PATTERN.exec(trimmed);
-  if (!match || !match.groups) return true;
-  const { colonStart, colonEnd, hashStart, hashEnd } = match.groups;
-  const start = colonStart ?? hashStart;
-  const end = colonEnd ?? hashEnd;
-  if (start === undefined) return false;
-  const startLine = Number(start);
-  const endLine = end === undefined ? startLine : Number(end);
-  return !isValidLineRange(startLine, endLine);
+  return parseCitationLineRanges(trimmed) === null;
 }
 
 /**

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -22,11 +22,13 @@ const CITATION_MARKER_PATTERN = /\^\[([^\]]+)\]/g;
 const SPAN_SUFFIX_PATTERN = /^(?<file>[^:#]+)(?:(?::(?<colonStart>\d+)(?:[,-]\s*(?<colonEnd>\d+))?)|(?:#L(?<hashStart>\d+)(?:-L(?<hashEnd>\d+))?))?$/;
 
 /**
- * Regex matching a colon-form entry with two or more comma-separated line numbers,
- * e.g. `source.md:1, 12` or `source.md:3,7,42`. Captured `lines` is the raw
- * digit-and-comma string; each token expands into its own single-line SourceSpan.
+ * Regex matching a colon-form entry with two or more comma-separated line tokens,
+ * where each token is a single number or a hyphen range. This matches formats the
+ * compile-time normalizer emits (`source.md:1, 12`, `source.md:3,7,42`,
+ * `source.md:1-5, 12`). Captured `lines` is the raw token string; each token
+ * expands into its own SourceSpan.
  */
-const COLON_MULTILINE_PATTERN = /^(?<file>[^:#]+):(?<lines>\d+(?:,\s*\d+)+)$/;
+const COLON_MULTILINE_PATTERN = /^(?<file>[^:#]+):(?<lines>\d+(?:-\d+)?(?:,\s*\d+(?:-\d+)?)+)$/;
 
 /** The minimum valid line number in a source span (lines are 1-indexed). */
 const MIN_LINE_NUMBER = 1;
@@ -209,16 +211,24 @@ function parseSpanEntries(entry: string): SourceSpan[] {
   return single !== undefined ? [single] : [];
 }
 
-/** Expand a comma-separated line-number string into individual single-line spans. */
+/** Expand a comma-separated line-token string (numbers or hyphen ranges) into spans. */
 function parseCommaLines(file: string, linesStr: string): SourceSpan[] {
   const spans: SourceSpan[] = [];
   for (const token of linesStr.split(/,\s*/)) {
-    const lineNum = Number(token);
-    if (isValidLineRange(lineNum, lineNum)) {
-      spans.push({ file, lines: { start: lineNum, end: lineNum } });
+    const { start, end } = parseLineToken(token);
+    if (isValidLineRange(start, end)) {
+      spans.push({ file, lines: { start, end } });
     }
   }
   return spans;
+}
+
+/** Parse a single line token (`12` or `1-5`) into a start/end pair. */
+function parseLineToken(token: string): { start: number; end: number } {
+  const [startStr, endStr] = token.split("-");
+  const start = Number(startStr.trim());
+  const end = endStr === undefined ? start : Number(endStr.trim());
+  return { start, end };
 }
 
 /**
@@ -256,6 +266,13 @@ export function isMalformedCitationEntry(entry: string): boolean {
   const trimmed = entry.trim();
   if (trimmed.length === 0) return true;
   if (!trimmed.includes(":") && !trimmed.includes("#")) return false;
+  const multi = COLON_MULTILINE_PATTERN.exec(trimmed);
+  if (multi?.groups) {
+    return multi.groups.lines.split(",").some((token) => {
+      const { start, end } = parseLineToken(token);
+      return !isValidLineRange(start, end);
+    });
+  }
   const match = SPAN_SUFFIX_PATTERN.exec(trimmed);
   if (!match || !match.groups) return true;
   const { colonStart, colonEnd, hashStart, hashEnd } = match.groups;

--- a/src/viewer/snapshot.ts
+++ b/src/viewer/snapshot.ts
@@ -25,7 +25,7 @@ import { countCandidates } from "../compiler/candidates.js";
 import { readStateClassified, isPlainObject } from "../utils/state.js";
 import { collectViewerPages, resolveBareSlugList } from "./collect.js";
 import { extractWikilinkSlugs } from "../wiki/collect.js";
-import { isMalformedCitationEntry } from "../utils/markdown.js";
+import { isMalformedCitationEntry, splitCitationMarker } from "../utils/markdown.js";
 import { buildGraphData } from "./graph.js";
 import type { EntityPageNode, GraphBuildOptions, RelationEdge } from "./graph.js";
 import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
@@ -234,13 +234,13 @@ function attachFreshness(page: ViewerPage, snapshot: FreshnessSnapshot): ViewerP
   };
 }
 
-/** Classify every comma-separated entry inside one `^[…]` marker. */
+/** Classify every source entry inside one `^[...]` marker. */
 function appendCitationWarningsForMarker(
   raw: string,
   sourceFiles: ReadonlySet<string>,
   into: ViewerWarning[],
 ): void {
-  for (const entry of raw.split(",")) {
+  for (const entry of splitCitationMarker(raw)) {
     const trimmed = entry.trim();
     if (trimmed.length === 0) continue;
     if (isMalformedCitationEntry(trimmed)) {
@@ -359,4 +359,3 @@ function buildRecentPages(pages: ViewerPage[]): ViewerRecentPage[] {
   rows.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   return rows.slice(0, RECENT_PAGES_LIMIT);
 }
-

--- a/test/citation-normalize.test.ts
+++ b/test/citation-normalize.test.ts
@@ -276,9 +276,11 @@ describe("normalizer output is always accepted by the malformed-citation validat
     "^[3-9]",
     "^[12,15,20]",
     "^[1-5, 12]",
+    "^[1, 12-15]",
     `^[${source}:4]`,
     `^[${source}:4-8]`,
     `^[${source}:12,15,20]`,
+    `^[${source}:1, 12-15]`,
     `^[${source}#L2-L6]`,
   ];
 

--- a/test/citation-normalize.test.ts
+++ b/test/citation-normalize.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeCitationsInBody,
   normalizeCitations,
 } from "../src/compiler/citation-normalize.js";
+import { checkPageMalformedCitations } from "../src/linter/rules-citations.js";
 import { makeNumberedContent } from "./fixtures/citation-content.js";
 
 // Alias for brevity in this test file.
@@ -261,5 +262,38 @@ describe("normalizeCitationsInBody — backward range handling", () => {
     const body = "Claim.^[81, 90]";
     const result = normalizeCitationsInBody(body, [source], content);
     expect(result).toBe(`Claim.^[${source}:81, 90]`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drift guard: citations the normalizer is allowed to emit must pass the validator
+// ---------------------------------------------------------------------------
+
+describe("normalizer output is always accepted by the malformed-citation validator", () => {
+  const source = "source.md";
+  const rawShapes = [
+    "^[7]",
+    "^[3-9]",
+    "^[12,15,20]",
+    "^[1-5, 12]",
+    `^[${source}:4]`,
+    `^[${source}:4-8]`,
+    `^[${source}:12,15,20]`,
+    `^[${source}#L2-L6]`,
+  ];
+
+  it.each(rawShapes)("normalized %s yields no malformed-citation findings", (marker) => {
+    const content = makeContent(source, 100);
+    const body = `Claim.${marker}`;
+    const result = normalizeCitationsInBody(body, [source], content);
+    expect(checkPageMalformedCitations(result, "wiki/concepts/test.md")).toEqual([]);
+  });
+
+  it("multi-source marker normalizes to validator-clean entries", () => {
+    const sources = ["a.md", "b.md"];
+    const content = makeContent("a.md", 50) + "\n\n" + makeContent("b.md", 50);
+    const body = "Claim.^[a.md:1-5, b.md:10]";
+    const result = normalizeCitationsInBody(body, sources, content);
+    expect(checkPageMalformedCitations(result, "wiki/concepts/test.md")).toEqual([]);
   });
 });

--- a/test/claim-provenance.test.ts
+++ b/test/claim-provenance.test.ts
@@ -69,6 +69,14 @@ describe("extractClaimCitations parser", () => {
     ]);
   });
 
+  it("keeps a non-leading comma range on the same file", () => {
+    const citations = extractClaimCitations("A claim. ^[source.md:1, 12-15]");
+    expect(citations[0].spans).toEqual([
+      { file: "source.md", lines: { start: 1, end: 1 } },
+      { file: "source.md", lines: { start: 12, end: 15 } },
+    ]);
+  });
+
   it("splits a digit-leading filename after a letter-leading one", () => {
     const citations = extractClaimCitations("A claim. ^[source.md, 2024-notes.md]");
     expect(citations).toHaveLength(1);
@@ -199,6 +207,7 @@ describe("isMalformedCitationEntry", () => {
   it("accepts comma-separated line numbers as a valid span form", () => {
     expect(isMalformedCitationEntry("file.md:8,12")).toBe(false);
     expect(isMalformedCitationEntry("file.md:1, 5")).toBe(false);
+    expect(isMalformedCitationEntry("file.md:1, 5-8")).toBe(false);
   });
 });
 
@@ -376,5 +385,20 @@ describe("checkBrokenCitations — out-of-bounds span detection", () => {
   it("reports no findings for a span well within a 100-line source", async () => {
     const results = await lintWithSpan(HUNDRED_LINE_SOURCE, "^[src.md:42-58]");
     expect(results).toHaveLength(0);
+  });
+
+  it("flags a comma-list line beyond the source line count", async () => {
+    const results = await lintWithSpan(THREE_LINE_SOURCE, "^[src.md:1,2,12]");
+    expectOutOfBounds(results);
+  });
+
+  it("flags the first range in a comma list when it is beyond the source", async () => {
+    const results = await lintWithSpan(THREE_LINE_SOURCE, "^[src.md:12,1]");
+    expectOutOfBounds(results);
+  });
+
+  it("flags a non-leading comma range beyond the source line count", async () => {
+    const results = await lintWithSpan(THREE_LINE_SOURCE, "^[src.md:1, 12-15]");
+    expectOutOfBounds(results);
   });
 });

--- a/test/provenance-violations.test.ts
+++ b/test/provenance-violations.test.ts
@@ -67,6 +67,18 @@ describe("checkPageMalformedCitations — pure body lint", () => {
       "Para one. ^[source.md]\n\nPara two. ^[other.md:1-3]\n\nPara three. ^[third.md#L10-L20]";
     expect(checkPageMalformedCitations(body, "wiki/concepts/test.md")).toEqual([]);
   });
+
+  it("accepts comma-separated line lists the normalizer emits", () => {
+    const body = "Para one. ^[file.md:12,15,20]";
+    expect(checkPageMalformedCitations(body, "wiki/concepts/test.md")).toEqual([]);
+  });
+
+  it("still flags comma lists containing line 0", () => {
+    const body = "Para one. ^[file.md:0,5]";
+    const findings = checkPageMalformedCitations(body, "wiki/concepts/test.md");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe("malformed-claim-citation");
+  });
 });
 
 describe("checkPageBrokenCitations — pure body lint", () => {

--- a/test/provenance-violations.test.ts
+++ b/test/provenance-violations.test.ts
@@ -48,7 +48,7 @@ const SAMPLE_PROVENANCE_VIOLATION: LintResult = {
   rule: "malformed-claim-citation",
   severity: "error",
   file: "wiki/concepts/sample.md",
-  message: "Malformed claim citation ^[file.md:abc] — expected file.md, file.md:N-N, or file.md#LN-LN",
+  message: "Malformed claim citation ^[file.md:abc] — expected file.md, file.md:N-N, file.md:N,N-M,…, or file.md#LN-LN",
 };
 
 describe("checkPageMalformedCitations — pure body lint", () => {

--- a/test/viewer-citation-warnings.test.ts
+++ b/test/viewer-citation-warnings.test.ts
@@ -80,4 +80,19 @@ describe("buildViewerSnapshot — citation warnings", () => {
     expect(codes).not.toContain("unresolved_citation");
     expect(codes).not.toContain("malformed_citation");
   });
+
+  it("does not treat comma-continuation lines as source filenames", async () => {
+    const root = await makeTempRoot("citation-warn-line-list");
+    await writeSource(root, "src.md");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "alpha",
+      { title: "Alpha" },
+      "A claim ^[src.md:1, 12-15].",
+    );
+    const snapshot = await buildViewerSnapshot(root);
+    const codes = warningCodes(snapshot, "alpha");
+    expect(codes).not.toContain("unresolved_citation");
+    expect(codes).not.toContain("malformed_citation");
+  });
 });

--- a/test/viewer-citation-warnings.test.ts
+++ b/test/viewer-citation-warnings.test.ts
@@ -27,6 +27,11 @@ function warningCodes(snapshot: { pages: Array<{ slug: string; warnings: Array<{
   return page.warnings.map((w) => w.code);
 }
 
+function expectNoCitationWarnings(codes: string[]): void {
+  expect(codes).not.toContain("unresolved_citation");
+  expect(codes).not.toContain("malformed_citation");
+}
+
 describe("buildViewerSnapshot — citation warnings", () => {
   it("emits `unresolved_citation` for a citation whose source file is not under sources/", async () => {
     const root = await makeTempRoot("citation-warn-unresolved");
@@ -77,8 +82,7 @@ describe("buildViewerSnapshot — citation warnings", () => {
     );
     const snapshot = await buildViewerSnapshot(root);
     const codes = warningCodes(snapshot, "alpha");
-    expect(codes).not.toContain("unresolved_citation");
-    expect(codes).not.toContain("malformed_citation");
+    expectNoCitationWarnings(codes);
   });
 
   it("does not treat comma-continuation lines as source filenames", async () => {
@@ -92,7 +96,6 @@ describe("buildViewerSnapshot — citation warnings", () => {
     );
     const snapshot = await buildViewerSnapshot(root);
     const codes = warningCodes(snapshot, "alpha");
-    expect(codes).not.toContain("unresolved_citation");
-    expect(codes).not.toContain("malformed_citation");
+    expectNoCitationWarnings(codes);
   });
 });


### PR DESCRIPTION
The compile-time normalizer emits comma-separated line lists like `file.md:12,15,20` and mixed lists like `file.md:1-5,12`, but nearby citation consumers re-derived that grammar differently.

This fix:
- Allows hyphen-range references in comma series
- Shares citation line-range parsing with malformed validation and bounds checks
- Checks every line-list range for out-of-bounds citations
- Uses the shared citation splitter in viewer warnings
- Adds regression coverage for normalizer round-trips, non-leading ranges, list bounds checks, and viewer warnings