### PR TITLE
fix(quickstart): route invalid --concurrency warning to stderr in --json mode

### DIFF
--- a/docs/cli/ingest.mdx
+++ b/docs/cli/ingest.mdx
@@ -111,7 +111,7 @@ Under the hood, `quickstart` runs `ingest` then `compile`. Compile requires LLM 
 | `--provider <name>` | Override `LLMWIKI_PROVIDER` for this invocation only (e.g. `openai`, `ollama`, `claude-agent`). |
 | `--lang <code>` | Generate wiki content in the specified language (e.g. `zh-CN`, `Japanese`, `ja`). Equivalent to setting `LLMWIKI_OUTPUT_LANG` for this run. |
 | `--concurrency <n>` | Maximum LLM calls run in parallel during the compile step (extraction and page generation). Overrides `LLMWIKI_COMPILE_CONCURRENCY`; defaults to `5`, clamped to `1`–`50`. Useful when quickstarting a large source. |
-| `--json` | Emit a machine-readable JSON envelope instead of human output. Implies `--no-open`. The envelope includes `ingest`, `compile`, and `viewer` sub-objects plus a `next` recommended action. |
+| `--json` | Emit one machine-readable JSON envelope on stdout instead of human output. Implies `--no-open`; option warnings remain visible on stderr. The envelope includes `ingest`, `compile`, and `viewer` sub-objects plus a `next` recommended action. |
 
 ### Examples
 

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -130,7 +130,7 @@ Non-numeric, zero, or negative values are silently ignored and the next source i
 
 | Variable | Default | Description |
 |---|---|---|
-| `LLMWIKI_COMPILE_CONCURRENCY` | `5` | Maximum LLM calls run in parallel during a compile, across both concept extraction and page generation. Raise it to cut wall-clock on cold starts and large refreshes; lower it to ease a provider's rate limits. Non-positive or non-integer values fall back to the default, and any value above `50` is clamped down with a warning. The `--concurrency` flag on `llmwiki compile`, `llmwiki refresh`, `llmwiki watch`, and `llmwiki quickstart` overrides this for a single run. An invalid `--concurrency` flag value is ignored with a warning, so this variable (or the default) still applies |
+| `LLMWIKI_COMPILE_CONCURRENCY` | `5` | Maximum LLM calls run in parallel during a compile, across both concept extraction and page generation. Raise it to cut wall-clock on cold starts and large refreshes; lower it to ease a provider's rate limits. Non-positive or non-integer values fall back to the default, and any value above `50` is clamped down with a warning. The `--concurrency` flag on `llmwiki compile`, `llmwiki refresh`, `llmwiki watch`, and `llmwiki quickstart` overrides this for a single run. An invalid `--concurrency` flag value is ignored with a warning, so this variable (or the default) still applies; `quickstart --json` writes that warning to stderr to keep stdout parseable, while human output keeps the warning on stdout |
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -386,7 +386,9 @@ program
       provider: options.provider,
       lang: options.lang,
       json: options.json,
-      concurrency: parseConcurrencyFlag(options.concurrency),
+      // Choose the warning channel here: argument expressions evaluate before the callee body runs.
+      // Quickstart's own JSON quiet mode therefore can never intercept this warning.
+      concurrency: parseConcurrencyFlag(options.concurrency, options.json ? "stderr" : "stdout"),
     }));
   });
 

