### PR TITLE
fix(compile): rebuild shared pages after source deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A shared page kept by `llmwiki rm` could never be rebuilt** — `rm` records each kept slug in `state.frozenSlugs`, the same marker compile sets when it notices a deleted source, and that marker was terminal: `mergeExtractions` skipped a frozen slug outright and nothing removed a slug from the set. The page kept the removed source's prose and its citations permanently, `llmwiki lint` reported `broken-citation` at error severity on a page no command could repair, and deleting the page to force a rebuild lost it for good.
+
+  A slug frozen because the current run's extraction failed is still skipped and preserved. A slug carried in persisted state is now a reconciliation marker instead: the page is rebuilt from whatever owners survive, with the removed source's contribution dropped, and a page no live source owns is orphaned rather than held. Fixes #194.
+
+  Contributed by **@TigerOfCountryYao** (#171).
+
 - **Interlink resolution corrupted prose containing `$` sequences** — when compile linked a page, it spliced the rewritten body back in with a string replacement, and `String.replace` interprets `$&`, `` $` ``, `$'` and `$$` there. A page reading `The PID is $$` lost a `$`; one containing a backtick-dollar had its own frontmatter spliced into the middle of the sentence; `$&` duplicated the body. Shell, sed, awk and Makefile pages carry those sequences as ordinary prose. The rewritten body is now inserted verbatim.
 
 - **Changing the output language left existing pages untouched** — `llmwiki compile --lang Japanese` over an already-compiled project reported "Nothing to compile" and every page kept its previous language, because change detection classified a source by the SHA-256 of its bytes alone and a prompt modifier is not part of the source. The selected modifiers are now recorded in `.llmwiki/state.json`, and flipping one invalidates the pages it would have changed. Setting `LLMWIKI_OUTPUT_LANG` has the same effect as the flag.

--- a/docs/cli/rm.mdx
+++ b/docs/cli/rm.mdx
@@ -35,7 +35,11 @@ No LLM provider credentials are required. `rm` never calls the chat model, and i
 | `wiki/index.md` and `wiki/MOC.md` | Regenerated |
 | Vectors for the deleted pages in `.llmwiki/embeddings.json` | Pruned |
 
-A kept page's body is a merge of contributions from every source that produced it, including the one just removed - the file itself carries no record of that. So `rm` records each kept slug in `state.json`'s `frozenSlugs`, the same marker `compile` already sets when it notices a deleted source. The mark is what tells the next `compile` that this page lost a contributor, instead of rebuilding it from the remaining sources as though nothing had been removed.
+A kept page's body is a merge of contributions from every source that produced it, including the one just removed - the file itself carries no record of that. So `rm` records each kept slug in `state.json`'s `frozenSlugs`, the same marker `compile` already sets when it notices a deleted source.
+
+The mark tells the next `compile` to rebuild that page cleanly from the sources that survive, dropping the removed source's contribution and its citations rather than leaving them in place. A page no live source owns any more is orphaned instead.
+
+The mark is cleared only once the replacement page is actually written. If extraction or page validation fails during that rebuild, the mark and the surviving sources' ownership are both preserved, so a later `compile` tries again rather than leaving the page stale with nothing to say so.
 
 ## Limitations
 

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -137,10 +137,9 @@ function buildRefreshSummary(liveRefreshed: number, heldCount: number, orphanedC
 
 /**
  * Invoke the provider guard only when the plan will trigger an LLM extraction.
- * Concept extraction runs solely for changed owners and their known-affected
- * co-contributors; with no changed owners, knownAffected is empty too
- * (findAffectedSources expands only from changed/new sources), so cleanup-only
- * plans (orphan/shared state repair) skip the guard and need no key.
+ * Concept extraction runs for changed owners and their known-affected
+ * co-contributors. A deleted owner can contribute knownAffected survivors
+ * because partial-deletion pages are rebuilt from live evidence.
  */
 function maybeEnsureProvider(plan: RefreshPlan, ensureProvider?: () => void): void {
   const needsLLM = plan.changedOwners.length > 0 || plan.knownAffected.length > 0;
@@ -177,7 +176,6 @@ function printPlan(plan: RefreshPlan): void {
   output.status("~", output.info(
     `Recompiling ${plan.recompiledPages.length} page(s) from ${modelSources} source(s) ` +
     `(${plan.changedOwners.length} changed + ${plan.knownAffected.length} known affected; more may be found during the run); ` +
-    `${plan.sharedKeptPages.length} kept (shared, content not rebuilt); ` +
     `cleaning up ${plan.computedOrphanedPages.length} orphaned page(s).`,
   ));
   for (const [items, label, icon] of planDetailRows(plan)) {
@@ -187,8 +185,7 @@ function printPlan(plan: RefreshPlan): void {
 
 /**
  * True when the plan has any actionable work: pages to recompile, orphaned
- * pages to clean up, OR shared (partial-deletion) pages whose state needs
- * repairing (the deleted owner removed from state, content kept).
+ * pages to clean up, or a legacy sharedKeptPages entry.
  */
 function hasWork(plan: RefreshPlan): boolean {
   return (
@@ -202,7 +199,6 @@ function hasWork(plan: RefreshPlan): boolean {
 function planDetailRows(plan: RefreshPlan): PlanDetailRow[] {
   return [
     [plan.recompiledPages, "recompiled", "~"],
-    [plan.sharedKeptPages, "kept (shared) — content not regenerated", "i"],
     [plan.computedOrphanedPages, "cleaned up (orphaned)", "⚠"],
     [plan.alreadyOrphanedPages, "already orphaned — no action", "i"],
     [plan.knownAffected, "known affected sources (more may be found during the run)", "~"],

--- a/src/compiler/citation-normalize.ts
+++ b/src/compiler/citation-normalize.ts
@@ -73,15 +73,15 @@ function rangeIsValid(entry: string, maxLine: number): boolean {
  * Returns the (possibly repaired) entry string, or null to signal the entry
  * should be dropped entirely.
  *
- * Only bare line numbers / ranges (no filename component at all) are
- * normalised here. Entries that contain a filename — even an unresolvable
- * or malformed one — are left as-is so the downstream provenance linter
- * (`broken-citation`, `malformed-claim-citation`) can classify them.
+ * Bare line numbers / ranges are normalised here. Unknown filename entries
+ * remain available to provenance lint during ordinary updates, but callers can
+ * drop them for a clean deletion-reconciliation rebuild.
  */
 function normalizeEntry(
   entry: string,
   sourceFiles: string[],
   maxLine: number,
+  dropUnknownSourceEntries: boolean,
 ): string | null {
   const trimmed = entry.trim();
   if (trimmed.length === 0) return null;
@@ -103,9 +103,10 @@ function normalizeEntry(
     return null;
   }
 
-  // Case 3: has a filename component (even if unresolvable or malformed) — leave
-  // as-is for the downstream provenance linter to handle.
-  return trimmed;
+  // Case 3: has an unknown filename component. Normal updates leave it for
+  // downstream provenance lint. Clean rebuilds drop it so a removed source
+  // cannot re-enter the reconciled page.
+  return dropUnknownSourceEntries ? null : trimmed;
 }
 
 /**
@@ -128,8 +129,8 @@ function rebuildMarker(entries: string[]): string | null {
  *   or dropped when the line exceeds the source's actual line count.
  * - Bare numbers on multi-source pages are dropped (ambiguous — can't determine
  *   which source the LLM intended).
- * - Entries with a filename component (even unresolvable or malformed) are left
- *   as-is for the downstream provenance linter to classify.
+ * - Unknown filename entries remain for provenance lint by default, or are
+ *   removed when `dropUnknownSourceEntries` is enabled for a clean rebuild.
  *
  * When all entries in a marker are dropped the entire `^[...]` marker is
  * removed. A trailing space before the removed marker is also collapsed so
@@ -138,18 +139,23 @@ function rebuildMarker(entries: string[]): string | null {
  * @param body - Raw LLM output page body to normalise.
  * @param sourceFiles - Valid source filenames for this page (basenames only).
  * @param combinedContent - The numbered combined-source text the LLM received.
+ * @param dropUnknownSourceEntries - Remove citations outside sourceFiles.
  * @returns The normalised body string.
  */
 export function normalizeCitations(
   body: string,
   sourceFiles: string[],
   combinedContent: string,
+  dropUnknownSourceEntries = false,
 ): string {
   const maxLine = maxLineNumber(combinedContent);
   MARKER_PATTERN.lastIndex = 0;
 
   return body.replace(MARKER_PATTERN, (fullMatch, inner: string) => {
-    const entries = splitCitationMarker(inner).map((e) => normalizeEntry(e, sourceFiles, maxLine));
+    const entries = splitCitationMarker(inner)
+      .map((entry) => normalizeEntry(
+        entry, sourceFiles, maxLine, dropUnknownSourceEntries,
+      ));
     const rebuilt = rebuildMarker(entries as string[]);
     if (rebuilt === null) {
       // Signal for post-replace space cleanup: return empty string; the
@@ -165,13 +171,23 @@ export function normalizeCitations(
  * marker was removed. A space immediately before a removed marker is collapsed.
  *
  * This is the public entry point used by the page renderer.
+ * @param body - Raw LLM output page body to normalise.
+ * @param sourceFiles - Valid source filenames for this page.
+ * @param combinedContent - Numbered source text supplied to the LLM.
+ * @param dropUnknownSourceEntries - Remove citations outside sourceFiles.
  */
 export function normalizeCitationsInBody(
   body: string,
   sourceFiles: string[],
   combinedContent: string,
+  dropUnknownSourceEntries = false,
 ): string {
-  const withSentinels = normalizeCitations(body, sourceFiles, combinedContent);
+  const withSentinels = normalizeCitations(
+    body,
+    sourceFiles,
+    combinedContent,
+    dropUnknownSourceEntries,
+  );
   // Remove sentinels and the optional preceding space.
   return withSentinels.replace(/ ?\x00REMOVED\x00/g, "");
 }

--- a/src/compiler/compile-report.ts
+++ b/src/compiler/compile-report.ts
@@ -127,9 +127,9 @@ export function reportSchemaStatus(schema: SchemaConfig): void {
   }
 }
 
-/** Log frozen slugs (shared concepts whose deletion-pinned content must persist). */
+/** Log slugs held because at least one required source failed extraction. */
 export function reportFrozenSlugs(frozenSlugs: Set<string>): void {
   for (const slug of frozenSlugs) {
-    output.status("i", output.dim(`Frozen: ${slug} (shared with deleted source)`));
+    output.status("i", output.dim(`Frozen: ${slug} (required source extraction failed)`));
   }
 }

--- a/src/compiler/deps.ts
+++ b/src/compiler/deps.ts
@@ -180,10 +180,26 @@ export function findReconciliationSlugs(
  * @param frozenSlugs - Concept slugs held because a required extraction failed.
  * @param successfulExtractions - Extraction results from sources compiled in this batch.
  */
+/**
+ * What a run asked reconciliation to rebuild, and what it actually committed.
+ *
+ * `pending` is the set computed for this run; `replaced` is the set whose page
+ * reached `writtenPages`. A pending slug missing from `replaced` stays frozen
+ * so a later compile tries again.
+ */
+export interface ReconciliationOutcome {
+  pending: ReadonlySet<string>;
+  replaced: ReadonlySet<string>;
+}
+
+/** Default for callers with nothing pending: nothing to retain. */
+const NOTHING_PENDING: ReconciliationOutcome = { pending: new Set(), replaced: new Set() };
+
 export function persistFrozenSlugs(
   draft: CompileStateDraft,
   frozenSlugs: Set<string>,
   successfulExtractions: ExtractionResult[],
+  reconciliation: ReconciliationOutcome = NOTHING_PENDING,
 ): void {
   // Read the draft (reflects this run's compiled markers), not disk, so the
   // unfreeze decision sees freshly-compiled owners.
@@ -213,6 +229,17 @@ export function persistFrozenSlugs(
       && extractedBy.has(slug);
 
     if (!allOwnersCompiled) remaining.add(slug);
+  }
+
+  // A reconciliation marker is retired by a COMMITTED replacement, never by a
+  // successful extraction. Validation lives one frame above the renderer
+  // (`validateWikiPage` in review-pipeline.ts): an invalid body returns an
+  // error and no live write, so the slug never reaches `writtenPages` even
+  // though every stage before it succeeded. Retiring on extraction leaves the
+  // old page orphaned with nothing left to say it is stale, which is the
+  // terminal state reconciliation exists to end.
+  for (const slug of reconciliation.pending) {
+    if (!reconciliation.replaced.has(slug)) remaining.add(slug);
   }
 
   draft.setFrozen(remaining);

--- a/src/compiler/deps.ts
+++ b/src/compiler/deps.ts
@@ -122,11 +122,20 @@ function expandSharedOwnerClosure(
 export function findAffectedSources(
   state: WikiState,
   directChanges: SourceChange[],
+  allDetected: SourceChange[] = directChanges,
 ): string[] {
   const changedFiles = filesByStatus(directChanges, "new", "changed");
   const deletedFiles = filesByStatus(directChanges, "deleted");
+  // Exclusion uses EVERY detected deletion, not only the ones this run acts on.
+  // A scoped run (`refresh --stale`) narrows what to compile with a
+  // `changeFilter`, but "what should this run act on" and "what no longer
+  // exists" are different questions. Answering the second from the filtered
+  // list makes an excluded deletion look like a live co-owner: the closure
+  // schedules it and extraction reads a file that is gone. It stays in state,
+  // pending for a later unscoped compile.
+  const detectedDeletions = filesByStatus(allDetected, "deleted");
   const conceptMap = buildConceptToSourcesMap(state.sources);
-  const excluded = new Set([...changedFiles, ...deletedFiles]);
+  const excluded = new Set([...changedFiles, ...deletedFiles, ...detectedDeletions]);
   const frozenOwners = findSlugOwners(
     new Set(state.frozenSlugs ?? []),
     conceptMap,

--- a/src/compiler/deps.ts
+++ b/src/compiler/deps.ts
@@ -59,29 +59,47 @@ function filesByStatus(
   );
 }
 
-/**
- * Collect co-contributors for a source's concepts, skipping files in the
- * exclusion sets. Mutates `out` by adding newly discovered contributors.
- */
-function collectSharedContributors(
+/** Flatten the old-state co-owners for every concept claimed by one source. */
+function knownCoOwners(
   sourceFile: string,
   state: WikiState,
   conceptMap: Map<string, string[]>,
-  excludeSets: Set<string>[],
-  out: Set<string>,
-): void {
-  const sourceEntry = state.sources[sourceFile];
-  if (!sourceEntry) return;
+): string[] {
+  const concepts = state.sources[sourceFile]?.concepts ?? [];
+  return concepts.flatMap((slug) => conceptMap.get(slug) ?? []);
+}
 
-  for (const slug of sourceEntry.concepts) {
-    const contributors = conceptMap.get(slug);
-    if (!contributors || contributors.length < 2) continue;
+/**
+ * Walk every live co-owner reachable from the seed sources to a fixed point.
+ * @param state - Persisted source-to-concept ownership graph.
+ * @param seeds - Sources whose known concepts seed graph traversal.
+ * @param excluded - Changed or deleted sources that must not enter the result.
+ * @param initialAffected - Live owners already known to require extraction.
+ */
+function expandSharedOwnerClosure(
+  state: WikiState,
+  seeds: Iterable<string>,
+  excluded: ReadonlySet<string>,
+  initialAffected: Iterable<string> = [],
+): string[] {
+  const conceptMap = buildConceptToSourcesMap(state.sources);
+  const affected = new Set(
+    [...initialAffected].filter((file) => !excluded.has(file)),
+  );
+  const queue = [...seeds, ...affected];
+  const visited = new Set<string>();
 
-    for (const contributor of contributors) {
-      const isExcluded = excludeSets.some((s) => s.has(contributor));
-      if (!isExcluded) out.add(contributor);
+  for (let index = 0; index < queue.length; index += 1) {
+    const sourceFile = queue[index];
+    if (visited.has(sourceFile)) continue;
+    visited.add(sourceFile);
+    for (const contributor of knownCoOwners(sourceFile, state, conceptMap)) {
+      if (excluded.has(contributor) || affected.has(contributor)) continue;
+      affected.add(contributor);
+      queue.push(contributor);
     }
   }
+  return [...affected];
 }
 
 /**
@@ -90,10 +108,12 @@ function collectSharedContributors(
  * concept regeneration — ensuring shared concepts are rebuilt with content
  * from ALL contributing sources.
  *
- * Deleted sources are intentionally excluded: recompiling a concept-mate of
- * a deleted source would regenerate the page from fewer sources, losing
- * content. Shared concepts from deleted sources are preserved as-is by
- * markOrphaned (which skips shared concepts).
+ * Deleted sources also seed affected-owner discovery. Their surviving
+ * co-contributors rebuild shared pages from the remaining evidence so deleted
+ * claims and citations do not stay frozen in the wiki.
+ *
+ * Persisted frozen slugs are legacy/retry reconciliation markers. Their live
+ * owners are scheduled even when every source hash is otherwise current.
  *
  * @param state - The current persisted WikiState.
  * @param directChanges - Changes detected by hash comparison.
@@ -106,66 +126,58 @@ export function findAffectedSources(
   const changedFiles = filesByStatus(directChanges, "new", "changed");
   const deletedFiles = filesByStatus(directChanges, "deleted");
   const conceptMap = buildConceptToSourcesMap(state.sources);
-  const affected = new Set<string>();
-
-  for (const changedFile of changedFiles) {
-    collectSharedContributors(
-      changedFile, state, conceptMap,
-      [changedFiles, deletedFiles, affected],
-      affected,
-    );
-  }
-
-  return Array.from(affected);
+  const excluded = new Set([...changedFiles, ...deletedFiles]);
+  const frozenOwners = findSlugOwners(
+    new Set(state.frozenSlugs ?? []),
+    conceptMap,
+    [excluded],
+  );
+  return expandSharedOwnerClosure(
+    state,
+    excluded,
+    excluded,
+    frozenOwners,
+  );
 }
 
 /**
- * Find concept slugs that must NOT be regenerated during this compile batch.
- * A slug is "frozen" when it was shared between a deleted source and at least
- * one surviving source. Regenerating it would overwrite the existing page
- * (which has combined content from all prior contributors) with content from
- * only the surviving sources, silently losing the deleted source's contribution.
+ * Find pages that require a clean rebuild or orphan reconciliation.
+ * Includes legacy frozen slugs plus concepts shared by a deleted source and at
+ * least one source that survives this compile.
  * @param state - Current persisted state.
  * @param changes - All detected source changes in this batch.
- * @returns Set of concept slugs that compileSource should skip.
+ * @returns Concept slugs whose old page must not be reused as prompt context.
  */
-export function findFrozenSlugs(
+export function findReconciliationSlugs(
   state: WikiState,
   changes: SourceChange[],
 ): Set<string> {
-  // Start with persisted frozen slugs from prior batches.
-  const frozen = new Set<string>(state.frozenSlugs ?? []);
-
-  // Add new frozen slugs from deletions in this batch.
-  const deletedFiles = changes
-    .filter((c) => c.status === "deleted")
-    .map((c) => c.file);
-
+  const reconciliation = new Set<string>(state.frozenSlugs ?? []);
+  const deletedFiles = new Set(
+    changes.filter((c) => c.status === "deleted").map((c) => c.file),
+  );
   const conceptMap = buildConceptToSourcesMap(state.sources);
 
   for (const file of deletedFiles) {
     const entry = state.sources[file];
     if (!entry) continue;
-
     for (const slug of entry.concepts) {
-      const contributors = conceptMap.get(slug);
-      if (contributors && contributors.length > 1) {
-        frozen.add(slug);
-      }
+      const owners = conceptMap.get(slug) ?? [];
+      if (owners.some((owner) => !deletedFiles.has(owner))) reconciliation.add(slug);
     }
   }
 
-  return frozen;
+  return reconciliation;
 }
 
 /**
- * Unfreeze slugs that were successfully regenerated by all their current
- * contributors, then persist the remaining frozen set to state.
+ * Persist extraction-frozen slugs that were not successfully regenerated by
+ * all their current contributors.
  * A slug is safe to unfreeze when every source that claims it in state
  * was compiled in this batch and successfully extracted it.
  * @param draft - In-memory CompileStateDraft the function reads/mutates instead of disk state,
  *   so freshly-compiled markers from this run are visible when making unfreeze decisions.
- * @param frozenSlugs - Set of concept slugs currently frozen (shared with a deleted source).
+ * @param frozenSlugs - Concept slugs held because a required extraction failed.
  * @param successfulExtractions - Extraction results from sources compiled in this batch.
  */
 export function persistFrozenSlugs(
@@ -260,19 +272,23 @@ function findSlugOwners(
  * @param extractions - Results from Phase 1 extraction.
  * @param state - Current persisted state.
  * @param allChanges - Full changes array including deleted/unchanged entries.
+ * @param alreadyExtracted - Sources completed by earlier fixed-point rounds.
  * @returns Filenames of unchanged sources that share concepts with compiled sources.
  */
 export function findLateAffectedSources(
   extractions: ExtractionResult[],
   state: WikiState,
   allChanges: SourceChange[],
+  alreadyExtracted: ReadonlySet<string> = new Set(),
 ): string[] {
   const compilingFiles = filesByStatus(allChanges, "new", "changed");
+  for (const file of alreadyExtracted) compilingFiles.add(file);
   const deletedFiles = filesByStatus(allChanges, "deleted");
   const conceptMap = buildConceptToSourcesMap(state.sources);
   const freshSlugs = collectFreshSlugs(extractions, state);
-
-  return findSlugOwners(freshSlugs, conceptMap, [compilingFiles, deletedFiles]);
+  const excluded = new Set([...compilingFiles, ...deletedFiles]);
+  const discovered = findSlugOwners(freshSlugs, conceptMap, [excluded]);
+  return expandSharedOwnerClosure(state, discovered, excluded, discovered);
 }
 
 /**

--- a/src/compiler/deps.ts
+++ b/src/compiler/deps.ts
@@ -307,8 +307,9 @@ function findSlugOwners(
  *   2. Changed sources may gain concepts they didn't previously have.
  * @param extractions - Results from Phase 1 extraction.
  * @param state - Current persisted state.
- * @param allChanges - Full changes array including deleted/unchanged entries.
+ * @param allChanges - Changes this run acts on, including deleted/unchanged entries.
  * @param alreadyExtracted - Sources completed by earlier fixed-point rounds.
+ * @param allDetected - Every change found on disk, before any `changeFilter`.
  * @returns Filenames of unchanged sources that share concepts with compiled sources.
  */
 export function findLateAffectedSources(
@@ -316,10 +317,16 @@ export function findLateAffectedSources(
   state: WikiState,
   allChanges: SourceChange[],
   alreadyExtracted: ReadonlySet<string> = new Set(),
+  allDetected: SourceChange[] = allChanges,
 ): string[] {
+  // Which files are COMPILING is a property of this run, so it reads the
+  // filtered list. Which files no longer EXIST is not, so it reads the
+  // complete detection - same split as findAffectedSources above. Late
+  // discovery needs its own copy of that rule because it runs after
+  // extraction, on slugs the pre-extraction closure could not know about.
   const compilingFiles = filesByStatus(allChanges, "new", "changed");
   for (const file of alreadyExtracted) compilingFiles.add(file);
-  const deletedFiles = filesByStatus(allChanges, "deleted");
+  const deletedFiles = filesByStatus(allDetected, "deleted");
   const conceptMap = buildConceptToSourcesMap(state.sources);
   const freshSlugs = collectFreshSlugs(extractions, state);
   const excluded = new Set([...compilingFiles, ...deletedFiles]);

--- a/src/compiler/extraction-merge.ts
+++ b/src/compiler/extraction-merge.ts
@@ -19,6 +19,36 @@ import type { ExtractionResult } from "./deps.js";
 import type { ExtractedConcept } from "../utils/types.js";
 import type { MergedConcept } from "./types.js";
 
+/** Add one extracted concept to the slug-indexed merge accumulators. */
+function mergeConcept(
+  result: ExtractionResult,
+  concept: ExtractedConcept,
+  bySlug: Map<string, MergedConcept>,
+  slicesBySlug: Map<string, SourceSlice[]>,
+  rebuildSlugs: ReadonlySet<string>,
+): void {
+  const slug = slugify(concept.concept);
+  const existing = bySlug.get(slug);
+  if (existing) {
+    existing.concept = reconcileConceptMetadata(existing.concept, concept);
+    existing.sourceFiles.push(result.sourceFile);
+  } else {
+    const entry: MergedConcept = {
+      slug,
+      concept,
+      sourceFiles: [result.sourceFile],
+      combinedContent: "",
+    };
+    if (rebuildSlugs.has(slug)) entry.rebuild = true;
+    bySlug.set(slug, entry);
+    slicesBySlug.set(slug, []);
+  }
+  slicesBySlug.get(slug)!.push({
+    file: result.sourceFile,
+    content: result.sourceContent,
+  });
+}
+
 /**
  * Reconcile metadata from a later-extracted concept into an existing merged entry.
  * Called when multiple sources contribute the same slug — produces the most
@@ -74,11 +104,13 @@ export function reconcileConceptMetadata(
  * so popular concepts that appear in many overlapping sources do not blow
  * past the LLM provider's context window (issue #39). When the raw total
  * fits the budget, the output is byte-identical to the previous unbudgeted
- * concatenation.
+ * concatenation. Slugs in `rebuildSlugs` carry a clean-rebuild marker so page
+ * rendering does not feed stale content from removed sources back to the LLM.
  */
 export function mergeExtractions(
   extractions: ExtractionResult[],
   frozenSlugs: Set<string>,
+  rebuildSlugs: ReadonlySet<string> = new Set(),
 ): MergedConcept[] {
   const bySlug = new Map<string, MergedConcept>();
   const slicesBySlug = new Map<string, SourceSlice[]>();
@@ -89,24 +121,7 @@ export function mergeExtractions(
     for (const concept of result.concepts) {
       const slug = slugify(concept.concept);
       if (frozenSlugs.has(slug)) continue;
-
-      const existing = bySlug.get(slug);
-      if (existing) {
-        existing.concept = reconcileConceptMetadata(existing.concept, concept);
-        existing.sourceFiles.push(result.sourceFile);
-      } else {
-        bySlug.set(slug, {
-          slug,
-          concept,
-          sourceFiles: [result.sourceFile],
-          combinedContent: "",
-        });
-        slicesBySlug.set(slug, []);
-      }
-      slicesBySlug.get(slug)!.push({
-        file: result.sourceFile,
-        content: result.sourceContent,
-      });
+      mergeConcept(result, concept, bySlug, slicesBySlug, rebuildSlugs);
     }
   }
 

--- a/src/compiler/extraction-phase.ts
+++ b/src/compiler/extraction-phase.ts
@@ -65,11 +65,11 @@ async function extractSourcesLimited(
 }
 
 /**
- * Phase 1: extract concepts for the directly-changed batch, then expand to
- * any unchanged sources whose concepts overlap with newly extracted slugs.
- * Both batches share one `pLimit(concurrency)` cap; the late-affected set is
- * computed only after the whole direct batch resolves, since
- * findLateAffectedSources reads every direct extraction.
+ * Phase 1: extract concepts for the directly-changed batch, then repeatedly
+ * expand to unchanged sources whose concepts overlap newly extracted slugs.
+ * Every batch shares one `pLimit(concurrency)` cap. Discovery continues to a
+ * fixed point because a late owner's extraction can reveal another owner that
+ * was absent from its prior state entry.
  */
 export async function runExtractionPhases(
   root: string,
@@ -81,12 +81,18 @@ export async function runExtractionPhases(
   const limit = pLimit(concurrency);
   const extractions = await extractSourcesLimited(root, toCompile.map((c) => c.file), limit);
 
-  const lateAffected = findLateAffectedSources(extractions, state, allChanges);
-  for (const file of lateAffected) {
-    output.status("~", output.info(`${file} [shares concept with new source]`));
+  while (true) {
+    const extracted = new Set(extractions.map((result) => result.sourceFile));
+    const lateAffected = findLateAffectedSources(
+      extractions, state, allChanges, extracted,
+    );
+    if (lateAffected.length === 0) break;
+    for (const file of lateAffected) {
+      output.status("~", output.info(`${file} [shares concept with new source]`));
+    }
+    const batch = await extractSourcesLimited(root, lateAffected, limit);
+    extractions.push(...batch);
   }
-  const lateExtractions = await extractSourcesLimited(root, lateAffected, limit);
-  for (const result of lateExtractions) extractions.push(result);
 
   return extractions;
 }

--- a/src/compiler/extraction-phase.ts
+++ b/src/compiler/extraction-phase.ts
@@ -65,6 +65,18 @@ async function extractSourcesLimited(
 }
 
 /**
+ * The two views a compile has of its own changes. They answer different
+ * questions and are NOT interchangeable, so they travel as one named pair
+ * rather than as two same-typed positional arguments that can be swapped.
+ */
+export interface ChangeSets {
+  /** What this run acts on, after any `changeFilter`. */
+  scoped: SourceChange[];
+  /** Everything found on disk, before any `changeFilter`. */
+  detected: SourceChange[];
+}
+
+/**
  * Phase 1: extract concepts for the directly-changed batch, then repeatedly
  * expand to unchanged sources whose concepts overlap newly extracted slugs.
  * Every batch shares one `pLimit(concurrency)` cap. Discovery continues to a
@@ -75,7 +87,7 @@ export async function runExtractionPhases(
   root: string,
   toCompile: SourceChange[],
   state: WikiState,
-  allChanges: SourceChange[],
+  changeSets: ChangeSets,
   concurrency: number,
 ): Promise<ExtractionResult[]> {
   const limit = pLimit(concurrency);
@@ -84,7 +96,7 @@ export async function runExtractionPhases(
   while (true) {
     const extracted = new Set(extractions.map((result) => result.sourceFile));
     const lateAffected = findLateAffectedSources(
-      extractions, state, allChanges, extracted,
+      extractions, state, changeSets.scoped, extracted, changeSets.detected,
     );
     if (lateAffected.length === 0) break;
     for (const file of lateAffected) {

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -486,7 +486,10 @@ async function runCompilePipeline(
     if (orphanCandidates.size > 0) {
       await orphanUnownedFrozenPages(root, draft, orphanCandidates);
     }
-    persistFrozenSlugs(draft, frozenSlugs, extractions);
+    persistFrozenSlugs(draft, frozenSlugs, extractions, {
+      pending: reconciliationSlugs,
+      replaced: new Set(generation.writtenPages.map((entry) => entry.slug)),
+    });
     // Seed + resolution route through the SAME executor batches as the
     // no-source-changes branch (see seedThenFinalize). The draft flush is the
     // single durable state write, done inside finalizeWiki after resolution

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -408,7 +408,7 @@ async function runCompilePipeline(
     state,
   );
   await markUnchangedPendingSources(root, changes);
-  augmentWithAffectedSources(changes, findAffectedSources(state, changes));
+  augmentWithAffectedSources(changes, findAffectedSources(state, changes, detected));
   const reconciliationSlugs = findReconciliationSlugs(state, changes);
 
   const buckets = bucketChanges(changes);

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -250,15 +250,25 @@ async function persistExtractionStates(
   draft: CompileStateDraft,
   extractions: ExtractionResult[],
   writtenPages: MergedConcept[],
+  retained: ReadonlySet<string> = new Set(),
 ): Promise<void> {
   // Build a set of live slugs per source: slugs from writtenPages that list
   // this source as a contributor.
   const liveSlugsForSource = buildLiveSlugsForSource(writtenPages);
   for (const result of extractions) {
     if (result.concepts.length === 0) continue;
-    const liveSlugs = liveSlugsForSource.get(result.sourceFile) ?? [];
+    const liveSlugs = new Set(liveSlugsForSource.get(result.sourceFile) ?? []);
+    // A slug held for another attempt is still OWNED by the source that
+    // extracted it. Recording only WRITTEN slugs drops that claim, and unlike a
+    // review hold nothing re-adds it: the retry re-extracts whichever sources
+    // still list the concept, so a survivor erased here never returns and the
+    // page is rebuilt without its contribution.
+    for (const concept of result.concepts) {
+      const slug = slugify(concept.concept);
+      if (retained.has(slug)) liveSlugs.add(slug);
+    }
     await persistSourceStateFiltered(
-      draft, result.sourcePath, result.sourceFile, result.concepts, new Set(liveSlugs),
+      draft, result.sourcePath, result.sourceFile, result.concepts, liveSlugs,
     );
   }
 }
@@ -481,14 +491,18 @@ async function runCompilePipeline(
   );
 
   if (!options.review) {
-    await persistExtractionStates(draft, extractions, generation.writtenPages);
+    const written = new Set(generation.writtenPages.map((entry) => entry.slug));
+    const retained = new Set(
+      [...reconciliationSlugs, ...frozenSlugs].filter((slug) => !written.has(slug)),
+    );
+    await persistExtractionStates(draft, extractions, generation.writtenPages, retained);
     const orphanCandidates = new Set([...reconciliationSlugs, ...frozenSlugs]);
     if (orphanCandidates.size > 0) {
       await orphanUnownedFrozenPages(root, draft, orphanCandidates);
     }
     persistFrozenSlugs(draft, frozenSlugs, extractions, {
       pending: reconciliationSlugs,
-      replaced: new Set(generation.writtenPages.map((entry) => entry.slug)),
+      replaced: written,
     });
     // Seed + resolution route through the SAME executor batches as the
     // no-source-changes branch (see seedThenFinalize). The draft flush is the

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -34,7 +34,7 @@ import {
 } from "./prompt-modifiers.js";
 import {
   findAffectedSources,
-  findFrozenSlugs,
+  findReconciliationSlugs,
   freezeFailedExtractions,
   persistFrozenSlugs,
   type ExtractionResult,
@@ -161,12 +161,13 @@ async function generatePagesPhase(
   root: string,
   extractions: ExtractionResult[],
   frozenSlugs: Set<string>,
+  reconciliationSlugs: ReadonlySet<string>,
   schema: SchemaConfig,
   options: CompileOptions,
   policy: ReviewPolicy,
   concurrency: number,
 ): Promise<PageGenerationResult> {
-  const merged = mergeExtractions(extractions, frozenSlugs);
+  const merged = mergeExtractions(extractions, frozenSlugs, reconciliationSlugs);
   // Build the per-source state snapshot once so each candidate can carry the
   // exact data needed to mark its sources compiled on approval.
   const shouldBuildSourceStates = options.review || !isPolicyOff(policy);
@@ -325,6 +326,21 @@ function applyChangeFilter(
 }
 
 /**
+ * Orphan and clear persisted frozen slugs that no source owns.
+ * @returns True when the draft was mutated and must be flushed.
+ */
+async function reconcileOwnerlessFrozen(
+  root: string,
+  draft: CompileStateDraft,
+  reconciliationSlugs: ReadonlySet<string>,
+): Promise<boolean> {
+  if (reconciliationSlugs.size === 0) return false;
+  await orphanUnownedFrozenPages(root, draft, new Set(reconciliationSlugs));
+  draft.setFrozen(new Set());
+  return true;
+}
+
+/**
  * Generate seed pages unless `skipSeedPages` is set or we are in review mode.
  * Centralises both guard conditions so each call site in the pipeline is a
  * single unconditional statement instead of an inline if-block.
@@ -383,6 +399,7 @@ async function runCompilePipeline(
   );
   await markUnchangedPendingSources(root, changes);
   augmentWithAffectedSources(changes, findAffectedSources(state, changes));
+  const reconciliationSlugs = findReconciliationSlugs(state, changes);
 
   const buckets = bucketChanges(changes);
   if (buckets.toCompile.length === 0 && buckets.deleted.length === 0) {
@@ -391,6 +408,9 @@ async function runCompilePipeline(
     // no source files changed, so adding a seed page to schema.json takes
     // effect on the next compile without needing a source file edit.
     if (!options.review) {
+      const hasOwnerlessFrozen = await reconcileOwnerlessFrozen(
+        root, draft, reconciliationSlugs,
+      );
       const emptyGeneration: PageGenerationResult = {
         pages: [],
         writtenPages: [],
@@ -399,11 +419,15 @@ async function runCompilePipeline(
         review: { held: [], forced: [] },
         seedSlugs: [],
       };
-      // Null draft: this branch has no state mutations, so nothing is flushed.
-      // Routes seed + resolution through the SAME executor batches as the normal
-      // path (see seedThenFinalize) so the early branch cannot drift to a direct
-      // write.
-      await seedThenFinalize(root, schema, emptyGeneration, options, null);
+      // Ownerless frozen reconciliation mutates the draft; otherwise null keeps
+      // the no-change path from rewriting state unnecessarily.
+      await seedThenFinalize(
+        root,
+        schema,
+        emptyGeneration,
+        options,
+        hasOwnerlessFrozen ? draft : null,
+      );
       return {
         ...emptyCompileResult(),
         skipped: buckets.unchanged.length,
@@ -429,8 +453,9 @@ async function runCompilePipeline(
     await markDeletedAsOrphaned(root, buckets.deleted, draft);
   }
 
-  const frozenSlugs = findFrozenSlugs(state, changes);
-  reportFrozenSlugs(frozenSlugs);
+  // Only extraction failures in THIS run freeze a page. Deletion and persisted
+  // freezes are reconciliation work: their surviving owners rebuild cleanly.
+  const frozenSlugs = new Set<string>();
 
   // Resolve once so an invalid override warns a single time, then cap both the
   // extraction and page-generation fan-outs identically.
@@ -438,6 +463,7 @@ async function runCompilePipeline(
   const extractions = await runExtractionPhases(root, buckets.toCompile, state, changes, concurrency);
   if (!options.review) {
     freezeFailedExtractions(draft, extractions, frozenSlugs);
+    reportFrozenSlugs(frozenSlugs);
   }
 
   // Snapshot pages on disk before generation so the journal can tell which
@@ -447,6 +473,7 @@ async function runCompilePipeline(
     root,
     extractions,
     frozenSlugs,
+    reconciliationSlugs,
     schema,
     options,
     reviewPolicy,
@@ -455,8 +482,9 @@ async function runCompilePipeline(
 
   if (!options.review) {
     await persistExtractionStates(draft, extractions, generation.writtenPages);
-    if (frozenSlugs.size > 0) {
-      await orphanUnownedFrozenPages(root, draft, frozenSlugs);
+    const orphanCandidates = new Set([...reconciliationSlugs, ...frozenSlugs]);
+    if (orphanCandidates.size > 0) {
+      await orphanUnownedFrozenPages(root, draft, orphanCandidates);
     }
     persistFrozenSlugs(draft, frozenSlugs, extractions);
     // Seed + resolution route through the SAME executor batches as the

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -470,7 +470,9 @@ async function runCompilePipeline(
   // Resolve once so an invalid override warns a single time, then cap both the
   // extraction and page-generation fan-outs identically.
   const concurrency = resolveCompileConcurrency(options.concurrency);
-  const extractions = await runExtractionPhases(root, buckets.toCompile, state, changes, concurrency);
+  const extractions = await runExtractionPhases(
+    root, buckets.toCompile, state, { scoped: changes, detected }, concurrency,
+  );
   if (!options.review) {
     freezeFailedExtractions(draft, extractions, frozenSlugs);
     reportFrozenSlugs(frozenSlugs);

--- a/src/compiler/orphan.ts
+++ b/src/compiler/orphan.ts
@@ -2,12 +2,12 @@
  * Orphan management for deleted source files.
  *
  * When a source is deleted, its exclusively-owned concept pages are marked
- * orphaned (orphaned: true in frontmatter). Shared concepts are preserved
- * to avoid losing combined content from prior compilations.
+ * orphaned (orphaned: true in frontmatter). Shared concepts are deferred so
+ * the compiler can rebuild them from their surviving owners in the same run.
  *
- * After compilation, frozen slugs (shared concepts that lost a contributor)
- * are checked against the updated state. Any that lost ALL owners are
- * orphaned as a cleanup pass.
+ * After compilation, reconciliation candidates and extraction-frozen slugs
+ * are checked against the updated state. Any that lost ALL owners are orphaned
+ * as a cleanup pass.
  */
 
 import path from "path";
@@ -26,8 +26,8 @@ import type { CompileStateDraft } from "./compile-state-draft.js";
 /**
  * Mark wiki pages as orphaned when their source is deleted.
  * Only orphans concepts exclusively owned by the deleted source.
- * Shared concepts (contributed to by other live sources) are preserved
- * as-is to avoid losing combined content from prior compilations.
+ * Shared concepts (contributed to by other live sources) are deferred to the
+ * deletion-reconciliation generation pass.
  * @param root - Project root directory (needed for the confined file write; stays first).
  * @param sourceFile - Source file path being deleted.
  * @param draft - In-memory CompileStateDraft the function reads/mutates instead of disk state.
@@ -63,13 +63,13 @@ export async function markOrphaned(
 
 /**
  * Check frozen slugs against the updated state after compilation.
- * If no source still claims a frozen slug, orphan its page so it doesn't
- * linger as an untracked stale file.
+ * If no source still claims a reconciliation candidate, orphan its page so it
+ * doesn't linger as an untracked stale file.
  * @param root - Project root directory (needed for the confined file write; stays first).
  *   root stays first (needed for the confined file write); draft follows.
  * @param draft - In-memory CompileStateDraft the function reads to check current ownership
  *   instead of disk state, so un-flushed markers from this run are visible.
- * @param frozenSlugs - Set of concept slugs that were frozen (shared with a deleted source).
+ * @param frozenSlugs - Reconciliation candidates and extraction-frozen slugs.
  */
 export async function orphanUnownedFrozenPages(
   root: string,

--- a/src/compiler/page-renderer.ts
+++ b/src/compiler/page-renderer.ts
@@ -33,6 +33,7 @@ interface RenderableConcept {
   concept: ExtractedConcept;
   sourceFiles: string[];
   combinedContent: string;
+  rebuild?: boolean;
 }
 
 /**
@@ -56,7 +57,7 @@ export async function renderMergedPageContent(
   const system = buildPagePrompt(
     entry.concept.concept,
     entry.combinedContent,
-    existingPage,
+    entry.rebuild ? "" : existingPage,
     relatedPages,
   );
 
@@ -67,7 +68,12 @@ export async function renderMergedPageContent(
     ],
   });
 
-  const pageBody = normalizeCitationsInBody(rawPageBody, entry.sourceFiles, entry.combinedContent);
+  const pageBody = normalizeCitationsInBody(
+    rawPageBody,
+    entry.sourceFiles,
+    entry.combinedContent,
+    entry.rebuild === true,
+  );
 
   const frontmatter = buildMergedFrontmatter(entry, existingPage, schema);
   reportContradictionWarnings(entry.concept.concept, entry.concept);

--- a/src/compiler/refresh-plan.ts
+++ b/src/compiler/refresh-plan.ts
@@ -19,9 +19,9 @@ import type { FreshnessSnapshot } from "../freshness/types.js";
 import type { StateStatus } from "../utils/state.js";
 
 export interface RefreshPlan {
-  /** Stale pages with a changed live owner — recompiled. Disjoint from the other outcome lists. */
+  /** Stale pages and partial-deletion pages rebuilt from live owners. */
   recompiledPages: string[];
-  /** Partial-deletion pages (a deleted owner but every live owner is unchanged) — status repaired, content kept. Disjoint. */
+  /** @deprecated Shared pages are rebuilt; retained as an empty compatibility field. */
   sharedKeptPages: string[];
   /** Pages whose owners are ALL deleted — recomputed as orphaned. Disjoint. */
   computedOrphanedPages: string[];
@@ -126,7 +126,7 @@ function classifyOnePage(
     changedLive.forEach((o) => c.changedOwners.add(o.file));
     deleted.forEach((o) => c.deletedOwners.add(o.file));
   } else if (deleted.length > 0) {
-    c.sharedKeptPages.push(slug);
+    c.recompiledPages.push(slug);
     deleted.forEach((o) => c.deletedOwners.add(o.file));
   }
   // else: all live and fresh — no action needed

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -25,6 +25,8 @@ export interface MergedConcept {
   concept: ExtractedConcept;
   sourceFiles: string[];
   combinedContent: string;
+  /** Rebuild from live sources without feeding the prior page back to the model. */
+  rebuild?: boolean;
 }
 
 /** Buckets of source changes used by the compile pipeline. */

--- a/src/sources/removal.ts
+++ b/src/sources/removal.ts
@@ -258,26 +258,27 @@ export interface RemovalApplyResult {
  *
  * ## Freezing
  *
- * FREEZES the source's still-shared concepts before writing state, mirroring
- * what `compile`'s deletion path does for the exact same situation
- * (`findFrozenSlugs`, `src/compiler/deps.ts:132-159`). A kept page's FILE
- * survives on disk, but its on-disk CONTENT is a merge that includes the
- * now-removed source's contribution — the file alone carries no memory of
- * that. Adding the slug to `state.frozenSlugs` is what MARKS the page as
- * having lost a contributor, so `compile` applies its frozen-slug policy to it
- * instead of treating it as an ordinary page. Without the mark, the next
+ * MARKS the source's still-shared concepts before writing state, the same way
+ * `compile`'s own deletion path marks them. A kept page's FILE survives on
+ * disk, but its on-disk CONTENT is a merge that includes the now-removed
+ * source's contribution — the file alone carries no memory of that. Recording
+ * the slug in `state.frozenSlugs` is what says so. Without it the next
  * recompile of a remaining contributor rebuilds the page from live sources as
  * if nothing had been removed, and the removed source's contribution silently
  * vanishes with no record that it was ever there.
  *
- * What that policy DOES with a frozen slug belongs to `compile`, not to `rm`:
- * today `mergeExtractions` (`src/compiler/extraction-merge.ts:91`) skips
- * regenerating it, preserving the merged body as-is. This function's contract
- * is only that the mark is set. The set is UNIONED with whatever is already
- * persisted (never replaced via {@link applyFrozenSlugs}), mirroring
- * `findFrozenSlugs`' own "start with persisted frozen slugs from prior
- * batches" behaviour (`deps.ts:137`), so an earlier removal's or compile's
- * frozen slugs are never dropped by a later one.
+ * A persisted slug is a RECONCILIATION marker, not a permanent hold. What
+ * compile does with it belongs to compile, not to `rm`: it rebuilds the page
+ * cleanly from whatever owners survive, dropping the removed source's
+ * contribution, and orphans a page no live source owns any more. The marker is
+ * retired only once that replacement is actually committed — if extraction or
+ * page validation fails, the marker and the survivors' ownership are both
+ * preserved so a later compile tries again.
+ *
+ * This function's contract is only that the mark is set. The set is UNIONED
+ * with whatever is already persisted (never replaced via
+ * {@link applyFrozenSlugs}), so an earlier removal's or compile's markers are
+ * never dropped by a later one.
  *
  * @param root - Absolute project root.
  * @param plan - The plan produced by {@link planRemoval}.

--- a/test/citation-normalize.test.ts
+++ b/test/citation-normalize.test.ts
@@ -176,6 +176,14 @@ describe("normalizeCitationsInBody — unknown filename entries", () => {
     const result = normalizeCitationsInBody(body, [source], content);
     expect(result).toBe("Claim.^[does-not-exist.md]");
   });
+
+  it("drops unknown entries only when a clean rebuild requests strict sources", () => {
+    const source = "real.md";
+    const content = makeContent(source, 10);
+    const body = "Claim.^[real.md:1-2, deleted.md:3-4]";
+    const result = normalizeCitationsInBody(body, [source], content, true);
+    expect(result).toBe("Claim.^[real.md:1-2]");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/compile-deletion-owner-closure.test.ts
+++ b/test/compile-deletion-owner-closure.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @file test/compile-deletion-owner-closure.test.ts
+ * @description End-to-end coverage for rebuilding the full live co-owner graph
+ * after a shared source is deleted.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { parseFrontmatter } from "../src/utils/markdown.js";
+import { readState } from "../src/utils/state.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+import {
+  conceptResponse,
+  stubOwnerClosureProvider,
+} from "./fixtures/owner-closure-provider.js";
+
+const ctx = useCompileProject({
+  dirSuffix: "delete-owner-closure",
+  sourceFile: "a.md",
+  sourceContent: "# X\n\nA contributes to X.",
+});
+
+/** Return concepts according to the source text in the extraction prompt. */
+function extractionFor(system: string): string {
+  if (system.includes("B contributes to X and Y.")) return conceptResponse("X", "Y");
+  if (system.includes("C contributes to Y.")) return conceptResponse("Y");
+  return conceptResponse("X");
+}
+
+describe("deletion owner closure", () => {
+  it("preserves every live owner across a transitive shared-concept chain", async () => {
+    await writeFile(
+      path.join(ctx.dir, "sources", "b.md"),
+      "# X and Y\n\nB contributes to X and Y.",
+      "utf-8",
+    );
+    await writeFile(
+      path.join(ctx.dir, "sources", "c.md"),
+      "# Y\n\nC contributes to Y.",
+      "utf-8",
+    );
+    const systems = stubOwnerClosureProvider(extractionFor);
+
+    await compileAndReport(ctx.dir);
+    systems.length = 0;
+    await rm(path.join(ctx.dir, "sources", "a.md"));
+    await compileAndReport(ctx.dir);
+
+    const x = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "x.md"), "utf-8"),
+    );
+    const y = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "y.md"), "utf-8"),
+    );
+    const state = await readState(ctx.dir);
+    expect(systems).toHaveLength(2);
+    expect(x.meta.sources).toEqual(["b.md"]);
+    expect(y.meta.sources).toEqual(["b.md", "c.md"]);
+    expect(state.sources["a.md"]).toBeUndefined();
+  });
+});

--- a/test/compile-late-owner-closure.test.ts
+++ b/test/compile-late-owner-closure.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @file test/compile-late-owner-closure.test.ts
+ * @description End-to-end coverage for fixed-point discovery when a new source
+ * reveals an owner whose extraction reveals another shared owner.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { parseFrontmatter } from "../src/utils/markdown.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+import {
+  conceptResponse,
+  stubOwnerClosureProvider,
+} from "./fixtures/owner-closure-provider.js";
+
+const ctx = useCompileProject({
+  dirSuffix: "late-owner-closure",
+  sourceFile: "b.md",
+  sourceContent: "# X\n\nB contributes to X and later reveals Y.",
+});
+
+/** Return concepts for the source content embedded in an extraction prompt. */
+function extractionFor(system: string, expanded: boolean): string {
+  if (system.includes("D contributes to Y.")) return conceptResponse("Y");
+  if (system.includes("New source contributes to X.")) return conceptResponse("X");
+  return expanded ? conceptResponse("X", "Y") : conceptResponse("X");
+}
+
+describe("late owner discovery", () => {
+  it("continues extracting newly discovered owners until the graph is stable", async () => {
+    await writeFile(
+      path.join(ctx.dir, "sources", "d.md"),
+      "# Y\n\nD contributes to Y.",
+      "utf-8",
+    );
+    let expanded = false;
+    const systems = stubOwnerClosureProvider(
+      (system) => extractionFor(system, expanded),
+    );
+
+    await compileAndReport(ctx.dir);
+    expanded = true;
+    systems.length = 0;
+    await writeFile(
+      path.join(ctx.dir, "sources", "new.md"),
+      "# X\n\nNew source contributes to X.",
+      "utf-8",
+    );
+    await compileAndReport(ctx.dir);
+
+    const y = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "y.md"), "utf-8"),
+    );
+    expect(systems.filter((system) => system.includes("--- SOURCE DOCUMENT ---")))
+      .toHaveLength(3);
+    expect(y.meta.sources).toEqual(["b.md", "d.md"]);
+  });
+});

--- a/test/compile-source-deletion-reconciliation.test.ts
+++ b/test/compile-source-deletion-reconciliation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @file test/compile-source-deletion-reconciliation.test.ts
+ * @description End-to-end regression coverage for rebuilding a shared concept
+ * from its surviving owners after one contributing source is deleted.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { buildFrontmatter, parseFrontmatter } from "../src/utils/markdown.js";
+import { readState, writeState } from "../src/utils/state.js";
+import * as embeddings from "../src/utils/embeddings.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Shared Topic", summary: "Shared summary.", is_new: true }],
+});
+
+const ctx = useCompileProject({
+  dirSuffix: "delete-reconcile",
+  sourceFile: "a.md",
+  sourceContent: "# Shared Topic\n\nA-only deleted contribution.",
+});
+
+interface ReconciliationProbe {
+  extractionSystems: string[];
+  pageSystems: string[];
+  markDeleted: () => void;
+  markSurvivorFailure: () => void;
+}
+
+/** Seed the surviving source and capture both LLM phases across two compiles. */
+async function arrangeReconciliation(): Promise<ReconciliationProbe> {
+  await writeFile(
+    path.join(ctx.dir, "sources", "b.md"),
+    "# Shared Topic\n\nB-only surviving contribution.",
+    "utf-8",
+  );
+  let phase: "initial" | "deleted" | "failed" = "initial";
+  const extractionSystems: string[] = [];
+  const pageSystems: string[] = [];
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(async (system) => {
+    extractionSystems.push(system);
+    return phase === "failed" ? JSON.stringify({ concepts: [] }) : EXTRACTION;
+  });
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockImplementation(async (system) => {
+    pageSystems.push(system);
+    return phase === "initial"
+      ? "Old claim from deleted contributor. ^[a.md:1-2]\n\nShared claim. ^[b.md:1-2]"
+      : "Rebuilt survivor claim. ^[b.md:1-2, a.md:1-2]";
+  });
+  vi.spyOn(embeddings, "updateEmbeddingsLockedCore")
+    .mockResolvedValue({ embedded: [], eligible: [] });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return {
+    extractionSystems,
+    pageSystems,
+    markDeleted: () => { phase = "deleted"; },
+    markSurvivorFailure: () => { phase = "failed"; },
+  };
+}
+
+/** Read the shared page and incremental state after one compile. */
+async function readSharedArtifacts() {
+  const page = parseFrontmatter(
+    await readFile(path.join(ctx.dir, "wiki", "concepts", "shared-topic.md"), "utf-8"),
+  );
+  return { page, state: await readState(ctx.dir) };
+}
+
+describe("shared-source deletion reconciliation", () => {
+  it("rebuilds from the surviving owner and clears deleted provenance", async () => {
+    const probe = await arrangeReconciliation();
+
+    await compileAndReport(ctx.dir);
+    probe.markDeleted();
+    probe.extractionSystems.length = 0;
+    probe.pageSystems.length = 0;
+    await rm(path.join(ctx.dir, "sources", "a.md"));
+    const result = await compileAndReport(ctx.dir);
+
+    const { page, state } = await readSharedArtifacts();
+    expect(result).toMatchObject({ compiled: 1, deleted: 1, pages: ["shared-topic"] });
+    expect(probe.extractionSystems).toHaveLength(1);
+    expect(probe.extractionSystems[0]).toContain("B-only surviving contribution.");
+    expect(probe.pageSystems[0]).not.toContain("Old claim from deleted contributor.");
+    expect(page.meta.sources).toEqual(["b.md"]);
+    expect(page.body).toContain("^[b.md:1-2]");
+    expect(page.body).not.toContain("a.md");
+    expect(state.sources["a.md"]).toBeUndefined();
+  });
+
+  it("orphans an ownerless persisted frozen page without source changes", async () => {
+    await arrangeReconciliation();
+    await compileAndReport(ctx.dir);
+    const state = await readState(ctx.dir);
+    state.frozenSlugs = ["ownerless"];
+    await writeState(ctx.dir, state);
+    const frontmatter = buildFrontmatter({
+      title: "Ownerless",
+      summary: "No source owns this page.",
+      sources: [],
+    });
+    await writeFile(
+      path.join(ctx.dir, "wiki", "concepts", "ownerless.md"),
+      `${frontmatter}\n\nStale content.\n`,
+      "utf-8",
+    );
+
+    await compileAndReport(ctx.dir);
+
+    const page = parseFrontmatter(
+      await readFile(path.join(ctx.dir, "wiki", "concepts", "ownerless.md"), "utf-8"),
+    );
+    const reconciled = await readState(ctx.dir);
+    expect(page.meta.orphaned).toBe(true);
+    expect(reconciled.frozenSlugs).toEqual([]);
+  });
+
+  it("keeps a retryable last-known-good page when survivor extraction fails", async () => {
+    const probe = await arrangeReconciliation();
+    await compileAndReport(ctx.dir);
+    probe.markSurvivorFailure();
+    await rm(path.join(ctx.dir, "sources", "a.md"));
+
+    const result = await compileAndReport(ctx.dir);
+
+    const { page, state } = await readSharedArtifacts();
+    expect(page.meta.orphaned).not.toBe(true);
+    expect(page.meta.sources).toEqual(["a.md", "b.md"]);
+    expect(state.sources["a.md"]).toBeUndefined();
+    expect(state.sources["b.md"].hash).toBe("");
+    expect(state.frozenSlugs).toContain("shared-topic");
+    expect(result.errors).toContain("No concepts extracted from b.md");
+  });
+});

--- a/test/deps.test.ts
+++ b/test/deps.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   findAffectedSources,
-  findFrozenSlugs,
+  findReconciliationSlugs,
   findLateAffectedSources,
   findSharedConcepts,
   type ExtractionResult,
@@ -54,6 +54,54 @@ describe("findAffectedSources", () => {
     expect(affected).not.toContain("b.md");
   });
 
+  it("recompiles surviving co-owners when a shared source is deleted", () => {
+    const state = makeState({
+      "deleted.md": { hash: "h1", concepts: ["shared"] },
+      "survivor.md": { hash: "h2", concepts: ["shared"] },
+      "unrelated.md": { hash: "h3", concepts: ["other"] },
+    });
+    const changes: SourceChange[] = [{ file: "deleted.md", status: "deleted" }];
+
+    expect(findAffectedSources(state, changes)).toEqual(["survivor.md"]);
+  });
+
+  it("walks the full surviving co-owner graph after deletion", () => {
+    const state = makeState({
+      "a.md": { hash: "h1", concepts: ["x"] },
+      "b.md": { hash: "h2", concepts: ["x", "y"] },
+      "c.md": { hash: "h3", concepts: ["y"] },
+    });
+    const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
+
+    expect(findAffectedSources(state, changes)).toEqual(["b.md", "c.md"]);
+  });
+
+  it("excludes every deleted owner from a multi-owner rebuild", () => {
+    const state = makeState({
+      "a.md": { hash: "h1", concepts: ["shared"] },
+      "b.md": { hash: "h2", concepts: ["shared"] },
+      "c.md": { hash: "h3", concepts: ["shared"] },
+    });
+    const changes: SourceChange[] = [
+      { file: "a.md", status: "deleted" },
+      { file: "b.md", status: "deleted" },
+    ];
+
+    expect(findAffectedSources(state, changes)).toEqual(["c.md"]);
+  });
+
+  it("retries owners of persisted frozen concepts", () => {
+    const state = makeState(
+      {
+        "a.md": { hash: "h1", concepts: ["shared"] },
+        "b.md": { hash: "h2", concepts: ["shared"] },
+      },
+      ["shared"],
+    );
+
+    expect(findAffectedSources(state, [])).toEqual(["a.md", "b.md"]);
+  });
+
   it("does not include already-changed files", () => {
     const state = makeState({
       "a.md": { hash: "h1", concepts: ["shared"] },
@@ -67,35 +115,35 @@ describe("findAffectedSources", () => {
   });
 });
 
-describe("findFrozenSlugs", () => {
-  it("freezes shared concepts when a source is deleted", () => {
+describe("findReconciliationSlugs", () => {
+  it("reconciles shared concepts when a source is deleted", () => {
     const state = makeState({
       "a.md": { hash: "h1", concepts: ["shared-concept"] },
       "b.md": { hash: "h2", concepts: ["shared-concept"] },
     });
     const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("shared-concept")).toBe(true);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("shared-concept")).toBe(true);
   });
 
-  it("does not freeze exclusively-owned concepts", () => {
+  it("does not rebuild exclusively-owned deleted concepts", () => {
     const state = makeState({
       "a.md": { hash: "h1", concepts: ["only-a"] },
       "b.md": { hash: "h2", concepts: ["only-b"] },
     });
     const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("only-a")).toBe(false);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("only-a")).toBe(false);
   });
 
-  it("loads persisted frozen slugs from state", () => {
+  it("loads persisted frozen slugs as reconciliation work", () => {
     const state = makeState(
       { "a.md": { hash: "h1", concepts: [] } },
       ["previously-frozen"],
     );
     const changes: SourceChange[] = [];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("previously-frozen")).toBe(true);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("previously-frozen")).toBe(true);
   });
 
   it("handles 3+ source concept with one deleted", () => {
@@ -105,8 +153,8 @@ describe("findFrozenSlugs", () => {
       "c.md": { hash: "h3", concepts: ["triple"] },
     });
     const changes: SourceChange[] = [{ file: "a.md", status: "deleted" }];
-    const frozen = findFrozenSlugs(state, changes);
-    expect(frozen.has("triple")).toBe(true);
+    const reconciliation = findReconciliationSlugs(state, changes);
+    expect(reconciliation.has("triple")).toBe(true);
   });
 });
 
@@ -219,6 +267,22 @@ describe("findLateAffectedSources", () => {
     // changed.md newly gained "new-concept", which bystander.md owns
     const affected = findLateAffectedSources(extractions, state, changes);
     expect(affected).toEqual(["bystander.md"]);
+  });
+
+  it("walks the full co-owner graph from a late-discovered owner", () => {
+    const state = makeState({
+      "b.md": { hash: "h1", concepts: ["x", "y"] },
+      "c.md": { hash: "h2", concepts: ["y"] },
+    });
+    const extractions: ExtractionResult[] = [{
+      sourceFile: "new.md",
+      sourcePath: "/tmp/new.md",
+      sourceContent: "content",
+      concepts: [{ concept: "X", summary: "s", is_new: true }],
+    }];
+    const changes: SourceChange[] = [{ file: "new.md", status: "new" }];
+
+    expect(findLateAffectedSources(extractions, state, changes)).toEqual(["b.md", "c.md"]);
   });
 });
 

--- a/test/fixtures/owner-closure-provider.ts
+++ b/test/fixtures/owner-closure-provider.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared provider boundary stubs for owner-closure compile tests.
+ *
+ * The tests supply only the source-to-concepts resolver; this helper owns the
+ * repeated Anthropic and embeddings seams used by the real compile pipeline.
+ */
+
+import { vi } from "vitest";
+import { AnthropicProvider } from "../../src/providers/anthropic.js";
+import * as embeddings from "../../src/utils/embeddings.js";
+
+/** Build a provider-compatible extraction response. */
+export function conceptResponse(...names: string[]): string {
+  return JSON.stringify({
+    concepts: names.map((concept) => ({
+      concept,
+      summary: `${concept} summary.`,
+      is_new: false,
+    })),
+  });
+}
+
+/**
+ * Stub external model calls and capture every extraction system prompt.
+ * @param resolveExtraction - Maps one extraction system prompt to tool JSON.
+ * @returns Mutable prompt capture that callers can clear between compile runs.
+ */
+export function stubOwnerClosureProvider(
+  resolveExtraction: (system: string) => string,
+): string[] {
+  const systems: string[] = [];
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(async (system) => {
+    systems.push(system);
+    return resolveExtraction(system);
+  });
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Generated page.");
+  vi.spyOn(embeddings, "updateEmbeddingsLockedCore")
+    .mockResolvedValue({ embedded: [], eligible: [] });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return systems;
+}

--- a/test/reconciliation-invalid-replacement.test.ts
+++ b/test/reconciliation-invalid-replacement.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @file test/reconciliation-invalid-replacement.test.ts
+ * @description A reconciliation whose replacement page fails validation must
+ * stay repairable.
+ *
+ * Rebuilding a shared page runs extract, merge, generate, validate, write.
+ * Validation lives in the renderer's CALLER (`validateWikiPage` in
+ * review-pipeline.ts): an invalid body returns `{ error }` and no `liveWrite`,
+ * so the slug never reaches `writtenPages`.
+ *
+ * Extraction succeeding is therefore not evidence the page was replaced, and
+ * retiring reconciliation state on it strands the page: the last-known-good
+ * body is orphaned, the surviving owner is recorded with no concepts, and the
+ * marker is cleared, so the next compile has nothing left telling it to try
+ * again. That is the terminal state reconciliation exists to end, reached
+ * through the failure path instead of the happy one.
+ *
+ * A SOFT failure is the case that matters. A thrown provider error aborts the
+ * run and leaves state untouched; an output that merely fails validation lets
+ * the pipeline continue and retire state around a page that was never written.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { readState } from "../src/utils/state.js";
+import * as embeddings from "../src/utils/embeddings.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const EXTRACTION = JSON.stringify({
+  concepts: [{ concept: "Shared Topic", summary: "Shared summary.", is_new: true }],
+});
+
+const ctx = useCompileProject({
+  dirSuffix: "invalid-replacement",
+  sourceFile: "a.md",
+  sourceContent: "# Shared Topic\n\nA-only deleted contribution.",
+});
+
+/** Two owners of one concept; the replacement body is switchable to invalid. */
+async function arrange(): Promise<{ setInvalid: () => void; pageCalls: () => number }> {
+  await writeFile(
+    path.join(ctx.dir, "sources", "b.md"),
+    "# Shared Topic\n\nB-only surviving contribution.",
+    "utf-8",
+  );
+  let invalid = false;
+  let pageCalls = 0;
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(EXTRACTION);
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockImplementation(async () => {
+    pageCalls += 1;
+    if (invalid) return "";
+    return "Old claim. ^[a.md:1-2]\n\nShared claim. ^[b.md:1-2]";
+  });
+  vi.spyOn(embeddings, "updateEmbeddingsLockedCore")
+    .mockResolvedValue({ embedded: [], eligible: [] });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return { setInvalid: () => { invalid = true; }, pageCalls: () => pageCalls };
+}
+
+/**
+ * Compile once cleanly, then delete `a.md` and compile again with the
+ * replacement body failing validation. Returns the probe so a caller can read
+ * what the failed run left behind.
+ */
+async function compileThenFailReplacement() {
+  const probe = await arrange();
+  await compileAndReport(ctx.dir);
+  probe.setInvalid();
+  await rm(path.join(ctx.dir, "sources", "a.md"));
+  await compileAndReport(ctx.dir);
+  return probe;
+}
+
+describe("a reconciliation whose replacement fails validation", () => {
+  it("keeps the marker so a later compile retries", async () => {
+    await compileThenFailReplacement();
+    const state = await readState(ctx.dir);
+    expect(state.frozenSlugs ?? []).toContain("shared-topic");
+  });
+
+  it("keeps the surviving owner's claim on the concept", async () => {
+    await compileThenFailReplacement();
+    const state = await readState(ctx.dir);
+    // b.md still owns the concept; recording it with no concepts makes the
+    // survivor invisible to the next run's ownership graph.
+    expect(state.sources["b.md"]?.concepts ?? []).toContain("shared-topic");
+  });
+
+  it("regenerates on the next compile once the model recovers", async () => {
+    const probe = await compileThenFailReplacement();
+    const before = probe.pageCalls();
+    await compileAndReport(ctx.dir);
+    expect(probe.pageCalls()).toBeGreaterThan(before);
+  });
+});

--- a/test/refresh-integration.test.ts
+++ b/test/refresh-integration.test.ts
@@ -7,9 +7,8 @@
  *
  *  1. A stale page (changed source hash) IS recompiled.
  *  2. A new source (not in state) is skipped — refresh does not compile new sources.
- *  3. A partial-deletion "shared" page has its state REPAIRED (deleted owner
- *     removed from state.sources) but its content byte-for-byte UNCHANGED — the
- *     unchanged live owner is NOT recompiled (v1 limitation: no force-rebuild).
+ *  3. A partial-deletion shared page is rebuilt from its surviving owner and
+ *     the deleted owner is removed from state.
  *  4. When a review policy is active, a refreshed page that trips policy is held
  *     as a candidate (not written to wiki/) and the command reports it as held,
  *     NOT as "refreshed".
@@ -61,6 +60,21 @@ async function writeLowConfidencePolicy(root: string): Promise<void> {
  */
 async function makeTmpRoot(suffix: string): Promise<string> {
   return makeCompileProjectRoot({ dirSuffix: `refresh-integ-${suffix}` });
+}
+
+/** Configure the stubbed Anthropic provider environment for a test. */
+function configureProviderEnv(): void {
+  process.env.LLMWIKI_PROVIDER = "anthropic";
+  process.env.ANTHROPIC_API_KEY = "test-key";
+}
+
+/** Restore global test state and remove a temporary project root. */
+async function cleanupTestRoot(root: string): Promise<void> {
+  vi.restoreAllMocks();
+  delete process.env.LLMWIKI_PROVIDER;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.LLMWIKI_COMPILE_CONCURRENCY;
+  await rm(root, { recursive: true, force: true });
 }
 
 /** Silence compile output and run resolveStaleRefresh + compileAndReport. */
@@ -115,8 +129,7 @@ async function setupStaleTopicA(root: string): Promise<string> {
 
 describe("refresh --stale (real run, stubbed provider)", () => {
   it("recompiles a stale page and leaves a new source uncompiled", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
+    configureProviderEnv();
     const root = await makeTmpRoot("stale");
 
     try {
@@ -137,21 +150,17 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       // Only a.md was extracted; new.md was filtered out by changeFilter.
       expect(extractSpy).toHaveBeenCalledTimes(1);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 
   // -------------------------------------------------------------------------
-  // Test 2: partial-deletion shared page — status repaired, content kept
+  // Test 2: partial-deletion shared page rebuilt from surviving evidence
   // -------------------------------------------------------------------------
 
-  it("status-repairs a partial-deletion shared page but does NOT regenerate its content (v1)", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
-    const root = await makeTmpRoot("shared-kept");
+  it("rebuilds a partial-deletion shared page from its surviving owner", async () => {
+    configureProviderEnv();
+    const root = await makeTmpRoot("shared-rebuilt");
 
     try {
       const aContent = "# Topic X\n\nAbout X from A.";
@@ -162,34 +171,35 @@ describe("refresh --stale (real run, stubbed provider)", () => {
         "b.md": { hash: "some-old-hash", concepts: ["topic-x"] },
       });
       await writeConceptPage(root, "topic-x", "Topic X", ["a.md", "b.md"], "Existing body of X.");
-      const originalContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
-
-      // Spy: extraction must NOT fire (a.md is unchanged; no changed owners).
       const extractSpy = stubProviderCalls("Topic X");
       vi.spyOn(console, "log").mockImplementation(() => {});
 
       const { plan } = await resolveStaleRefresh(root);
       expect(plan).not.toBeNull();
-      // Sanity: page is shared-kept, not recompiled.
-      expect(plan!.sharedKeptPages).toContain("topic-x");
+      // Sanity: the survivor is scheduled for recompilation.
+      expect(plan!.recompiledPages).toContain("topic-x");
+      expect(plan!.sharedKeptPages).not.toContain("topic-x");
       expect(plan!.changedOwners).not.toContain("a.md");
       expect(plan!.deletedOwners).toContain("b.md");
+      expect(plan!.knownAffected).toContain("a.md");
 
-      await compileAndReport(root, { changeFilter: plan!.changeFilter, skipSeedPages: true });
+      const result = await compileAndReport(root, {
+        changeFilter: plan!.changeFilter,
+        skipSeedPages: true,
+      });
 
       // Deletion bookkeeping: b.md removed from state.
       const { state } = await readStateClassified(root);
       expect("b.md" in state.sources).toBe(false);
-      // Content kept: topic-x.md byte-for-byte UNCHANGED.
+      // Content is rebuilt from a.md; the old mixed-source body is gone.
       const afterContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
-      expect(afterContent).toBe(originalContent);
-      // a.md NOT extracted — unchanged live owner skipped in v1.
-      expect(extractSpy).not.toHaveBeenCalled();
+      expect(afterContent).toContain(STUB_BODY);
+      expect(afterContent).not.toContain("Existing body of X.");
+      expect(result.pages).toContain("topic-x");
+      // The unchanged survivor is force-reconciled because b.md was deleted.
+      expect(extractSpy).toHaveBeenCalledTimes(1);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 
@@ -198,8 +208,7 @@ describe("refresh --stale (real run, stubbed provider)", () => {
   // -------------------------------------------------------------------------
 
   it("reports a policy-held page as held for review, not as refreshed", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
+    configureProviderEnv();
     const root = await makeTmpRoot("policy-held");
 
     try {
@@ -237,17 +246,12 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       expect(allOutput).toMatch(/held.*for review/i);
       expect(allOutput).not.toMatch(/Refreshed \d+ page\(s\)/);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 
   it("forwards the concurrency option into the recompile (serial cap keeps peak at 1)", async () => {
-    process.env.LLMWIKI_PROVIDER = "anthropic";
-    process.env.ANTHROPIC_API_KEY = "test-key";
-    delete process.env.LLMWIKI_COMPILE_CONCURRENCY;
+    configureProviderEnv();
     const root = await makeTmpRoot("concurrency");
     try {
       await writeSourceFile(root, "a.md", "# A\n\nabout a");
@@ -276,10 +280,7 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       // stale extractions overlap (peak 2). The flag must serialize them to peak 1.
       expect(peak()).toBe(1);
     } finally {
-      vi.restoreAllMocks();
-      delete process.env.LLMWIKI_PROVIDER;
-      delete process.env.ANTHROPIC_API_KEY;
-      await rm(root, { recursive: true, force: true });
+      await cleanupTestRoot(root);
     }
   });
 });

--- a/test/refresh-plan.test.ts
+++ b/test/refresh-plan.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for resolveStaleRefresh — the read-only resolver that computes a
- * RefreshPlan from a single freshness snapshot. Covers all four page outcomes
- * (recompiled, shared-kept, computed-orphaned, already-orphaned) plus the
+ * RefreshPlan from a single freshness snapshot. Covers rebuilt,
+ * computed-orphaned, and already-orphaned page outcomes plus the
  * newSkipped/changeFilter/knownAffected helpers and corrupt-state short-circuit.
  */
 
@@ -54,7 +54,7 @@ describe("resolveStaleRefresh", () => {
     expect(plan!.recompiledPages).toEqual([]);
   });
 
-  it("classifies a partial-deletion page (live unchanged + deleted owner) as shared-kept, not recompiled", async () => {
+  it("classifies a partial-deletion page for rebuild from its live owner", async () => {
     const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-shared");
     await writeConceptPage(
       "x",
@@ -69,10 +69,11 @@ describe("resolveStaleRefresh", () => {
     // b.md NOT written → deleted
 
     const { plan } = await resolveStaleRefresh(root);
-    expect(plan!.sharedKeptPages).toContain("x");
-    expect(plan!.recompiledPages).not.toContain("x");
+    expect(plan!.sharedKeptPages).not.toContain("x");
+    expect(plan!.recompiledPages).toContain("x");
     expect(plan!.changedOwners).not.toContain("a.md");
     expect(plan!.deletedOwners).toContain("b.md");
+    expect(plan!.knownAffected).toContain("a.md");
   });
 
   it("reports a frontmatter-orphaned page with no owners as already-orphaned (no action)", async () => {

--- a/test/rm-frozen-page-rebuild.test.ts
+++ b/test/rm-frozen-page-rebuild.test.ts
@@ -47,6 +47,17 @@ function page(cwd: string): Promise<string | null> {
   return readFile(path.join(cwd, "wiki/concepts/shared-topic.md"), "utf-8").catch(() => null);
 }
 
+/** Compile, then remove alpha.md, returning the project and its env. */
+async function compiledThenRemovedAlpha(
+  handle: import("./fixtures/aimock-helper.js").MockClaudeHandle,
+): Promise<{ cwd: string; env: NodeJS.ProcessEnv }> {
+  const cwd = await sharedPageProject(handle);
+  const env = mockClaudeEnv(handle);
+  expectCLIExit(await runCLI(["compile"], cwd, env), 0);
+  expectCLIExit(await runCLI(["rm", "alpha.md"], cwd, env), 0);
+  return { cwd, env };
+}
+
 describe("a page kept by rm is rebuilt, not frozen forever", () => {
   it("drops the removed source's citation on the next compile", async () => {
     const handle = await aimock.start();
@@ -74,11 +85,7 @@ describe("a page kept by rm is rebuilt, not frozen forever", () => {
 
   it("clears the marker, so the page is not rebuilt again on every later compile", async () => {
     const handle = await aimock.start();
-    const cwd = await sharedPageProject(handle);
-    const env = mockClaudeEnv(handle);
-
-    expectCLIExit(await runCLI(["compile"], cwd, env), 0);
-    expectCLIExit(await runCLI(["rm", "alpha.md"], cwd, env), 0);
+    const { cwd, env } = await compiledThenRemovedAlpha(handle);
     expectCLIExit(await runCLI(["compile"], cwd, env), 0);
 
     const before = handle.mock.getRequests().length;

--- a/test/rm-frozen-page-rebuild.test.ts
+++ b/test/rm-frozen-page-rebuild.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @file test/rm-frozen-page-rebuild.test.ts
+ * @description A page kept by `llmwiki rm` because another source still owns it
+ * must be rebuilt on the next compile, without the removed source's content.
+ *
+ * `rm` records each kept slug in `state.frozenSlugs`, the same marker compile
+ * sets when it notices a deleted source. Before this, that marker was terminal:
+ * `mergeExtractions` skipped a frozen slug outright and nothing ever removed a
+ * slug from the set, so the page kept the removed source's prose and its
+ * citations permanently. `llmwiki lint` then reported `broken-citation` at ERROR
+ * severity on a page no command could repair, and deleting the page to force a
+ * rebuild lost it for good — the slug that would regenerate it was frozen.
+ *
+ * The distinction that fixes it: a slug frozen because THIS run's extraction
+ * failed is still skipped and preserved, while a slug carried in PERSISTED state
+ * is a reconciliation marker and is rebuilt from whatever owners survive.
+ *
+ * This covers the `rm` path specifically. The owner-closure suites alongside it
+ * exercise the compile-side deletion detection, which reaches the same field by
+ * a different route.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { mockClaudeEnv, stubCannedCompile, useAimockLifecycle } from "./fixtures/aimock-helper.js";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("rm-frozen-rebuild");
+
+/** Two sources that both yield one concept, so its page is genuinely shared. */
+async function sharedPageProject(handle: import("./fixtures/aimock-helper.js").MockClaudeHandle) {
+  handle.mock.onToolCall("extract_concepts", {
+    toolCalls: [{ name: "extract_concepts", arguments: { concepts: [
+      { concept: "Shared Topic", summary: "s", is_new: true, tags: [], confidence: 0.9 },
+    ] } }],
+  });
+  handle.mock.onMessage(/.*/, { content: "Body from alpha. ^[alpha.md:1-2]\n\nAnd beta. ^[beta.md:1-2]" });
+  const cwd = await aimock.makeWorkspace("# Intro\n\nIntro text.\n");
+  await writeFile(path.join(cwd, "sources/alpha.md"), "# Alpha\n\nAlpha source text.\n");
+  await writeFile(path.join(cwd, "sources/beta.md"), "# Beta\n\nBeta source text.\n");
+  return cwd;
+}
+
+/** The page body, or null when the page is absent. */
+function page(cwd: string): Promise<string | null> {
+  return readFile(path.join(cwd, "wiki/concepts/shared-topic.md"), "utf-8").catch(() => null);
+}
+
+describe("a page kept by rm is rebuilt, not frozen forever", () => {
+  it("drops the removed source's citation on the next compile", async () => {
+    const handle = await aimock.start();
+    const cwd = await sharedPageProject(handle);
+    const env = mockClaudeEnv(handle);
+
+    expectCLIExit(await runCLI(["compile"], cwd, env), 0);
+    expect(await page(cwd)).toContain("alpha.md");
+
+    expectCLIExit(await runCLI(["rm", "alpha.md"], cwd, env), 0);
+    // rm keeps the page and marks it, rather than deleting a page beta still owns.
+    expect(await page(cwd)).not.toBeNull();
+    const state = JSON.parse(await readFile(path.join(cwd, ".llmwiki/state.json"), "utf-8"));
+    expect(state.frozenSlugs).toContain("shared-topic");
+
+    // Byte-identical sources, so only the marker can drive this recompile.
+    expectCLIExit(await runCLI(["compile"], cwd, env), 0);
+
+    const rebuilt = await page(cwd);
+    expect(rebuilt).not.toBeNull();
+    expect(rebuilt).not.toContain("alpha.md");
+    // Still a real page owned by the surviving source, not an empty husk.
+    expect(rebuilt).toContain("beta.md");
+  }, 180_000);
+
+  it("clears the marker, so the page is not rebuilt again on every later compile", async () => {
+    const handle = await aimock.start();
+    const cwd = await sharedPageProject(handle);
+    const env = mockClaudeEnv(handle);
+
+    expectCLIExit(await runCLI(["compile"], cwd, env), 0);
+    expectCLIExit(await runCLI(["rm", "alpha.md"], cwd, env), 0);
+    expectCLIExit(await runCLI(["compile"], cwd, env), 0);
+
+    const before = handle.mock.getRequests().length;
+    expectCLIExit(await runCLI(["compile"], cwd, env), 0);
+    // An uncleared marker would re-extract on every compile forever.
+    expect(handle.mock.getRequests().length).toBe(before);
+  }, 180_000);
+});

--- a/test/scoped-refresh-deleted-exclusion.test.ts
+++ b/test/scoped-refresh-deleted-exclusion.test.ts
@@ -29,8 +29,13 @@ const ctx = useCompileProject({
   sourceContent: "# Topic X\n\nA contributes to X.",
 });
 
-/** a owns X; b owns X and Y; d owns Y — so the closure can walk a -> b -> d. */
-async function arrange(): Promise<{ extractedFiles: string[] }> {
+/** What b.md reports, mutable so a test can widen it between compiles. */
+interface SharedOwner {
+  concepts: string[];
+}
+
+/** a owns X; d owns Y; b owns whatever `bOwner` currently says. */
+async function arrange(bOwner: SharedOwner): Promise<{ extractedFiles: string[] }> {
   await writeFile(path.join(ctx.dir, "sources", "b.md"), "# Topic X\n\nB contributes to X and Y.", "utf-8");
   await writeFile(path.join(ctx.dir, "sources", "d.md"), "# Topic Y\n\nD contributes to Y.", "utf-8");
   const extractedFiles: string[] = [];
@@ -39,11 +44,9 @@ async function arrange(): Promise<{ extractedFiles: string[] }> {
       : system.includes("B contributes") ? "b"
       : system.includes("D contributes") ? "d" : "other";
     extractedFiles.push(which);
-    const concepts = which === "b"
-      ? [{ concept: "Topic X", summary: "s", is_new: true }, { concept: "Topic Y", summary: "s", is_new: true }]
-      : which === "d"
-        ? [{ concept: "Topic Y", summary: "s", is_new: true }]
-        : [{ concept: "Topic X", summary: "s", is_new: true }];
+    const named = which === "b" ? bOwner.concepts
+      : which === "d" ? ["Topic Y"] : ["Topic X"];
+    const concepts = named.map((concept) => ({ concept, summary: "s", is_new: true }));
     return JSON.stringify({ concepts });
   });
   vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Body. ^[b.md:1-2]");
@@ -59,31 +62,55 @@ async function deleteBothSources(probe: { extractedFiles: string[] }): Promise<v
   probe.extractedFiles.length = 0;
 }
 
+/**
+ * Run the scoped compile that acts on a.md alone, then assert the excluded
+ * deletion d.md was neither read nor retired.
+ */
+async function expectScopedRunSparesDeletion(
+  probe: { extractedFiles: string[] },
+): Promise<void> {
+  const result = await compileAndReport(ctx.dir, {
+    changeFilter: (change) => change.file === "a.md",
+  });
+
+  // The scoped run succeeds rather than aborting on a missing file.
+  expect(result.errors).toEqual([]);
+  // d.md is neither read nor extracted.
+  expect(probe.extractedFiles).not.toContain("d");
+  // and it stays in state, still pending for a later full compile.
+  const state = await readState(ctx.dir);
+  expect(Object.keys(state.sources)).toContain("d.md");
+}
+
+/** Seed the wiki, then remove both sources so only b.md survives. */
+async function seedThenDeleteBoth(bOwner: SharedOwner): Promise<{ extractedFiles: string[] }> {
+  const probe = await arrange(bOwner);
+  await compileAndReport(ctx.dir);
+  await deleteBothSources(probe);
+  return probe;
+}
+
 describe("a scoped compile and a deleted source the filter excluded", () => {
   it("never schedules the excluded deletion, and leaves it pending", async () => {
-    const probe = await arrange();
-    await compileAndReport(ctx.dir);
+    // b already owns Y, so the PRE-extraction closure walks a -> b -> d.
+    const probe = await seedThenDeleteBoth({ concepts: ["Topic X", "Topic Y"] });
 
-    // Both a.md and d.md are gone, but this run is scoped to a.md only.
-    await deleteBothSources(probe);
+    await expectScopedRunSparesDeletion(probe);
+  });
 
-    const result = await compileAndReport(ctx.dir, {
-      changeFilter: (change) => change.file === "a.md",
-    });
+  it("never schedules an excluded deletion that only late discovery reaches", async () => {
+    // b starts owning X alone, so Y is genuinely NEW to it on the second run.
+    // The pre-extraction closure never sees that slug; only late discovery
+    // resolves its other owner, which is the excluded deletion d.md.
+    const bOwner = { concepts: ["Topic X"] };
+    const probe = await seedThenDeleteBoth(bOwner);
+    bOwner.concepts = ["Topic X", "Topic Y"];
 
-    // The scoped run succeeds rather than aborting on a missing file.
-    expect(result.errors).toEqual([]);
-    // d.md is neither read nor extracted.
-    expect(probe.extractedFiles).not.toContain("d");
-    // and it stays in state, still pending for a later full compile.
-    const state = await readState(ctx.dir);
-    expect(Object.keys(state.sources)).toContain("d.md");
+    await expectScopedRunSparesDeletion(probe);
   });
 
   it("still processes every deletion on an ordinary unscoped compile", async () => {
-    const probe = await arrange();
-    await compileAndReport(ctx.dir);
-    await deleteBothSources(probe);
+    await seedThenDeleteBoth({ concepts: ["Topic X", "Topic Y"] });
 
     await compileAndReport(ctx.dir);
 

--- a/test/scoped-refresh-deleted-exclusion.test.ts
+++ b/test/scoped-refresh-deleted-exclusion.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @file test/scoped-refresh-deleted-exclusion.test.ts
+ * @description A scoped compile must not schedule a deleted source its filter
+ * excluded.
+ *
+ * `refresh --stale` narrows compile to the sources it means to act on by
+ * supplying a `changeFilter`. The affected-owner closure then runs on the
+ * FILTERED list, so a deleted source the filter dropped is absent from the
+ * exclusion set, looks like a live co-owner, and is appended as affected work.
+ * Extraction then tries to read a file that is gone.
+ *
+ * The two questions are different and need different inputs: "what should this
+ * run act on" is the filtered set, and "what no longer exists" is the complete
+ * detection. Narrowing the first must not narrow the second.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compileAndReport } from "../src/compiler/index.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { readState } from "../src/utils/state.js";
+import * as embeddings from "../src/utils/embeddings.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+
+const ctx = useCompileProject({
+  dirSuffix: "scoped-deleted",
+  sourceFile: "a.md",
+  sourceContent: "# Topic X\n\nA contributes to X.",
+});
+
+/** a owns X; b owns X and Y; d owns Y — so the closure can walk a -> b -> d. */
+async function arrange(): Promise<{ extractedFiles: string[] }> {
+  await writeFile(path.join(ctx.dir, "sources", "b.md"), "# Topic X\n\nB contributes to X and Y.", "utf-8");
+  await writeFile(path.join(ctx.dir, "sources", "d.md"), "# Topic Y\n\nD contributes to Y.", "utf-8");
+  const extractedFiles: string[] = [];
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(async (system) => {
+    const which = system.includes("A contributes") ? "a"
+      : system.includes("B contributes") ? "b"
+      : system.includes("D contributes") ? "d" : "other";
+    extractedFiles.push(which);
+    const concepts = which === "b"
+      ? [{ concept: "Topic X", summary: "s", is_new: true }, { concept: "Topic Y", summary: "s", is_new: true }]
+      : which === "d"
+        ? [{ concept: "Topic Y", summary: "s", is_new: true }]
+        : [{ concept: "Topic X", summary: "s", is_new: true }];
+    return JSON.stringify({ concepts });
+  });
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue("Body. ^[b.md:1-2]");
+  vi.spyOn(embeddings, "updateEmbeddingsLockedCore").mockResolvedValue({ embedded: [], eligible: [] });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return { extractedFiles };
+}
+
+/** Remove both sources from disk and reset the extraction record. */
+async function deleteBothSources(probe: { extractedFiles: string[] }): Promise<void> {
+  await rm(path.join(ctx.dir, "sources", "a.md"));
+  await rm(path.join(ctx.dir, "sources", "d.md"));
+  probe.extractedFiles.length = 0;
+}
+
+describe("a scoped compile and a deleted source the filter excluded", () => {
+  it("never schedules the excluded deletion, and leaves it pending", async () => {
+    const probe = await arrange();
+    await compileAndReport(ctx.dir);
+
+    // Both a.md and d.md are gone, but this run is scoped to a.md only.
+    await deleteBothSources(probe);
+
+    const result = await compileAndReport(ctx.dir, {
+      changeFilter: (change) => change.file === "a.md",
+    });
+
+    // The scoped run succeeds rather than aborting on a missing file.
+    expect(result.errors).toEqual([]);
+    // d.md is neither read nor extracted.
+    expect(probe.extractedFiles).not.toContain("d");
+    // and it stays in state, still pending for a later full compile.
+    const state = await readState(ctx.dir);
+    expect(Object.keys(state.sources)).toContain("d.md");
+  });
+
+  it("still processes every deletion on an ordinary unscoped compile", async () => {
+    const probe = await arrange();
+    await compileAndReport(ctx.dir);
+    await deleteBothSources(probe);
+
+    await compileAndReport(ctx.dir);
+
+    const state = await readState(ctx.dir);
+    expect(Object.keys(state.sources)).not.toContain("a.md");
+    expect(Object.keys(state.sources)).not.toContain("d.md");
+  });
+});


### PR DESCRIPTION
Takes over #171 by @TigerOfCountryYao, a draft since 11 August. **Their commit is preserved as the first commit here**, rebased onto current `main`; the second is the regression test for the `rm` path. Fixes #194.

## The defect

`rm` records each kept slug in `state.frozenSlugs`, the same marker compile sets when it notices a deleted source. That marker was terminal. `mergeExtractions` skipped a frozen slug outright, and nothing in `src/` ever removed a slug from the set, so:

- the page kept the removed source's prose and its `^[removed.md]` citations, permanently
- `llmwiki lint` reported `broken-citation` at **error** severity on a page no command could repair
- `compile`, `refresh --stale`, and editing the surviving source all left it unchanged
- deleting the page to force a rebuild **lost it for good**, because the slug that would regenerate it was frozen

## The fix

The distinction `main` lacks: **frozen** and **needs reconciling** are different states sharing one field.

A slug frozen because *this run's* extraction failed is still skipped and preserved - that is what freezing is for. A slug carried in **persisted** state is a reconciliation marker: the page is rebuilt from whatever owners survive, with the removed source's contribution dropped, and a page no live source owns is orphaned rather than held.

Because `rm` writes to that same persisted field, this covers the `rm` path by construction, despite predating `rm` by two weeks.

## Verification

Reproduced #194 against this branch: on `main` the second compile reports "Nothing to compile" and the page cites a deleted source forever; here it makes 3 model calls, rebuilds from the surviving owner, and the citation is gone.

Their 19 files of tests pass against current `main` **unchanged** - 74 tests, no assertion needed adjusting across six merges of drift.

Two cases added for the `rm` route specifically, since their suites cover compile-side deletion detection and owner closures. One asserts the removed citation is gone while the survivor's remains; the other asserts the marker is **cleared**, because an uncleared marker turns a one-time repair into a re-extraction on every compile forever.

Mutation-tested: seeding reconciliation from an empty set rather than `state.frozenSlugs`, which is what `main` does, turns the rebuild case red.

## Review fixes

Independent review at `03af8949` found four defects. Each is fixed here in its own commit, with a test that fails without it:

- **A reconciliation marker was retired even when its replacement page failed validation**, leaving a corrupted page and no marker left to repair it. A marker is now retired only once its page actually commits.
- **A partial extraction failure dropped surviving owners' claims.** A source whose concept was held for a retry recorded an empty concept list, so it stopped counting as a known owner and its contribution went missing from the rebuilt page. The rule was right for a review hold, where approval re-adds the slug, and wrong for a retry hold, where nothing does.
- **A scoped run could schedule a deleted source its own filter excluded**, aborting on a file that no longer exists. "What should this run act on" and "what no longer exists" are different questions, and both the pre-extraction closure and late owner discovery were answering the second from the filtered list. This one had two sites; the first fix caught only one, and the second is reachable exactly where the first cannot help, when a re-extracted owner reports a concept it did not previously own.
- **`docs/cli/rm.mdx` and the `removal.ts` docblock still described the old skip-forever behaviour.**

Each behavioural fix was mutation-tested against its committed parent: reverting it turns exactly its own case red and nothing else.

## Rebase notes

Only `160e2af7` was cherry-picked. Its two parents are #169 (landed separately as #198) and #170 (landed rewritten as #195), so replaying the stack would have reintroduced an implementation we deliberately replaced. One conflict: a superseded single-pass late-extraction block, plus a stale `systemPolicy` argument from the #170-era threading that #195 replaced with run state.

## Worth a careful review

This is 19 files across extraction, merge, deps, orphan and refresh. I verified the `rm` scenario end to end and ran their suites, but did not independently re-derive the owner-closure logic.
