### PR TITLE
refactor(compile): name finalizeWiki's behavioural flags

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -347,13 +347,9 @@ async function seedThenFinalize(
   draft: CompileStateDraft | null,
 ): Promise<void> {
   await maybeSeedPages(root, schema, generation, options);
-  await finalizeWiki(
-    root,
-    draft,
-    generation.writtenPages,
-    generation.seedSlugs,
-    options.changeFilter !== undefined,
-  );
+  await finalizeWiki(root, draft, generation.writtenPages, generation.seedSlugs, {
+    scoped: options.changeFilter !== undefined,
+  });
 }
 
 /** Inner pipeline, runs under lock protection. Returns structured CompileResult. */
@@ -531,6 +527,25 @@ async function markDeletedAsOrphaned(
 }
 
 /**
+ * Behavioural switches for {@link finalizeWiki}, named rather than positional.
+ *
+ * They arrive as an object because they are same-typed booleans that each
+ * INVERT a behaviour: as adjacent positional parameters, transposing two of
+ * them type-checks silently and the compile does the opposite of what the
+ * caller asked, on paths whose whole point is that they run less than the
+ * default. One flag was tolerable; a second one arriving is the signal to name
+ * them rather than to add a sixth parameter.
+ */
+interface FinalizeFlags {
+  /**
+   * The run recompiled a SUBSET by design (`refresh --stale` supplies a
+   * `changeFilter`), so it must not record the prompt-modifier selection as
+   * true of the whole project — see the flush below.
+   */
+  scoped?: boolean;
+}
+
+/**
  * Resolve interlinks, regenerate index/MOC, refresh embeddings
  * post-write. Seed-page slugs are folded into both the changed-slug
  * set (so embeddings refresh covers them) and the new-slug set (so
@@ -543,8 +558,9 @@ async function finalizeWiki(
   draft: CompileStateDraft | null,
   pages: MergedConcept[],
   seedSlugs: string[] = [],
-  scoped = false,
+  flags: FinalizeFlags = {},
 ): Promise<void> {
+  const { scoped = false } = flags;
   const conceptChangedSlugs = pages.map((entry) => entry.slug);
   const conceptNewSlugs = pages
     .filter((entry) => entry.concept.is_new)


### PR DESCRIPTION
`finalizeWiki` took `scoped` as a fifth positional boolean, added when the prompt-modifier fingerprint landed (#188). #169 wants a sixth in the same shape, to skip the embedding refresh.

Two adjacent defaulted booleans is the wrong place to be. They are the same type, so transposing them type-checks silently, and each one *inverts* a behaviour on a path whose whole point is to do less than the default: a scoped run that must not record the modifier selection as true of the project, and a compile that must not embed. Swapping them produces a compile that does the opposite of what the caller asked, with nothing to catch it.

They move into a named `FinalizeFlags` object. One flag was tolerable; a second one arriving is the signal to name them rather than to add a parameter.

No behaviour change. #188's scoped control was mutation-tested through the new shape at both the call site and the destructure, and each mutant is still caught.

Unblocks the rebase on #169, where the conflict is ours rather than the contributor's.