### PR TITLE
docs: fix Atomic Memory comparison table

### DIFF
--- a/docs/guides/atomic-memory-bridge.mdx
+++ b/docs/guides/atomic-memory-bridge.mdx
@@ -11,7 +11,7 @@ These tools are independently valuable, and you do not need both. But when you a
 ## The two tools at a glance
 
 | | llmwiki | Atomic Memory |
-|--|---------|---------------|
+| --- | --- | --- |
 | **Primary artifact** | Compiled markdown wiki on disk | Runtime memory records |
 | **Browsable by humans** | Yes - local viewer, Obsidian-compatible | Via inspection tools |
 | **Citation-traced** | Yes - paragraph and claim-level | Preserved from llmwiki via bridge |


### PR DESCRIPTION
## Summary

- fix the Markdown delimiter row in the llmwiki/Atomic Memory comparison table
- use valid GFM delimiter cells so the table renders consistently

## Why

The first delimiter cell used only two hyphens. GFM table delimiter cells require at least three.

## Validation

- `git diff --check`
- `npx tsc --noEmit`
- `npm run build`
- `npm test` (4,860 passed, 3 skipped)
- `npm run fallow:ci`
