### PR TITLE
feat(compile): add a caller system policy, as a prompt modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Caller system policy on compile** — `compile({ systemPolicy })` appends deployment-specific editorial or publication guidance to the built-in compile prompts, for SDK hosts that need it without forking the prompts. It is additive rather than a replacement, sits before the source material, and blank or omitted leaves the prompt byte-identical.
+
+  It is advisory rather than enforceable: a policy makes a model more likely to follow a rule, and nothing downstream verifies that it did. Anything that must hold belongs in a lint rule or a trust gate.
+
+  The policy is a prompt modifier, so changing or clearing it regenerates the pages compiled under the previous one, and replaces a pending review candidate produced under it. Each page records the policy's **digest**, never its text, since the modifier set travels into `state.json`, page frontmatter and the JSON export. `PROMPT_VERSION` advances to `v2`.
+
+  Groundwork by **@TigerOfCountryYao** (#170), and see #144 for the request this partly answers.
+
 - **Atlas Cloud provider** — `LLMWIKI_PROVIDER=atlascloud` (aliases `atlas-cloud`, `atlas`) routes chat and tool calls through the [Atlas Cloud](https://www.atlascloud.ai) gateway, which exposes an OpenAI-compatible API across models from several publishers. Authenticate with `ATLASCLOUD_API_KEY` or `ATLAS_CLOUD_API_KEY`; `ATLASCLOUD_BASE_URL` overrides the endpoint.
 
   Model ids are namespaced by publisher, and `compile` extracts concepts through a tool call, so the default is a model Atlas Cloud lists as supporting tools. Embeddings are not wired up: the provider fails closed rather than inheriting OpenAI's semantics, so route them elsewhere with `LLMWIKI_EMBEDDING_PROVIDER` for semantic search.

--- a/docs/guides/sdk.mdx
+++ b/docs/guides/sdk.mdx
@@ -80,6 +80,11 @@ Both methods return `IngestResult` with `filename`, `chars`, and `truncated` fie
   Run the incremental compile pipeline. Extracts concepts from new or changed sources, generates typed wiki pages, resolves `[[wikilinks]]`, and rebuilds the index. **Requires LLM credentials.**
 
   - `options.review` - when `true`, writes generated pages to `.llmwiki/candidates/` for review instead of directly to `wiki/`. Same behavior as `llmwiki compile --review`.
+  - `options.systemPolicy` - extra instructions appended to the built-in compile prompts, for deployment-specific editorial or publication guidance without forking the prompts. Additive: it never replaces a built-in instruction, and it is placed before the source material. Blank or omitted leaves the prompt unchanged.
+
+    It is **advisory, not enforceable**. A policy makes the model more likely to follow a rule; it cannot make it obey one, and nothing verifies that it did. Anything that must hold belongs in a lint rule or a trust gate.
+
+    Changing it **regenerates the pages compiled under the previous policy**, the same way changing the output language does, so it costs a full compile of the affected pages. Each page records the policy's digest (never its text) in `promptModifiers`.
 
   Source content is sent to the configured LLM provider during compilation. Do not compile wikis containing confidential data unless the provider's data-handling policies are acceptable for that content.
 

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -27,7 +27,11 @@ import {
 } from "./prompts.js";
 import { loadSchema, type SchemaConfig } from "../schema/index.js";
 import { detectChanges, hashFile } from "./hasher.js";
-import { promoteForPromptModifiers, promptModifiersDigest } from "./prompt-modifiers.js";
+import {
+  promoteForPromptModifiers,
+  promptModifiersDigest,
+  withRunSystemPolicy,
+} from "./prompt-modifiers.js";
 import {
   findAffectedSources,
   findFrozenSlugs,
@@ -132,7 +136,12 @@ export async function compileAndReport(
     if (recovery.status === "unsafe") {
       throw new JournalUnsafeError("pre-compile journal recovery unsafe");
     }
-    return await runCompilePipeline(root, options);
+    // The policy is established for the WHOLE run, before change detection, so
+    // the modifier digest it contributes is visible to the invalidation check
+    // rather than only to the prompt builders further down.
+    return await withRunSystemPolicy(options.systemPolicy, () =>
+      runCompilePipeline(root, options),
+    );
   } finally {
     await releaseLock(root);
   }

--- a/src/compiler/prompt-modifiers.ts
+++ b/src/compiler/prompt-modifiers.ts
@@ -4,8 +4,8 @@
  * and as a digest.
  *
  * A modifier is a knob that changes what the page prompt ASKS FOR without
- * changing the committed prompt wording — today only the output language, set
- * by `--lang` or `LLMWIKI_OUTPUT_LANG`. Two facts follow from that, and this
+ * changing the committed prompt wording: the output language, set by `--lang`
+ * or `LLMWIKI_OUTPUT_LANG`, and the caller policy passed to `compile`. Two facts follow from that, and this
  * module is the single source for both:
  *
  *  - **Change detection.** `detectChanges` classifies a source purely by the
@@ -24,6 +24,7 @@
  * recording it would invalidate pages that are byte-identical under it.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
 import { getOutputLanguage } from "../utils/output-language.js";
 import type { SourceChange, WikiState } from "../utils/types.js";
@@ -38,7 +39,68 @@ export function activePromptModifiers(): Record<string, string> {
   const modifiers: Record<string, string> = {};
   const lang = getOutputLanguage();
   if (lang) modifiers.lang = lang;
+  const policy = activeSystemPolicy();
+  if (policy) modifiers.policy = sha256(policy);
   return modifiers;
+}
+
+/**
+ * The caller policy for the current async call tree.
+ *
+ * `AsyncLocalStorage` rather than a module variable, matching `quietScope` and
+ * `verboseScope` in utils/output.ts. The SDK documents that "concurrent calls
+ * are fully isolated" with "no global state" (docs/guides/sdk.mdx), and the
+ * compile lock is per ROOT, so two SDK callers compiling different projects
+ * genuinely overlap in one process.
+ *
+ * A save-and-restore module variable does NOT survive that. It handles nesting
+ * and fails on interleaving: the run that finishes first restores the value it
+ * captured, which belongs to neither run. Measured on the earlier
+ * implementation, two overlapping runs observed `["Policy B", undefined]` where
+ * they should observe `["Policy A", "Policy B"]` — one project reading another's
+ * policy, and the other losing its own.
+ *
+ * That matters beyond the prompt text: the policy feeds the modifier digest, so
+ * a leak writes one project's selection into another's `state.json`, its
+ * candidates, and its page provenance.
+ *
+ * An env slot was the other option and is worse: `systemPolicy` is an SDK
+ * option and nothing else, so it would mean documenting a variable that exists
+ * only to carry a value across module boundaries — and env is process-global,
+ * which is the same bug.
+ */
+const policyScope = new AsyncLocalStorage<string | undefined>();
+
+/**
+ * Run `fn` with `policy` as the active caller policy, restoring the previous
+ * value afterwards even if `fn` throws.
+ *
+ * Blank and whitespace-only policies are normalised to `undefined` HERE, once,
+ * so every downstream reader (the digest, the frontmatter stamp, the prompt
+ * builders) agrees on what "no policy" means without each re-deciding.
+ */
+export function withRunSystemPolicy<T>(policy: string | undefined, fn: () => T): T {
+  const trimmed = policy?.trim();
+  return policyScope.run(trimmed && trimmed.length > 0 ? trimmed : undefined, fn);
+}
+
+/** The active caller policy, already trimmed, or `undefined` when none is set. */
+export function activeSystemPolicy(): string | undefined {
+  return policyScope.getStore();
+}
+
+/**
+ * The policy's DIGEST rather than its text is what enters the modifier set.
+ *
+ * A policy is caller-authored prose of unbounded length, and the modifier set is
+ * hashed into `state.json`, stamped onto every page's frontmatter, and published
+ * through the JSON export. Carrying the text would put an operator's editorial
+ * instructions into three artifacts that outlive the run, one of them shipped to
+ * downstream consumers. The digest answers the only question the mechanism asks
+ * of it: is this the same policy as last time?
+ */
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 /**

--- a/src/compiler/prompts.ts
+++ b/src/compiler/prompts.ts
@@ -12,6 +12,7 @@ import type {
 } from "../utils/types.js";
 import type { PageKindRule, SeedPage } from "../schema/index.js";
 import { languageDirective } from "../utils/output-language.js";
+import { activeSystemPolicy } from "./prompt-modifiers.js";
 
 /**
  * Build a list of optional prompt lines, omitting empty entries so the
@@ -34,7 +35,35 @@ function withLangLine(...lines: string[]): string[] {
  * downstream auditor can distinguish pages produced under different prompt
  * generations even when the model id is identical. Format is `vMAJOR`.
  */
-export const PROMPT_VERSION = "v1";
+export const PROMPT_VERSION = "v2";
+
+/**
+ * The caller's system policy as prompt lines, or nothing when none is set.
+ *
+ * ADDITIVE by construction: the policy lands after every built-in instruction
+ * and is introduced as something to follow *in addition to* them, never as a
+ * replacement. It is also placed before the source material, so the whole
+ * instruction block still precedes the untrusted content it describes.
+ *
+ * This is advisory prompt text, not an enforceable boundary. A policy makes a
+ * model more likely to follow an editorial or publication rule; it cannot make
+ * the model obey one, and nothing downstream verifies that it did. Anything
+ * that must hold should be a lint rule or a trust gate instead.
+ *
+ * Read from run state rather than taken as a parameter so the three prompt
+ * builders keep their signatures and the option does not have to be threaded
+ * through extraction, page rendering, the review pipeline and seed pages, none
+ * of which otherwise need to know it exists.
+ */
+function systemPolicyLines(): string[] {
+  const policy = activeSystemPolicy();
+  if (!policy) return [];
+  return [
+    "",
+    "Additional system policy (follow in addition to every built-in instruction above):",
+    policy,
+  ];
+}
 
 /** Allowed provenance state strings emitted by the LLM tool schema. */
 const PROVENANCE_STATE_VALUES: ProvenanceState[] = [
@@ -141,6 +170,7 @@ export function buildExtractionPrompt(
     "    or 'ambiguous' if the source is contradictory or unclear.",
     "  - contradicted_by: slugs of other concepts (in this batch or the index)",
     "    whose evidence conflicts with this one.",
+    ...systemPolicyLines(),
     indexSection,
     "\n\n--- SOURCE DOCUMENT ---\n\n",
     sourceContent,
@@ -196,6 +226,7 @@ export function buildPagePrompt(
     "If a paragraph is your inference rather than a direct extraction, leave it",
     "uncited — downstream lint rules will count uncited paragraphs as 'inferred'",
     "so lint can surface excess-inferred-paragraphs warnings on review.",
+    ...systemPolicyLines(),
     existingSection,
     relatedSection,
     "\n\n--- SOURCE MATERIAL ---\n\n",
@@ -283,6 +314,7 @@ export function buildSeedPagePrompt(
       linkExpectation,
       "Write in a neutral, informative tone. Be concise but thorough.",
     ),
+    ...systemPolicyLines(),
     "\n\n--- RELATED PAGES ---\n\n",
     relatedPagesContent,
   ].join("\n");

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,6 +85,18 @@ export interface SdkCompileOptions {
    * out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Extra instructions appended to the built-in compile prompts, for a host that
+   * needs deployment-specific editorial or publication guidance without forking
+   * the prompts. Additive, never a replacement; blank is the same as omitted.
+   *
+   * Advisory rather than enforceable: it makes the model more likely to follow a
+   * rule, and nothing verifies that it did.
+   *
+   * Changing it invalidates pages compiled under the previous policy, the same
+   * way changing the output language does.
+   */
+  systemPolicy?: string;
 }
 
 /** Options for `getContextPack`. Maps onto the subset of BuildContextPackOptions needed externally. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -200,6 +200,24 @@ export interface CompileOptions {
    * the built-in default. Out-of-range values are clamped with a warning.
    */
   concurrency?: number;
+  /**
+   * Extra instructions appended to the built-in compile prompts, for a host
+   * that needs deployment-specific editorial or publication guidance without
+   * forking the prompts.
+   *
+   * ADDITIVE: it never replaces a built-in instruction, and it is placed before
+   * the source material so the full instruction block still precedes the
+   * content it describes. Blank or whitespace-only is the same as omitting it,
+   * and omitting it leaves the prompt byte-identical.
+   *
+   * ADVISORY, not enforceable. It makes a model more likely to follow a rule; it
+   * cannot make it obey one, and nothing verifies that it did. Anything that
+   * must hold belongs in a lint rule or a trust gate.
+   *
+   * A prompt modifier: changing it invalidates pages compiled under the previous
+   * policy, and its digest is recorded per page. See compiler/prompt-modifiers.ts.
+   */
+  systemPolicy?: string;
 }
 
 /**

--- a/test/system-policy-invalidation.test.ts
+++ b/test/system-policy-invalidation.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @file test/system-policy-invalidation.test.ts
+ * @description Changing the caller policy regenerates the pages compiled under
+ * the previous one, through the real compile pipeline.
+ *
+ * The unit tests pin the digest's arithmetic. None of them can tell whether the
+ * policy is actually wired into change detection, and that is the whole feature:
+ * a settled project whose sources have not changed short-circuits at "Nothing to
+ * compile" long before any prompt is built. The control that matters is a SECOND
+ * compile over byte-identical sources.
+ *
+ * Pending review candidates are the second surface. Deduplication compares a
+ * candidate's source hash and the selection it was generated under, so a
+ * candidate written under one policy must not satisfy a run asking for another.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createWiki } from "../src/sdk/wiki.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Alpha", summary: "Alpha summary.", is_new: true }],
+});
+
+const ctx = useCompileProject({
+  dirSuffix: "policy-invalidation",
+  sourceFile: "sample.md",
+  sourceContent: "# Alpha\n\nAlpha is documented here.",
+});
+
+/** Stub both LLM phases and count how many page generations ran. */
+function stubCompile(): { pages: () => number } {
+  let pages = 0;
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(EXTRACTION);
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockImplementation(async () => {
+    pages += 1;
+    return "Alpha body. ^[sample.md]";
+  });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return { pages: () => pages };
+}
+
+/** The modifier digest recorded in the project's state. */
+async function recordedDigest(): Promise<string | undefined> {
+  const raw = await readFile(path.join(ctx.dir, ".llmwiki/state.json"), "utf-8");
+  return (JSON.parse(raw) as { promptModifiers?: string }).promptModifiers;
+}
+
+/**
+ * Compile twice over byte-identical sources and report how many page
+ * generations each run performed.
+ *
+ * Both runs go through the real pipeline, so the second one exercises change
+ * detection rather than a stub: `second > 0` means the run was invalidated,
+ * `second === 0` means it short-circuited at "Nothing to compile".
+ */
+async function compileTwice(
+  first: Parameters<ReturnType<typeof createWiki>["compile"]>[0],
+  second: Parameters<ReturnType<typeof createWiki>["compile"]>[0],
+): Promise<{ first: number; second: number }> {
+  const spy = stubCompile();
+  const wiki = createWiki({ root: ctx.dir });
+  await wiki.compile(first);
+  const afterFirst = spy.pages();
+  await wiki.compile(second);
+  return { first: afterFirst, second: spy.pages() - afterFirst };
+}
+
+describe("changing the policy invalidates what the old one produced", () => {
+  it("recompiles byte-identical sources when the policy changes", async () => {
+    const runs = await compileTwice({ systemPolicy: "Policy A" }, { systemPolicy: "Policy B" });
+    expect(runs.first).toBeGreaterThan(0);
+    expect(runs.second).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("recompiles when the policy is cleared", async () => {
+    const runs = await compileTwice({ systemPolicy: "Policy A" }, {});
+    expect(runs.second).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("leaves a settled project alone when the policy is unchanged", async () => {
+    const runs = await compileTwice({ systemPolicy: "Policy A" }, { systemPolicy: "Policy A" });
+    expect(runs.second).toBe(0);
+  }, 60_000);
+
+  it("treats a blank policy as no policy, leaving a settled project alone", async () => {
+    const runs = await compileTwice({}, { systemPolicy: "   " });
+    expect(runs.second).toBe(0);
+    expect(await recordedDigest()).toBe("");
+  }, 60_000);
+
+  it("replaces a pending candidate generated under a different policy", async () => {
+    // Same source bytes, different policy: the pending candidate was produced
+    // under a selection this run is not asking for, so it is not a duplicate.
+    const runs = await compileTwice(
+      { review: true, systemPolicy: "Policy A" },
+      { review: true, systemPolicy: "Policy B" },
+    );
+    expect(runs.first).toBeGreaterThan(0);
+    expect(runs.second).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/test/system-policy.test.ts
+++ b/test/system-policy.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @file test/system-policy.test.ts
+ * @description The caller policy: how it reaches the prompts, and why it is a
+ * prompt modifier rather than a plain option.
+ *
+ * A policy changes what the compile prompt ASKS FOR without changing any source
+ * byte, which is exactly the shape `compiler/prompt-modifiers.ts` exists to
+ * handle. Registering it there is what makes changing a policy invalidate the
+ * pages compiled under the previous one; without that, a settled project reports
+ * "Nothing to compile" and silently keeps content generated under a policy the
+ * operator has already replaced.
+ *
+ * The DIGEST enters the modifier set, never the text. The set is hashed into
+ * `state.json`, stamped on every page's frontmatter, and published through the
+ * JSON export, so carrying the prose would put an operator's editorial
+ * instructions into three artifacts that outlive the run.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  activePromptModifiers,
+  activeSystemPolicy,
+  promptModifiersChanged,
+  promptModifiersDigest,
+  withRunSystemPolicy,
+} from "../src/compiler/prompt-modifiers.js";
+import { PROMPT_VERSION, buildPagePrompt, buildExtractionPrompt } from "../src/compiler/prompts.js";
+
+const LANG = "LLMWIKI_OUTPUT_LANG";
+afterEach(() => { delete process.env[LANG]; });
+
+/** Resolve `fn` under `policy`, returning its value. */
+function under<T>(policy: string | undefined, fn: () => T): Promise<T> {
+  return withRunSystemPolicy(policy, async () => fn());
+}
+
+describe("the policy as run state", () => {
+  it("is absent outside a run", () => {
+    expect(activeSystemPolicy()).toBeUndefined();
+  });
+
+  it("is trimmed, and blank is the same as absent", async () => {
+    expect(await under("  Prefer plain language.  ", activeSystemPolicy)).toBe("Prefer plain language.");
+    expect(await under("   ", activeSystemPolicy)).toBeUndefined();
+    expect(await under("", activeSystemPolicy)).toBeUndefined();
+  });
+
+  it("does not outlive the run, even when the run throws", async () => {
+    await expect(
+      withRunSystemPolicy("A", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(activeSystemPolicy()).toBeUndefined();
+  });
+
+  // The SDK documents that concurrent calls are fully isolated with no global
+  // state, and the compile lock is per ROOT, so two callers compiling different
+  // projects genuinely overlap in one process. A save-and-restore module
+  // variable handles nesting and fails here: whichever run finishes first
+  // restores the value it captured, which belongs to neither. That implementation
+  // produced ["Policy B", undefined] on this test - one project reading
+  // another's policy, and the other losing its own.
+  /**
+   * Start two policy runs, let both yield, then read `observe` inside each.
+   *
+   * The yield is the point: a save-and-restore module variable only fails once
+   * the two runs interleave, so a test that reads without awaiting would pass
+   * against the broken implementation.
+   */
+  async function observeOverlapping<T>(observe: () => T): Promise<[T, T]> {
+    const seen: T[] = [];
+    const pause = () => new Promise<void>((resolve) => setTimeout(resolve, 10));
+    const run = (policy: string, slot: number) =>
+      withRunSystemPolicy(policy, async () => {
+        await pause();
+        seen[slot] = observe();
+      });
+    await Promise.all([run("Policy A", 0), run("Policy B", 1)]);
+    return [seen[0], seen[1]];
+  }
+
+  it("keeps overlapping runs isolated from each other", async () => {
+    expect(await observeOverlapping(activeSystemPolicy)).toEqual(["Policy A", "Policy B"]);
+  });
+
+  it("keeps the modifier digest isolated across overlapping runs too", async () => {
+    // The leak is not confined to prompt text: the policy feeds the digest that
+    // reaches state.json, candidates and page provenance.
+    const [a, b] = await observeOverlapping(promptModifiersDigest);
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("the policy is a prompt modifier", () => {
+  it("contributes a digest, never the policy text", async () => {
+    const policy = "Never mention internal codenames.";
+    const modifiers = await under(policy, activePromptModifiers);
+    expect(modifiers.policy).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(modifiers)).not.toContain("codenames");
+  });
+
+  it("invalidates when one policy replaces another", async () => {
+    const a = await under("Policy A", promptModifiersDigest);
+    const changed = await under("Policy B", () => promptModifiersChanged(a));
+    expect(changed).toBe(true);
+  });
+
+  it("invalidates when a policy is cleared", async () => {
+    const a = await under("Policy A", promptModifiersDigest);
+    expect(promptModifiersChanged(a)).toBe(true);
+  });
+
+  it("leaves a project with no policy untouched", async () => {
+    const none = promptModifiersDigest();
+    expect(none).toBe("");
+    expect(await under(undefined, () => promptModifiersChanged(none))).toBe(false);
+    expect(await under("   ", () => promptModifiersChanged(none))).toBe(false);
+  });
+
+  it("composes with the output language rather than replacing it", async () => {
+    process.env[LANG] = "Japanese";
+    const modifiers = await under("Policy A", activePromptModifiers);
+    expect(Object.keys(modifiers).sort()).toEqual(["lang", "policy"]);
+  });
+});
+
+describe("the policy in the prompt", () => {
+  const POLICY = "Prefer British spelling.";
+
+  it("is absent by default, leaving the prompt as it was", () => {
+    expect(buildPagePrompt("C", "src", "", "")).not.toContain(POLICY);
+  });
+
+  it("appears in the page prompt before the source material", async () => {
+    const prompt = await under(POLICY, () => buildPagePrompt("C", "SRC-BODY", "", ""));
+    expect(prompt).toContain(POLICY);
+    expect(prompt.indexOf(POLICY)).toBeLessThan(prompt.indexOf("--- SOURCE MATERIAL ---"));
+  });
+
+  it("appears in the extraction prompt before the source document", async () => {
+    const prompt = await under(POLICY, () => buildExtractionPrompt("SRC-BODY", ""));
+    expect(prompt).toContain(POLICY);
+    expect(prompt.indexOf(POLICY)).toBeLessThan(prompt.indexOf("--- SOURCE DOCUMENT ---"));
+  });
+
+  it("is introduced as additive, not as a replacement", async () => {
+    const prompt = await under(POLICY, () => buildPagePrompt("C", "src", "", ""));
+    expect(prompt).toContain("in addition to every built-in instruction above");
+    expect(prompt).toContain("Draw facts only from the provided source material.");
+  });
+});
+
+describe("PROMPT_VERSION", () => {
+  // The constant names the prompt IMPLEMENTATION, so the conditional policy
+  // branch is a new generation. Pinned because nothing else in the repo asserts
+  // its value, and a silent revert would mislabel every page compiled after it.
+  it("is v2, the generation that can carry a caller policy", () => {
+    expect(PROMPT_VERSION).toBe("v2");
+  });
+});


### PR DESCRIPTION
Picks up #170, rebased onto current `main` and finished against the review. @TigerOfCountryYao is credited as co-author. Partly answers #144.

## What it does

`compile({ systemPolicy })` appends deployment-specific editorial or publication guidance to the built-in compile prompts, for an SDK host that needs it without forking the prompts. Additive rather than a replacement, placed before the source material, and blank or omitted leaves the prompt byte-identical.

It is **advisory**. A policy makes a model more likely to follow a rule; it cannot make it obey one, and nothing downstream verifies that it did. Anything that must hold belongs in a lint rule or a trust gate, and the docs say so rather than letting the word "policy" imply a boundary.

## The substantive change from #170

**The policy is registered as a prompt modifier.** It alters what the prompt asks for without changing a source byte, so without this a settled project reports "Nothing to compile" and keeps content generated under a policy the operator has already replaced. A pending review candidate has the same problem.

Registering it in `activePromptModifiers` means it inherits the whole mechanism from #188: invalidation on change, candidate-aware deduplication, the scoped-refresh guard, and per-page provenance. Bumping `PROMPT_VERSION` alone does not achieve this, since two different policies share a version.

The **digest** enters the modifier set, never the text. That set is hashed into `state.json`, stamped onto every page's frontmatter, and published through the JSON export, so carrying the prose would put an operator's editorial instructions into three artifacts that outlive the run.

## Smaller than the original

The prompt builders read the policy from run state rather than taking it as a parameter, so their signatures are unchanged and the option is not threaded through extraction, page rendering, the review pipeline and seed pages. `withRunSystemPolicy` restores the previous value rather than clearing, so overlapping SDK callers on different roots cannot strand a policy they did not set.


## Isolation

The policy lives in `AsyncLocalStorage`, matching `quietScope` and `verboseScope` in `utils/output.ts`. The SDK documents that concurrent calls are fully isolated with no global state, and the compile lock is per **root**, so two callers compiling different projects genuinely overlap in one process.

A module variable that saves and restores handles nesting and fails on interleaving. Measured on an earlier revision of this branch, two overlapping runs observed `["Policy B", undefined]` where they should observe `["Policy A", "Policy B"]` - one project reading another's policy, and the other losing its own. That reaches past prompt text, since the policy feeds the digest written to `state.json`, candidates and page provenance.

Two tests pin it, one on the policy and one on the digest, and both yield before reading: the broken implementation only fails once the runs actually interleave.

## Tests

Thirteen unit cases plus five that drive the real pipeline twice over byte-identical sources: policy A to B, policy cleared, policy unchanged, blank treated as absent, and a pending candidate produced under a different policy. Only the pipeline cases can detect the wiring.

Every control is mutation-tested: removing the policy from the modifier set turns 7 red, reverting `PROMPT_VERSION` turns 1 red, and removing it from the prompts turns 3 red.

## On #144

This is the SDK primitive underneath that request, not a closure of it. #144 asks for a `SOUL.md`-style **file**, and a file or CLI surface on top of this is a reasonable next step.

## Not included

`#169`'s embeddings flag. The feature has no dependency on it, only a shared test file, so this is unstacked.
