### PR TITLE
test: broaden quickstart --concurrency witnesses

### DIFF
--- a/test/quickstart-json-stdout.test.ts
+++ b/test/quickstart-json-stdout.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from "vitest";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { runCLI } from "./fixtures/run-cli.js";
+import { expectCLIExit, runCLI } from "./fixtures/run-cli.js";
 
 /** A workspace holding one local source, enough for quickstart to reach compile. */
 async function workspace(): Promise<string> {
@@ -30,29 +30,64 @@ async function workspace(): Promise<string> {
   return dir;
 }
 
-/** Blank credentials so the run is hermetic rather than inheriting an ambient key. */
+/**
+ * Blank credentials so the run is hermetic rather than inheriting an ambient key, and blank
+ * the two ambient knobs that could perturb the run: a developer's LLMWIKI_COMPILE_CONCURRENCY
+ * would add its own resolution path, and a local Claude settings file could leak provider
+ * configuration into the subprocess.
+ */
 const NO_CREDENTIALS = {
   LLMWIKI_PROVIDER: "anthropic",
   ANTHROPIC_API_KEY: "",
   ANTHROPIC_AUTH_TOKEN: "",
+  LLMWIKI_COMPILE_CONCURRENCY: "",
+  LLMWIKI_CLAUDE_SETTINGS_PATH: "/path/does/not/exist.json",
 };
 
 describe("quickstart --json and a rejected --concurrency value", () => {
-  it("puts only the envelope on stdout, and still reports the rejected value", async () => {
+  // One case per rejection branch of `!Number.isInteger(n) || n <= 0`: non-numeric,
+  // zero, non-integer, negative.
+  it.each(["eight", "0", "2.5", "-1"])(
+    "puts only the envelope on stdout, exits 0, and still reports %s",
+    async (invalidValue) => {
+      const cwd = await workspace();
+      try {
+        const result = await runCLI(
+          ["quickstart", "src.md", "--json", "--no-open", "--concurrency", invalidValue],
+          cwd,
+          NO_CREDENTIALS,
+        );
+
+        // The defect was "exit 0 + unparseable stream"; pin BOTH coordinates —
+        // runCLI never throws, so without this a nonzero-exit regression with an
+        // intact envelope would pass.
+        expectCLIExit(result, 0);
+
+        // stdout is the data channel: it must parse whole, with nothing ahead of it.
+        expect(result.stdout.trimStart().startsWith("{")).toBe(true);
+        expect(JSON.parse(result.stdout).version).toBe(1);
+
+        // and the diagnostic still reaches the operator, on the other channel.
+        expect(result.stderr).toContain(`"${invalidValue}"`);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  it("keeps the warning visible in human mode", async () => {
     const cwd = await workspace();
     try {
       const result = await runCLI(
-        ["quickstart", "src.md", "--json", "--no-open", "--concurrency", "eight"],
+        ["quickstart", "src.md", "--no-open", "--concurrency", "eight"],
         cwd,
         NO_CREDENTIALS,
       );
 
-      // stdout is the data channel: it must parse whole, with nothing ahead of it.
-      expect(result.stdout.trimStart().startsWith("{")).toBe(true);
-      expect(JSON.parse(result.stdout).version).toBe(1);
-
-      // and the diagnostic still reaches the operator, on the other channel.
-      expect(result.stderr).toContain('"eight"');
+      expectCLIExit(result, 0);
+      // Without --json the channel split is not the contract; visibility is.
+      expect(`${result.stdout}\n${result.stderr}`).toContain('"eight"');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Broaden the quickstart --concurrency witnesses (stacked on #201)

Test-only additions to `test/quickstart-json-stdout.test.ts`, pinning the coordinates the
defect report named but the original oracle left open:

- **Input-space coverage**: parameterized over `eight` / `0` / `2.5` / `-1` — one case per
  rejection branch of `!Number.isInteger(n) || n <= 0`.
- **Exit-code pinning**: `expectCLIExit(result, 0)` in every case. `runCLI` never throws, so
  previously a nonzero-exit regression with an intact envelope would pass; the defect was
  precisely "exit 0 + unparseable stream", so both coordinates are pinned.
- **Human-mode witness**: same invalid flag without `--json` — exit 0 and the warning visible.
  Channel-agnostic by design: it survives the channel fix and fails only if the diagnostic is
  dropped entirely.
- **Hermeticity**: the fixture env now also blanks `LLMWIKI_COMPILE_CONCURRENCY` and points
  `LLMWIKI_CLAUDE_SETTINGS_PATH` at a nonexistent file, so ambient developer configuration
  cannot perturb the subprocess.

Mutation-tested both directions: restoring the stdout write turns the four channel witnesses
red (human-mode stays green, as designed); deleting the diagnostic turns all five red.
Full suite green (5033 passed), `tsc --noEmit` clean, fallow clean.

Based on `fix/quickstart-json-stdout` (#201) — merging order stays with #201.
