### PR TITLE
fix(compile): reconcile shared pages after source deletion

### DIFF
--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -81,6 +81,7 @@ Both methods return `IngestResult` with `filename`, `chars`, and `truncated` fie
 
   - `options.review` - when `true`, writes generated pages to `.llmwiki/candidates/` for review instead of directly to `wiki/`. Same behavior as `llmwiki compile --review`.
   - `options.embeddings` - set to `false` to skip embedding generation and pending-embedding retries. Page generation, links, and the lexical index still run.
+  - `options.systemPolicy` - a trusted caller policy appended to both extraction and page-writing system prompts. It supplements rather than replaces the compiler's built-in instructions.
 
   Source content is sent to the configured LLM provider during compilation. Do not compile wikis containing confidential data unless the provider's data-handling policies are acceptable for that content.
 

--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -80,6 +80,7 @@ Both methods return `IngestResult` with `filename`, `chars`, and `truncated` fie
   Run the incremental compile pipeline. Extracts concepts from new or changed sources, generates typed wiki pages, resolves `[[wikilinks]]`, and rebuilds the index. **Requires LLM credentials.**
 
   - `options.review` - when `true`, writes generated pages to `.llmwiki/candidates/` for review instead of directly to `wiki/`. Same behavior as `llmwiki compile --review`.
