### PR TITLE
fix(compile): stop interlink resolution corrupting prose that contains $

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Interlink resolution corrupted prose containing `$` sequences** — when compile linked a page, it spliced the rewritten body back in with a string replacement, and `String.replace` interprets `$&`, `` $` ``, `$'` and `$$` there. A page reading `The PID is $$` lost a `$`; one containing a backtick-dollar had its own frontmatter spliced into the middle of the sentence; `$&` duplicated the body. Shell, sed, awk and Makefile pages carry those sequences as ordinary prose. The rewritten body is now inserted verbatim.
+
 - **Changing the output language left existing pages untouched** — `llmwiki compile --lang Japanese` over an already-compiled project reported "Nothing to compile" and every page kept its previous language, because change detection classified a source by the SHA-256 of its bytes alone and a prompt modifier is not part of the source. The selected modifiers are now recorded in `.llmwiki/state.json`, and flipping one invalidates the pages it would have changed. Setting `LLMWIKI_OUTPUT_LANG` has the same effect as the flag.
 
   Pages also carry a `promptModifiers` frontmatter entry naming the modifiers active when they were generated, surfaced per page in the JSON export. `promptVersion` names the prompt implementation and is identical whether or not a modifier was selected, so it could not tell two such pages apart.

--- a/src/compiler/resolver.ts
+++ b/src/compiler/resolver.ts
@@ -203,13 +203,23 @@ function namespaceForPath(filePath: string): CompilePageNamespace {
   return "concepts";
 }
 
-/** Build the rewritten-page write for a PageInfo, or null when its body is unchanged. */
+/**
+ * Build the rewritten-page write for a PageInfo, or null when its body is unchanged.
+ *
+ * The replacement is a FUNCTION, not the string itself. `String.replace`
+ * interprets `$&`, `` $` ``, `$'` and `$$` in a string replacement even when the
+ * search argument is a plain string, and `linked` is page prose: a page reading
+ * "the PID is $$" lost a `$`, and one containing a backtick-dollar had this
+ * page's own frontmatter spliced into the middle of the sentence. Passing a
+ * function suppresses that substitution entirely, so the rewritten body is
+ * inserted verbatim.
+ */
 function rewritePage(page: PageInfo, content: string, linked: string, body: string): CompilePageWrite | null {
   if (linked === body) return null;
   return {
     namespace: namespaceForPath(page.filePath),
     slug: page.slug,
-    body: content.replace(body, linked),
+    body: content.replace(body, () => linked),
   };
 }
 

--- a/test/resolver-dollar-patterns.test.ts
+++ b/test/resolver-dollar-patterns.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @file test/resolver-dollar-patterns.test.ts
+ * @description Interlink resolution must insert a rewritten body verbatim,
+ * including `$` sequences that `String.replace` would otherwise treat as
+ * substitution patterns.
+ *
+ * `rewritePage` splices the linked body back into the page with
+ * `content.replace(body, ...)`. A STRING replacement there is interpreted:
+ * `$&` re-inserts the match, `` $` `` inserts everything before it — which is
+ * this page's own frontmatter — `$'` inserts everything after, and `$$` becomes
+ * a single `$`. None of that is hypothetical for a wiki: shell, sed, awk and
+ * Makefile pages carry those sequences as ordinary prose, and `$$` for a process
+ * id is common.
+ *
+ * The bug was silent. The link resolved correctly and the page was rewritten,
+ * so nothing failed; the prose around the link was simply wrong afterwards.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resolveAndApplyLinks } from "../src/compiler/resolver.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  while (roots.length > 0) rmSync(roots.pop() as string, { recursive: true, force: true });
+});
+
+/** A project with a link TARGET page, plus one page whose prose contains `body`. */
+const FRONTMATTER = "---\ntitle: PID Tricks\nsummary: s\nsources: []\n---\n\n";
+
+function projectWithBody(body: string): { root: string; pagePath: string } {
+  const root = mkdtempSync(path.join(tmpdir(), "resolver-dollar-"));
+  roots.push(root);
+  mkdirSync(path.join(root, "wiki/concepts"), { recursive: true });
+  writeFileSync(
+    path.join(root, "wiki/concepts/shell-quoting-rules.md"),
+    "---\ntitle: Shell Quoting Rules\nsummary: s\nsources: []\n---\n\nTarget page.\n",
+  );
+  const pagePath = path.join(root, "wiki/concepts/pid-tricks.md");
+  writeFileSync(pagePath, FRONTMATTER + body);
+  return { root, pagePath };
+}
+
+describe("interlink resolution preserves $ sequences in prose", () => {
+  // A bare title mention is what triggers a rewrite; an existing [[link]] is
+  // skipped by isInsideWikilink, so it would never reach the splice at all.
+  it.each([
+    ["$$ (process id)", "The PID is $$ here.\n\nSee Shell Quoting Rules for more.\n"],
+    ["$& (whole match)", "Use $& in sed.\n\nSee Shell Quoting Rules for more.\n"],
+    ["$` (prefix)", "Use $` in sed.\n\nSee Shell Quoting Rules for more.\n"],
+    ["$' (suffix)", "Use $' in sed.\n\nSee Shell Quoting Rules for more.\n"],
+  ])("keeps %s exactly as written", async (_label, body) => {
+    const { root, pagePath } = projectWithBody(body);
+    await resolveAndApplyLinks(root, ["pid-tricks"], []);
+    const after = readFileSync(pagePath, "utf-8");
+
+    // EXACT equality, not containment. `$&` re-inserts the match, which
+    // duplicates the body rather than mangling it — every `toContain` on the
+    // original prose still passes against a page that now says everything
+    // twice. Only comparing the whole file catches that.
+    const expected = FRONTMATTER + body.replace(
+      "Shell Quoting Rules",
+      "[[shell-quoting-rules|Shell Quoting Rules]]",
+    );
+    expect(after).toBe(expected);
+  }, 30_000);
+});


### PR DESCRIPTION
Interlink resolution splices the linked body back into the page with `content.replace(body, linked)`. `String.replace` interprets `$&`, `` $` ``, `$'` and `$$` in a **string** replacement even when the search argument is a plain string, and `linked` is page prose.

Measured on a page reading ``The PID is $$ and sed uses $` for the prefix.``:

```
before:  The PID is $$ and sed uses $` for the prefix.

after:   The PID is $ and sed uses ---
         title: PID Tricks
         summary: s
         sources: []
         --- for the prefix.
```

`$$` collapsed to a single `$`, and `` $` `` spliced the page's own frontmatter into the middle of the sentence. `$&` duplicates the whole body; `$'` deletes everything after it.

Shell, sed, awk and Makefile pages carry those sequences as ordinary prose, and `$$` for a process id is common, so this is reachable by compiling ordinary technical documentation. It is also silent: the link resolves correctly and the page is rewritten, so nothing fails. The prose around the link is simply wrong afterwards.

## The fix

Passing a replacer **function** suppresses the substitution entirely, so the rewritten body is inserted verbatim. One line.

Every other non-regex `.replace()` in `src/` was swept: the rest pass a replacer function or a literal containing no `$`.

## On the tests

The four regression cases assert **exact whole-file equality**, not containment. An earlier draft used `toContain` and passed against the bug for `$&`, because duplicating the body leaves every substring of the original present — the page said everything twice and the assertions were satisfied. Only comparing the whole file tests what this pass actually promises, which is that nothing but the link changes.

Mutation-tested: restoring the string replacement turns all four red.

## Provenance

Found while reviewing #193, which copies this line into a second pass. That PR should adopt the fixed form rather than the current one; this lands first so it has something correct to copy.