### PR TITLE
fix(profile): correct titleField diagnostics and the comments describing it

### DIFF
--- a/docs/configuration/profiles.mdx
+++ b/docs/configuration/profiles.mdx
@@ -95,13 +95,18 @@ load.
 }
 ```
 
-A type that declares no `titleField` falls back to the literal `title` key, and a
-page whose title field is missing, blank, or not a string falls back to its slug.
+A type that declares no `titleField` falls back to the literal `title` key,
+unchanged: whatever that key holds is used as written.
 
-It is a **display** title, and only display surfaces use it: `llmwiki status`,
-the JSON export, context packs, the wiki index, an Open Knowledge Format bundle's
-table of contents, and the local viewer's page list, page header and graph
-labels. Adding `titleField` to an existing profile changes what those show.
+For a type that DOES declare one, a page whose title field is missing, blank, or
+not a string falls back to its slug, and a title carrying surrounding whitespace
+is trimmed before it is displayed.
+
+It is a **display** title, and only display surfaces use it: the JSON export,
+context packs, the wiki index, an Open Knowledge Format bundle's table of
+contents, and the local viewer's page list, page header and graph labels. Adding
+`titleField` to an existing profile changes what those show. `llmwiki status`
+is unaffected: it counts pages rather than naming them.
 
 Two surfaces deliberately keep reading the literal `title` key instead:
 

--- a/src/profile/collect.ts
+++ b/src/profile/collect.ts
@@ -186,9 +186,16 @@ function validateScan(
  * (AutoSci's `people`, keyed `name`) had no title at all and every surface fell
  * back to its slug.
  *
- * Resolved HERE rather than in any one reader so `status`, the JSON export,
- * context packs, index generation, lint and the viewer all read one declaration
- * one way — a reader-local fix would give a single declaration two meanings.
+ * Resolved HERE rather than in any one reader, so every surface that renders a
+ * display title reads one declaration one way: the viewer, context packs, index
+ * generation and the JSON export. A reader-local fix would give a single
+ * declaration two meanings.
+ *
+ * Two surfaces deliberately do NOT consume it, and both say so at their own
+ * call site: `empty-page` in lint.ts judges the LITERAL `title` key, because a
+ * frontmatter-only record type is not an empty page; and the OKF export carries
+ * the literal key too, because publishing the resolved title would ship one
+ * value under two keys. `status` reads neither — it counts pages.
  *
  * `undefined` — never `""` — is the answer for anything unusable, because every
  * downstream surface already falls back to the slug on undefined and a blank
@@ -196,16 +203,26 @@ function validateScan(
  *
  * A type declaring NO `titleField` keeps the previous behaviour byte-for-byte,
  * down to `parseStatus.hasTitle`'s non-empty (untrimmed) test. The declared path
- * additionally trims, so a title of `"   "` is treated as absent rather than
- * rendered as a blank heading; the asymmetry is deliberate — the existing path
- * was left exactly as it was.
+ * trims: `"   "` reads as absent rather than as a blank heading, and `"  Ada  "`
+ * resolves to `"Ada"` rather than carrying padding into every surface that
+ * renders it. The asymmetry is deliberate; the existing path was left as it was.
+ *
+ * The `string` test is also what confines an inherited name. `titleField` is
+ * validated to name a declared own field, but this indexes user-authored
+ * frontmatter with a profile-supplied key, and an unvalidated profile reaching
+ * here (the SDK, a test) could name `constructor` or `toString` — which resolve
+ * off `Object.prototype` to FUNCTIONS, never strings, and so fall out here as
+ * absent. An own-property guard would be redundant with it, and no test could
+ * tell the two apart.
  */
 function pageTitle(def: EntityTypeDef, scan: RawEntityScan): string | undefined {
   if (def.titleField === undefined) {
     return scan.parseStatus.hasTitle ? (scan.frontmatter.title as string) : undefined;
   }
   const declared = scan.frontmatter[def.titleField];
-  return typeof declared === "string" && declared.trim().length > 0 ? declared : undefined;
+  if (typeof declared !== "string") return undefined;
+  const trimmed = declared.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 /**

--- a/src/profile/types.ts
+++ b/src/profile/types.ts
@@ -338,8 +338,12 @@ export interface EntityPageRef {
  *
  * Where `EntityPageRef` is identity-only, `EntityPage` additionally carries the
  * page's parsed `frontmatter`, its markdown `body`, and a convenience `title`
- * (the frontmatter title when present). It is produced by the content-carrying
- * collector so downstream read surfaces can render a page without re-reading it.
+ * resolved from the type's declared `titleField` (falling back to the literal
+ * `title` key for a type that declares none), or `undefined` when the page
+ * carries no usable one. It is produced by the content-carrying collector so
+ * downstream read surfaces can render a page without re-reading it. Surfaces
+ * that must judge or publish what the page literally WROTE read the frontmatter
+ * key directly instead — see `pageTitle` in collect.ts.
  *
  * This is the INTERNAL collector output: it carries an ABSOLUTE `filePath`
  * (inherited from `EntityPageRef`). Never expose it directly on a public read

--- a/src/profile/validate.ts
+++ b/src/profile/validate.ts
@@ -196,14 +196,23 @@ function validateRequiredFields(entityType: string, def: EntityTypeDef): void {
  * because the slug is already what an untitled page falls back to, so titling by
  * one would be a no-op dressed as a choice. `string[]` is excluded too: a title
  * is one value, and picking an element would be a rule the profile never stated.
+ *
+ * The declared-field test is confined to OWN properties. `titleField` comes from
+ * profile JSON and indexes a plain object, so a bare read resolves inherited
+ * names: `titleField: "constructor"` returned `Object.prototype.constructor`,
+ * slipped past the undeclared-field check, and was rejected by the type check
+ * below as "must be a 'string' field, not 'undefined'" — the right outcome
+ * reported as the wrong problem, telling an author their field is mistyped when
+ * it does not exist.
  */
 function validateTitleField(entityType: string, def: EntityTypeDef): void {
   if (def.titleField === undefined) return;
-  const field = def.fields?.[def.titleField];
+  const fields = def.fields ?? {};
   assert(
-    field !== undefined,
+    Object.hasOwn(fields, def.titleField),
     `entity '${entityType}' titleField '${def.titleField}' is not a declared field`,
   );
+  const field = fields[def.titleField];
   assert(
     field.type === "string",
     `entity '${entityType}' titleField '${def.titleField}' must be a 'string' field, not '${field.type}'`,

--- a/test/profile-title-field.test.ts
+++ b/test/profile-title-field.test.ts
@@ -8,10 +8,12 @@
  * display name lives under another key (AutoSci's `people`, keyed `name`) had no
  * title at all and every read surface fell back to its slug.
  *
- * Resolution belongs in the COLLECTOR rather than in one reader, so `status`,
- * the JSON export, context packs, index generation, lint and the viewer all read
- * one declaration one way. A viewer-only fix would give a single declaration two
- * meanings, which is the dual-source problem this codebase keeps removing.
+ * Resolution belongs in the COLLECTOR rather than in one reader, so every
+ * surface that renders a display title reads one declaration one way: the
+ * viewer, context packs, index generation and the JSON export. A viewer-only fix
+ * would give a single declaration two meanings, which is the dual-source problem
+ * this codebase keeps removing. Lint and the OKF export deliberately read the
+ * literal key instead, which `profile-title-field-blast-radius.test.ts` pins.
  *
  * Scope is deliberately narrow, and these tests pin all three edges of it: the
  * declared field is read when `titleField` is present; the literal `title` key
@@ -89,6 +91,34 @@ describe("an unusable titleField value leaves the title undefined", () => {
     expect(page?.title).toBeUndefined();
   });
 
+  it("trims the resolved title rather than carrying padding to every surface", async () => {
+    const page = await collectOne("wiki/people", "ada", 'name: "   Ada Lovelace   "');
+    expect(page?.title).toBe("Ada Lovelace");
+  });
+
+  // Validation rejects a titleField naming an inherited property, so reaching
+  // the collector with one means an unvalidated profile — the SDK, or a test.
+  // `Object.prototype.constructor` resolves to a FUNCTION, so the `string` test
+  // is what turns it into an absent title; this pins that, not a guard.
+  it("leaves it undefined when the declared field names an inherited property", async () => {
+    const root = await makeTempRoot("profile-title-field");
+    roots.push(root);
+    await writeMarkdownPage(root, "wiki/people", "ada", "---\naffiliation: none\n---\n\nBody.");
+    const unvalidated: ProfilePack = {
+      schemaVersion: 1,
+      profileId: "newsroom",
+      entities: {
+        people: {
+          directory: "wiki/people",
+          titleField: "constructor",
+          fields: { affiliation: { type: "string" } },
+        },
+      },
+    };
+    const { pages } = await collectEntityPages(root, unvalidated);
+    expect(pages[0]?.title).toBeUndefined();
+  });
+
   it("leaves it undefined when the declared field holds a non-string", async () => {
     const page = await collectOne("wiki/people", "ada", "name: 42");
     expect(page?.title).toBeUndefined();
@@ -126,6 +156,18 @@ describe("titleField is validated against the fields it claims to name", () => {
   it("rejects a field the type does not declare", () => {
     expect(() => validateProfileShape(packTitledBy("headline"))).toThrow(/titleField/);
   });
+
+  it.each(["constructor", "toString", "hasOwnProperty"])(
+    "reports %s as undeclared rather than as a mistyped field",
+    (inherited) => {
+      // A bare index resolved these off Object.prototype, so the undeclared
+      // check passed and the type check rejected them as "not 'undefined'" —
+      // the right outcome reported as the wrong problem.
+      expect(() => validateProfileShape(packTitledBy(inherited))).toThrow(
+        /is not a declared field/,
+      );
+    },
+  );
 
   it("rejects a declared field that cannot hold a title", () => {
     expect(() => validateProfileShape(packTitledBy("active"))).toThrow(/titleField/);


### PR DESCRIPTION
Follow-ups from #180, all found while reviewing it. No behaviour change beyond trimming a resolved title and one corrected validation message.

**`titleField` validation reported the wrong problem.** `validateTitleField` indexed `def.fields` with a key from profile JSON, so inherited names resolved off `Object.prototype`. `titleField: "constructor"` returned `Object.prototype.constructor`, passed the undeclared-field assert, and was rejected by the type assert as `must be a 'string' field, not 'undefined'` — the right outcome reported as the wrong problem, telling an author their field is mistyped when it does not exist. Now confined to own properties, matching the `Object.hasOwn` convention already used in `validate-workflow-actions.ts`.

**A resolved title kept its padding.** `pageTitle` trimmed only for the emptiness test and returned the raw value, so `"  Ada  "` carried padding into every surface that renders it. It now returns the trimmed value, which is what the comment already claimed.

**Four comments described behaviour that does not exist.** `collect.ts` and the test docstring both said `status` and `lint` read the resolved title. Lint deliberately reads the literal key, with its own docstring at the call site explaining why, and `status` reads no title at all — it counts pages. `EntityPage.title` in `types.ts` still described itself as the literal frontmatter title. And `profiles.mdx` said a blank title falls back to the slug, which holds only for a declared `titleField`: the legacy path preserves whatever the `title` key holds, so `title: "   "` on a type declaring none stays `"   "`. The guide now separates the two paths.

That third group mattered most: two comments in the same file tree contradicted each other, so whichever a future reader trusted, one would have sent them to edit the wrong file.

**No own-property guard was added to `pageTitle`.** One was drafted and dropped. `typeof declared !== "string"` already resolves an inherited name to absent, because a prototype member is a function and never a string, so the type check is total for that class. Removing the guard left every title-field test green, which is the evidence it was redundant rather than untested.

Five new cases, all mutation-tested against a committed baseline.
