### PR TITLE
fix(citations): accept whitespace around line-list commas

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -18,8 +18,14 @@ export { atomicWrite } from "./atomic-write.js";
 /** Regex matching `^[...]` citation markers (paragraph or claim-level). */
 const CITATION_MARKER_PATTERN = /\^\[([^\]]+)\]/g;
 
-/** Regex matching the optional `:start-end` or `#Lstart-Lend` span suffix on a citation entry. */
-const SPAN_SUFFIX_PATTERN = /^(?<file>[^:#]+)(?:(?::(?<colonStart>\d+)(?:[,-]\s*(?<colonEnd>\d+))?)|(?:#L(?<hashStart>\d+)(?:-L(?<hashEnd>\d+))?))?$/;
+/**
+ * Regex matching the optional `:start-end` or `#Lstart-Lend` span suffix on a
+ * citation entry. Only single spans reach this pattern; comma-separated lists
+ * are matched by {@link COLON_MULTILINE_PATTERN}, which every caller tries
+ * first. The colon separator is therefore a hyphen alone — admitting a comma
+ * here would let `81,90` be read as the range `81-90`.
+ */
+const SPAN_SUFFIX_PATTERN = /^(?<file>[^:#]+)(?:(?::(?<colonStart>\d+)(?:-\s*(?<colonEnd>\d+))?)|(?:#L(?<hashStart>\d+)(?:-L(?<hashEnd>\d+))?))?$/;
 
 /**
  * Regex matching a colon-form entry with two or more comma-separated line tokens,
@@ -27,8 +33,13 @@ const SPAN_SUFFIX_PATTERN = /^(?<file>[^:#]+)(?:(?::(?<colonStart>\d+)(?:[,-]\s*
  * compile-time normalizer emits (`source.md:1, 12`, `source.md:3,7,42`,
  * `source.md:1-5, 12`). Captured `lines` is the raw token string; each token
  * expands into its own SourceSpan.
+ *
+ * Whitespace is allowed on BOTH sides of each comma because the normalizer's
+ * bare-line pattern accepts it, so `^[81 , 90]` is repaired to
+ * `^[source.md:81 , 90]` — a form this pattern has to admit or the normalizer
+ * would emit citations its own validator rejects.
  */
-const COLON_MULTILINE_PATTERN = /^(?<file>[^:#]+):(?<lines>\d+(?:-\d+)?(?:,\s*\d+(?:-\d+)?)+)$/;
+const COLON_MULTILINE_PATTERN = /^(?<file>[^:#]+):(?<lines>\d+(?:-\d+)?(?:\s*,\s*\d+(?:-\d+)?)+)$/;
 
 /** The minimum valid line number in a source span (lines are 1-indexed). */
 const MIN_LINE_NUMBER = 1;
@@ -224,7 +235,7 @@ function parseLineToken(token: string): { start: number; end: number } {
 
 /** Parse comma-separated line tokens, returning null if any token is invalid. */
 function parseLineTokens(linesStr: string): Array<{ start: number; end: number }> | null {
-  const ranges = linesStr.split(/,\s*/).map(parseLineToken);
+  const ranges = linesStr.split(/\s*,\s*/).map(parseLineToken);
   return ranges.every(({ start, end }) => isValidLineRange(start, end)) ? ranges : null;
 }
 

--- a/test/citation-normalize.test.ts
+++ b/test/citation-normalize.test.ts
@@ -277,10 +277,15 @@ describe("normalizer output is always accepted by the malformed-citation validat
     "^[12,15,20]",
     "^[1-5, 12]",
     "^[1, 12-15]",
+    // The normalizer's bare-line pattern tolerates space on both sides of the
+    // comma, so the validator has to accept what that repairs into.
+    "^[81 , 90]",
+    "^[1-5 , 12]",
     `^[${source}:4]`,
     `^[${source}:4-8]`,
     `^[${source}:12,15,20]`,
     `^[${source}:1, 12-15]`,
+    `^[${source}:81 , 90]`,
     `^[${source}#L2-L6]`,
   ];
 

--- a/test/claim-provenance.test.ts
+++ b/test/claim-provenance.test.ts
@@ -77,6 +77,22 @@ describe("extractClaimCitations parser", () => {
     ]);
   });
 
+  it("reads a two-token comma list as two lines, not as a range", () => {
+    const citations = extractClaimCitations("A claim. ^[source.md:81,90]");
+    expect(citations[0].spans).toEqual([
+      { file: "source.md", lines: { start: 81, end: 81 } },
+      { file: "source.md", lines: { start: 90, end: 90 } },
+    ]);
+  });
+
+  it("tolerates space on either side of the separating comma", () => {
+    const citations = extractClaimCitations("A claim. ^[source.md:81 , 90]");
+    expect(citations[0].spans).toEqual([
+      { file: "source.md", lines: { start: 81, end: 81 } },
+      { file: "source.md", lines: { start: 90, end: 90 } },
+    ]);
+  });
+
   it("splits a digit-leading filename after a letter-leading one", () => {
     const citations = extractClaimCitations("A claim. ^[source.md, 2024-notes.md]");
     expect(citations).toHaveLength(1);
@@ -208,6 +224,12 @@ describe("isMalformedCitationEntry", () => {
     expect(isMalformedCitationEntry("file.md:8,12")).toBe(false);
     expect(isMalformedCitationEntry("file.md:1, 5")).toBe(false);
     expect(isMalformedCitationEntry("file.md:1, 5-8")).toBe(false);
+  });
+
+  it("accepts space on either side of the separating comma", () => {
+    expect(isMalformedCitationEntry("file.md:81 , 90")).toBe(false);
+    expect(isMalformedCitationEntry("file.md:81 ,90")).toBe(false);
+    expect(isMalformedCitationEntry("file.md:1-5 , 12")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Follow-up to #166. The compile-time normalizer tolerates spaces on either side of the comma in a bare line list, but the validator required the comma tight against the digits — so `^[81 , 90]` was repaired into `^[source.md:81 , 90]` and then rejected by the malformed-citation rule.

Also drops the comma from the span-suffix separator. That branch became unreachable once comma lists were routed to the multiline pattern, and had anything reached it the two tokens would have been stitched into the range `81-90` rather than read as two lines.
