### PR TITLE
feat(compile): add an additive system policy hook

### DIFF
--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -81,6 +81,7 @@ Both methods return `IngestResult` with `filename`, `chars`, and `truncated` fie
 
   - `options.review` - when `true`, writes generated pages to `.llmwiki/candidates/` for review instead of directly to `wiki/`. Same behavior as `llmwiki compile --review`.
   - `options.embeddings` - set to `false` to skip embedding generation and pending-embedding retries. Page generation, links, and the lexical index still run.
+  - `options.systemPolicy` - a trusted caller policy appended to both extraction and page-writing system prompts. It supplements rather than replaces the compiler's built-in instructions.
 
   Source content is sent to the configured LLM provider during compilation. Do not compile wikis containing confidential data unless the provider's data-handling policies are acceptable for that content.
 

--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -80,6 +80,7 @@ Both methods return `IngestResult` with `filename`, `chars`, and `truncated` fie
   Run the incremental compile pipeline. Extracts concepts from new or changed sources, generates typed wiki pages, resolves `[[wikilinks]]`, and rebuilds the index. **Requires LLM credentials.**
 
   - `options.review` - when `true`, writes generated pages to `.llmwiki/candidates/` for review instead of directly to `wiki/`. Same behavior as `llmwiki compile --review`.
+  - `options.embeddings` - set to `false` to skip embedding generation and pending-embedding retries. Page generation, links, and the lexical index still run.
 
   Source content is sent to the configured LLM provider during compilation. Do not compile wikis containing confidential data unless the provider's data-handling policies are acceptable for that content.
 

