### PR TITLE
feat(compile): allow callers to disable embeddings

### DIFF
--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -80,6 +80,7 @@ Both methods return `IngestResult` with `filename`, `chars`, and `truncated` fie
   Run the incremental compile pipeline. Extracts concepts from new or changed sources, generates typed wiki pages, resolves `[[wikilinks]]`, and rebuilds the index. **Requires LLM credentials.**
 
   - `options.review` - when `true`, writes generated pages to `.llmwiki/candidates/` for review instead of directly to `wiki/`. Same behavior as `llmwiki compile --review`.
+  - `options.embeddings` - set to `false` to skip embedding generation and pending-embedding retries. Page generation, links, and the lexical index still run.
 
   Source content is sent to the configured LLM provider during compilation. Do not compile wikis containing confidential data unless the provider's data-handling policies are acceptable for that content.
 

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -346,7 +346,13 @@ async function seedThenFinalize(
   draft: CompileStateDraft | null,
 ): Promise<void> {
   await maybeSeedPages(root, schema, generation, options);
-  await finalizeWiki(root, draft, generation.writtenPages, generation.seedSlugs);
+  await finalizeWiki(
+    root,
+    draft,
+    generation.writtenPages,
+    generation.seedSlugs,
+    options.embeddings !== false,
+  );
 }
 
 /** Inner pipeline, runs under lock protection. Returns structured CompileResult. */
@@ -510,6 +516,7 @@ async function finalizeWiki(
   draft: CompileStateDraft | null,
   pages: MergedConcept[],
   seedSlugs: string[] = [],
+  embeddingsEnabled = true,
 ): Promise<void> {
   const conceptChangedSlugs = pages.map((entry) => entry.slug);
   const conceptNewSlugs = pages
@@ -534,7 +541,7 @@ async function finalizeWiki(
 
   await generateIndex(root);
   await generateMOC(root);
-  await safelyUpdateEmbeddings(root, allChangedSlugs);
+  if (embeddingsEnabled) await safelyUpdateEmbeddings(root, allChangedSlugs);
 }
 
 /**

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,6 +85,11 @@ export interface SdkCompileOptions {
    * out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Refresh semantic embeddings after compilation. Defaults to true.
+   * False prevents embedding-provider calls and pending-embedding retries.
+   */
+  embeddings?: boolean;
 }
 
 /** Options for `getContextPack`. Maps onto the subset of BuildContextPackOptions needed externally. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -186,6 +186,12 @@ export interface CompileOptions {
    * the built-in default. Out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Refresh semantic embeddings after compilation. Defaults to true.
+   * Set to false for a lexical-only build with no embedding-provider calls or
+   * pending-embedding retries.
+   */
+  embeddings?: boolean;
 }
 
 /**

--- a/test/compile-options.test.ts
+++ b/test/compile-options.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @file test/compile-options.test.ts
+ * @description Public compile-option coverage for embedding suppression.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createWiki } from "../src/sdk/wiki.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import * as embeddings from "../src/utils/embeddings.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Alpha", summary: "Alpha summary.", is_new: true }],
+});
+
+const ctx = useCompileProject({
+  dirSuffix: "options",
+  sourceFile: "sample.md",
+  sourceContent: "# Alpha\n\nAlpha is documented here.",
+});
+
+/** Stub a one-concept compile and suppress terminal noise. */
+function stubCompile(): void {
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(EXTRACTION);
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Alpha body. ^[sample.md]");
+  vi.spyOn(console, "log").mockImplementation(() => {});
+}
+
+describe("compile options", () => {
+  it("embeddings:false skips embedding refresh while still compiling pages", async () => {
+    stubCompile();
+    const embedSpy = vi
+      .spyOn(embeddings, "updateEmbeddingsLockedCore")
+      .mockResolvedValue({ embedded: [], eligible: [] });
+
+    const result = await createWiki({ root: ctx.dir }).compile({ embeddings: false });
+
+    expect(result.pages).toContain("alpha");
+    expect(embedSpy).not.toHaveBeenCalled();
+  });


### PR DESCRIPTION
Adds an optional embeddings flag to the compile API. The default remains true for full backward compatibility; callers that maintain an independent semantic index can explicitly pass false. Includes API and compile-path coverage. Verified with TypeScript, build, targeted tests, and changed-scope checks.