+  - `options.embeddings` - set to `false` to skip embedding generation and pending-embedding retries. Page generation, links, and the lexical index still run.
 
   Source content is sent to the configured LLM provider during compilation. Do not compile wikis containing confidential data unless the provider's data-handling policies are acceptable for that content.
 

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -137,10 +137,9 @@ function buildRefreshSummary(liveRefreshed: number, heldCount: number, orphanedC
 
 /**
  * Invoke the provider guard only when the plan will trigger an LLM extraction.
- * Concept extraction runs solely for changed owners and their known-affected
- * co-contributors; with no changed owners, knownAffected is empty too
- * (findAffectedSources expands only from changed/new sources), so cleanup-only
- * plans (orphan/shared state repair) skip the guard and need no key.
+ * Concept extraction runs for changed owners and their known-affected
+ * co-contributors. A deleted owner can contribute knownAffected survivors
+ * because partial-deletion pages are rebuilt from live evidence.
  */
 function maybeEnsureProvider(plan: RefreshPlan, ensureProvider?: () => void): void {
   const needsLLM = plan.changedOwners.length > 0 || plan.knownAffected.length > 0;
@@ -177,7 +176,6 @@ function printPlan(plan: RefreshPlan): void {
   output.status("~", output.info(
     `Recompiling ${plan.recompiledPages.length} page(s) from ${modelSources} source(s) ` +
     `(${plan.changedOwners.length} changed + ${plan.knownAffected.length} known affected; more may be found during the run); ` +
-    `${plan.sharedKeptPages.length} kept (shared, content not rebuilt); ` +
     `cleaning up ${plan.computedOrphanedPages.length} orphaned page(s).`,
   ));
   for (const [items, label, icon] of planDetailRows(plan)) {
@@ -187,8 +185,7 @@ function printPlan(plan: RefreshPlan): void {
 
 /**
  * True when the plan has any actionable work: pages to recompile, orphaned
- * pages to clean up, OR shared (partial-deletion) pages whose state needs
- * repairing (the deleted owner removed from state, content kept).
+ * pages to clean up, or a legacy sharedKeptPages entry.
  */
 function hasWork(plan: RefreshPlan): boolean {
   return (
@@ -202,7 +199,6 @@ function hasWork(plan: RefreshPlan): boolean {
 function planDetailRows(plan: RefreshPlan): PlanDetailRow[] {
   return [
     [plan.recompiledPages, "recompiled", "~"],
-    [plan.sharedKeptPages, "kept (shared) — content not regenerated", "i"],
     [plan.computedOrphanedPages, "cleaned up (orphaned)", "⚠"],
     [plan.alreadyOrphanedPages, "already orphaned — no action", "i"],
     [plan.knownAffected, "known affected sources (more may be found during the run)", "~"],

--- a/src/compiler/citation-normalize.ts
+++ b/src/compiler/citation-normalize.ts
@@ -73,15 +73,15 @@ function rangeIsValid(entry: string, maxLine: number): boolean {
  * Returns the (possibly repaired) entry string, or null to signal the entry
  * should be dropped entirely.
  *
- * Only bare line numbers / ranges (no filename component at all) are
- * normalised here. Entries that contain a filename — even an unresolvable
- * or malformed one — are left as-is so the downstream provenance linter
- * (`broken-citation`, `malformed-claim-citation`) can classify them.
+ * Bare line numbers / ranges are normalised here. Unknown filename entries
+ * remain available to provenance lint during ordinary updates, but callers can
+ * drop them for a clean deletion-reconciliation rebuild.
  */
 function normalizeEntry(
   entry: string,
   sourceFiles: string[],
   maxLine: number,
+  dropUnknownSourceEntries: boolean,
 ): string | null {
   const trimmed = entry.trim();
   if (trimmed.length === 0) return null;
@@ -103,9 +103,10 @@ function normalizeEntry(
     return null;
   }
 
-  // Case 3: has a filename component (even if unresolvable or malformed) — leave
-  // as-is for the downstream provenance linter to handle.
-  return trimmed;
+  // Case 3: has an unknown filename component. Normal updates leave it for
+  // downstream provenance lint. Clean rebuilds drop it so a removed source
+  // cannot re-enter the reconciled page.
+  return dropUnknownSourceEntries ? null : trimmed;
 }
 
 /**
@@ -128,8 +129,8 @@ function rebuildMarker(entries: string[]): string | null {
  *   or dropped when the line exceeds the source's actual line count.
  * - Bare numbers on multi-source pages are dropped (ambiguous — can't determine
  *   which source the LLM intended).
- * - Entries with a filename component (even unresolvable or malformed) are left
- *   as-is for the downstream provenance linter to classify.
+ * - Unknown filename entries remain for provenance lint by default, or are
+ *   removed when `dropUnknownSourceEntries` is enabled for a clean rebuild.
  *
  * When all entries in a marker are dropped the entire `^[...]` marker is
  * removed. A trailing space before the removed marker is also collapsed so
@@ -138,18 +139,23 @@ function rebuildMarker(entries: string[]): string | null {
  * @param body - Raw LLM output page body to normalise.
  * @param sourceFiles - Valid source filenames for this page (basenames only).
  * @param combinedContent - The numbered combined-source text the LLM received.
+ * @param dropUnknownSourceEntries - Remove citations outside sourceFiles.
  * @returns The normalised body string.
  */
 export function normalizeCitations(
   body: string,
   sourceFiles: string[],
   combinedContent: string,
+  dropUnknownSourceEntries = false,
 ): string {
   const maxLine = maxLineNumber(combinedContent);
   MARKER_PATTERN.lastIndex = 0;
 
   return body.replace(MARKER_PATTERN, (fullMatch, inner: string) => {
-    const entries = splitCitationMarker(inner).map((e) => normalizeEntry(e, sourceFiles, maxLine));
+    const entries = splitCitationMarker(inner)
+      .map((entry) => normalizeEntry(
+        entry, sourceFiles, maxLine, dropUnknownSourceEntries,
+      ));
     const rebuilt = rebuildMarker(entries as string[]);
     if (rebuilt === null) {
       // Signal for post-replace space cleanup: return empty string; the
@@ -165,13 +171,23 @@ export function normalizeCitations(
  * marker was removed. A space immediately before a removed marker is collapsed.
  *
  * This is the public entry point used by the page renderer.
+ * @param body - Raw LLM output page body to normalise.
+ * @param sourceFiles - Valid source filenames for this page.
+ * @param combinedContent - Numbered source text supplied to the LLM.
+ * @param dropUnknownSourceEntries - Remove citations outside sourceFiles.
  */
 export function normalizeCitationsInBody(
   body: string,
   sourceFiles: string[],
   combinedContent: string,
+  dropUnknownSourceEntries = false,
 ): string {
-  const withSentinels = normalizeCitations(body, sourceFiles, combinedContent);
+  const withSentinels = normalizeCitations(
+    body,
+    sourceFiles,
+    combinedContent,
+    dropUnknownSourceEntries,
+  );
   // Remove sentinels and the optional preceding space.
   return withSentinels.replace(/ ?\x00REMOVED\x00/g, "");
 }

--- a/src/compiler/compile-report.ts
+++ b/src/compiler/compile-report.ts
@@ -127,9 +127,9 @@ export function reportSchemaStatus(schema: SchemaConfig): void {
   }
 }
 
-/** Log frozen slugs (shared concepts whose deletion-pinned content must persist). */
+/** Log slugs held because at least one required source failed extraction. */
 export function reportFrozenSlugs(frozenSlugs: Set<string>): void {
   for (const slug of frozenSlugs) {
-    output.status("i", output.dim(`Frozen: ${slug} (shared with deleted source)`));
+    output.status("i", output.dim(`Frozen: ${slug} (required source extraction failed)`));
   }
 }

--- a/src/compiler/deps.ts
+++ b/src/compiler/deps.ts
@@ -59,29 +59,47 @@ function filesByStatus(
   );
 }
 
-/**
- * Collect co-contributors for a source's concepts, skipping files in the
- * exclusion sets. Mutates `out` by adding newly discovered contributors.
- */
-function collectSharedContributors(
+/** Flatten the old-state co-owners for every concept claimed by one source. */
+function knownCoOwners(
   sourceFile: string,
   state: WikiState,
   conceptMap: Map<string, string[]>,
-  excludeSets: Set<string>[],
-  out: Set<string>,
-): void {
-  const sourceEntry = state.sources[sourceFile];
-  if (!sourceEntry) return;
+): string[] {
+  const concepts = state.sources[sourceFile]?.concepts ?? [];
+  return concepts.flatMap((slug) => conceptMap.get(slug) ?? []);
+}
 
-  for (const slug of sourceEntry.concepts) {
-    const contributors = conceptMap.get(slug);
-    if (!contributors || contributors.length < 2) continue;
+/**
+ * Walk every live co-owner reachable from the seed sources to a fixed point.
+ * @param state - Persisted source-to-concept ownership graph.
+ * @param seeds - Sources whose known concepts seed graph traversal.
+ * @param excluded - Changed or deleted sources that must not enter the result.
+ * @param initialAffected - Live owners already known to require extraction.
+ */
+function expandSharedOwnerClosure(
+  state: WikiState,
+  seeds: Iterable<string>,
+  excluded: ReadonlySet<string>,
+  initialAffected: Iterable<string> = [],
+): string[] {
+  const conceptMap = buildConceptToSourcesMap(state.sources);
+  const affected = new Set(
+    [...initialAffected].filter((file) => !excluded.has(file)),
+  );
+  const queue = [...seeds, ...affected];
+  const visited = new Set<string>();
 
-    for (const contributor of contributors) {
-      const isExcluded = excludeSets.some((s) => s.has(contributor));
-      if (!isExcluded) out.add(contributor);
+  for (let index = 0; index < queue.length; index += 1) {
+    const sourceFile = queue[index];
+    if (visited.has(sourceFile)) continue;
+    visited.add(sourceFile);
+    for (const contributor of knownCoOwners(sourceFile, state, conceptMap)) {
+      if (excluded.has(contributor) || affected.has(contributor)) continue;
+      affected.add(contributor);
+      queue.push(contributor);
     }
   }
+  return [...affected];
 }
 
 /**
@@ -90,10 +108,12 @@ function collectSharedContributors(
  * concept regeneration — ensuring shared concepts are rebuilt with content
  * from ALL contributing sources.
  *
- * Deleted sources are intentionally excluded: recompiling a concept-mate of
- * a deleted source would regenerate the page from fewer sources, losing
- * content. Shared concepts from deleted sources are preserved as-is by
- * markOrphaned (which skips shared concepts).
+ * Deleted sources also seed affected-owner discovery. Their surviving
+ * co-contributors rebuild shared pages from the remaining evidence so deleted
+ * claims and citations do not stay frozen in the wiki.
+ *
+ * Persisted frozen slugs are legacy/retry reconciliation markers. Their live
+ * owners are scheduled even when every source hash is otherwise current.
  *
  * @param state - The current persisted WikiState.
  * @param directChanges - Changes detected by hash comparison.
@@ -106,66 +126,58 @@ export function findAffectedSources(
   const changedFiles = filesByStatus(directChanges, "new", "changed");
   const deletedFiles = filesByStatus(directChanges, "deleted");
   const conceptMap = buildConceptToSourcesMap(state.sources);
-  const affected = new Set<string>();
-
-  for (const changedFile of changedFiles) {
-    collectSharedContributors(
-      changedFile, state, conceptMap,
-      [changedFiles, deletedFiles, affected],
-      affected,
-    );
-  }
-
-  return Array.from(affected);
+  const excluded = new Set([...changedFiles, ...deletedFiles]);
+  const frozenOwners = findSlugOwners(
+    new Set(state.frozenSlugs ?? []),
+    conceptMap,
+    [excluded],
+  );
+  return expandSharedOwnerClosure(
+    state,
+    excluded,
+    excluded,
+    frozenOwners,
+  );
 }
 
 /**
- * Find concept slugs that must NOT be regenerated during this compile batch.
- * A slug is "frozen" when it was shared between a deleted source and at least
- * one surviving source. Regenerating it would overwrite the existing page
- * (which has combined content from all prior contributors) with content from
- * only the surviving sources, silently losing the deleted source's contribution.
+ * Find pages that require a clean rebuild or orphan reconciliation.
+ * Includes legacy frozen slugs plus concepts shared by a deleted source and at
+ * least one source that survives this compile.
  * @param state - Current persisted state.
  * @param changes - All detected source changes in this batch.
- * @returns Set of concept slugs that compileSource should skip.
+ * @returns Concept slugs whose old page must not be reused as prompt context.
  */
-export function findFrozenSlugs(
+export function findReconciliationSlugs(
   state: WikiState,
   changes: SourceChange[],
 ): Set<string> {
-  // Start with persisted frozen slugs from prior batches.
-  const frozen = new Set<string>(state.frozenSlugs ?? []);
-
-  // Add new frozen slugs from deletions in this batch.
-  const deletedFiles = changes
-    .filter((c) => c.status === "deleted")
-    .map((c) => c.file);
-
+  const reconciliation = new Set<string>(state.frozenSlugs ?? []);
+  const deletedFiles = new Set(
+    changes.filter((c) => c.status === "deleted").map((c) => c.file),
+  );
   const conceptMap = buildConceptToSourcesMap(state.sources);
 
   for (const file of deletedFiles) {
     const entry = state.sources[file];
     if (!entry) continue;
-
     for (const slug of entry.concepts) {
-      const contributors = conceptMap.get(slug);
-      if (contributors && contributors.length > 1) {
-        frozen.add(slug);
-      }
+      const owners = conceptMap.get(slug) ?? [];
+      if (owners.some((owner) => !deletedFiles.has(owner))) reconciliation.add(slug);
     }
   }
 
-  return frozen;
+  return reconciliation;
 }
 
 /**
- * Unfreeze slugs that were successfully regenerated by all their current
- * contributors, then persist the remaining frozen set to state.
+ * Persist extraction-frozen slugs that were not successfully regenerated by
+ * all their current contributors.
  * A slug is safe to unfreeze when every source that claims it in state
  * was compiled in this batch and successfully extracted it.
  * @param draft - In-memory CompileStateDraft the function reads/mutates instead of disk state,
  *   so freshly-compiled markers from this run are visible when making unfreeze decisions.
- * @param frozenSlugs - Set of concept slugs currently frozen (shared with a deleted source).
+ * @param frozenSlugs - Concept slugs held because a required extraction failed.
  * @param successfulExtractions - Extraction results from sources compiled in this batch.
  */
 export function persistFrozenSlugs(
@@ -260,19 +272,23 @@ function findSlugOwners(
  * @param extractions - Results from Phase 1 extraction.
  * @param state - Current persisted state.
  * @param allChanges - Full changes array including deleted/unchanged entries.
+ * @param alreadyExtracted - Sources completed by earlier fixed-point rounds.
  * @returns Filenames of unchanged sources that share concepts with compiled sources.
  */
 export function findLateAffectedSources(
   extractions: ExtractionResult[],
   state: WikiState,
   allChanges: SourceChange[],
+  alreadyExtracted: ReadonlySet<string> = new Set(),
 ): string[] {
   const compilingFiles = filesByStatus(allChanges, "new", "changed");
+  for (const file of alreadyExtracted) compilingFiles.add(file);
   const deletedFiles = filesByStatus(allChanges, "deleted");
   const conceptMap = buildConceptToSourcesMap(state.sources);
   const freshSlugs = collectFreshSlugs(extractions, state);
-
-  return findSlugOwners(freshSlugs, conceptMap, [compilingFiles, deletedFiles]);
+  const excluded = new Set([...compilingFiles, ...deletedFiles]);
+  const discovered = findSlugOwners(freshSlugs, conceptMap, [excluded]);
+  return expandSharedOwnerClosure(state, discovered, excluded, discovered);
 }
 
 /**

--- a/src/compiler/extraction-merge.ts
+++ b/src/compiler/extraction-merge.ts
@@ -19,6 +19,36 @@ import type { ExtractionResult } from "./deps.js";
 import type { ExtractedConcept } from "../utils/types.js";
 import type { MergedConcept } from "./types.js";
 
+/** Add one extracted concept to the slug-indexed merge accumulators. */
+function mergeConcept(
+  result: ExtractionResult,
+  concept: ExtractedConcept,
+  bySlug: Map<string, MergedConcept>,
+  slicesBySlug: Map<string, SourceSlice[]>,
+  rebuildSlugs: ReadonlySet<string>,
+): void {
+  const slug = slugify(concept.concept);
+  const existing = bySlug.get(slug);
+  if (existing) {
+    existing.concept = reconcileConceptMetadata(existing.concept, concept);
+    existing.sourceFiles.push(result.sourceFile);
+  } else {
+    const entry: MergedConcept = {
+      slug,
+      concept,
+      sourceFiles: [result.sourceFile],
+      combinedContent: "",
+    };
+    if (rebuildSlugs.has(slug)) entry.rebuild = true;
+    bySlug.set(slug, entry);
+    slicesBySlug.set(slug, []);
+  }
+  slicesBySlug.get(slug)!.push({
+    file: result.sourceFile,
+    content: result.sourceContent,
+  });
+}
+
 /**
  * Reconcile metadata from a later-extracted concept into an existing merged entry.
  * Called when multiple sources contribute the same slug — produces the most
@@ -74,11 +104,13 @@ export function reconcileConceptMetadata(
  * so popular concepts that appear in many overlapping sources do not blow
  * past the LLM provider's context window (issue #39). When the raw total
  * fits the budget, the output is byte-identical to the previous unbudgeted
- * concatenation.
+ * concatenation. Slugs in `rebuildSlugs` carry a clean-rebuild marker so page
+ * rendering does not feed stale content from removed sources back to the LLM.
  */
 export function mergeExtractions(
   extractions: ExtractionResult[],
   frozenSlugs: Set<string>,
+  rebuildSlugs: ReadonlySet<string> = new Set(),
 ): MergedConcept[] {
   const bySlug = new Map<string, MergedConcept>();
   const slicesBySlug = new Map<string, SourceSlice[]>();
@@ -89,24 +121,7 @@ export function mergeExtractions(
     for (const concept of result.concepts) {
       const slug = slugify(concept.concept);
       if (frozenSlugs.has(slug)) continue;
-
-      const existing = bySlug.get(slug);
-      if (existing) {
-        existing.concept = reconcileConceptMetadata(existing.concept, concept);
-        existing.sourceFiles.push(result.sourceFile);
-      } else {
-        bySlug.set(slug, {
-          slug,
-          concept,
-          sourceFiles: [result.sourceFile],
-          combinedContent: "",
-        });
-        slicesBySlug.set(slug, []);
-      }
-      slicesBySlug.get(slug)!.push({
-        file: result.sourceFile,
-        content: result.sourceContent,
-      });
+      mergeConcept(result, concept, bySlug, slicesBySlug, rebuildSlugs);
     }
   }
 

--- a/src/compiler/extraction-phase.ts
+++ b/src/compiler/extraction-phase.ts
@@ -66,11 +66,11 @@ async function extractSourcesLimited(
 }
 
 /**
- * Phase 1: extract concepts for the directly-changed batch, then expand to
- * any unchanged sources whose concepts overlap with newly extracted slugs.
- * Both batches share one `pLimit(concurrency)` cap; the late-affected set is
- * computed only after the whole direct batch resolves, since
- * findLateAffectedSources reads every direct extraction.
+ * Phase 1: extract concepts for the directly-changed batch, then repeatedly
+ * expand to unchanged sources whose concepts overlap newly extracted slugs.
+ * Every batch shares one `pLimit(concurrency)` cap. Discovery continues to a
+ * fixed point because a late owner's extraction can reveal another owner that
+ * was absent from its prior state entry.
  */
 export async function runExtractionPhases(
   root: string,
@@ -85,12 +85,18 @@ export async function runExtractionPhases(
     root, toCompile.map((c) => c.file), limit, systemPolicy,
   );
 
-  const lateAffected = findLateAffectedSources(extractions, state, allChanges);
-  for (const file of lateAffected) {
-    output.status("~", output.info(`${file} [shares concept with new source]`));
+  while (true) {
+    const extracted = new Set(extractions.map((result) => result.sourceFile));
+    const lateAffected = findLateAffectedSources(
+      extractions, state, allChanges, extracted,
+    );
+    if (lateAffected.length === 0) break;
+    for (const file of lateAffected) {
+      output.status("~", output.info(`${file} [shares concept with new source]`));
+    }
+    const batch = await extractSourcesLimited(root, lateAffected, limit, systemPolicy);
+    extractions.push(...batch);
   }
-  const lateExtractions = await extractSourcesLimited(root, lateAffected, limit, systemPolicy);
-  for (const result of lateExtractions) extractions.push(result);
 
   return extractions;
 }

--- a/src/compiler/extraction-phase.ts
+++ b/src/compiler/extraction-phase.ts
@@ -51,12 +51,13 @@ async function extractSourcesLimited(
   root: string,
   files: string[],
   limit: ReturnType<typeof pLimit>,
+  systemPolicy?: string,
 ): Promise<ExtractionResult[]> {
   let aborted = false;
   return Promise.all(files.map((file) => limit(async () => {
     if (aborted) throw new Error(`extraction skipped for ${file}: a prior source failed`);
     try {
-      return await extractForSource(root, file);
+      return await extractForSource(root, file, systemPolicy);
     } catch (err) {
       aborted = true;
       throw err;
@@ -77,15 +78,18 @@ export async function runExtractionPhases(
   state: WikiState,
   allChanges: SourceChange[],
   concurrency: number,
+  systemPolicy?: string,
 ): Promise<ExtractionResult[]> {
   const limit = pLimit(concurrency);
-  const extractions = await extractSourcesLimited(root, toCompile.map((c) => c.file), limit);
+  const extractions = await extractSourcesLimited(
+    root, toCompile.map((c) => c.file), limit, systemPolicy,
+  );
 
   const lateAffected = findLateAffectedSources(extractions, state, allChanges);
   for (const file of lateAffected) {
     output.status("~", output.info(`${file} [shares concept with new source]`));
   }
-  const lateExtractions = await extractSourcesLimited(root, lateAffected, limit);
+  const lateExtractions = await extractSourcesLimited(root, lateAffected, limit, systemPolicy);
   for (const result of lateExtractions) extractions.push(result);
 
   return extractions;
@@ -98,6 +102,7 @@ export async function runExtractionPhases(
 async function extractForSource(
   root: string,
   sourceFile: string,
+  systemPolicy?: string,
 ): Promise<ExtractionResult> {
   output.status("*", output.info(`Extracting: ${sourceFile}`));
 
@@ -107,7 +112,7 @@ async function extractForSource(
   const chars = sourceContent.length;
   verbose(`source ${sourceFile}: ${lines} lines, ${chars} chars`);
   const existingIndex = await readConfinedExtractionIndex(root);
-  const concepts = await extractConcepts(sourceContent, existingIndex);
+  const concepts = await extractConcepts(sourceContent, existingIndex, systemPolicy);
 
   if (concepts.length > 0) {
     const names = concepts.map((c) => c.concept).join(", ");
@@ -141,13 +146,15 @@ async function readConfinedExtractionIndex(root: string): Promise<string> {
  * Call Claude to extract concepts from a source document.
  * @param sourceContent - Full source document text.
  * @param existingIndex - Current wiki index for deduplication.
+ * @param systemPolicy - Optional trusted caller policy added to the prompt.
  * @returns Parsed array of extracted concepts.
  */
 async function extractConcepts(
   sourceContent: string,
   existingIndex: string,
+  systemPolicy?: string,
 ): Promise<ExtractedConcept[]> {
-  const system = buildExtractionPrompt(sourceContent, existingIndex);
+  const system = buildExtractionPrompt(sourceContent, existingIndex, systemPolicy);
   const rawOutput = await callClaude({
     system,
     messages: [{ role: "user", content: "Extract the key concepts from this source." }],

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -326,7 +326,7 @@ async function maybeSeedPages(
   options: CompileOptions,
 ): Promise<void> {
   if (!options.review && !options.skipSeedPages) {
-    await generateSeedPages(root, schema, generation);
+    await generateSeedPages(root, schema, generation, options.systemPolicy);
   }
 }
 
@@ -425,7 +425,14 @@ async function runCompilePipeline(
   // Resolve once so an invalid override warns a single time, then cap both the
   // extraction and page-generation fan-outs identically.
   const concurrency = resolveCompileConcurrency(options.concurrency);
-  const extractions = await runExtractionPhases(root, buckets.toCompile, state, changes, concurrency);
+  const extractions = await runExtractionPhases(
+    root,
+    buckets.toCompile,
+    state,
+    changes,
+    concurrency,
+    options.systemPolicy,
+  );
   if (!options.review) {
     freezeFailedExtractions(draft, extractions, frozenSlugs);
   }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -346,7 +346,13 @@ async function seedThenFinalize(
   draft: CompileStateDraft | null,
 ): Promise<void> {
   await maybeSeedPages(root, schema, generation, options);
-  await finalizeWiki(root, draft, generation.writtenPages, generation.seedSlugs);
+  await finalizeWiki(
+    root,
+    draft,
+    generation.writtenPages,
+    generation.seedSlugs,
+    options.embeddings !== false,
+  );
 }
 
 /** Inner pipeline, runs under lock protection. Returns structured CompileResult. */
@@ -510,6 +516,7 @@ async function finalizeWiki(
   draft: CompileStateDraft | null,
   pages: MergedConcept[],
   seedSlugs: string[] = [],
+  embeddingsEnabled = true,
 ): Promise<void> {
   const conceptChangedSlugs = pages.map((entry) => entry.slug);
   const conceptNewSlugs = pages
@@ -534,7 +541,7 @@ async function finalizeWiki(
 
   await generateIndex(root);
   await generateMOC(root);
-  await safelyUpdateEmbeddings(root, allChangedSlugs);
+  if (embeddingsEnabled) await safelyUpdateEmbeddings(root, allChangedSlugs);
 }
 
 /**

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -29,7 +29,7 @@ import { loadSchema, type SchemaConfig } from "../schema/index.js";
 import { detectChanges, hashFile } from "./hasher.js";
 import {
   findAffectedSources,
-  findFrozenSlugs,
+  findReconciliationSlugs,
   freezeFailedExtractions,
   persistFrozenSlugs,
   type ExtractionResult,
@@ -151,12 +151,13 @@ async function generatePagesPhase(
   root: string,
   extractions: ExtractionResult[],
   frozenSlugs: Set<string>,
+  reconciliationSlugs: ReadonlySet<string>,
   schema: SchemaConfig,
   options: CompileOptions,
   policy: ReviewPolicy,
   concurrency: number,
 ): Promise<PageGenerationResult> {
-  const merged = mergeExtractions(extractions, frozenSlugs);
+  const merged = mergeExtractions(extractions, frozenSlugs, reconciliationSlugs);
   // Build the per-source state snapshot once so each candidate can carry the
   // exact data needed to mark its sources compiled on approval.
   const shouldBuildSourceStates = options.review || !isPolicyOff(policy);
@@ -315,6 +316,21 @@ function applyChangeFilter(
 }
 
 /**
+ * Orphan and clear persisted frozen slugs that no source owns.
+ * @returns True when the draft was mutated and must be flushed.
+ */
+async function reconcileOwnerlessFrozen(
+  root: string,
+  draft: CompileStateDraft,
+  reconciliationSlugs: ReadonlySet<string>,
+): Promise<boolean> {
+  if (reconciliationSlugs.size === 0) return false;
+  await orphanUnownedFrozenPages(root, draft, new Set(reconciliationSlugs));
+  draft.setFrozen(new Set());
+  return true;
+}
+
+/**
  * Generate seed pages unless `skipSeedPages` is set or we are in review mode.
  * Centralises both guard conditions so each call site in the pipeline is a
  * single unconditional statement instead of an inline if-block.
@@ -373,6 +389,7 @@ async function runCompilePipeline(
   const changes = applyChangeFilter(detected, options.changeFilter);
   await markUnchangedPendingSources(root, changes);
   augmentWithAffectedSources(changes, findAffectedSources(state, changes));
+  const reconciliationSlugs = findReconciliationSlugs(state, changes);
 
   const buckets = bucketChanges(changes);
   if (buckets.toCompile.length === 0 && buckets.deleted.length === 0) {
@@ -381,6 +398,9 @@ async function runCompilePipeline(
     // no source files changed, so adding a seed page to schema.json takes
     // effect on the next compile without needing a source file edit.
     if (!options.review) {
+      const hasOwnerlessFrozen = await reconcileOwnerlessFrozen(
+        root, draft, reconciliationSlugs,
+      );
       const emptyGeneration: PageGenerationResult = {
         pages: [],
         writtenPages: [],
@@ -389,11 +409,15 @@ async function runCompilePipeline(
         review: { held: [], forced: [] },
         seedSlugs: [],
       };
-      // Null draft: this branch has no state mutations, so nothing is flushed.
-      // Routes seed + resolution through the SAME executor batches as the normal
-      // path (see seedThenFinalize) so the early branch cannot drift to a direct
-      // write.
-      await seedThenFinalize(root, schema, emptyGeneration, options, null);
+      // Ownerless frozen reconciliation mutates the draft; otherwise null keeps
+      // the no-change path from rewriting state unnecessarily.
+      await seedThenFinalize(
+        root,
+        schema,
+        emptyGeneration,
+        options,
+        hasOwnerlessFrozen ? draft : null,
+      );
       return {
         ...emptyCompileResult(),
         skipped: buckets.unchanged.length,
@@ -419,8 +443,9 @@ async function runCompilePipeline(
     await markDeletedAsOrphaned(root, buckets.deleted, draft);
   }
 
-  const frozenSlugs = findFrozenSlugs(state, changes);
-  reportFrozenSlugs(frozenSlugs);
+  // Only extraction failures in THIS run freeze a page. Deletion and persisted
+  // freezes are reconciliation work: their surviving owners rebuild cleanly.
+  const frozenSlugs = new Set<string>();
 
   // Resolve once so an invalid override warns a single time, then cap both the
   // extraction and page-generation fan-outs identically.
@@ -435,6 +460,7 @@ async function runCompilePipeline(
   );
   if (!options.review) {
     freezeFailedExtractions(draft, extractions, frozenSlugs);
+    reportFrozenSlugs(frozenSlugs);
   }
 
   // Snapshot pages on disk before generation so the journal can tell which
@@ -444,6 +470,7 @@ async function runCompilePipeline(
     root,
     extractions,
     frozenSlugs,
+    reconciliationSlugs,
     schema,
     options,
     reviewPolicy,
@@ -452,8 +479,9 @@ async function runCompilePipeline(
 
   if (!options.review) {
     await persistExtractionStates(draft, extractions, generation.writtenPages);
-    if (frozenSlugs.size > 0) {
-      await orphanUnownedFrozenPages(root, draft, frozenSlugs);
+    const orphanCandidates = new Set([...reconciliationSlugs, ...frozenSlugs]);
+    if (orphanCandidates.size > 0) {
+      await orphanUnownedFrozenPages(root, draft, orphanCandidates);
     }
     persistFrozenSlugs(draft, frozenSlugs, extractions);
     // Seed + resolution route through the SAME executor batches as the

--- a/src/compiler/orphan.ts
+++ b/src/compiler/orphan.ts
@@ -2,12 +2,12 @@
  * Orphan management for deleted source files.
  *
  * When a source is deleted, its exclusively-owned concept pages are marked
- * orphaned (orphaned: true in frontmatter). Shared concepts are preserved
- * to avoid losing combined content from prior compilations.
+ * orphaned (orphaned: true in frontmatter). Shared concepts are deferred so
+ * the compiler can rebuild them from their surviving owners in the same run.
  *
- * After compilation, frozen slugs (shared concepts that lost a contributor)
- * are checked against the updated state. Any that lost ALL owners are
- * orphaned as a cleanup pass.
+ * After compilation, reconciliation candidates and extraction-frozen slugs
+ * are checked against the updated state. Any that lost ALL owners are orphaned
+ * as a cleanup pass.
  */
 
 import path from "path";
@@ -26,8 +26,8 @@ import type { CompileStateDraft } from "./compile-state-draft.js";
 /**
  * Mark wiki pages as orphaned when their source is deleted.
  * Only orphans concepts exclusively owned by the deleted source.
- * Shared concepts (contributed to by other live sources) are preserved
- * as-is to avoid losing combined content from prior compilations.
+ * Shared concepts (contributed to by other live sources) are deferred to the
+ * deletion-reconciliation generation pass.
  * @param root - Project root directory (needed for the confined file write; stays first).
  * @param sourceFile - Source file path being deleted.
  * @param draft - In-memory CompileStateDraft the function reads/mutates instead of disk state.
@@ -63,13 +63,13 @@ export async function markOrphaned(
 
 /**
  * Check frozen slugs against the updated state after compilation.
- * If no source still claims a frozen slug, orphan its page so it doesn't
- * linger as an untracked stale file.
+ * If no source still claims a reconciliation candidate, orphan its page so it
+ * doesn't linger as an untracked stale file.
  * @param root - Project root directory (needed for the confined file write; stays first).
  *   root stays first (needed for the confined file write); draft follows.
  * @param draft - In-memory CompileStateDraft the function reads to check current ownership
  *   instead of disk state, so un-flushed markers from this run are visible.
- * @param frozenSlugs - Set of concept slugs that were frozen (shared with a deleted source).
+ * @param frozenSlugs - Reconciliation candidates and extraction-frozen slugs.
  */
 export async function orphanUnownedFrozenPages(
   root: string,

--- a/src/compiler/page-renderer.ts
+++ b/src/compiler/page-renderer.ts
@@ -33,6 +33,7 @@ interface RenderableConcept {
   concept: ExtractedConcept;
   sourceFiles: string[];
   combinedContent: string;
+  rebuild?: boolean;
 }
 
 /**
@@ -58,7 +59,7 @@ export async function renderMergedPageContent(
   const system = buildPagePrompt(
     entry.concept.concept,
     entry.combinedContent,
-    existingPage,
+    entry.rebuild ? "" : existingPage,
     relatedPages,
     systemPolicy,
   );
@@ -70,7 +71,12 @@ export async function renderMergedPageContent(
     ],
   });
 
-  const pageBody = normalizeCitationsInBody(rawPageBody, entry.sourceFiles, entry.combinedContent);
+  const pageBody = normalizeCitationsInBody(
+    rawPageBody,
+    entry.sourceFiles,
+    entry.combinedContent,
+    entry.rebuild === true,
+  );
 
   const frontmatter = buildMergedFrontmatter(entry, existingPage, schema);
   reportContradictionWarnings(entry.concept.concept, entry.concept);

--- a/src/compiler/page-renderer.ts
+++ b/src/compiler/page-renderer.ts
@@ -41,12 +41,14 @@ interface RenderableConcept {
  * @param root - Project root directory.
  * @param entry - The merged concept to render.
  * @param schema - Resolved schema config, used to stamp `kind` on frontmatter.
+ * @param systemPolicy - Optional trusted caller policy added to the page prompt.
  * @returns Full markdown content (frontmatter + body, trailing newline).
  */
 export async function renderMergedPageContent(
   root: string,
   entry: RenderableConcept,
   schema: SchemaConfig,
+  systemPolicy?: string,
 ): Promise<string> {
   const existingPage = await readWikiPageContentOrWarn(
     root, CONCEPTS_DIR, entry.slug, false /* new page — absence is normal */,
@@ -58,6 +60,7 @@ export async function renderMergedPageContent(
     entry.combinedContent,
     existingPage,
     relatedPages,
+    systemPolicy,
   );
 
   const rawPageBody = await callClaude({

--- a/src/compiler/prompts.ts
+++ b/src/compiler/prompts.ts
@@ -34,7 +34,22 @@ function withLangLine(...lines: string[]): string[] {
  * downstream auditor can distinguish pages produced under different prompt
  * generations even when the model id is identical. Format is `vMAJOR`.
  */
-export const PROMPT_VERSION = "v1";
+export const PROMPT_VERSION = "v2";
+
+/**
+ * Append a trusted caller policy without replacing any built-in instruction.
+ * Empty policies are omitted so the default prompt stays byte-identical.
+ */
+function withSystemPolicy(lines: string[], systemPolicy?: string): string[] {
+  const policy = systemPolicy?.trim();
+  if (!policy) return lines;
+  return [
+    ...lines,
+    "",
+    "Additional system policy (follow in addition to every built-in instruction above):",
+    policy,
+  ];
+}
 
 /** Allowed provenance state strings emitted by the LLM tool schema. */
 const PROVENANCE_STATE_VALUES: ProvenanceState[] = [
@@ -114,17 +129,19 @@ export const CONCEPT_EXTRACTION_TOOL = {
  * Instructs the LLM to analyze a source document and identify distinct concepts.
  * @param sourceContent - The full text of the source document.
  * @param existingIndex - The current wiki index.md contents (may be empty).
+ * @param systemPolicy - Optional trusted caller policy appended to built-in instructions.
  * @returns System prompt string for the extraction call.
  */
 export function buildExtractionPrompt(
   sourceContent: string,
   existingIndex: string,
+  systemPolicy?: string,
 ): string {
   const indexSection = existingIndex
     ? `\n\nHere is the existing wiki index — avoid duplicating concepts already covered:\n\n${existingIndex}`
     : "\n\nNo existing wiki pages yet.";
 
-  return [
+  const instructions = [
     ...withLangLine(
       "You are a knowledge extraction engine. Analyze the following source document",
       "and identify 3-8 distinct, meaningful concepts worth documenting as wiki pages.",
@@ -141,6 +158,10 @@ export function buildExtractionPrompt(
     "    or 'ambiguous' if the source is contradictory or unclear.",
     "  - contradicted_by: slugs of other concepts (in this batch or the index)",
     "    whose evidence conflicts with this one.",
+  ];
+
+  return [
+    ...withSystemPolicy(instructions, systemPolicy),
     indexSection,
     "\n\n--- SOURCE DOCUMENT ---\n\n",
     sourceContent,
@@ -154,6 +175,7 @@ export function buildExtractionPrompt(
  * @param sourceContent - The source material to draw from.
  * @param existingPage - The current page content if updating (empty for new pages).
  * @param relatedPages - Concatenated content of related wiki pages for context.
+ * @param systemPolicy - Optional trusted caller policy appended to built-in instructions.
  * @returns System prompt string for the page generation call.
  */
 export function buildPagePrompt(
@@ -161,6 +183,7 @@ export function buildPagePrompt(
   sourceContent: string,
   existingPage: string,
   relatedPages: string,
+  systemPolicy?: string,
 ): string {
   const existingSection = existingPage
     ? `\n\nExisting page to update:\n\n${existingPage}`
@@ -170,7 +193,7 @@ export function buildPagePrompt(
     ? `\n\nRelated wiki pages for cross-referencing:\n\n${relatedPages}`
     : "";
 
-  return [
+  const instructions = [
     ...withLangLine(
       `You are a wiki author. Write a clear, well-structured markdown page about "${concept}".`,
       "Draw facts only from the provided source material.",
@@ -196,6 +219,10 @@ export function buildPagePrompt(
     "If a paragraph is your inference rather than a direct extraction, leave it",
     "uncited — downstream lint rules will count uncited paragraphs as 'inferred'",
     "so lint can surface excess-inferred-paragraphs warnings on review.",
+  ];
+
+  return [
+    ...withSystemPolicy(instructions, systemPolicy),
     existingSection,
     relatedSection,
     "\n\n--- SOURCE MATERIAL ---\n\n",
@@ -263,26 +290,29 @@ function mapRawConcept(c: RawConcept): ExtractedConcept {
  * @param seed - Seed page definition pulled from the schema.
  * @param rule - Per-kind rule (used for the description and link minimum).
  * @param relatedPagesContent - Concatenated content of related concept pages.
+ * @param systemPolicy - Optional trusted caller policy appended to built-in instructions.
  * @returns System prompt string for the page generation call.
  */
 export function buildSeedPagePrompt(
   seed: SeedPage,
   rule: PageKindRule,
   relatedPagesContent: string,
+  systemPolicy?: string,
 ): string {
   const minLinks = rule.minWikilinks;
   const linkExpectation = minLinks > 0
     ? `Include at least ${minLinks} [[wikilinks]] to related pages.`
     : "Use [[wikilinks]] when referencing other pages.";
+  const instructions = withLangLine(
+    `You are a wiki author. Write a ${seed.kind} page titled "${seed.title}".`,
+    `Page-kind guidance: ${rule.description}`,
+    `Summary line for context: ${seed.summary}`,
+    "Draw facts only from the related wiki pages provided below.",
+    linkExpectation,
+    "Write in a neutral, informative tone. Be concise but thorough.",
+  );
   return [
-    ...withLangLine(
-      `You are a wiki author. Write a ${seed.kind} page titled "${seed.title}".`,
-      `Page-kind guidance: ${rule.description}`,
-      `Summary line for context: ${seed.summary}`,
-      "Draw facts only from the related wiki pages provided below.",
-      linkExpectation,
-      "Write in a neutral, informative tone. Be concise but thorough.",
-    ),
+    ...withSystemPolicy(instructions, systemPolicy),
     "\n\n--- RELATED PAGES ---\n\n",
     relatedPagesContent,
   ].join("\n");

--- a/src/compiler/refresh-plan.ts
+++ b/src/compiler/refresh-plan.ts
@@ -19,9 +19,9 @@ import type { FreshnessSnapshot } from "../freshness/types.js";
 import type { StateStatus } from "../utils/state.js";
 
 export interface RefreshPlan {
-  /** Stale pages with a changed live owner — recompiled. Disjoint from the other outcome lists. */
+  /** Stale pages and partial-deletion pages rebuilt from live owners. */
   recompiledPages: string[];
-  /** Partial-deletion pages (a deleted owner but every live owner is unchanged) — status repaired, content kept. Disjoint. */
+  /** @deprecated Shared pages are rebuilt; retained as an empty compatibility field. */
   sharedKeptPages: string[];
   /** Pages whose owners are ALL deleted — recomputed as orphaned. Disjoint. */
   computedOrphanedPages: string[];
@@ -126,7 +126,7 @@ function classifyOnePage(
     changedLive.forEach((o) => c.changedOwners.add(o.file));
     deleted.forEach((o) => c.deletedOwners.add(o.file));
   } else if (deleted.length > 0) {
-    c.sharedKeptPages.push(slug);
+    c.recompiledPages.push(slug);
     deleted.forEach((o) => c.deletedOwners.add(o.file));
   }
   // else: all live and fresh — no action needed

--- a/src/compiler/review-pipeline.ts
+++ b/src/compiler/review-pipeline.ts
@@ -65,7 +65,7 @@ export async function generateMergedPage(
   sourceStates: SourceStateMap,
   policy: ReviewPolicy,
 ): Promise<MergedPageOutcome> {
-  const fullPage = await renderMergedPageContent(root, entry, schema);
+  const fullPage = await renderMergedPageContent(root, entry, schema, options.systemPolicy);
   const diagnostics = await collectReviewDiagnostics(root, entry, fullPage, schema);
   const signals = buildPolicySignals(fullPage, diagnostics);
   const reasons = evaluatePolicy(signals, policy);

--- a/src/compiler/seed-pages.ts
+++ b/src/compiler/seed-pages.ts
@@ -40,11 +40,13 @@ import type { PageGenerationResult } from "./types.js";
  * @param root - Project root directory.
  * @param schema - Resolved schema config.
  * @param generation - Result of the concept-page generation phase.
+ * @param systemPolicy - Optional trusted caller policy added to seed prompts.
  */
 export async function generateSeedPages(
   root: string,
   schema: SchemaConfig,
   generation: PageGenerationResult,
+  systemPolicy?: string,
 ): Promise<void> {
   if (schema.seedPages.length === 0) return;
   // Dedup seeds by slug FIRST-SEEN-WINS before rendering, mirroring
@@ -60,7 +62,7 @@ export async function generateSeedPages(
   // an error and is excluded from the batch (skip-not-abort, like generation).
   const writes: CompilePageWrite[] = [];
   for (const seed of dedupedSeeds) {
-    const result = await generateSingleSeedPage(root, schema, seed);
+    const result = await generateSingleSeedPage(root, schema, seed, systemPolicy);
     if (result.error) {
       generation.errors.push(result.error);
       continue;
@@ -136,11 +138,12 @@ async function generateSingleSeedPage(
   root: string,
   schema: SchemaConfig,
   seed: SeedPage,
+  systemPolicy?: string,
 ): Promise<SeedPageOutcome> {
   const slug = slugify(seed.title);
   const relatedContent = await loadSeedRelatedPages(root, seed.relatedSlugs ?? []);
   const rule = schema.kinds[seed.kind];
-  const system = buildSeedPagePrompt(seed, rule, relatedContent);
+  const system = buildSeedPagePrompt(seed, rule, relatedContent, systemPolicy);
   const pageBody = await callClaude({
     system,
     messages: [{ role: "user", content: `Write the ${seed.kind} page titled "${seed.title}".` }],

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -25,6 +25,8 @@ export interface MergedConcept {
   concept: ExtractedConcept;
   sourceFiles: string[];
   combinedContent: string;
+  /** Rebuild from live sources without feeding the prior page back to the model. */
+  rebuild?: boolean;
 }
 
 /** Buckets of source changes used by the compile pipeline. */

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,6 +85,11 @@ export interface SdkCompileOptions {
    * out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Refresh semantic embeddings after compilation. Defaults to true.
+   * False prevents embedding-provider calls and pending-embedding retries.
+   */
+  embeddings?: boolean;
 }
 
 /** Options for `getContextPack`. Maps onto the subset of BuildContextPackOptions needed externally. */

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -90,6 +90,11 @@ export interface SdkCompileOptions {
    * False prevents embedding-provider calls and pending-embedding retries.
    */
   embeddings?: boolean;
+  /**
+   * Trusted caller policy appended to both compile-time system prompts.
+   * The compiler's built-in extraction and page-writing instructions remain.
+   */
+  systemPolicy?: string;
 }
 
 /** Options for `getContextPack`. Maps onto the subset of BuildContextPackOptions needed externally. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -186,6 +186,12 @@ export interface CompileOptions {
    * the built-in default. Out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Refresh semantic embeddings after compilation. Defaults to true.
+   * Set to false for a lexical-only build with no embedding-provider calls or
+   * pending-embedding retries.
+   */
+  embeddings?: boolean;
 }
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -192,6 +192,11 @@ export interface CompileOptions {
    * pending-embedding retries.
    */
   embeddings?: boolean;
+  /**
+   * Trusted caller policy appended to the built-in extraction and page-writing
+   * system instructions. The built-in instructions are never replaced.
+   */
+  systemPolicy?: string;
 }
 
 /**

--- a/test/citation-normalize.test.ts
+++ b/test/citation-normalize.test.ts
@@ -176,6 +176,14 @@ describe("normalizeCitationsInBody — unknown filename entries", () => {
     const result = normalizeCitationsInBody(body, [source], content);
     expect(result).toBe("Claim.^[does-not-exist.md]");
   });
+
+  it("drops unknown entries only when a clean rebuild requests strict sources", () => {
+    const source = "real.md";
+    const content = makeContent(source, 10);
+    const body = "Claim.^[real.md:1-2, deleted.md:3-4]";
+    const result = normalizeCitationsInBody(body, [source], content, true);
+    expect(result).toBe("Claim.^[real.md:1-2]");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/compile-deletion-owner-closure.test.ts
+++ b/test/compile-deletion-owner-closure.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @file test/compile-deletion-owner-closure.test.ts
+ * @description End-to-end coverage for rebuilding the full live co-owner graph
+ * after a shared source is deleted.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { parseFrontmatter } from "../src/utils/markdown.js";
+import { readState } from "../src/utils/state.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+import {
+  conceptResponse,
+  stubOwnerClosureProvider,
+} from "./fixtures/owner-closure-provider.js";
+
+const ctx = useCompileProject({
+  dirSuffix: "delete-owner-closure",
+  sourceFile: "a.md",
+  sourceContent: "# X\n\nA contributes to X.",
+});
+
+/** Return concepts according to the source text in the extraction prompt. */
+function extractionFor(system: string): string {
+  if (system.includes("B contributes to X and Y.")) return conceptResponse("X", "Y");
+  if (system.includes("C contributes to Y.")) return conceptResponse("Y");
+  return conceptResponse("X");
+}
+
+describe("deletion owner closure", () => {
+  it("preserves every live owner across a transitive shared-concept chain", async () => {
+    await writeFile(
+      path.join(ctx.dir, "sources", "b.md"),
+      "# X and Y\n\nB contributes to X and Y.",
+      "utf-8",
+    );
+    await writeFile(
+      path.join(ctx.dir, "sources", "c.md"),
+      "# Y\n\nC contributes to Y.",
+      "utf-8",
+    );
+    const systems = stubOwnerClosureProvider(extractionFor);
+
+    await compileAndReport(ctx.dir);
+    systems.length = 0;
+    await rm(path.join(ctx.dir, "sources", "a.md"));
+    await compileAndReport(ctx.dir);
+
+    const x = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "x.md"), "utf-8"),
+    );
+    const y = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "y.md"), "utf-8"),
+    );
+    const state = await readState(ctx.dir);
+    expect(systems).toHaveLength(2);
+    expect(x.meta.sources).toEqual(["b.md"]);
+    expect(y.meta.sources).toEqual(["b.md", "c.md"]);
+    expect(state.sources["a.md"]).toBeUndefined();
+  });
+});

--- a/test/compile-late-owner-closure.test.ts
+++ b/test/compile-late-owner-closure.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @file test/compile-late-owner-closure.test.ts
+ * @description End-to-end coverage for fixed-point discovery when a new source
+ * reveals an owner whose extraction reveals another shared owner.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { parseFrontmatter } from "../src/utils/markdown.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+import {
+  conceptResponse,
+  stubOwnerClosureProvider,
+} from "./fixtures/owner-closure-provider.js";
+
+const ctx = useCompileProject({
+  dirSuffix: "late-owner-closure",
+  sourceFile: "b.md",
+  sourceContent: "# X\n\nB contributes to X and later reveals Y.",
+});
+
+/** Return concepts for the source content embedded in an extraction prompt. */
+function extractionFor(system: string, expanded: boolean): string {
+  if (system.includes("D contributes to Y.")) return conceptResponse("Y");
+  if (system.includes("New source contributes to X.")) return conceptResponse("X");
+  return expanded ? conceptResponse("X", "Y") : conceptResponse("X");
+}
+
+describe("late owner discovery", () => {
+  it("continues extracting newly discovered owners until the graph is stable", async () => {
+    await writeFile(
+      path.join(ctx.dir, "sources", "d.md"),
+      "# Y\n\nD contributes to Y.",
+      "utf-8",
+    );
+    let expanded = false;
+    const systems = stubOwnerClosureProvider(
+      (system) => extractionFor(system, expanded),
+    );
+
+    await compileAndReport(ctx.dir);
+    expanded = true;
+    systems.length = 0;
+    await writeFile(
+      path.join(ctx.dir, "sources", "new.md"),
+      "# X\n\nNew source contributes to X.",
+      "utf-8",
+    );
+    await compileAndReport(ctx.dir);
+
+    const y = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "y.md"), "utf-8"),
+    );
+    expect(systems.filter((system) => system.includes("--- SOURCE DOCUMENT ---")))
+      .toHaveLength(3);
+    expect(y.meta.sources).toEqual(["b.md", "d.md"]);
+  });
+});

--- a/test/compile-options.test.ts
+++ b/test/compile-options.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @file test/compile-options.test.ts
+ * @description Public compile-option coverage for embedding suppression.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createWiki } from "../src/sdk/wiki.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import * as embeddings from "../src/utils/embeddings.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Alpha", summary: "Alpha summary.", is_new: true }],
+});
+
+const ctx = useCompileProject({
+  dirSuffix: "options",
+  sourceFile: "sample.md",
+  sourceContent: "# Alpha\n\nAlpha is documented here.",
+});
+
+/** Stub a one-concept compile and suppress terminal noise. */
+function stubCompile(): void {
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(EXTRACTION);
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Alpha body. ^[sample.md]");
+  vi.spyOn(console, "log").mockImplementation(() => {});
+}
+
+describe("compile options", () => {
+  it("embeddings:false skips embedding refresh while still compiling pages", async () => {
+    stubCompile();
+    const embedSpy = vi
+      .spyOn(embeddings, "updateEmbeddingsLockedCore")
+      .mockResolvedValue({ embedded: [], eligible: [] });
+
+    const result = await createWiki({ root: ctx.dir }).compile({ embeddings: false });
+
+    expect(result.pages).toContain("alpha");
+    expect(embedSpy).not.toHaveBeenCalled();
+  });

--- a/test/compile-options.test.ts
+++ b/test/compile-options.test.ts
@@ -1,6 +1,7 @@
 /**
  * @file test/compile-options.test.ts
- * @description Public compile-option coverage for embedding suppression.
+ * @description Public compile-option coverage for embedding suppression and
+ * caller-provided additive system policy across both LLM phases.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -9,6 +10,7 @@ import { AnthropicProvider } from "../src/providers/anthropic.js";
 import * as embeddings from "../src/utils/embeddings.js";
 import { useCompileProject } from "./fixtures/compile-project.js";
 
+const POLICY = "Never publish credential values from the supplied sources.";
 const EXTRACTION = JSON.stringify({
   concepts: [{ concept: "Alpha", summary: "Alpha summary.", is_new: true }],
 });
@@ -26,6 +28,14 @@ function stubCompile(): void {
   vi.spyOn(console, "log").mockImplementation(() => {});
 }
 
+/** Return a provider stub that records its system prompt. */
+function captureSystem<T>(systems: string[], value: T): (system: string) => Promise<T> {
+  return async (system) => {
+    systems.push(system);
+    return value;
+  };
+}
+
 describe("compile options", () => {
   it("embeddings:false skips embedding refresh while still compiling pages", async () => {
     stubCompile();
@@ -38,3 +48,22 @@ describe("compile options", () => {
     expect(result.pages).toContain("alpha");
     expect(embedSpy).not.toHaveBeenCalled();
   });
+
+  it("adds one caller policy to both built-in system prompts before source material", async () => {
+    const extractionSystems: string[] = [];
+    const pageSystems: string[] = [];
+    vi.spyOn(AnthropicProvider.prototype, "toolCall")
+      .mockImplementation(captureSystem(extractionSystems, EXTRACTION));
+    vi.spyOn(AnthropicProvider.prototype, "complete")
+      .mockImplementation(captureSystem(pageSystems, "Alpha body. ^[sample.md]"));
+
+    await createWiki({ root: ctx.dir }).compile({ embeddings: false, systemPolicy: POLICY });
+
+    expect(extractionSystems[0]).toContain("You are a knowledge extraction engine.");
+    expect(pageSystems[0]).toContain("You are a wiki author.");
+    expect(extractionSystems[0]).toContain(POLICY);
+    expect(pageSystems[0]).toContain(POLICY);
+    expect(extractionSystems[0].indexOf(POLICY)).toBeLessThan(extractionSystems[0].indexOf("--- SOURCE DOCUMENT ---"));
+    expect(pageSystems[0].indexOf(POLICY)).toBeLessThan(pageSystems[0].indexOf("--- SOURCE MATERIAL ---"));
+  });
+});

--- a/test/compile-source-deletion-reconciliation.test.ts
+++ b/test/compile-source-deletion-reconciliation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @file test/compile-source-deletion-reconciliation.test.ts
+ * @description End-to-end regression coverage for rebuilding a shared concept
+ * from its surviving owners after one contributing source is deleted.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { buildFrontmatter, parseFrontmatter } from "../src/utils/markdown.js";
+import { readState, writeState } from "../src/utils/state.js";
+import * as embeddings from "../src/utils/embeddings.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Shared Topic", summary: "Shared summary.", is_new: true }],
+});
+
+const ctx = useCompileProject({
+  dirSuffix: "delete-reconcile",
+  sourceFile: "a.md",
+  sourceContent: "# Shared Topic\n\nA-only deleted contribution.",
+});
+
+interface ReconciliationProbe {
+  extractionSystems: string[];
+  pageSystems: string[];
+  markDeleted: () => void;
+  markSurvivorFailure: () => void;
+}
+
+/** Seed the surviving source and capture both LLM phases across two compiles. */
+async function arrangeReconciliation(): Promise<ReconciliationProbe> {
+  await writeFile(
+    path.join(ctx.dir, "sources", "b.md"),
+    "# Shared Topic\n\nB-only surviving contribution.",
+    "utf-8",
+  );
+  let phase: "initial" | "deleted" | "failed" = "initial";
+  const extractionSystems: string[] = [];
+  const pageSystems: string[] = [];
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(async (system) => {
+    extractionSystems.push(system);
+    return phase === "failed" ? JSON.stringify({ concepts: [] }) : EXTRACTION;
+  });
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockImplementation(async (system) => {
+    pageSystems.push(system);
+    return phase === "initial"
+      ? "Old claim from deleted contributor. ^[a.md:1-2]\n\nShared claim. ^[b.md:1-2]"
+      : "Rebuilt survivor claim. ^[b.md:1-2, a.md:1-2]";
+  });
+  vi.spyOn(embeddings, "updateEmbeddingsLockedCore")
+    .mockResolvedValue({ embedded: [], eligible: [] });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return {
+    extractionSystems,
+    pageSystems,
+    markDeleted: () => { phase = "deleted"; },
+    markSurvivorFailure: () => { phase = "failed"; },
+  };
+}
+
+/** Read the shared page and incremental state after one compile. */
+async function readSharedArtifacts() {
+  const page = parseFrontmatter(
+    await readFile(path.join(ctx.dir, "wiki", "concepts", "shared-topic.md"), "utf-8"),
+  );
+  return { page, state: await readState(ctx.dir) };
+}
+
+describe("shared-source deletion reconciliation", () => {
+  it("rebuilds from the surviving owner and clears deleted provenance", async () => {
+    const probe = await arrangeReconciliation();
+
+    await compileAndReport(ctx.dir);
+    probe.markDeleted();
+    probe.extractionSystems.length = 0;
+    probe.pageSystems.length = 0;
+    await rm(path.join(ctx.dir, "sources", "a.md"));
+    const result = await compileAndReport(ctx.dir);
+
+    const { page, state } = await readSharedArtifacts();
+    expect(result).toMatchObject({ compiled: 1, deleted: 1, pages: ["shared-topic"] });
+    expect(probe.extractionSystems).toHaveLength(1);
+    expect(probe.extractionSystems[0]).toContain("B-only surviving contribution.");
+    expect(probe.pageSystems[0]).not.toContain("Old claim from deleted contributor.");
+    expect(page.meta.sources).toEqual(["b.md"]);
+    expect(page.body).toContain("^[b.md:1-2]");
+    expect(page.body).not.toContain("a.md");
+    expect(state.sources["a.md"]).toBeUndefined();
+  });
+
+  it("orphans an ownerless persisted frozen page without source changes", async () => {
+    await arrangeReconciliation();
+    await compileAndReport(ctx.dir);
+    const state = await readState(ctx.dir);
+    state.frozenSlugs = ["ownerless"];
+    await writeState(ctx.dir, state);
+    const frontmatter = buildFrontmatter({
+      title: "Ownerless",
+      summary: "No source owns this page.",
+      sources: [],
+    });
+    await writeFile(
+      path.join(ctx.dir, "wiki", "concepts", "ownerless.md"),
+      `${frontmatter}\n\nStale content.\n`,
+      "utf-8",
+    );
+
+    await compileAndReport(ctx.dir);
+
+    const page = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "ownerless.md"), "utf-8"),
+    );
+    const reconciled = await readState(ctx.dir);
+    expect(page.meta.orphaned).toBe(true);
+    expect(reconciled.frozenSlugs).toEqual([]);
+  });
+
+  it("keeps a retryable last-known-good page when survivor extraction fails", async () => {
+    const probe = await arrangeReconciliation();
+    await compileAndReport(ctx.dir);
+    probe.markSurvivorFailure();
+    await rm(path.join(ctx.dir, "sources", "a.md"));
+
+    const result = await compileAndReport(ctx.dir);
+
+    const { page, state } = await readSharedArtifacts();
+    expect(page.meta.orphaned).not.toBe(true);
+    expect(page.meta.sources).toEqual(["a.md", "b.md"]);
+    expect(state.sources["a.md"]).toBeUndefined();
+    expect(state.sources["b.md"].hash).toBe("");
+    expect(state.frozenSlugs).toContain("shared-topic");
+    expect(result.errors).toContain("No concepts extracted from b.md");
+  });
+});

--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   findAffectedSources,
-  findFrozenSlugs,
+  findReconciliationSlugs,
   findLateAffectedSources,
   findSharedConcepts,
   type ExtractionResult,
@@ -54,6 +54,54 @@ describe("findAffectedSources", () => {
     expect(affected).not.toContain("b.md");
   });
 
+  it("recompiles surviving co-owners when a shared source is deleted", () => {
+    const state = makeState({
+      "deleted.md": { hash: "h1", concepts: ["shared"] },
+      "survivor.md": { hash: "h2", concepts: ["shared"] },
+      "unrelated.md": { hash: "h3", concepts: ["other"] },
+    });
+    const changes: SourceChange[] = [{ file: "deleted.md", status: "deleted" }];
+
+    expect(findAffectedSources(state, changes)).toEqual(["survivor.md"]);
+  });
+
+  it("walks the full surviving co-owner graph after deletion", () => {
+    const state = makeState({
+      "a.md": { hash: "h1", concepts: ["x"] },
+      "b.md": { hash: "h2", concepts: ["x", "y"] },
+      "c.md": { hash: "h3", concepts: ["y"] },
+    });
+    const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
+
+    expect(findAffectedSources(state, changes)).toEqual(["b.md", "c.md"]);
+  });
+
+  it("excludes every deleted owner from a multi-owner rebuild", () => {
+    const state = makeState({
+      "a.md": { hash: "h1", concepts: ["shared"] },
+      "b.md": { hash: "h2", concepts: ["shared"] },
+      "c.md": { hash: "h3", concepts: ["shared"] },
+    });
+    const changes: SourceChange[] = [
+      { file: "a.md", status: "deleted" },
+      { file: "b.md", status: "deleted" },
+    ];
+
+    expect(findAffectedSources(state, changes)).toEqual(["c.md"]);
+  });
+
+  it("retries owners of persisted frozen concepts", () => {
+    const state = makeState(
+      {
+        "a.md": { hash: "h1", concepts: ["shared"] },
+        "b.md": { hash: "h2", concepts: ["shared"] },
+      },
+      ["shared"],
+    );
+
+    expect(findAffectedSources(state, [])).toEqual(["a.md", "b.md"]);
+  });
+
   it("does not include already-changed files", () => {
     const state = makeState({
       "a.md": { hash: "h1", concepts: ["shared"] },
@@ -67,35 +115,35 @@ describe("findAffectedSources", () => {
   });
 });
 
-describe("findFrozenSlugs", () => {
-  it("freezes shared concepts when a source is deleted", () => {
+describe("findReconciliationSlugs", () => {
+  it("reconciles shared concepts when a source is deleted", () => {
     const state = makeState({
       "a.md": { hash: "h1", concepts: ["shared-concept"] },
       "b.md": { hash: "h2", concepts: ["shared-concept"] },
     });
     const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("shared-concept")).toBe(true);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("shared-concept")).toBe(true);
   });
 
-  it("does not freeze exclusively-owned concepts", () => {
+  it("does not rebuild exclusively-owned deleted concepts", () => {
     const state = makeState({
       "a.md": { hash: "h1", concepts: ["only-a"] },
       "b.md": { hash: "h2", concepts: ["only-b"] },
     });
     const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("only-a")).toBe(false);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("only-a")).toBe(false);
   });
 
-  it("loads persisted frozen slugs from state", () => {
+  it("loads persisted frozen slugs as reconciliation work", () => {
     const state = makeState(
       { "a.md": { hash: "h1", concepts: [] } },
       ["previously-frozen"],
     );
     const changes: SourceChange[] = [];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("previously-frozen")).toBe(true);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("previously-frozen")).toBe(true);
   });
 
   it("handles 3+ source concept with one deleted", () => {
@@ -105,8 +153,8 @@ describe("findFrozenSlugs", () => {
       "c.md": { hash: "h3", concepts: ["triple"] },
     });
     const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("triple")).toBe(true);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("triple")).toBe(true);
   });
 });
 
@@ -219,6 +267,22 @@ describe("findLateAffectedSources", () => {
     // changed.md newly gained "new-concept", which bystander.md owns
     const affected = findLateAffectedSources(extractions, state, changes);
     expect(affected).toEqual(["bystander.md"]);
+  });
+
+  it("walks the full co-owner graph from a late-discovered owner", () => {
+    const state = makeState({
+      "b.md": { hash: "h1", concepts: ["x", "y"] },
+      "c.md": { hash: "h2", concepts: ["y"] },
+    });
+    const extractions: ExtractionResult[] = [{
+      sourceFile: "new.md",
+      sourcePath: "/tmp/new.md",
+      sourceContent: "content",
+      concepts: [{ concept: "X", summary: "s", is_new: true }],
+    }];
+    const changes: SourceChange[] = [{ file: "new.md", status: "new" }];
+
+    expect(findLateAffectedSources(extractions, state, changes)).toEqual(["b.md", "c.md"]);
   });
 });
 

--- a/test/fixtures/owner-closure-provider.ts
+++ b/test/fixtures/owner-closure-provider.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared provider boundary stubs for owner-closure compile tests.
+ *
+ * The tests supply only the source-to-concepts resolver; this helper owns the
+ * repeated Anthropic and embeddings seams used by the real compile pipeline.
+ */
+
+import { vi } from "vitest";
+import { AnthropicProvider } from "../../src/providers/anthropic.js";
+import * as embeddings from "../../src/utils/embeddings.js";
+
+/** Build a provider-compatible extraction response. */
+export function conceptResponse(...names: string[]): string {
+  return JSON.stringify({
+    concepts: names.map((concept) => ({
+      concept,
+      summary: `${concept} summary.`,
+      is_new: false,
+    })),
+  });
+}
+
+/**
+ * Stub external model calls and capture every extraction system prompt.
+ * @param resolveExtraction - Maps one extraction system prompt to tool JSON.
+ * @returns Mutable prompt capture that callers can clear between compile runs.
+ */
+export function stubOwnerClosureProvider(
+  resolveExtraction: (system: string) => string,
+): string[] {
+  const systems: string[] = [];
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(async (system) => {
+    systems.push(system);
+    return resolveExtraction(system);
+  });
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Generated page.");
+  vi.spyOn(embeddings, "updateEmbeddingsLockedCore")
+    .mockResolvedValue({ embedded: [], eligible: [] });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return systems;
+}

--- a/test/refresh-integration.test.ts
+++ b/test/refresh-integration.test.ts
@@ -7,9 +7,8 @@
  *
  *  1. A stale page (changed source hash) IS recompiled.
  *  2. A new source (not in state) is skipped — refresh does not compile new sources.
- *  3. A partial-deletion "shared" page has its state REPAIRED (deleted owner
- *     removed from state.sources) but its content byte-for-byte UNCHANGED — the
- *     unchanged live owner is NOT recompiled (v1 limitation: no force-rebuild).
+ *  3. A partial-deletion shared page is rebuilt from its surviving owner and
+ *     the deleted owner is removed from state.
  *  4. When a review policy is active, a refreshed page that trips policy is held
  *     as a candidate (not written to wiki/) and the command reports it as held,
  *     NOT as "refreshed".
@@ -61,6 +60,21 @@ async function writeLowConfidencePolicy(root: string): Promise<void> {
  */
 async function makeTmpRoot(suffix: string): Promise<string> {
   return makeCompileProjectRoot({ dirSuffix: `refresh-integ-${suffix}` });
+}
+
+/** Configure the stubbed Anthropic provider environment for a test. */
+function configureProviderEnv(): void {
+  process.env.LLMWIKI_PROVIDER = "anthropic";
+  process.env.ANTHROPIC_API_KEY = "test-key";
+}
+
+/** Restore global test state and remove a temporary project root. */
+async function cleanupTestRoot(root: string): Promise<void> {
+  vi.restoreAllMocks();
+  delete process.env.LLMWIKI_PROVIDER;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.LLMWIKI_COMPILE_CONCURRENCY;
+  await rm(root, { recursive: true, force: true });
 }
 
 /** Silence compile output and run resolveStaleRefresh + compileAndReport. */
@@ -115,8 +129,7 @@ async function setupStaleTopicA(root: string): Promise<string> {
 
 describe("refresh --stale (real run, stubbed provider)", () => {
   it("recompiles a stale page and leaves a new source uncompiled", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
+    configureProviderEnv();
     const root = await makeTmpRoot("stale");
 
     try {
@@ -137,21 +150,17 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       // Only a.md was extracted; new.md was filtered out by changeFilter.
       expect(extractSpy).toHaveBeenCalledTimes(1);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 
   // -------------------------------------------------------------------------
-  // Test 2: partial-deletion shared page — status repaired, content kept
+  // Test 2: partial-deletion shared page rebuilt from surviving evidence
   // -------------------------------------------------------------------------
 
-  it("status-repairs a partial-deletion shared page but does NOT regenerate its content (v1)", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
-    const root = await makeTmpRoot("shared-kept");
+  it("rebuilds a partial-deletion shared page from its surviving owner", async () => {
+    configureProviderEnv();
+    const root = await makeTmpRoot("shared-rebuilt");
 
     try {
       const aContent = "# Topic X\n\nAbout X from A.";
@@ -162,34 +171,35 @@ describe("refresh --stale (real run, stubbed provider)", () => {
         "b.md": { hash: "some-old-hash", concepts: ["topic-x"] },
       });
       await writeConceptPage(root, "topic-x", "Topic X", ["a.md", "b.md"], "Existing body of X.");
-      const originalContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
-
-      // Spy: extraction must NOT fire (a.md is unchanged; no changed owners).
       const extractSpy = stubProviderCalls("Topic X");
       vi.spyOn(console, "log").mockImplementation(() => {});
 
       const { plan } = await resolveStaleRefresh(root);
       expect(plan).not.toBeNull();
-      // Sanity: page is shared-kept, not recompiled.
-      expect(plan!.sharedKeptPages).toContain("topic-x");
+      // Sanity: the survivor is scheduled for recompilation.
+      expect(plan!.recompiledPages).toContain("topic-x");
+      expect(plan!.sharedKeptPages).not.toContain("topic-x");
       expect(plan!.changedOwners).not.toContain("a.md");
       expect(plan!.deletedOwners).toContain("b.md");
+      expect(plan!.knownAffected).toContain("a.md");
 
-      await compileAndReport(root, { changeFilter: plan!.changeFilter, skipSeedPages: true });
+      const result = await compileAndReport(root, {
+        changeFilter: plan!.changeFilter,
+        skipSeedPages: true,
+      });
 
       // Deletion bookkeeping: b.md removed from state.
       const { state } = await readStateClassified(root);
       expect("b.md" in state.sources).toBe(false);
-      // Content kept: topic-x.md byte-for-byte UNCHANGED.
+      // Content is rebuilt from a.md; the old mixed-source body is gone.
       const afterContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
-      expect(afterContent).toBe(originalContent);
-      // a.md NOT extracted — unchanged live owner skipped in v1.
-      expect(extractSpy).not.toHaveBeenCalled();
+      expect(afterContent).toContain(STUB_BODY);
+      expect(afterContent).not.toContain("Existing body of X.");
+      expect(result.pages).toContain("topic-x");
+      // The unchanged survivor is force-reconciled because b.md was deleted.
+      expect(extractSpy).toHaveBeenCalledTimes(1);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 
@@ -198,8 +208,7 @@ describe("refresh --stale (real run, stubbed provider)", () => {
   // -------------------------------------------------------------------------
 
   it("reports a policy-held page as held for review, not as refreshed", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
+    configureProviderEnv();
     const root = await makeTmpRoot("policy-held");
 
     try {
@@ -237,17 +246,12 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       expect(allOutput).toMatch(/held.*for review/i);
       expect(allOutput).not.toMatch(/Refreshed \d+ page\(s\)/);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 
   it("forwards the concurrency option into the recompile (serial cap keeps peak at 1)", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
-    delete process.env.LLMWIKI_COMPILE_CONCURRENCY;
+    configureProviderEnv();
     const root = await makeTmpRoot("concurrency");
     try {
       await writeSourceFile(root, "a.md", "# A\n\nabout a");
@@ -276,10 +280,7 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       // stale extractions overlap (peak 2). The flag must serialize them to peak 1.
       expect(peak()).toBe(1);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 });

--- a/test/refresh-plan.test.ts
+++ b/test/refresh-plan.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for resolveStaleRefresh — the read-only resolver that computes a
- * RefreshPlan from a single freshness snapshot. Covers all four page outcomes
- * (recompiled, shared-kept, computed-orphaned, already-orphaned) plus the
+ * RefreshPlan from a single freshness snapshot. Covers rebuilt,
+ * computed-orphaned, and already-orphaned page outcomes plus the
  * newSkipped/changeFilter/knownAffected helpers and corrupt-state short-circuit.
  */
 
@@ -54,7 +54,7 @@ describe("resolveStaleRefresh", () => {
     expect(plan!.recompiledPages).toEqual([]);
   });
 
-  it("classifies a partial-deletion page (live unchanged + deleted owner) as shared-kept, not recompiled", async () => {
+  it("classifies a partial-deletion page for rebuild from its live owner", async () => {
     const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-shared");
     await writeConceptPage(
       "x",
@@ -69,10 +69,11 @@ describe("resolveStaleRefresh", () => {
     // b.md NOT written → deleted
 
     const { plan } = await resolveStaleRefresh(root);
-    expect(plan!.sharedKeptPages).toContain("x");
-    expect(plan!.recompiledPages).not.toContain("x");
+    expect(plan!.sharedKeptPages).not.toContain("x");
+    expect(plan!.recompiledPages).toContain("x");
     expect(plan!.changedOwners).not.toContain("a.md");
     expect(plan!.deletedOwners).toContain("b.md");
+    expect(plan!.knownAffected).toContain("a.md");
   });
 
   it("reports a frontmatter-orphaned page with no owners as already-orphaned (no action)", async () => {


### PR DESCRIPTION
Rebuilds shared pages through a fixed-point owner closure after source deletion, filters non-surviving citations during clean rebuilds, and orphans ownerless frozen slugs. Covers deletion chains, multiple deleted owners, late-discovered owners, unknown citations, ownerless pages, and survivor extraction failure. This branch is stacked on #169 and #170; the intended incremental review is commit 160e2af. Verification: 96 targeted tests, TypeScript, build, changed-scope checks, and diff checks pass.