--- a/src/compiler/extraction-phase.ts
+++ b/src/compiler/extraction-phase.ts
@@ -51,12 +51,13 @@ async function extractSourcesLimited(
   root: string,
   files: string[],
   limit: ReturnType<typeof pLimit>,
+  systemPolicy?: string,
 ): Promise<ExtractionResult[]> {
   let aborted = false;
   return Promise.all(files.map((file) => limit(async () => {
     if (aborted) throw new Error(`extraction skipped for ${file}: a prior source failed`);
     try {
-      return await extractForSource(root, file);
+      return await extractForSource(root, file, systemPolicy);
     } catch (err) {
       aborted = true;
       throw err;
@@ -77,15 +78,18 @@ export async function runExtractionPhases(
   state: WikiState,
   allChanges: SourceChange[],
   concurrency: number,
+  systemPolicy?: string,
 ): Promise<ExtractionResult[]> {
   const limit = pLimit(concurrency);
-  const extractions = await extractSourcesLimited(root, toCompile.map((c) => c.file), limit);
+  const extractions = await extractSourcesLimited(
+    root, toCompile.map((c) => c.file), limit, systemPolicy,
+  );
 
   const lateAffected = findLateAffectedSources(extractions, state, allChanges);
   for (const file of lateAffected) {
     output.status("~", output.info(`${file} [shares concept with new source]`));
   }
-  const lateExtractions = await extractSourcesLimited(root, lateAffected, limit);
+  const lateExtractions = await extractSourcesLimited(root, lateAffected, limit, systemPolicy);
   for (const result of lateExtractions) extractions.push(result);
 
   return extractions;
@@ -98,6 +102,7 @@ export async function runExtractionPhases(
 async function extractForSource(
   root: string,
   sourceFile: string,
+  systemPolicy?: string,
 ): Promise<ExtractionResult> {
   output.status("*", output.info(`Extracting: ${sourceFile}`));
 
@@ -107,7 +112,7 @@ async function extractForSource(
   const chars = sourceContent.length;
   verbose(`source ${sourceFile}: ${lines} lines, ${chars} chars`);
   const existingIndex = await readConfinedExtractionIndex(root);
-  const concepts = await extractConcepts(sourceContent, existingIndex);
+  const concepts = await extractConcepts(sourceContent, existingIndex, systemPolicy);
 
   if (concepts.length > 0) {
     const names = concepts.map((c) => c.concept).join(", ");
@@ -141,13 +146,15 @@ async function readConfinedExtractionIndex(root: string): Promise<string> {
  * Call Claude to extract concepts from a source document.
  * @param sourceContent - Full source document text.
  * @param existingIndex - Current wiki index for deduplication.
+ * @param systemPolicy - Optional trusted caller policy added to the prompt.
  * @returns Parsed array of extracted concepts.
  */
 async function extractConcepts(
   sourceContent: string,
   existingIndex: string,
+  systemPolicy?: string,
 ): Promise<ExtractedConcept[]> {
-  const system = buildExtractionPrompt(sourceContent, existingIndex);
+  const system = buildExtractionPrompt(sourceContent, existingIndex, systemPolicy);
   const rawOutput = await callClaude({
     system,
     messages: [{ role: "user", content: "Extract the key concepts from this source." }],

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -326,7 +326,7 @@ async function maybeSeedPages(
   options: CompileOptions,
 ): Promise<void> {
   if (!options.review && !options.skipSeedPages) {
-    await generateSeedPages(root, schema, generation);
+    await generateSeedPages(root, schema, generation, options.systemPolicy);
   }
 }
 
@@ -425,7 +425,14 @@ async function runCompilePipeline(
   // Resolve once so an invalid override warns a single time, then cap both the
   // extraction and page-generation fan-outs identically.
   const concurrency = resolveCompileConcurrency(options.concurrency);
-  const extractions = await runExtractionPhases(root, buckets.toCompile, state, changes, concurrency);
+  const extractions = await runExtractionPhases(
+    root,
+    buckets.toCompile,
+    state,
+    changes,
+    concurrency,
+    options.systemPolicy,
+  );
   if (!options.review) {
     freezeFailedExtractions(draft, extractions, frozenSlugs);
   }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -346,7 +346,13 @@ async function seedThenFinalize(
   draft: CompileStateDraft | null,
 ): Promise<void> {
   await maybeSeedPages(root, schema, generation, options);
-  await finalizeWiki(root, draft, generation.writtenPages, generation.seedSlugs);
+  await finalizeWiki(
+    root,
+    draft,
+    generation.writtenPages,
+    generation.seedSlugs,
+    options.embeddings !== false,
+  );
 }
 
 /** Inner pipeline, runs under lock protection. Returns structured CompileResult. */
@@ -510,6 +516,7 @@ async function finalizeWiki(
   draft: CompileStateDraft | null,
   pages: MergedConcept[],
   seedSlugs: string[] = [],
+  embeddingsEnabled = true,
 ): Promise<void> {
   const conceptChangedSlugs = pages.map((entry) => entry.slug);
   const conceptNewSlugs = pages
@@ -534,7 +541,7 @@ async function finalizeWiki(
 
   await generateIndex(root);
   await generateMOC(root);
-  await safelyUpdateEmbeddings(root, allChangedSlugs);
+  if (embeddingsEnabled) await safelyUpdateEmbeddings(root, allChangedSlugs);
 }
 
 /**

--- a/src/compiler/page-renderer.ts
+++ b/src/compiler/page-renderer.ts
@@ -41,12 +41,14 @@ interface RenderableConcept {
  * @param root - Project root directory.
  * @param entry - The merged concept to render.
  * @param schema - Resolved schema config, used to stamp `kind` on frontmatter.
+ * @param systemPolicy - Optional trusted caller policy added to the page prompt.
  * @returns Full markdown content (frontmatter + body, trailing newline).
  */
 export async function renderMergedPageContent(
   root: string,
   entry: RenderableConcept,
   schema: SchemaConfig,
+  systemPolicy?: string,
 ): Promise<string> {
   const existingPage = await readWikiPageContentOrWarn(
     root, CONCEPTS_DIR, entry.slug, false /* new page — absence is normal */,
@@ -58,6 +60,7 @@ export async function renderMergedPageContent(
     entry.combinedContent,
     existingPage,
     relatedPages,
+    systemPolicy,
   );
 
   const rawPageBody = await callClaude({

--- a/src/compiler/prompts.ts
+++ b/src/compiler/prompts.ts
@@ -34,7 +34,22 @@ function withLangLine(...lines: string[]): string[] {
  * downstream auditor can distinguish pages produced under different prompt
  * generations even when the model id is identical. Format is `vMAJOR`.
  */
-export const PROMPT_VERSION = "v1";
+export const PROMPT_VERSION = "v2";
+
+/**
+ * Append a trusted caller policy without replacing any built-in instruction.
+ * Empty policies are omitted so the default prompt stays byte-identical.
+ */
+function withSystemPolicy(lines: string[], systemPolicy?: string): string[] {
+  const policy = systemPolicy?.trim();
+  if (!policy) return lines;
+  return [
+    ...lines,
+    "",
+    "Additional system policy (follow in addition to every built-in instruction above):",
+    policy,
+  ];
+}
 
 /** Allowed provenance state strings emitted by the LLM tool schema. */
 const PROVENANCE_STATE_VALUES: ProvenanceState[] = [
@@ -114,17 +129,19 @@ export const CONCEPT_EXTRACTION_TOOL = {
  * Instructs the LLM to analyze a source document and identify distinct concepts.
  * @param sourceContent - The full text of the source document.
  * @param existingIndex - The current wiki index.md contents (may be empty).
+ * @param systemPolicy - Optional trusted caller policy appended to built-in instructions.
  * @returns System prompt string for the extraction call.
  */
 export function buildExtractionPrompt(
   sourceContent: string,
   existingIndex: string,
+  systemPolicy?: string,
 ): string {
   const indexSection = existingIndex
     ? `\n\nHere is the existing wiki index — avoid duplicating concepts already covered:\n\n${existingIndex}`
     : "\n\nNo existing wiki pages yet.";
 
-  return [
+  const instructions = [
     ...withLangLine(
       "You are a knowledge extraction engine. Analyze the following source document",
       "and identify 3-8 distinct, meaningful concepts worth documenting as wiki pages.",
@@ -141,6 +158,10 @@ export function buildExtractionPrompt(
     "    or 'ambiguous' if the source is contradictory or unclear.",
     "  - contradicted_by: slugs of other concepts (in this batch or the index)",
     "    whose evidence conflicts with this one.",
+  ];
+
+  return [
+    ...withSystemPolicy(instructions, systemPolicy),
     indexSection,
     "\n\n--- SOURCE DOCUMENT ---\n\n",
     sourceContent,
@@ -154,6 +175,7 @@ export function buildExtractionPrompt(
  * @param sourceContent - The source material to draw from.
  * @param existingPage - The current page content if updating (empty for new pages).
  * @param relatedPages - Concatenated content of related wiki pages for context.
+ * @param systemPolicy - Optional trusted caller policy appended to built-in instructions.
  * @returns System prompt string for the page generation call.
  */
 export function buildPagePrompt(
@@ -161,6 +183,7 @@ export function buildPagePrompt(
   sourceContent: string,
   existingPage: string,
   relatedPages: string,
+  systemPolicy?: string,
 ): string {
   const existingSection = existingPage
     ? `\n\nExisting page to update:\n\n${existingPage}`
@@ -170,7 +193,7 @@ export function buildPagePrompt(
     ? `\n\nRelated wiki pages for cross-referencing:\n\n${relatedPages}`
     : "";
 
-  return [
+  const instructions = [
     ...withLangLine(
       `You are a wiki author. Write a clear, well-structured markdown page about "${concept}".`,
       "Draw facts only from the provided source material.",
@@ -196,6 +219,10 @@ export function buildPagePrompt(
     "If a paragraph is your inference rather than a direct extraction, leave it",
     "uncited — downstream lint rules will count uncited paragraphs as 'inferred'",
     "so lint can surface excess-inferred-paragraphs warnings on review.",
+  ];
+
+  return [
+    ...withSystemPolicy(instructions, systemPolicy),
     existingSection,
     relatedSection,
     "\n\n--- SOURCE MATERIAL ---\n\n",
@@ -263,26 +290,29 @@ function mapRawConcept(c: RawConcept): ExtractedConcept {
  * @param seed - Seed page definition pulled from the schema.
  * @param rule - Per-kind rule (used for the description and link minimum).
  * @param relatedPagesContent - Concatenated content of related concept pages.
+ * @param systemPolicy - Optional trusted caller policy appended to built-in instructions.
  * @returns System prompt string for the page generation call.
  */
 export function buildSeedPagePrompt(
   seed: SeedPage,
   rule: PageKindRule,
   relatedPagesContent: string,
+  systemPolicy?: string,
 ): string {
   const minLinks = rule.minWikilinks;
   const linkExpectation = minLinks > 0
     ? `Include at least ${minLinks} [[wikilinks]] to related pages.`
     : "Use [[wikilinks]] when referencing other pages.";
+  const instructions = withLangLine(
+    `You are a wiki author. Write a ${seed.kind} page titled "${seed.title}".`,
+    `Page-kind guidance: ${rule.description}`,
+    `Summary line for context: ${seed.summary}`,
+    "Draw facts only from the related wiki pages provided below.",
+    linkExpectation,
+    "Write in a neutral, informative tone. Be concise but thorough.",
+  );
   return [
-    ...withLangLine(
-      `You are a wiki author. Write a ${seed.kind} page titled "${seed.title}".`,
-      `Page-kind guidance: ${rule.description}`,
-      `Summary line for context: ${seed.summary}`,
-      "Draw facts only from the related wiki pages provided below.",
-      linkExpectation,
-      "Write in a neutral, informative tone. Be concise but thorough.",
-    ),
+    ...withSystemPolicy(instructions, systemPolicy),
     "\n\n--- RELATED PAGES ---\n\n",
     relatedPagesContent,
   ].join("\n");

--- a/src/compiler/review-pipeline.ts
+++ b/src/compiler/review-pipeline.ts
@@ -65,7 +65,7 @@ export async function generateMergedPage(
   sourceStates: SourceStateMap,
   policy: ReviewPolicy,
 ): Promise<MergedPageOutcome> {
-  const fullPage = await renderMergedPageContent(root, entry, schema);
+  const fullPage = await renderMergedPageContent(root, entry, schema, options.systemPolicy);
   const diagnostics = await collectReviewDiagnostics(root, entry, fullPage, schema);
   const signals = buildPolicySignals(fullPage, diagnostics);
   const reasons = evaluatePolicy(signals, policy);

--- a/src/compiler/seed-pages.ts
+++ b/src/compiler/seed-pages.ts
@@ -40,11 +40,13 @@ import type { PageGenerationResult } from "./types.js";
  * @param root - Project root directory.
  * @param schema - Resolved schema config.
  * @param generation - Result of the concept-page generation phase.
+ * @param systemPolicy - Optional trusted caller policy added to seed prompts.
  */
 export async function generateSeedPages(
   root: string,
   schema: SchemaConfig,
   generation: PageGenerationResult,
+  systemPolicy?: string,
 ): Promise<void> {
   if (schema.seedPages.length === 0) return;
   // Dedup seeds by slug FIRST-SEEN-WINS before rendering, mirroring
@@ -60,7 +62,7 @@ export async function generateSeedPages(
   // an error and is excluded from the batch (skip-not-abort, like generation).
   const writes: CompilePageWrite[] = [];
   for (const seed of dedupedSeeds) {
-    const result = await generateSingleSeedPage(root, schema, seed);
+    const result = await generateSingleSeedPage(root, schema, seed, systemPolicy);
     if (result.error) {
       generation.errors.push(result.error);
       continue;
@@ -136,11 +138,12 @@ async function generateSingleSeedPage(
   root: string,
   schema: SchemaConfig,
   seed: SeedPage,
+  systemPolicy?: string,
 ): Promise<SeedPageOutcome> {
   const slug = slugify(seed.title);
   const relatedContent = await loadSeedRelatedPages(root, seed.relatedSlugs ?? []);
   const rule = schema.kinds[seed.kind];
-  const system = buildSeedPagePrompt(seed, rule, relatedContent);
+  const system = buildSeedPagePrompt(seed, rule, relatedContent, systemPolicy);
   const pageBody = await callClaude({
     system,
     messages: [{ role: "user", content: `Write the ${seed.kind} page titled "${seed.title}".` }],

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,6 +85,11 @@ export interface SdkCompileOptions {
    * out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Refresh semantic embeddings after compilation. Defaults to true.
+   * False prevents embedding-provider calls and pending-embedding retries.
+   */
+  embeddings?: boolean;
 }
 
 /** Options for `getContextPack`. Maps onto the subset of BuildContextPackOptions needed externally. */

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -90,6 +90,11 @@ export interface SdkCompileOptions {
    * False prevents embedding-provider calls and pending-embedding retries.
    */
   embeddings?: boolean;
+  /**
+   * Trusted caller policy appended to both compile-time system prompts.
+   * The compiler's built-in extraction and page-writing instructions remain.
+   */
+  systemPolicy?: string;
 }
 
 /** Options for `getContextPack`. Maps onto the subset of BuildContextPackOptions needed externally. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -186,6 +186,12 @@ export interface CompileOptions {
    * the built-in default. Out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Refresh semantic embeddings after compilation. Defaults to true.
+   * Set to false for a lexical-only build with no embedding-provider calls or
+   * pending-embedding retries.
+   */
+  embeddings?: boolean;
 }
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -192,6 +192,11 @@ export interface CompileOptions {
    * pending-embedding retries.
    */
   embeddings?: boolean;
+  /**
+   * Trusted caller policy appended to the built-in extraction and page-writing
+   * system instructions. The built-in instructions are never replaced.
+   */
+  systemPolicy?: string;
 }
 
 /**

--- a/test/compile-options.test.ts
+++ b/test/compile-options.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @file test/compile-options.test.ts
+ * @description Public compile-option coverage for embedding suppression.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createWiki } from "../src/sdk/wiki.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import * as embeddings from "../src/utils/embeddings.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Alpha", summary: "Alpha summary.", is_new: true }],
+});
+
+const ctx = useCompileProject({
+  dirSuffix: "options",
+  sourceFile: "sample.md",
+  sourceContent: "# Alpha\n\nAlpha is documented here.",
+});
+
+/** Stub a one-concept compile and suppress terminal noise. */
+function stubCompile(): void {
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(EXTRACTION);
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Alpha body. ^[sample.md]");
+  vi.spyOn(console, "log").mockImplementation(() => {});
+}
+
+describe("compile options", () => {
+  it("embeddings:false skips embedding refresh while still compiling pages", async () => {
+    stubCompile();
+    const embedSpy = vi
+      .spyOn(embeddings, "updateEmbeddingsLockedCore")
+      .mockResolvedValue({ embedded: [], eligible: [] });
+
+    const result = await createWiki({ root: ctx.dir }).compile({ embeddings: false });
+
+    expect(result.pages).toContain("alpha");
+    expect(embedSpy).not.toHaveBeenCalled();
+  });

--- a/test/compile-options.test.ts
+++ b/test/compile-options.test.ts
@@ -1,6 +1,7 @@
 /**
  * @file test/compile-options.test.ts
- * @description Public compile-option coverage for embedding suppression.
+ * @description Public compile-option coverage for embedding suppression and
+ * caller-provided additive system policy across both LLM phases.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -9,6 +10,7 @@ import { AnthropicProvider } from "../src/providers/anthropic.js";
 import * as embeddings from "../src/utils/embeddings.js";
 import { useCompileProject } from "./fixtures/compile-project.js";
 
+const POLICY = "Never publish credential values from the supplied sources.";
 const EXTRACTION = JSON.stringify({
   concepts: [{ concept: "Alpha", summary: "Alpha summary.", is_new: true }],
 });
@@ -26,6 +28,14 @@ function stubCompile(): void {
   vi.spyOn(console, "log").mockImplementation(() => {});
 }
 
+/** Return a provider stub that records its system prompt. */
+function captureSystem<T>(systems: string[], value: T): (system: string) => Promise<T> {
+  return async (system) => {
+    systems.push(system);
+    return value;
+  };
+}
+
 describe("compile options", () => {
   it("embeddings:false skips embedding refresh while still compiling pages", async () => {
     stubCompile();
@@ -38,3 +48,22 @@ describe("compile options", () => {
     expect(result.pages).toContain("alpha");
     expect(embedSpy).not.toHaveBeenCalled();
   });
+
+  it("adds one caller policy to both built-in system prompts before source material", async () => {
+    const extractionSystems: string[] = [];
+    const pageSystems: string[] = [];
+    vi.spyOn(AnthropicProvider.prototype, "toolCall")
+      .mockImplementation(captureSystem(extractionSystems, EXTRACTION));
+    vi.spyOn(AnthropicProvider.prototype, "complete")
+      .mockImplementation(captureSystem(pageSystems, "Alpha body. ^[sample.md]"));
+
+    await createWiki({ root: ctx.dir }).compile({ embeddings: false, systemPolicy: POLICY });
+
+    expect(extractionSystems[0]).toContain("You are a knowledge extraction engine.");
+    expect(pageSystems[0]).toContain("You are a wiki author.");
+    expect(extractionSystems[0]).toContain(POLICY);
+    expect(pageSystems[0]).toContain(POLICY);
+    expect(extractionSystems[0].indexOf(POLICY)).toBeLessThan(extractionSystems[0].indexOf("--- SOURCE DOCUMENT ---"));
+    expect(pageSystems[0].indexOf(POLICY)).toBeLessThan(pageSystems[0].indexOf("--- SOURCE MATERIAL ---"));
+  });
+});


### PR DESCRIPTION
Adds an optional additive systemPolicy compile input so host applications can append safety and publication policy without replacing the compiler prompts. Existing behavior is unchanged when omitted. This branch is stacked on #169; the intended incremental review is commit 77a43a7. Verified with TypeScript, build, targeted tests, and changed-scope checks.