### PR TITLE
fix(cli): keep a rejected --concurrency value off stdout

### DIFF
--- a/src/compiler/concurrency.ts
+++ b/src/compiler/concurrency.ts
@@ -38,6 +38,13 @@ function pickOverride(override: number | undefined): OverrideSource {
  * input so a typo like `--concurrency eight` reports "eight", not "NaN" — and
  * yields undefined so resolution falls through to the env var / default. A
  * valid integer is returned as-is; out-of-range clamping is the resolver's job.
+ *
+ * The rejection goes to stderr via `note`, not to stdout via `status`, because
+ * the CLI evaluates this while assembling a command's arguments, before that
+ * command's body can enable quiet mode. Anything written to stdout from here is
+ * therefore unsuppressible, and in a `--json` run it lands ahead of the
+ * envelope and breaks the parse for a caller that still sees exit 0. stderr
+ * keeps the diagnostic visible without touching the data channel.
  * @param raw - The flag value Commander parsed, or undefined when not passed.
  * @returns A positive integer, or undefined to defer to env/default.
  */
@@ -45,8 +52,8 @@ export function parseConcurrencyFlag(raw?: string): number | undefined {
   if (raw === undefined) return undefined;
   const n = Number(raw);
   if (!Number.isInteger(n) || n <= 0) {
-    output.status("!", output.warn(
-      `--concurrency value "${raw}" is not a positive integer; ignoring it.`,
+    output.note(output.warn(
+      `! --concurrency value "${raw}" is not a positive integer; ignoring it.`,
     ));
     return undefined;
   }

--- a/test/compile-concurrency.test.ts
+++ b/test/compile-concurrency.test.ts
@@ -21,19 +21,25 @@ import {
   ENV_COMPILE_CONCURRENCY,
 } from "../src/utils/constants.js";
 
-/** Run fn while capturing console.log (output.status writes there) and return the joined text. */
-function captureStatus(fn: () => void): string {
-  const logs: string[] = [];
-  const spy = vi.spyOn(console, "log").mockImplementation((m?: unknown) => {
-    logs.push(String(m));
+/** Run fn while capturing one console channel, and return the joined text. */
+function capture(channel: "log" | "warn", fn: () => void): string {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, channel).mockImplementation((m?: unknown) => {
+    lines.push(String(m));
   });
   try {
     fn();
   } finally {
     spy.mockRestore();
   }
-  return logs.join("\n");
+  return lines.join("\n");
 }
+
+/** Capture stdout, where `output.status` writes. */
+const captureStatus = (fn: () => void): string => capture("log", fn);
+
+/** Capture stderr, where `output.note` writes. */
+const captureNote = (fn: () => void): string => capture("warn", fn);
 import { compileAndReport } from "../src/compiler/index.js";
 import { AnthropicProvider } from "../src/providers/anthropic.js";
 import { parseFrontmatter } from "../src/utils/markdown.js";
@@ -100,9 +106,18 @@ describe("parseConcurrencyFlag", () => {
     expect(parseConcurrencyFlag("999")).toBe(999);
   });
 
-  it("rejects a non-integer flag and echoes the raw input the user typed", () => {
-    const out = captureStatus(() => expect(parseConcurrencyFlag("eight")).toBeUndefined());
-    expect(out).toContain('"eight"');
+  it("rejects a non-integer flag on stderr, echoing the raw input, and leaves stdout clean", () => {
+    let stdout = "";
+    const stderr = captureNote(() => {
+      stdout = captureStatus(() => expect(parseConcurrencyFlag("eight")).toBeUndefined());
+    });
+
+    expect(stderr).toContain('"eight"');
+    // The CLI parses this flag while assembling a command's arguments, before
+    // the command body can enable quiet mode, so a stdout write here is
+    // unsuppressible and corrupts a --json envelope. See
+    // test/quickstart-json-stdout.test.ts for that contract end to end.
+    expect(stdout).toBe("");
   });
 });
 

--- a/test/quickstart-json-stdout.test.ts
+++ b/test/quickstart-json-stdout.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @file test/quickstart-json-stdout.test.ts
+ * @description `quickstart --json` must put nothing but its envelope on stdout.
+ *
+ * `--concurrency` is parsed while the CLI assembles quickstartCommand's
+ * arguments, which happens BEFORE the command body can enable quiet mode. A
+ * diagnostic emitted from there escapes quiet mode entirely, and on stdout it
+ * lands ahead of the JSON envelope. The command still exits 0, so an automated
+ * caller reads a successful-looking stream that does not parse.
+ *
+ * The contract has two halves and both need pinning: stdout stays parseable,
+ * and the diagnostic is still delivered. Dropping the warning would satisfy the
+ * first half on its own, so an assertion for each is what keeps the pair honest.
+ *
+ * No credentials are needed. Quickstart ingests the local file, fails at the
+ * provider, and reports that inside the envelope, which is exactly the shape an
+ * automated caller has to be able to read.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runCLI } from "./fixtures/run-cli.js";
+
+/** A workspace holding one local source, enough for quickstart to reach compile. */
+async function workspace(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "llmwiki-qs-json-"));
+  await writeFile(path.join(dir, "src.md"), "# Topic\n\nProse about a topic.\n", "utf-8");
+  return dir;
+}
+
+/** Blank credentials so the run is hermetic rather than inheriting an ambient key. */
+const NO_CREDENTIALS = {
+  LLMWIKI_PROVIDER: "anthropic",
+  ANTHROPIC_API_KEY: "",
+  ANTHROPIC_AUTH_TOKEN: "",
+};
+
+describe("quickstart --json and a rejected --concurrency value", () => {
+  it("puts only the envelope on stdout, and still reports the rejected value", async () => {
+    const cwd = await workspace();
+    try {
+      const result = await runCLI(
+        ["quickstart", "src.md", "--json", "--no-open", "--concurrency", "eight"],
+        cwd,
+        NO_CREDENTIALS,
+      );
+
+      // stdout is the data channel: it must parse whole, with nothing ahead of it.
+      expect(result.stdout.trimStart().startsWith("{")).toBe(true);
+      expect(JSON.parse(result.stdout).version).toBe(1);
+
+      // and the diagnostic still reaches the operator, on the other channel.
+      expect(result.stderr).toContain('"eight"');
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
Fixes #191, reported by @graysoncooper with a diagnosis that pointed straight at the cause.

## What

`quickstart --json` promises a single parseable envelope on stdout. It did not deliver one when `--concurrency` was invalid:

```
$ llmwiki quickstart src.md --json --no-open --concurrency eight
! --concurrency value "eight" is not a positive integer; ignoring it.
{
  "version": 1,
  ...
```

Exit code is 0, so an automated caller sees success and then fails to parse.

## Why it happened

The value is parsed while the CLI assembles the command's arguments, at `cli.ts:389`, and quiet mode is enabled later inside the command body at `quickstart.ts:147`. Argument expressions are evaluated before the callee runs, so quiet mode was never early enough to suppress it. Moving the `setQuiet` call earlier cannot fix this, because there is no point inside the command that precedes its own arguments.

The channel was the real problem. stdout is the data channel, and a complaint about invalid input belongs on stderr. `output.note` already exists for exactly that and has eighteen callers, so the fix is to use it.

That also fixes `compile`, `refresh` and `watch`, which take the same flag, and it keeps the warning visible rather than trading a corrupt envelope for a silent one.

## Tests

- `test/quickstart-json-stdout.test.ts` drives the real CLI through `dist/` and asserts both halves of the contract: stdout parses whole, and stderr still names the rejected value. No credentials needed, since the provider failure is reported inside the envelope, which is the shape a caller has to read anyway.
- The existing unit test asserted the rejection appeared on stdout, so it encoded the defect. It now pins the channel split instead.

Both tests were mutation-tested against the committed fix. Restoring the stdout write turns both red, and deleting the diagnostic altogether also turns both red, so a fix that simply silenced the warning would not pass.

The two other warnings in `concurrency.ts` are left alone deliberately: they run inside the command, where quiet mode governs them correctly.