--- a/src/compiler/concurrency.ts
+++ b/src/compiler/concurrency.ts
@@ -39,15 +39,22 @@ function pickOverride(override: number | undefined): OverrideSource {
  * yields undefined so resolution falls through to the env var / default. A
  * valid integer is returned as-is; out-of-range clamping is the resolver's job.
  * @param raw - The flag value Commander parsed, or undefined when not passed.
+ * @param diagnosticTarget - Stream for invalid-value warnings; human commands
+ *                           retain stdout while JSON callers can protect it.
  * @returns A positive integer, or undefined to defer to env/default.
  */
-export function parseConcurrencyFlag(raw?: string): number | undefined {
+export function parseConcurrencyFlag(
+  raw?: string,
+  diagnosticTarget: "stdout" | "stderr" = "stdout",
+): number | undefined {
   if (raw === undefined) return undefined;
   const n = Number(raw);
   if (!Number.isInteger(n) || n <= 0) {
-    output.status("!", output.warn(
+    const warning = output.warn(
       `--concurrency value "${raw}" is not a positive integer; ignoring it.`,
-    ));
+    );
+    if (diagnosticTarget === "stderr") output.note(`! ${warning}`);
+    else output.status("!", warning);
     return undefined;
   }
   return n;

--- a/test/quickstart-json-stdout.test.ts
+++ b/test/quickstart-json-stdout.test.ts
@@ -1,0 +1,61 @@
+/**
+ * CLI regressions for invalid quickstart concurrency diagnostics.
+ *
+ * These subprocess tests exercise the built user-facing entry point with the
+ * documented quickstart arguments. Machine mode must reserve stdout for one
+ * JSON envelope while keeping the warning visible on stderr; human mode keeps
+ * the historical yellow status line on stdout.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { runCLI, expectCLIExit, type CLIResult } from "./fixtures/run-cli.js";
+import { stripAnsi } from "./fixtures/cli-runner.js";
+
+const INVALID_WARNING = (value: string): string =>
+  `--concurrency value "${value}" is not a positive integer; ignoring it.`;
+const quickstartRoots: string[] = [];
+
+/** Run quickstart against a real Markdown source without calling a provider. */
+async function runInvalidConcurrency(jsonMode: boolean, value = "eight"): Promise<CLIResult> {
+  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-quickstart-json-"));
+  quickstartRoots.push(cwd);
+  await writeFile(path.join(cwd, "source.md"), "# Source\n\nRegression witness.\n", "utf-8");
+  const args = jsonMode
+    ? ["quickstart", "source.md", "--json", "--no-open", "--concurrency", value]
+    : ["quickstart", "source.md", "--no-open", "--concurrency", "eight"];
+  return runCLI(args, cwd, {
+    LLMWIKI_PROVIDER: "anthropic",
+    LLMWIKI_COMPILE_CONCURRENCY: "",
+    ANTHROPIC_API_KEY: "",
+    ANTHROPIC_AUTH_TOKEN: "",
+    LLMWIKI_CLAUDE_SETTINGS_PATH: "/path/does/not/exist.json",
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(quickstartRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("quickstart invalid --concurrency diagnostics", () => {
+  it.each(["eight", "0", "2.5", "-1"])(
+    "keeps --json stdout as one envelope and writes the warning to stderr for %s",
+    async (value) => {
+      const result = await runInvalidConcurrency(true, value);
+      expectCLIExit(result, 0);
+      const envelope = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(Object.keys(envelope)).toEqual(["version", "source", "ingest", "compile", "viewer", "next"]);
+      expect(result.stdout).not.toContain("--concurrency");
+      expect(stripAnsi(result.stderr).trim()).toBe(`! ${INVALID_WARNING(value)}`);
+    },
+  );
+
+  it("keeps the yellow status warning on stdout without --json", async () => {
+    const result = await runInvalidConcurrency(false);
+    expectCLIExit(result, 0);
+    expect(result.stdout).toContain(`! \x1b[33m${INVALID_WARNING("eight")}\x1b[0m`);
+    expect(result.stderr).not.toContain("--concurrency");
+  });
+});


### PR DESCRIPTION
Closes #191.

## What

In `--json` mode, an invalid `--concurrency` value (`eight`, `0`, `2.5`, `-1`) emitted a
yellow ANSI warning on **stdout before the JSON envelope** while still exiting 0 — silently
unparseable output for any automated caller.

Root cause: the warning fires while Commander constructs `quickstartCommand`'s arguments —
argument expressions evaluate before the callee body, so `setQuiet(jsonMode)` inside
`quickstartCommand` can never intercept it. The channel has to be chosen at the call site.

## How

`parseConcurrencyFlag` gains an explicit diagnostic target (default `stdout`):

- `quickstart --json` routes the warning to **stderr** — visible to the operator, stdout
  stays a single parseable envelope.
- Human mode (and `compile`/`refresh`/`watch`, which have no `--json`) keeps today's stdout
  warning **byte-for-byte**.
- Invalid input still returns `undefined`, so the env-var/default fallback and the exit
  code are unchanged. Suppressing the warning outright was rejected — the diagnostic must
  remain visible.

## Tests

New end-to-end test drives the **built CLI**:

- `--json`, parameterized over all four rejection shapes (`eight`, `0`, `2.5`, `-1`):
  exit 0, stdout parses as one envelope with exactly its existing keys (no new diagnostic
  field), stdout free of the warning, stderr carries the byte-exact warning.
- Human mode: the unchanged yellow warning bytes on stdout, stderr clean.
- Hermetic env: provider credentials and `LLMWIKI_COMPILE_CONCURRENCY` blanked so ambient
  environment cannot perturb the fallback under test.

Full suite: 671 files, 5,033 tests passing.

## Docs

Updated the `--json` flag row (`docs/cli/ingest.mdx`) and the invalid-flag note in
`docs/configuration/environment-variables.mdx`.

Note: #201 addresses the same issue with an equivalent stderr routing; this PR additionally
covers all four rejection shapes, pins the envelope shape, preserves the human-mode warning
bytes exactly, and updates the docs — one of the two should close #191.
