### PR TITLE
Add the codex-agent provider: keyless completions through the Codex CLI

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -3,7 +3,9 @@
   "entry": [
     "src/viewer/assets/viewer.js",
     "scripts/copy-viewer-assets.mjs",
-    "src/viewer/assets/viewer-theme-boot.js"
+    "src/viewer/assets/viewer-theme-boot.js",
+    "test/fixtures/mock-embeddings.mjs",
+    "test/fixtures/track-dotenv-read.mjs"
   ],
   "ignorePatterns": [
     "docs/**",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OpenAI Codex CLI provider** — `LLMWIKI_PROVIDER=codex-agent` or
+  `--provider codex-agent` delegates chat and structured generation to a locally
+  authenticated Codex CLI. The same one-run `--provider` override is now
+  available on `compile`, `refresh`, `query`, `watch`, `rules extract`, `eval`,
+  and `quickstart`. Codex runs non-interactively in an ephemeral read-only
+  sandbox with a minimal environment, bounded output and process-tree lifetime,
+  interruption cleanup, and independently validated structured results. It
+  never reads project `.env` files or falls back to API-key authentication when
+  explicitly selected; embeddings require an explicit existing backend.
+
 - **Skip embeddings on compile** — `compile({ embeddings: false })` runs page generation, links and the lexical index without any embedding-provider call or pending-embedding retry, for an SDK host that maintains its own semantic index. Omitting it is unchanged.
 
   The flag closes a gap that is provider-specific. With `anthropic` or `claude-agent` a caller can already opt out by not setting `VOYAGE_API_KEY`, but the `openai` embedding credential falls back to `OPENAI_API_KEY` and `ollama` needs no key at all, so those callers had no way to compile without embedding except to break chat.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Do not use llmwiki as a general static-site generator, a heavy ontology database
 - **SDK.** `createWiki({ root })` drives ingest, compile, query, context, status, export, eval, and OKF import/export from TypeScript without shelling out.
 - **Open Knowledge Format exchange.** Export and import OKF bundles for portable, markdown-native knowledge exchange. External OKF imports are staged through the review queue by default; trusted bundles can be written live explicitly.
 - **Other portable exports.** Export JSON, JSON-LD, GraphML, Marp slides, and `llms.txt` for downstream systems.
-- **Provider portable.** Anthropic, Claude Agent SDK local login, OpenAI-compatible servers, Ollama, GitHub Copilot, Atlas Cloud, and local OpenAI-compatible runtimes.
+- **Provider portable.** Anthropic, Claude Agent SDK local login, OpenAI Codex CLI local login, OpenAI-compatible servers, Ollama, GitHub Copilot, Atlas Cloud, and local OpenAI-compatible runtimes.
 
 ## Configurable Lifecycle Profiles (CLP)
 
@@ -273,6 +273,7 @@ Provider selection is environment-driven:
 |---|---|
 | Anthropic | `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` |
 | Claude Agent SDK | Local Claude Code login, `LLMWIKI_PROVIDER=claude-agent` |
+| OpenAI Codex CLI | Local Codex login / ChatGPT subscription, `LLMWIKI_PROVIDER=codex-agent`; explicit embedding provider required |
 | OpenAI-compatible | `LLMWIKI_PROVIDER=openai`, `OPENAI_API_KEY`, optional `OPENAI_BASE_URL` |
 | Ollama | `LLMWIKI_PROVIDER=ollama`, `OLLAMA_HOST` |
 | GitHub Copilot | `LLMWIKI_PROVIDER=copilot`, `GITHUB_TOKEN=$(gh auth token)` |

--- a/docs/cli/compile.mdx
+++ b/docs/cli/compile.mdx
@@ -21,6 +21,7 @@ Run from your project root. If `sources/` is empty or doesn't exist yet, compile
 | Flag | Description |
 |------|-------------|
 | `--review` | Write generated pages to `.llmwiki/candidates/` instead of `wiki/`. Pages are held for human review and don't appear in the live wiki until you approve them with `llmwiki review approve <id>`. |
+| `--provider <name>` | Override `LLMWIKI_PROVIDER` for this compile only. Use `codex-agent` to delegate both compile phases to non-interactive `codex exec`. |
 | `--lang <code>` | Override the output language for this compile run (e.g. `zh-CN`, `Chinese`, `ja`, `Japanese`). Wins over the `LLMWIKI_OUTPUT_LANG` environment variable. Unset preserves the model's default behaviour. Changing it regenerates already-compiled pages — see [Prompt modifiers and recompilation](#prompt-modifiers-and-recompilation). |
 | `--concurrency <n>` | Maximum LLM calls run in parallel during this compile, across both extraction and page generation. Wins over the `LLMWIKI_COMPILE_CONCURRENCY` environment variable; defaults to `5`. Values above `50` are clamped. |
 | `--verbose` | Print detailed per-step progress: source sizes, concept merge details, page char counts, embedding batch summary, and total compile time. Equivalent to setting `LLMWIKI_VERBOSE=1`. Quiet mode (`--json`) always wins over verbose. |

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -14,14 +14,26 @@ You don't need to set everything - only the variables relevant to your chosen pr
 
 | Variable | Default | Description |
 |---|---|---|
-| `LLMWIKI_PROVIDER` | `anthropic` | Provider to use. One of: `anthropic`, `openai`, `ollama`, `minimax`, `copilot`, `claude-agent`, `atlascloud` (aliases: `atlas-cloud`, `atlas`) |
-| `LLMWIKI_MODEL` | Provider default | Model name to use. Overrides the provider's built-in default model |
+| `LLMWIKI_PROVIDER` | `anthropic` | Provider to use. One of: `anthropic`, `openai`, `ollama`, `minimax`, `copilot`, `claude-agent`, `codex-agent`, `atlascloud` (aliases: `atlas-cloud`, `atlas`) |
+| `LLMWIKI_MODEL` | Provider default | Model name to use. Overrides the provider's built-in default model. For `codex-agent`, unset delegates model choice to Codex and a set value is passed through with `--model` |
 | `LLMWIKI_EMBEDDING_PROVIDER` | Active chat provider | Backend serving embeddings, independent of `LLMWIKI_PROVIDER`. One of `anthropic`, `claude-agent`, `openai`, `ollama` |
 | `LLMWIKI_EMBEDDING_MODEL` | Provider default | Embedding model to use. Applies only when the effective embedding provider is `openai` or `ollama` - ignored for `anthropic` and `claude-agent`, even when `LLMWIKI_EMBEDDING_PROVIDER` names one of them explicitly |
 
 When you set `LLMWIKI_EMBEDDING_PROVIDER`, the named provider's own credential is required: `VOYAGE_API_KEY` for `anthropic` or `claude-agent`, `OPENAI_API_KEY` (or `OPENAI_EMBEDDINGS_API_KEY`) for `openai`, and no key for `ollama`. Setting `OPENAI_EMBEDDINGS_BASE_URL` marks a self-hosted OpenAI-compatible endpoint that needs no key, so `OPENAI_API_KEY` is not required in that case. This check only runs when `LLMWIKI_EMBEDDING_PROVIDER` is set - leaving it unset keeps today's behavior unchanged.
 
 The check runs at startup, before any compile or query work begins, so a misspelled provider name or a missing key fails immediately instead of part-way through a run.
+
+`codex-agent` is the exception to the default embedding-provider value: because
+Codex cannot embed, it requires `LLMWIKI_EMBEDDING_PROVIDER` to be set
+explicitly. A missing or unusable embedding backend fails actionably rather
+than silently degrading. The keyless combination is `codex-agent` chat plus
+`ollama` embeddings.
+
+When `codex-agent` is selected explicitly through `--provider` or a
+shell-exported `LLMWIKI_PROVIDER`, llmwiki does not open the project `.env`
+file, because that file may contain API keys. Export the Codex model, embedding
+provider, and embedding-backend settings in the shell for that run. Other
+providers retain the existing shell-over-`.env` precedence.
 
 <Warning>
   If you point `OPENAI_EMBEDDINGS_BASE_URL` at a host you do not operate, set `OPENAI_EMBEDDINGS_API_KEY` as well. Without it the embeddings client reuses `OPENAI_API_KEY`, which sends your cloud OpenAI key to that host. llmwiki warns when this happens, except for endpoints on `localhost`.
@@ -59,6 +71,26 @@ Either `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` satisfies authentication - 
 | `OPENAI_BASE_URL` | For custom or local endpoints | Base URL for chat and tool calls. **Must include `/v1`** |
 | `OPENAI_EMBEDDINGS_BASE_URL` | No | Separate base URL for embeddings requests. When unset, embeddings use the same client and base URL as chat |
 | `OPENAI_EMBEDDINGS_API_KEY` | No | Credential for embeddings requests. When unset, embeddings reuse `OPENAI_API_KEY` - set this whenever the embeddings endpoint belongs to someone else |
+
+---
+
+## OpenAI Codex CLI
+
+| Variable | Required | Description |
+|---|---|---|
+| `LLMWIKI_PROVIDER` | Yes | Set to `codex-agent` |
+| `LLMWIKI_MODEL` | No | Passed to `codex exec --model`; when unset, Codex chooses its own available default |
+| `LLMWIKI_EMBEDDING_PROVIDER` | Yes | Existing provider that serves embeddings; use `ollama` for a keyless setup |
+
+Authentication is managed only by the installed Codex CLI (`codex login`).
+llmwiki does not read Codex auth files or any OpenAI API key for chat. The CLI
+does not expose a `maxTokens` control, so llmwiki cannot honor that internal
+hint for this provider. Each request has a fixed 10-minute timeout and 1 MiB
+process/final-output caps.
+
+The minimum verified compatible Codex CLI version is **0.152.1**. If an older
+binary rejects a required secure flag, llmwiki reports it as incompatible;
+update with `npm install -g @openai/codex@latest`.
 
 ---
 
@@ -214,5 +246,5 @@ ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 <Note>
-  The `.env` file is read from your project root at startup. It is a convenience for projects where you don't want to export variables in your shell every session. Shell environment variables always take precedence over `.env` values, so you can override any `.env` setting with a one-off `export` without editing the file.
+  Except for explicitly selected `codex-agent` runs, the `.env` file is read from your project root at startup. It is a convenience for projects where you don't want to export variables in your shell every session. Shell environment variables always take precedence over `.env` values, so you can override any `.env` setting with a one-off `export` without editing the file.
 </Note>

--- a/docs/configuration/providers.mdx
+++ b/docs/configuration/providers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "LLM Provider Setup and Configuration Guide for llmwiki"
 sidebarTitle: "Providers"
-description: "Configure llmwiki to use Anthropic, OpenAI-compatible endpoints, Ollama, GitHub Copilot, Atlas Cloud, or the Claude Agent SDK provider for local login."
+description: "Configure llmwiki to use Anthropic, OpenAI-compatible endpoints, Ollama, GitHub Copilot, Atlas Cloud, Claude Agent SDK, or OpenAI Codex CLI."
 ---
 
 llmwiki is provider-portable. Whether you have an Anthropic API key, a GitHub Copilot subscription, a locally-running Ollama server, or just a Claude Code login, you can point llmwiki at the right backend with a handful of environment variables - no config files required for most setups. Choose the provider that matches your existing credentials and infrastructure.
@@ -99,6 +99,79 @@ LLMWIKI_DEBUG=1 LLMWIKI_PROVIDER=claude-agent llmwiki compile
 <Warning>
   This provider drives your Claude Code / Agent SDK session programmatically to compile wikis. That is not automatically appropriate for every account type, plan, or environment. Before using it, review Anthropic's current [Claude Code](https://www.anthropic.com/legal/consumer-terms) and [Agent SDK](https://docs.anthropic.com/en/api/agent-sdk/overview) terms and usage policies, and make sure your intended use complies with them.
 </Warning>
+
+  </Tab>
+  <Tab title="OpenAI Codex CLI">
+
+The `codex-agent` provider delegates every completion and structured extraction
+request to the locally installed OpenAI Codex CLI. Authentication belongs
+entirely to Codex, so a ChatGPT subscriber can use an existing `codex login`;
+llmwiki does not require, read, copy, store, or log an OpenAI API key.
+
+**Setup**
+
+```bash
+npm install -g @openai/codex@latest
+codex login
+
+export LLMWIKI_PROVIDER=codex-agent
+export LLMWIKI_EMBEDDING_PROVIDER=ollama
+export OLLAMA_HOST=http://localhost:11434/v1
+llmwiki compile
+
+# Equivalent one-run selection:
+llmwiki compile --provider codex-agent
+```
+
+The `--provider` override is available on `compile`, `refresh`, `query`,
+`watch`, `rules extract`, `eval`, and `quickstart`. If Codex is missing or its
+login is unusable, llmwiki exits nonzero with a Codex-specific remediation;
+there is no fallback to an API-key provider.
+
+llmwiki's minimum verified compatible Codex CLI version is **0.152.1**. Older
+versions may not support the secure non-interactive flags this provider
+requires. If llmwiki reports an incompatible Codex CLI, update with
+`npm install -g @openai/codex@latest` and verify with `codex --version`.
+
+<Warning>
+  When `codex-agent` is selected by `--provider` or a shell-exported
+  `LLMWIKI_PROVIDER`, llmwiki deliberately does not open the project `.env`
+  file because it may contain API keys. Export `LLMWIKI_EMBEDDING_PROVIDER`,
+  `LLMWIKI_MODEL`, and any embedding-backend settings in the shell for that
+  run; do not rely on `.env` for Codex Agent configuration.
+</Warning>
+
+**Execution and option semantics**
+
+- Every request is a new non-interactive `codex exec` process with
+  `--ephemeral`, `--sandbox read-only`, ignored user config/rules, and an empty
+  throwaway working directory that is removed on success and failure.
+- The child receives a minimal environment allowlist for PATH, the local Codex
+  home/login location, temporary-directory selection, locale, and TLS trust.
+  API-key/token variables and unrelated parent variables are never forwarded.
+- A request is terminated after 10 minutes, first with `SIGTERM` and then with
+  `SIGKILL` after a one-second grace period. Retained stderr diagnostics are
+  capped at 1 MiB; stdout is drained without retention because the final message
+  is read from its separately capped 1 MiB file. The provider does not request
+  Codex's unused JSON event stream. Child diagnostics are never echoed in errors,
+  so credential-like output cannot escape into logs. Parent interruption
+  terminates the active Codex process tree and removes its throwaway directory
+  before llmwiki exits.
+- `LLMWIKI_MODEL`, when set, is passed to `codex exec --model`. When it is
+  unset, the Codex CLI chooses its own subscription-available default.
+- The Codex CLI has no `maxTokens` option, so llmwiki's internal `maxTokens`
+  hints cannot be honored by this provider and are not passed. Streaming is
+  buffered by Codex and delivered as one final chunk rather than token-by-token.
+- Structured requests use `--output-schema` and llmwiki independently validates
+  the returned JSON against that schema before the compiler can consume it.
+
+**Embeddings fail closed**
+
+Codex has no embeddings interface. `codex-agent` therefore requires an explicit
+`LLMWIKI_EMBEDDING_PROVIDER` naming an existing embedding backend; it never
+silently falls back to lexical-only behavior. Use `ollama` for a fully keyless
+setup, or configure `openai`, `anthropic`, or `claude-agent` embeddings with
+that backend's existing settings.
 
   </Tab>
   <Tab title="OpenAI-Compatible">

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Installing llmwiki: npm Setup and Provider Configuration"
 sidebarTitle: "Installation"
-description: "Install llmwiki globally with npm and configure your LLM provider - Anthropic, OpenAI-compatible, Ollama, GitHub Copilot, or Claude Agent SDK."
+description: "Install llmwiki globally with npm and configure Anthropic, OpenAI-compatible, Ollama, GitHub Copilot, Claude Agent SDK, or Codex CLI."
 ---
 
 llmwiki is a Node.js CLI that you install once globally with npm. After installation, you point it at an LLM provider by setting a handful of environment variables - or in some cases, no variables at all if you're already logged into Claude Code. This page covers the full installation process and every supported provider.
@@ -78,6 +78,35 @@ llmwiki calls an LLM during the compile and query phases. It does **not** requir
     <Warning>
       The `claude-agent` provider drives your Claude Code / Agent SDK session programmatically. Before using it, review Anthropic's current [Claude Code](https://www.anthropic.com/legal/consumer-terms) and Agent SDK terms to ensure your intended use complies with them.
     </Warning>
+  </Tab>
+
+  <Tab title="OpenAI Codex CLI">
+    The `codex-agent` provider uses your local Codex CLI login and ChatGPT
+    subscription. llmwiki never handles the stored credential or an OpenAI API
+    key. Install and authenticate Codex first, then choose an existing embedding
+    backend explicitly:
+
+    ```bash
+    npm install -g @openai/codex@latest
+    codex login
+    export LLMWIKI_PROVIDER=codex-agent
+    export LLMWIKI_EMBEDDING_PROVIDER=ollama
+    export OLLAMA_HOST=http://localhost:11434/v1
+    llmwiki compile
+    ```
+
+    You can also select it for one run with
+    `llmwiki compile --provider codex-agent`. Codex runs non-interactively in an
+    ephemeral read-only sandbox and a throwaway directory. It does not expose a
+    `maxTokens` option; model overrides pass through via `LLMWIKI_MODEL`.
+
+    The minimum verified compatible Codex CLI version is **0.152.1**. Run
+    `codex --version` to check it; if llmwiki reports an incompatible binary,
+    update `@openai/codex` to the latest release.
+
+    Explicit Codex Agent selection bypasses the project `.env` file so llmwiki
+    cannot accidentally read API keys stored there. Export the provider,
+    embedding backend, model, and related embedding settings in your shell.
   </Tab>
 
   <Tab title="OpenAI-compatible">

--- a/docs/troubleshooting/faq.mdx
+++ b/docs/troubleshooting/faq.mdx
@@ -44,11 +44,12 @@ If you don't have an Anthropic API key, see the next question for keyless altern
 </Accordion>
 
 <Accordion title="Can I use llmwiki without an Anthropic API key?">
-Yes. llmwiki supports three keyless or non-Anthropic providers:
+Yes. llmwiki supports four keyless or non-Anthropic providers:
 
 | Provider | How to activate | Notes |
 |---|---|---|
 | `claude-agent` | `LLMWIKI_PROVIDER=claude-agent` | Uses your local Claude Code login (OAuth/subscription). No `ANTHROPIC_API_KEY` needed - if `claude` runs in your terminal, this works. |
+| `codex-agent` | `LLMWIKI_PROVIDER=codex-agent` | Uses the installed Codex CLI and its local ChatGPT login. Requires an explicit existing embedding provider; pair with `ollama` for a keyless setup. |
 | `ollama` | `LLMWIKI_PROVIDER=ollama` | Runs entirely against a local Ollama instance. Set `LLMWIKI_MODEL` and `OLLAMA_HOST`. |
 | `copilot` | `LLMWIKI_PROVIDER=copilot` | Uses your GitHub Copilot subscription. Requires an OAuth token with the `copilot` scope (`gh auth refresh --scopes copilot`). Classic PATs are not supported. |
 
@@ -60,6 +61,16 @@ llmwiki compile
 ```
 
 Review the [provider terms of service](https://www.anthropic.com/legal/consumer-terms) that apply to your account type before using `claude-agent` for automated compilation workloads.
+
+For Codex, run `codex login`, set `LLMWIKI_PROVIDER=codex-agent`, and set
+`LLMWIKI_EMBEDDING_PROVIDER`. A missing binary or unusable login fails with a
+Codex-specific error and never falls back to an API key.
+
+Codex Agent requires a compatible Codex CLI; the minimum verified version is
+0.152.1. Update with `npm install -g @openai/codex@latest` if llmwiki reports
+that the installed CLI does not support its required secure flags. Export Codex
+Agent and embedding settings in the shell: explicit Codex selection bypasses
+the project `.env` file so llmwiki never opens a file that may contain API keys.
 </Accordion>
 
 <Accordion title="How do I switch providers mid-project?">

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,6 @@
  * Designed for `npx llmwiki` or global install via `npm install -g llm-wiki-compiler`.
  */
 
-import "dotenv/config";
 import { createRequire } from "module";
 import { Command } from "commander";
 import ingestCommand from "./commands/ingest.js";
@@ -42,6 +41,14 @@ import { registerReviewCommands } from "./cli/review-commands.js";
 import { registerEvalCommands } from "./cli/eval-commands.js";
 import { registerWorkflowCommands } from "./cli/workflow-commands.js";
 import { registerConnectorCommands } from "./cli/connector-commands.js";
+import {
+  addProviderOption,
+  applyProviderOption,
+  type ProviderOption,
+} from "./cli/provider-option.js";
+import { loadCliEnvironment } from "./cli/environment.js";
+
+loadCliEnvironment();
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -106,9 +113,7 @@ program
     }
   });
 
-program
-  .command("compile")
-  .description("Compile sources/ into an interlinked wiki")
+addProviderOption(program.command("compile").description("Compile sources/ into an interlinked wiki"))
   .option(
     "--review",
     "Write generated pages as review candidates under .llmwiki/candidates/ instead of mutating wiki/. Orphan-marking for deleted sources is deferred until the next non-review compile.",
@@ -122,8 +127,9 @@ program
     "Max concurrent LLM calls during compile (or set LLMWIKI_COMPILE_CONCURRENCY; default 5)",
   )
   .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
-  .action(async (options: { review?: boolean; lang?: string; concurrency?: string; verbose?: boolean }) => {
+  .action(async (options: ProviderOption & { review?: boolean; lang?: string; concurrency?: string; verbose?: boolean }) => {
     try {
+      applyProviderOption(options);
       setVerbose(verboseEnabled(options.verbose));
       applyLanguageOption(options.lang);
       requireProvider();
@@ -148,9 +154,7 @@ program
     }
   });
 
-program
-  .command("refresh")
-  .description("Recompile only stale/changed pages without touching unrelated new sources")
+addProviderOption(program.command("refresh").description("Recompile only stale/changed pages without touching unrelated new sources"))
   .option("--stale", "Resolve stale/orphaned pages and recompile them")
   .option("--dry-run", "Print the refresh plan without calling the LLM or writing files")
   .option(
@@ -158,8 +162,9 @@ program
     "Max concurrent LLM calls during the recompile (or set LLMWIKI_COMPILE_CONCURRENCY; default 5)",
   )
   .option("--verbose", "Print detailed progress (or set LLMWIKI_VERBOSE=1)")
-  .action(async (options: { stale?: boolean; dryRun?: boolean; concurrency?: string; verbose?: boolean }) => {
+  .action(async (options: ProviderOption & { stale?: boolean; dryRun?: boolean; concurrency?: string; verbose?: boolean }) => {
     try {
+      applyProviderOption(options);
       setVerbose(verboseEnabled(options.verbose));
       const code = await refreshCommand(
         { stale: options.stale, dryRun: options.dryRun, concurrency: parseConcurrencyFlag(options.concurrency) },
@@ -190,9 +195,7 @@ program
 
 registerRulesCommand(program, requireProvider);
 
-program
-  .command("query <question>")
-  .description("Ask a question against the wiki")
+addProviderOption(program.command("query <question>").description("Ask a question against the wiki"))
   .option("--save", "Save the answer as a wiki page")
   .option("--debug", "Print which pages and chunks were selected and their scores")
   .option(
@@ -203,9 +206,10 @@ program
   .action(
     async (
       question: string,
-      options: { save?: boolean; debug?: boolean; lang?: string; verbose?: boolean },
+      options: ProviderOption & { save?: boolean; debug?: boolean; lang?: string; verbose?: boolean },
     ) => {
       try {
+        applyProviderOption(options);
         setVerbose(verboseEnabled(options.verbose));
         applyLanguageOption(options.lang);
         requireProvider();
@@ -217,15 +221,14 @@ program
     },
   );
 
-program
-  .command("watch")
-  .description("Watch sources/ and auto-recompile on changes")
+addProviderOption(program.command("watch").description("Watch sources/ and auto-recompile on changes"))
   .option(
     "--concurrency <n>",
     "Max concurrent LLM calls per recompile (or set LLMWIKI_COMPILE_CONCURRENCY; default 5)",
   )
-  .action(async (options: { concurrency?: string }) => {
+  .action(async (options: ProviderOption & { concurrency?: string }) => {
     try {
+      applyProviderOption(options);
       requireProvider();
       await watchCommand({ concurrency: parseConcurrencyFlag(options.concurrency) });
     } catch (err) {
@@ -360,7 +363,7 @@ program
   .option("--no-open", "Skip the viewer handoff after a successful compile")
   .option(
     "--provider <name>",
-    "Override LLMWIKI_PROVIDER for this run only (e.g. anthropic, openai, ollama, atlascloud)",
+    "Override LLMWIKI_PROVIDER for this run only (e.g. anthropic, codex-agent, openai, ollama)",
   )
   .option(
     "--lang <code>",

--- a/src/cli/environment.ts
+++ b/src/cli/environment.ts
@@ -1,0 +1,43 @@
+/**
+ * Load project environment configuration without crossing Codex's credential boundary.
+ *
+ * Explicit `codex-agent` selection must be determined from argv or the inherited
+ * shell environment before dotenv can open a project file containing API keys.
+ */
+
+import { createRequire } from "node:module";
+
+const CODEX_AGENT = "codex-agent";
+const require = createRequire(import.meta.url);
+
+/** Parse one provider option spelling without interpreting other arguments. */
+function providerValue(argument: string, nextArgument?: string): string | undefined {
+  if (argument === "--provider") return nextArgument;
+  const prefix = "--provider=";
+  return argument.startsWith(prefix) ? argument.slice(prefix.length) : undefined;
+}
+
+/** Collapse missing and whitespace-only provider names to no override. */
+function normalizedProvider(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+/** Return the last provider override before Commander’s option terminator. */
+function providerFlag(argv: string[]): string | undefined {
+  const commandArguments = argv.slice(2);
+  const terminator = commandArguments.indexOf("--");
+  const scannable = terminator < 0 ? commandArguments : commandArguments.slice(0, terminator);
+  const providers = scannable.map((argument, index) => providerValue(argument, scannable[index + 1]));
+  return normalizedProvider(providers.reverse().find((value) => value !== undefined));
+}
+
+/** Load `.env` unless explicit effective selection already names Codex Agent. */
+export function loadCliEnvironment(
+  argv: string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const selectedProvider = providerFlag(argv) ?? env.LLMWIKI_PROVIDER?.trim();
+  if (selectedProvider === CODEX_AGENT) return;
+  require("dotenv/config");
+}

--- a/src/cli/eval-commands.ts
+++ b/src/cli/eval-commands.ts
@@ -15,6 +15,7 @@ import evalCommand, {
   evalHistoryCommand,
   evalJudgementsCommand,
 } from "../commands/eval.js";
+import { addProviderOption, applyProviderOption, type ProviderOption } from "./provider-option.js";
 
 /** Register the `eval cache` sub-group (`clear`, `show`) under the parent `eval` command. */
 function registerEvalCacheCommands(evalCmd: Command): void {
@@ -39,14 +40,15 @@ function registerEvalCacheCommands(evalCmd: Command): void {
 
 /** Register the `eval` command group (root eval + `cache`/`report`/`history`/`judgements`) on `program`. */
 export function registerEvalCommands(program: Command): void {
-  const evalCmd = program
-    .command("eval")
-    .description("Evaluate wiki quality (health, citation coverage, LLM judge)")
+  const evalCmd = addProviderOption(
+    program.command("eval").description("Evaluate wiki quality (health, citation coverage, LLM judge)"),
+  )
     .option("--suite <level>", "fast (deterministic) or full (+ LLM judge)", "fast")
     .option("--out <format>", "terminal or json", "terminal")
     .option("--sample <n>", "number of citations to judge in full suite", "20")
-    .action(async (opts) => {
+    .action(async (opts: ProviderOption & { suite: string; out: string; sample: string }) => {
       try {
+        applyProviderOption(opts);
         await evalCommand(opts);
       } catch (err) {
         console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);

--- a/src/cli/provider-option.ts
+++ b/src/cli/provider-option.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared Commander support for one-run LLM provider overrides.
+ *
+ * Environment selection remains the durable configuration mechanism. The CLI
+ * flag only sets the current process before the provider guard and factory run.
+ */
+
+import type { Command } from "commander";
+
+const DESCRIPTION =
+  "Override LLMWIKI_PROVIDER for this run only (e.g. anthropic, codex-agent, openai, ollama)";
+
+/** Options shape contributed by {@link addProviderOption}. */
+export interface ProviderOption {
+  provider?: string;
+}
+
+/** Add the standard provider override to an LLM-backed command. */
+export function addProviderOption(command: Command): Command {
+  return command.option("--provider <name>", DESCRIPTION);
+}
+
+/** Apply a non-empty provider override before guarding or constructing it. */
+export function applyProviderOption(options: ProviderOption): void {
+  const provider = options.provider?.trim();
+  if (provider) process.env.LLMWIKI_PROVIDER = provider;
+}

--- a/src/commands/rules-register.ts
+++ b/src/commands/rules-register.ts
@@ -14,6 +14,7 @@ import {
   rulesListCommand,
   rulesRejectCommand,
 } from "./rules.js";
+import { addProviderOption, applyProviderOption, type ProviderOption } from "../cli/provider-option.js";
 
 /** Provider guard injected by the CLI entrypoint. */
 type RequireProvider = () => void;
@@ -39,11 +40,14 @@ export function registerRulesCommand(program: Command, requireProvider: RequireP
 
 /** Register `rules extract`. */
 function registerExtract(rulesCommand: Command, requireProvider: RequireProvider): void {
-  rulesCommand
-    .command("extract")
-    .description("Extract rule candidates from changed sources (writes .llmwiki/rule-candidates/)")
-    .action(async () =>
+  addProviderOption(
+    rulesCommand
+      .command("extract")
+      .description("Extract rule candidates from changed sources (writes .llmwiki/rule-candidates/)"),
+  )
+    .action(async (options: ProviderOption) =>
       runRulesAction(async () => {
+        applyProviderOption(options);
         requireProvider();
         await rulesExtractCommand();
       }),

--- a/src/providers/codex-agent-lifecycle.ts
+++ b/src/providers/codex-agent-lifecycle.ts
@@ -1,0 +1,138 @@
+/**
+ * Process-tree custody for active Codex CLI invocations.
+ *
+ * Codex runs in detached process groups so timeout termination reaches every
+ * descendant. This registry preserves that custody when the llmwiki parent is
+ * interrupted or exits, and removes invocation-owned temporary directories.
+ */
+
+import {
+  spawn,
+  spawnSync,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { rmSync } from "node:fs";
+import { rm } from "node:fs/promises";
+
+interface ActiveCodexProcess {
+  child: ChildProcessWithoutNullStreams;
+  closed: Promise<void>;
+  cwd: string;
+  graceMs: number;
+}
+
+const activeProcesses = new Map<number, ActiveCodexProcess>();
+const EXIT_WAIT_MS = 1_000;
+let interrupting = false;
+
+/** Signal one isolated Codex process tree without exposing child output. */
+export function signalCodexTree(
+  child: ChildProcessWithoutNullStreams,
+  signal: NodeJS.Signals,
+): void {
+  if (child.pid === undefined) return;
+  if (process.platform === "win32") {
+    const args = ["/PID", String(child.pid), "/T"];
+    if (signal === "SIGKILL") args.push("/F");
+    const killer = spawn("taskkill", args, { stdio: "ignore", windowsHide: true });
+    killer.once("error", () => child.kill(signal));
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") child.kill(signal);
+  }
+}
+
+/** Force process-tree termination from Node's synchronous exit hook. */
+function forceTreeOnExit(entry: ActiveCodexProcess): void {
+  const pid = entry.child.pid;
+  if (pid === undefined) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    // The group already exited.
+  }
+}
+
+/** Wait a bounded interval without retaining any invocation resources. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Gracefully stop, force the tree, await pipe closure, and clean its cwd. */
+async function stopForInterrupt(entry: ActiveCodexProcess): Promise<void> {
+  signalCodexTree(entry.child, "SIGTERM");
+  await delay(entry.graceMs);
+  signalCodexTree(entry.child, "SIGKILL");
+  await Promise.race([entry.closed, delay(EXIT_WAIT_MS)]);
+  await rm(entry.cwd, { recursive: true, force: true });
+}
+
+/** Own parent interruption while at least one detached Codex tree is live. */
+async function interrupt(signal: "SIGINT" | "SIGTERM"): Promise<void> {
+  if (interrupting) return;
+  interrupting = true;
+  try {
+    await Promise.allSettled([...activeProcesses.values()].map(stopForInterrupt));
+  } finally {
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  }
+}
+
+const onSigint = (): void => { void interrupt("SIGINT"); };
+const onSigterm = (): void => { void interrupt("SIGTERM"); };
+const onExit = (): void => {
+  for (const entry of activeProcesses.values()) {
+    try {
+      forceTreeOnExit(entry);
+    } finally {
+      try {
+        rmSync(entry.cwd, { recursive: true, force: true });
+      } catch {
+        // Exit hooks cannot retry asynchronously; continue cleaning other entries.
+      }
+    }
+  }
+};
+
+/** Install parent-lifecycle handlers only while Codex owns live resources. */
+function installHandlers(): void {
+  if (activeProcesses.size !== 1) return;
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  process.once("exit", onExit);
+}
+
+/** Remove idle handlers so unrelated commands retain their prior lifecycle. */
+function removeHandlers(): void {
+  if (activeProcesses.size > 0 || interrupting) return;
+  process.removeListener("SIGINT", onSigint);
+  process.removeListener("SIGTERM", onSigterm);
+  process.removeListener("exit", onExit);
+}
+
+/** Register one detached Codex invocation and return its artifact-cleanup release. */
+export function registerCodexProcess(
+  child: ChildProcessWithoutNullStreams,
+  cwd: string,
+  graceMs: number,
+): () => void {
+  if (child.pid === undefined) return () => undefined;
+  const pid = child.pid;
+  const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+  activeProcesses.set(pid, { child, closed, cwd, graceMs });
+  installHandlers();
+  return () => {
+    activeProcesses.delete(pid);
+    removeHandlers();
+  };
+}

--- a/src/providers/codex-agent.ts
+++ b/src/providers/codex-agent.ts
@@ -1,0 +1,378 @@
+/**
+ * OpenAI Codex CLI-backed LLM provider.
+ *
+ * Every request launches a fresh `codex exec` process in an empty throwaway
+ * directory. The child is ephemeral, read-only sandboxed, non-interactive, and
+ * receives only a small environment allowlist needed to locate Codex and its
+ * locally managed login. llmwiki never opens Codex credential files or forwards
+ * API-key environment variables.
+ */
+
+import { spawn } from "node:child_process";
+import { accessSync, constants as fsConstants, statSync } from "node:fs";
+import { mkdtemp, open, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import Ajv from "ajv";
+import type { LLMMessage, LLMProvider, LLMTool } from "../utils/provider.js";
+import { registerCodexProcess, signalCodexTree } from "./codex-agent-lifecycle.js";
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_TERMINATE_GRACE_MS = 1_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+const OUTPUT_FILE = "last-message.txt";
+const SCHEMA_FILE = "output-schema.json";
+const MINIMUM_CODEX_VERSION = "0.152.1";
+const ENV_ALLOWLIST = [
+  "PATH",
+  "HOME",
+  "USERPROFILE",
+  "CODEX_HOME",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "LANG",
+  "LC_ALL",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "SYSTEMROOT",
+  "COMSPEC",
+  "PATHEXT",
+] as const;
+const ajv = new Ajv({ allErrors: true, strict: false });
+
+/** Testable resource bounds; production uses the secure defaults above. */
+export interface CodexAgentProviderOptions {
+  timeoutMs?: number;
+  terminateGraceMs?: number;
+  maxOutputBytes?: number;
+}
+
+/** Provider failure that the shared retry loop must not repeat. */
+class CodexAgentError extends Error {
+  readonly nonRetryable = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexAgentError";
+  }
+}
+
+/** Report the required local dependency without exposing lookup internals. */
+function missingCodexError(): CodexAgentError {
+  return new CodexAgentError(
+    "Codex CLI is not installed or is unavailable on PATH. Install the OpenAI Codex CLI, run `codex login`, and retry.",
+  );
+}
+
+interface ProcessResult {
+  code: number;
+  stderr: string;
+}
+
+type TerminationReason = "timeout" | "output-limit";
+
+interface ProcessState {
+  stderr: string;
+  stderrBytes: number;
+  reason?: TerminationReason;
+  timeout: NodeJS.Timeout;
+  forceTimer?: NodeJS.Timeout;
+}
+
+/** Render system and conversation roles into one stdin-only Codex request. */
+function buildPrompt(system: string, messages: LLMMessage[], structured = false): string {
+  const conversation = messages
+    .map((message) => `${message.role === "user" ? "User" : "Assistant"}: ${message.content}`)
+    .join("\n\n");
+  const outputRule = structured
+    ? "Return only one JSON value matching the supplied output schema."
+    : "Return only the requested final content, without commentary or a Markdown fence.";
+  return [
+    "Fulfill this single llmwiki language-model request without inspecting files or using tools.",
+    outputRule,
+    "",
+    "System instructions:",
+    system,
+    "",
+    "Conversation:",
+    conversation,
+  ].join("\n");
+}
+
+/** Construct the complete, deliberately small child environment. */
+function childEnvironment(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { NO_COLOR: "1" };
+  for (const name of ENV_ALLOWLIST) {
+    const value = process.env[name];
+    if (value !== undefined) env[name] = value;
+  }
+  if (env.PATH && process.platform !== "win32") env.PATH = interpreterSafePath(env.PATH);
+  return env;
+}
+
+/** Keep env-based Node shebangs away from wrappers that synthesize variables. */
+function interpreterSafePath(searchPath: string): string {
+  const runtimeDirectory = path.dirname(process.execPath);
+  const directories = searchPath.split(path.delimiter)
+    .filter((directory) => directory && directory !== runtimeDirectory);
+  return [runtimeDirectory, ...directories].join(path.delimiter);
+}
+
+/** Select Codex before changing interpreter lookup, preserving PATH precedence. */
+function resolveCodexExecutable(searchPath: string | undefined): string {
+  if (process.platform === "win32") return "codex";
+  if (!searchPath) throw missingCodexError();
+  for (const directory of searchPath.split(path.delimiter)) {
+    if (!directory || !path.isAbsolute(directory)) continue;
+    const candidate = path.join(directory, "codex");
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      if (!statSync(candidate).isFile()) continue;
+      return candidate;
+    } catch {
+      // Continue through eligible entries in the original PATH order.
+    }
+  }
+  throw missingCodexError();
+}
+
+/** Retain child diagnostics while enforcing their byte ceiling. */
+function captureStderr(state: ProcessState, chunk: Buffer, limit: number): boolean {
+  state.stderrBytes += chunk.byteLength;
+  if (state.stderrBytes > limit) return false;
+  state.stderr += chunk.toString("utf8");
+  return true;
+}
+
+/** Spawn one bounded Codex child, escalating SIGTERM to SIGKILL when needed. */
+function finishProcess(
+  code: number | null,
+  state: ProcessState,
+  options: Required<CodexAgentProviderOptions>,
+  resolve: (result: ProcessResult) => void,
+  reject: (error: Error) => void,
+): void {
+  clearTimeout(state.timeout);
+  if (state.forceTimer) clearTimeout(state.forceTimer);
+  if (state.reason === "timeout") {
+    reject(new CodexAgentError(`Codex CLI timed out after ${options.timeoutMs}ms.`));
+  } else if (state.reason === "output-limit") {
+    reject(new CodexAgentError(`Codex CLI exceeded the ${options.maxOutputBytes}-byte output limit.`));
+  } else {
+    resolve({ code: code ?? 1, stderr: state.stderr });
+  }
+}
+
+/** Spawn one bounded Codex child, escalating SIGTERM to SIGKILL when needed. */
+function runCodex(
+  args: string[],
+  cwd: string,
+  prompt: string,
+  options: Required<CodexAgentProviderOptions>,
+  retainCustody: (release: () => void) => void,
+): Promise<ProcessResult> {
+  return new Promise((resolve, reject) => {
+    const executable = resolveCodexExecutable(process.env.PATH);
+    const child = spawn(executable, args, {
+      cwd,
+      detached: true,
+      env: childEnvironment(),
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const state: ProcessState = {
+      stderr: "",
+      stderrBytes: 0,
+      timeout: setTimeout(() => terminate("timeout"), options.timeoutMs),
+    };
+    retainCustody(registerCodexProcess(child, cwd, options.terminateGraceMs));
+    function terminate(reason: TerminationReason): void {
+      if (state.reason) return;
+      state.reason = reason;
+      signalCodexTree(child, "SIGTERM");
+      state.forceTimer = setTimeout(
+        () => signalCodexTree(child, "SIGKILL"),
+        options.terminateGraceMs,
+      );
+    }
+    const capture = (chunk: Buffer): void => {
+      if (!captureStderr(state, chunk, options.maxOutputBytes)) terminate("output-limit");
+    };
+    child.stdout.resume();
+    child.stderr.on("data", capture);
+    child.once("error", (error: NodeJS.ErrnoException) => reject(spawnError(error)));
+    child.once("close", (code) => {
+      finishProcess(code, state, options, resolve, reject);
+    });
+    child.stdin.on("error", () => undefined);
+    child.stdin.end(prompt);
+  });
+}
+
+/** Translate spawn failures without ever echoing unsanitized process detail. */
+function spawnError(error: NodeJS.ErrnoException): CodexAgentError {
+  if (error.code === "ENOENT") return missingCodexError();
+  return new CodexAgentError(
+    `Codex CLI could not start (${error.code ?? "unknown process error"}). ` +
+      "Check the local Codex installation and retry.",
+  );
+}
+
+/** Read at most `limit + 1` bytes so a hostile output file cannot race a stat. */
+async function readBoundedFile(filePath: string, limit: number): Promise<string> {
+  const handle = await open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    if (!(await handle.stat()).isFile()) {
+      throw new CodexAgentError("Codex CLI last-message output was not a regular file.");
+    }
+    const buffer = Buffer.alloc(limit + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead > limit) {
+      throw new CodexAgentError(`Codex CLI last message exceeded the ${limit}-byte output limit.`);
+    }
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Build fixed safety flags plus optional model/schema arguments. */
+function codexArgs(cwd: string, outputPath: string, model?: string, schemaPath?: string): string[] {
+  return [
+    "exec",
+    "--ephemeral",
+    "--sandbox", "read-only",
+    "--skip-git-repo-check",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--color", "never",
+    "--cd", cwd,
+    "--output-last-message", outputPath,
+    ...(schemaPath ? ["--output-schema", schemaPath] : []),
+    ...(model ? ["--model", model] : []),
+    "-",
+  ];
+}
+
+/** Turn a non-zero Codex exit into an actionable error without echoing child output. */
+function exitError(result: ProcessResult): CodexAgentError {
+  const authFailed = /auth|credential|log(?:ged)?[- ]?in/i.test(result.stderr);
+  const incompatible = /(?:unknown|unexpected|unrecognized|invalid)\s+(?:argument|option)/i
+    .test(result.stderr);
+  if (incompatible) {
+    return new CodexAgentError(
+      `Installed Codex CLI is incompatible with codex-agent. Upgrade to Codex CLI ${MINIMUM_CODEX_VERSION} or newer. ` +
+        "Child output was withheld to protect secrets.",
+    );
+  }
+  if (authFailed) {
+    return new CodexAgentError(
+      "Codex CLI authentication failed: it is not authenticated or its login was rejected. " +
+        "Run `codex login` and retry. " +
+        "Child output was withheld to protect secrets.",
+    );
+  }
+  return new CodexAgentError(
+    `Codex CLI failed with exit code ${result.code}. Check the local Codex installation and retry. ` +
+      "Child output was withheld to protect secrets.",
+  );
+}
+
+/** Codex CLI-backed provider using the CLI's locally managed ChatGPT login. */
+export class CodexAgentProvider implements LLMProvider {
+  private readonly model?: string;
+  private readonly options: Required<CodexAgentProviderOptions>;
+
+  constructor(model?: string, options: CodexAgentProviderOptions = {}) {
+    this.model = model?.trim() || undefined;
+    this.options = {
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      terminateGraceMs: options.terminateGraceMs ?? DEFAULT_TERMINATE_GRACE_MS,
+      maxOutputBytes: options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+    };
+  }
+
+  /** Complete one request. `maxTokens` is unsupported by Codex CLI and intentionally not forwarded. */
+  async complete(system: string, messages: LLMMessage[], _maxTokens: number): Promise<string> {
+    return this.invoke(buildPrompt(system, messages));
+  }
+
+  /** Codex buffers its final message; expose it as one callback chunk after completion. */
+  async stream(
+    system: string,
+    messages: LLMMessage[],
+    _maxTokens: number,
+    onToken?: (text: string) => void,
+  ): Promise<string> {
+    const text = await this.invoke(buildPrompt(system, messages));
+    onToken?.(text);
+    return text;
+  }
+
+  /** Request one schema-constrained JSON result and validate it again before returning it. */
+  async toolCall(
+    system: string,
+    messages: LLMMessage[],
+    tools: LLMTool[],
+    _maxTokens: number,
+  ): Promise<string> {
+    if (tools.length !== 1) {
+      throw new CodexAgentError(`Codex CLI requires exactly one structured tool schema; received ${tools.length}.`);
+    }
+    const schema = tools[0].input_schema;
+    const raw = await this.invoke(buildPrompt(system, messages, true), schema);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new CodexAgentError("Codex CLI returned invalid JSON for a structured request.");
+    }
+    const validate = ajv.compile(schema);
+    if (!validate(parsed)) {
+      throw new CodexAgentError(`Codex CLI response failed schema validation: ${ajv.errorsText(validate.errors)}`);
+    }
+    return JSON.stringify(parsed);
+  }
+
+  /** Codex CLI exposes no embeddings API; an explicit existing backend is required. */
+  async embed(_text: string): Promise<number[]> {
+    throw new CodexAgentError(
+      "The codex-agent provider cannot serve embeddings. Set LLMWIKI_EMBEDDING_PROVIDER to an existing embedding backend.",
+    );
+  }
+
+  /** Execute one request with private artifacts that are removed on every path. */
+  private async invoke(prompt: string, schema?: Record<string, unknown>): Promise<string> {
+    const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-codex-agent-"));
+    const outputPath = path.join(cwd, OUTPUT_FILE);
+    const schemaPath = schema ? path.join(cwd, SCHEMA_FILE) : undefined;
+    let releaseCustody = (): void => undefined;
+    try {
+      if (schemaPath) await writeFile(schemaPath, JSON.stringify(schema), { mode: 0o600 });
+      const result = await runCodex(
+        codexArgs(cwd, outputPath, this.model, schemaPath),
+        cwd,
+        prompt,
+        this.options,
+        (release) => { releaseCustody = release; },
+      );
+      if (result.code !== 0) throw exitError(result);
+      try {
+        return await readBoundedFile(outputPath, this.options.maxOutputBytes);
+      } catch (error) {
+        if (error instanceof CodexAgentError) throw error;
+        throw new CodexAgentError(
+          "Codex CLI completed without a readable final message. " +
+            "Its diagnostics were withheld to protect secrets; retry after checking the local Codex installation.",
+        );
+      }
+    } finally {
+      try {
+        await rm(cwd, { recursive: true, force: true });
+      } finally {
+        releaseCustody();
+      }
+    }
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -70,6 +70,7 @@ export const DEFAULT_PROVIDER = "anthropic";
 export const SUPPORTED_PROVIDER_INPUTS = [
   "anthropic",
   "claude-agent",
+  "codex-agent",
   "openai",
   "ollama",
   "minimax",
@@ -91,6 +92,7 @@ export function normalizeProviderName(providerName: string): string {
 export const PROVIDER_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-6",
   "claude-agent": "claude-sonnet-4-6",
+  "codex-agent": "codex-cli-default",
   openai: "gpt-4o",
   ollama: "llama3.1",
   minimax: "MiniMax-M2.7",

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -22,6 +22,7 @@ const NON_RETRIABLE_RE = /^4(?!29)\d\d\b/;
 
 /** Return true for client errors that will never succeed on retry (e.g. 401, 403). */
 function isNonRetriable(error: unknown): boolean {
+  if ((error as { nonRetryable?: unknown })?.nonRetryable === true) return true;
   const msg = error instanceof Error ? error.message : String(error);
   return NON_RETRIABLE_RE.test(msg);
 }

--- a/src/utils/provider-guard.ts
+++ b/src/utils/provider-guard.ts
@@ -24,7 +24,10 @@ import {
   normalizeProviderName,
 } from "./constants.js";
 import { resolveAnthropicAuthFromEnv } from "./claude-settings.js";
-import { findEmbeddingProviderProblem } from "./embedding-provider.js";
+import {
+  findEmbeddingProviderProblem,
+  isEmbeddingProviderExplicit,
+} from "./embedding-provider.js";
 
 /** Thrown when the active provider has no usable credentials. */
 export class ProviderUnavailableError extends Error {
@@ -53,6 +56,7 @@ export class UnknownProviderError extends Error {
 const PROVIDER_KEY_VARS: Record<string, string | readonly string[] | null> = {
   anthropic: "ANTHROPIC_API_KEY",
   "claude-agent": null,
+  "codex-agent": null,
   openai: "OPENAI_API_KEY",
   ollama: null,
   minimax: "MINIMAX_API_KEY",
@@ -97,6 +101,15 @@ function ensureEmbeddingProviderAvailable(): void {
 export function ensureProviderAvailable(): void {
   ensureEmbeddingProviderAvailable();
   const provider = normalizeProviderName(process.env.LLMWIKI_PROVIDER ?? DEFAULT_PROVIDER);
+
+  if (provider === "codex-agent" && !isEmbeddingProviderExplicit()) {
+    throw new ProviderUnavailableError(
+      provider,
+      ["LLMWIKI_EMBEDDING_PROVIDER"],
+      `The "codex-agent" provider cannot serve embeddings and never degrades silently.\n` +
+        `  Set LLMWIKI_EMBEDDING_PROVIDER to an existing embedding backend such as "ollama" or "openai".`,
+    );
+  }
 
   if (provider === "anthropic") {
     const auth = resolveAnthropicAuthFromEnv();

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -4,7 +4,7 @@
  * Defines the LLMProvider interface and a factory function that reads
  * LLMWIKI_PROVIDER and LLMWIKI_MODEL env vars to instantiate the
  * appropriate backend (Anthropic, Claude Agent SDK, OpenAI, Ollama, MiniMax,
- * GitHub Copilot, or Atlas Cloud).
+ * GitHub Copilot, Codex CLI, or Atlas Cloud).
  */
 
 import {
@@ -20,6 +20,7 @@ import { OllamaProvider } from "../providers/ollama.js";
 import { MiniMaxProvider } from "../providers/minimax.js";
 import { CopilotProvider } from "../providers/copilot.js";
 import { ClaudeAgentProvider } from "../providers/claude-agent.js";
+import { CodexAgentProvider } from "../providers/codex-agent.js";
 import {
   AtlasCloudProvider,
   resolveAtlasCloudApiKeyFromEnv,
@@ -93,6 +94,8 @@ export function buildProvider(providerName: string): LLMProvider {
       return getAnthropicProvider();
     case "claude-agent":
       return getClaudeAgentProvider();
+    case "codex-agent":
+      return new CodexAgentProvider(readOptionalEnv("LLMWIKI_MODEL"));
     case "openai":
       return new OpenAIProvider(getModelForProvider("openai"), {
         baseURL: readOptionalEnv("OPENAI_BASE_URL"),
@@ -228,6 +231,9 @@ export function resolveActiveModelId(): string {
   }
   if (providerName === "claude-agent") {
     return resolveAnthropicModelFromEnv() ?? PROVIDER_MODELS["claude-agent"];
+  }
+  if (providerName === "codex-agent") {
+    return readOptionalEnv("LLMWIKI_MODEL") ?? PROVIDER_MODELS["codex-agent"];
   }
   return getModelForProvider(
     providerName as "openai" | "ollama" | "minimax" | "copilot" | "atlascloud",

--- a/test/codex-agent-cli.test.ts
+++ b/test/codex-agent-cli.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Real-entry-point regressions for `LLMWIKI_PROVIDER=codex-agent` and
+ * `llmwiki compile --provider codex-agent`.
+ *
+ * Codex is mocked only at the executable boundary. The test otherwise drives
+ * the built CLI, complete compiler, page writer, and explicit Ollama-compatible
+ * embedding path.
+ */
+
+import { spawnSync } from "node:child_process";
+import { access, chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAimockLifecycle } from "./fixtures/aimock-helper.js";
+import { installFakeCodex, type FakeCodex } from "./fixtures/fake-codex.js";
+import { CLI, expectCLIFailure, expectCLIExit, runCLI } from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("codex-agent-cli");
+const fakes: FakeCodex[] = [];
+const tempRoots: string[] = [];
+const EMBEDDING_PRELOAD = path.resolve("test/fixtures/mock-embeddings.mjs");
+
+/** Copy Node with any adjacent runtime libraries needed after relocation. */
+async function copyNodeRuntime(runtime: string): Promise<string> {
+  const copiedNode = path.join(runtime, "node");
+  await copyFile(process.execPath, copiedNode);
+  await chmod(copiedNode, 0o755);
+  if (process.platform !== "darwin") return copiedNode;
+  const linked = spawnSync("/usr/bin/otool", ["-L", process.execPath], { encoding: "utf8" });
+  const libraries = [...linked.stdout.matchAll(/\t@rpath\/([^ ]+)/g)].map((match) => match[1]);
+  for (const library of libraries) {
+    const source = path.resolve(path.dirname(process.execPath), "../lib", library);
+    const destination = path.resolve(runtime, "../lib", library);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await copyFile(source, destination);
+  }
+  return copiedNode;
+}
+
+/** Install the process-boundary fake and register it for cleanup. */
+async function fakeCodex(options: Parameters<typeof installFakeCodex>[0] = {}): Promise<FakeCodex> {
+  const fake = await installFakeCodex(options);
+  fakes.push(fake);
+  return fake;
+}
+
+/** Environment for Codex chat plus an explicit keyless embedding backend. */
+function codexEnv(fake: FakeCodex): NodeJS.ProcessEnv {
+  return {
+    PATH: `${fake.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    NODE_OPTIONS: `--import=${EMBEDDING_PRELOAD}`,
+    LLMWIKI_PROVIDER: "codex-agent",
+    LLMWIKI_EMBEDDING_PROVIDER: "ollama",
+    OLLAMA_HOST: "http://127.0.0.1:1/v1",
+    OLLAMA_EMBEDDINGS_HOST: "http://127.0.0.1:1/v1",
+    OPENAI_API_KEY: "sk-parent-trap-must-not-reach-codex",
+  };
+}
+
+/** Valid extraction result used by the real compile pipeline. */
+function extractedConcept(): unknown {
+  return {
+    concepts: [{
+      concept: "Codex Agent Concept",
+      summary: "Produced through the process-boundary Codex fake.",
+      is_new: true,
+      tags: ["codex"],
+      confidence: 0.9,
+    }],
+  };
+}
+
+afterEach(async () => {
+  for (const fake of fakes.splice(0)) await fake.cleanup();
+  for (const root of tempRoots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("codex-agent through the real llmwiki CLI", () => {
+  it.each([
+    { label: "compile", args: ["compile"] },
+    { label: "refresh", args: ["refresh"] },
+    { label: "query", args: ["query"] },
+    { label: "watch", args: ["watch"] },
+    { label: "eval", args: ["eval"] },
+    { label: "quickstart", args: ["quickstart"] },
+    { label: "rules extract", args: ["rules", "extract"] },
+  ])("offers the standard provider flag on llmwiki $label", async ({ args }) => {
+    const cwd = await aimock.makeWorkspace("# Provider option surface\n");
+    const result = await runCLI([...args, "--help"], cwd);
+    expectCLIExit(result, 0);
+    expect(result.stdout).toContain("--provider <name>");
+  });
+
+  it.each([
+    { label: "environment", args: ["compile"], baseProvider: "codex-agent" },
+    { label: "provider flag", args: ["compile", "--provider", "codex-agent"], baseProvider: "openai" },
+  ])("runs the full compile pipeline via $label selection", async ({ args, baseProvider }) => {
+    const cwd = await aimock.makeWorkspace("# Codex source\n\nA durable source about Codex agent compilation.\n");
+    const fake = await fakeCodex({
+      toolOutput: extractedConcept(),
+      textOutput: "# Codex Agent Concept\n\nCompiled by the Codex CLI provider.",
+    });
+    const env = { ...codexEnv(fake), LLMWIKI_PROVIDER: baseProvider };
+
+    const result = await runCLI(args, cwd, env);
+
+    expectCLIExit(result, 0);
+    const pages = await readdir(path.join(cwd, "wiki", "concepts"));
+    expect(pages).toHaveLength(1);
+    expect(await readFile(path.join(cwd, "wiki", "concepts", pages[0]), "utf8"))
+      .toContain("Compiled by the Codex CLI provider");
+    const calls = await fake.calls();
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls.some((call) => call.args.includes("--output-schema"))).toBe(true);
+    expect(calls.some((call) => !call.args.includes("--output-schema"))).toBe(true);
+    for (const call of calls) {
+      expect(call.env.OPENAI_API_KEY).toBeUndefined();
+      expect(call.env.NODE_OPTIONS).toBeUndefined();
+      await expect(access(call.cwd)).rejects.toThrow();
+    }
+  }, 30_000);
+
+  it("fails actionably without silently falling back when codex is absent", async () => {
+    const cwd = await aimock.makeWorkspace("# Source\n\nCodex must be installed.\n");
+    const pathWithoutCodex = await mkdtemp(path.join(tmpdir(), "llmwiki-no-codex-"));
+    tempRoots.push(pathWithoutCodex);
+    const result = await runCLI(["compile"], cwd, {
+      PATH: pathWithoutCodex,
+      LLMWIKI_PROVIDER: "codex-agent",
+      LLMWIKI_EMBEDDING_PROVIDER: "ollama",
+    });
+    expectCLIFailure(result);
+    expect(result.stderr).toMatch(/Codex CLI.*install|install.*Codex CLI/i);
+    expect(result.stderr).not.toContain("ANTHROPIC_API_KEY");
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "never executes a Codex binary beside Node when the caller PATH excludes it",
+    async () => {
+      const cwd = await aimock.makeWorkspace("# Source\n\nCodex is excluded from PATH.\n");
+      const root = await mkdtemp(path.join(tmpdir(), "llmwiki-excluded-codex-"));
+      tempRoots.push(root);
+      const runtime = path.join(root, "runtime");
+      const emptyPath = path.join(root, "empty-path");
+      await Promise.all([mkdir(runtime), mkdir(emptyPath)]);
+      const copiedNode = await copyNodeRuntime(runtime);
+      const marker = path.join(root, "sibling-ran");
+      await writeFile(path.join(runtime, "codex"), `#!/bin/sh\nprintf ran > '${marker}'\nexit 9\n`, { mode: 0o755 });
+      const result = spawnSync(copiedNode, [CLI, "compile", "--provider", "codex-agent"], {
+        cwd,
+        env: { PATH: emptyPath, LLMWIKI_EMBEDDING_PROVIDER: "ollama" },
+        encoding: "utf8",
+      });
+      expect(result.status).not.toBe(0);
+      await expect(access(marker)).rejects.toThrow();
+      expect(result.stderr).toMatch(/Codex CLI.*not installed|install.*Codex CLI/i);
+    },
+  );
+
+  it.each([
+    {
+      label: "an incompatible secure flag",
+      exitCode: 2,
+      diagnostic: "error: unexpected argument '--ignore-user-config'; token=secret-value",
+      expected: /Codex CLI.*0\.152\.1.*newer|incompatible Codex CLI/i,
+      secret: /ignore-user-config|secret-value/,
+    },
+    {
+      label: "an authentication failure",
+      exitCode: 7,
+      diagnostic: "login rejected: Bearer subscription.secret OPENAI_API_KEY=sk-do-not-print",
+      expected: /Codex CLI.*authenticated|authenticated.*Codex CLI/i,
+      secret: /subscription\.secret|sk-do-not-print/,
+    },
+  ])("reports $label without exposing child output", async (failure) => {
+    const cwd = await aimock.makeWorkspace("# Source\n\nCodex must fail safely.\n");
+    const fake = await fakeCodex({ exitCode: failure.exitCode, stderr: failure.diagnostic });
+    const result = await runCLI(["compile"], cwd, codexEnv(fake));
+    expectCLIFailure(result);
+    expect(result.stderr).toMatch(failure.expected);
+    expect(result.stderr).not.toMatch(failure.secret);
+    expect(await fake.calls()).toHaveLength(1);
+  });
+
+  it("fails before invoking Codex when no embedding provider is explicit", async () => {
+    const cwd = await aimock.makeWorkspace("# Source\n\nEmbeddings must be explicit.\n");
+    const fake = await fakeCodex();
+    const result = await runCLI(["compile"], cwd, {
+      PATH: `${fake.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      LLMWIKI_PROVIDER: "codex-agent",
+      LLMWIKI_EMBEDDING_PROVIDER: "",
+      OPENAI_API_KEY: "sk-must-not-be-used",
+    });
+    expectCLIFailure(result);
+    expect(result.stderr).toMatch(/codex-agent[\s\S]*LLMWIKI_EMBEDDING_PROVIDER/i);
+    expect(await fake.calls()).toEqual([]);
+  });
+});

--- a/test/codex-agent-environment.test.ts
+++ b/test/codex-agent-environment.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Real-entrypoint checks for Codex provider selection before dotenv loading.
+ *
+ * A preload records actual `.env` reads, proving explicit Codex selection does
+ * not merely discard credentials after the project file has already been read.
+ */
+
+import { access, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { useAimockLifecycle } from "./fixtures/aimock-helper.js";
+import { installFakeCodex } from "./fixtures/fake-codex.js";
+import { expectCLIFailure, expectCLIExit, runCLI } from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("codex-agent-environment");
+const tracker = path.resolve("test/fixtures/track-dotenv-read.mjs");
+
+/** Environment that records dotenv reads and reaches the Codex boundary. */
+function trackedEnv(logPath: string): NodeJS.ProcessEnv {
+  return {
+    NODE_OPTIONS: `--import=${tracker}`,
+    LLMWIKI_TEST_DOTENV_READ_LOG: logPath,
+    LLMWIKI_EMBEDDING_PROVIDER: "ollama",
+  };
+}
+
+describe("codex-agent environment-file isolation", () => {
+  it.each([
+    { label: "provider flag", args: ["compile", "--provider", "codex-agent"], provider: "openai" },
+    { label: "provider equals flag", args: ["compile", "--provider=codex-agent"], provider: "openai" },
+    { label: "provider environment", args: ["compile"], provider: "codex-agent" },
+  ])("does not read project .env for explicit $label selection", async ({ args, provider }) => {
+    const cwd = await aimock.makeWorkspace("# Source\n\nDo not read project credentials.\n");
+    const logPath = path.join(cwd, "dotenv-reads.log");
+    await writeFile(path.join(cwd, ".env"), "OPENAI_API_KEY=sk-project-secret\n", "utf8");
+    const result = await runCLI(args, cwd, {
+      ...trackedEnv(logPath),
+      LLMWIKI_PROVIDER: provider,
+      PATH: path.join(cwd, "missing-bin"),
+    });
+    expectCLIFailure(result);
+    await expect(access(logPath)).rejects.toThrow();
+  });
+
+  it("retains project .env loading when codex-agent is not explicitly selected", async () => {
+    const cwd = await aimock.makeWorkspace("# Source\n");
+    const logPath = path.join(cwd, "dotenv-reads.log");
+    await writeFile(path.join(cwd, ".env"), "LLMWIKI_VERBOSE=1\n", "utf8");
+    const result = await runCLI(["--version"], cwd, {
+      ...trackedEnv(logPath),
+      LLMWIKI_PROVIDER: "",
+    });
+    expectCLIExit(result, 0);
+    expect(await readFile(logPath, "utf8")).toContain(path.join(cwd, ".env"));
+  });
+
+  it("retains DOTENV_CONFIG_PATH when codex-agent is not explicitly selected", async () => {
+    const cwd = await aimock.makeWorkspace("# Source\n");
+    const logPath = path.join(cwd, "dotenv-reads.log");
+    const configuredPath = path.join(cwd, "operator.env");
+    await writeFile(configuredPath, "LLMWIKI_VERBOSE=1\n", "utf8");
+    const result = await runCLI(["--version"], cwd, {
+      ...trackedEnv(logPath),
+      DOTENV_CONFIG_PATH: configuredPath,
+      LLMWIKI_TEST_DOTENV_TARGET: configuredPath,
+      LLMWIKI_PROVIDER: "",
+    });
+    expectCLIExit(result, 0);
+    expect(await readFile(logPath, "utf8")).toContain(configuredPath);
+  });
+});

--- a/test/codex-agent-interrupt.test.ts
+++ b/test/codex-agent-interrupt.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Real-entrypoint interruption custody for a running Codex invocation.
+ *
+ * The test signals llmwiki itself—not the fake—and observes the process PID and
+ * throwaway cwd captured at the literal Codex executable boundary.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { access, rm } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAimockLifecycle } from "./fixtures/aimock-helper.js";
+import { installFakeCodex, type CapturedCodexCall, type FakeCodex } from "./fixtures/fake-codex.js";
+import { CLI } from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("codex-agent-interrupt");
+const fakes: FakeCodex[] = [];
+const interruptionCases: Array<{ label: string; signals: NodeJS.Signals[] }> = [
+  { label: "one SIGINT", signals: ["SIGINT"] },
+  { label: "repeated SIGINT", signals: ["SIGINT", "SIGINT"] },
+  { label: "one SIGTERM", signals: ["SIGTERM"] },
+  { label: "repeated SIGTERM", signals: ["SIGTERM", "SIGTERM"] },
+];
+
+/** Wait until the fake has captured its first real process-boundary call. */
+async function waitForCall(fake: FakeCodex): Promise<CapturedCodexCall> {
+  await fake.ready();
+  const [call] = await fake.calls();
+  if (!call) throw new Error("Codex fake reported ready without a captured call");
+  return call;
+}
+
+/** Wait for the llmwiki parent to honor an interruption signal. */
+async function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await once(child, "exit");
+}
+
+/** Check PID liveness without reading any process-owned state. */
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Deliver repeated interrupts only after cleanup has observably started. */
+async function sendInterrupts(
+  child: ChildProcess,
+  fake: FakeCodex,
+  signals: NodeJS.Signals[],
+): Promise<void> {
+  child.kill(signals[0]);
+  await fake.waitForSignal("SIGTERM");
+  for (const signal of signals.slice(1)) child.kill(signal);
+}
+
+afterEach(async () => {
+  await Promise.all(fakes.splice(0).map((fake) => fake.cleanup()));
+});
+
+describe("codex-agent parent interruption", () => {
+  it.each(interruptionCases)(
+    "terminates the active Codex tree and removes its cwd after $label",
+    async ({ signals }) => {
+      const cwd = await aimock.makeWorkspace("# Source\n\nInterrupt the compile.\n");
+      const fake = await installFakeCodex({ hang: true, ignoreTerm: true });
+      fakes.push(fake);
+      const child = spawn(process.execPath, [CLI, "compile", "--provider", "codex-agent"], {
+        cwd,
+        env: {
+          ...process.env,
+          PATH: `${fake.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          LLMWIKI_EMBEDDING_PROVIDER: "ollama",
+        },
+        stdio: "ignore",
+      });
+      let call: CapturedCodexCall | undefined;
+      try {
+        call = await waitForCall(fake);
+        const exited = waitForExit(child);
+        await sendInterrupts(child, fake, signals);
+        await exited;
+        expect(processIsAlive(call.pid)).toBe(false);
+        await expect(access(call.cwd)).rejects.toThrow();
+      } finally {
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+        if (call && processIsAlive(call.pid)) process.kill(-call.pid, "SIGKILL");
+        if (call) await rm(call.cwd, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/test/codex-agent-preservation.test.ts
+++ b/test/codex-agent-preservation.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Preservation witnesses for adding the opt-in Codex provider.
+ *
+ * These pin the old default and an existing explicit provider while also
+ * proving that only the new provider receives stricter embedding treatment.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { AtlasCloudProvider } from "../src/providers/atlascloud.js";
+import { ClaudeAgentProvider } from "../src/providers/claude-agent.js";
+import { CopilotProvider } from "../src/providers/copilot.js";
+import { MiniMaxProvider } from "../src/providers/minimax.js";
+import { OpenAIProvider } from "../src/providers/openai.js";
+import { OllamaProvider } from "../src/providers/ollama.js";
+import { getEmbeddingProvider } from "../src/utils/embedding-provider.js";
+import { ensureProviderAvailable } from "../src/utils/provider-guard.js";
+import { getProvider } from "../src/utils/provider.js";
+
+const originalEnv = { ...process.env };
+afterEach(() => { process.env = { ...originalEnv }; });
+
+describe("codex-agent opt-in preservation", () => {
+  it("keeps Anthropic as the default provider", () => {
+    delete process.env.LLMWIKI_PROVIDER;
+    expect(getProvider()).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it("keeps the existing OpenAI selection and key guard unchanged", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.OPENAI_API_KEY = "existing-openai-key";
+    expect(() => ensureProviderAvailable()).not.toThrow();
+    expect(getProvider()).toBeInstanceOf(OpenAIProvider);
+  });
+
+  it.each([
+    ["anthropic", "ANTHROPIC_API_KEY", AnthropicProvider],
+    ["claude-agent", "", ClaudeAgentProvider],
+    ["openai", "OPENAI_API_KEY", OpenAIProvider],
+    ["ollama", "", OllamaProvider],
+    ["minimax", "MINIMAX_API_KEY", MiniMaxProvider],
+    ["copilot", "GITHUB_TOKEN", CopilotProvider],
+    ["atlascloud", "ATLASCLOUD_API_KEY", AtlasCloudProvider],
+  ])("keeps the existing %s provider factory behavior", (provider, key, expected) => {
+    process.env.LLMWIKI_PROVIDER = provider;
+    if (key) process.env[key] = "existing-provider-credential";
+    expect(() => ensureProviderAvailable()).not.toThrow();
+    expect(getProvider()).toBeInstanceOf(expected);
+  });
+
+  it("keeps existing providers' soft default embedding behavior", () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    process.env.ANTHROPIC_API_KEY = "existing-anthropic-key";
+    delete process.env.LLMWIKI_EMBEDDING_PROVIDER;
+    delete process.env.VOYAGE_API_KEY;
+    expect(() => ensureProviderAvailable()).not.toThrow();
+  });
+
+  it("accepts keyless codex chat only with an explicit usable embedding provider", () => {
+    process.env.LLMWIKI_PROVIDER = "codex-agent";
+    process.env.LLMWIKI_EMBEDDING_PROVIDER = "ollama";
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    expect(() => ensureProviderAvailable()).not.toThrow();
+    expect(getEmbeddingProvider()).toBeInstanceOf(OllamaProvider);
+  });
+
+  it("rejects implicit embedding degradation only for codex-agent", () => {
+    process.env.LLMWIKI_PROVIDER = "codex-agent";
+    delete process.env.LLMWIKI_EMBEDDING_PROVIDER;
+    expect(() => ensureProviderAvailable()).toThrow(/LLMWIKI_EMBEDDING_PROVIDER/);
+  });
+});

--- a/test/fixtures/fake-codex.ts
+++ b/test/fixtures/fake-codex.ts
@@ -1,0 +1,167 @@
+/**
+ * Process-boundary fake for Codex CLI provider tests.
+ *
+ * Installs an executable named exactly `codex` in a temporary PATH directory.
+ * The executable records argv, cwd, stdin, schema, and its complete environment
+ * before returning configured last-message output. This keeps tests faithful to
+ * the real spawn boundary without adding a production-only binary override.
+ */
+
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/** Behavior configured into one fake Codex executable. */
+export interface FakeCodexOptions {
+  toolOutput?: unknown;
+  rawToolOutput?: string;
+  textOutput?: string;
+  stderr?: string;
+  stdoutBytes?: number;
+  jsonStdoutBytes?: number;
+  exitCode?: number;
+  hang?: boolean;
+  ignoreTerm?: boolean;
+  forkDescendant?: boolean;
+  omitOutput?: boolean;
+}
+
+/** One invocation captured by the fake executable. */
+export interface CapturedCodexCall {
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  pid: number;
+  prompt: string;
+  schema: unknown | null;
+}
+
+/** Installed fake plus helpers for reading its journal and cleaning it up. */
+export interface FakeCodex {
+  binDir: string;
+  capturePath: string;
+  readyPath: string;
+  signalPath: string;
+  calls(): Promise<CapturedCodexCall[]>;
+  ready(): Promise<void>;
+  waitForSignal(signal: NodeJS.Signals): Promise<void>;
+  cleanup(): Promise<void>;
+}
+
+/** Read changing fixture state without treating a missing journal as an error. */
+async function fileContains(filePath: string, expected: string): Promise<boolean> {
+  try {
+    return (await readFile(filePath, "utf8")).includes(expected);
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve once a child-owned journal records expected state, without clock assumptions. */
+async function waitForFileContent(filePath: string, expected: string): Promise<void> {
+  while (!(await fileContains(filePath, expected))) {
+    // Each asynchronous read yields to the child process that owns the journal.
+  }
+}
+
+/** Serialize a value for embedding in the generated CommonJS fixture. */
+function literal(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+/** JavaScript expression yielding the fake's structured final-message bytes. */
+function structuredOutputExpression(options: FakeCodexOptions): string {
+  if (options.rawToolOutput !== undefined) return literal(options.rawToolOutput);
+  return `JSON.stringify(${literal(options.toolOutput ?? { value: "ok" })})`;
+}
+
+/** Build the fixture script body from immutable test configuration. */
+function fixtureSource(
+  capturePath: string,
+  readyPath: string,
+  signalPath: string,
+  options: FakeCodexOptions,
+): string {
+  const structuredOutput = structuredOutputExpression(options);
+  return `#!/usr/bin/env node
+const fs = require("node:fs");
+const { spawn } = require("node:child_process");
+const args = process.argv.slice(2);
+const after = (flag) => { const i = args.indexOf(flag); return i < 0 ? null : args[i + 1]; };
+let prompt = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { prompt += chunk; });
+process.stdin.on("end", () => {
+  const schemaPath = after("--output-schema");
+  const outputPath = after("--output-last-message");
+  const schema = schemaPath ? JSON.parse(fs.readFileSync(schemaPath, "utf8")) : null;
+  fs.appendFileSync(${literal(capturePath)}, JSON.stringify({
+    args, cwd: process.cwd(), env: process.env, pid: process.pid, prompt, schema,
+  }) + "\\n");
+  if (${literal(options.hang === true)}) {
+    const markReady = () => fs.writeFileSync(${literal(readyPath)}, "ready\\n");
+    process.on("SIGTERM", () => {
+      fs.appendFileSync(${literal(signalPath)}, "SIGTERM\\n");
+      if (!${literal(options.ignoreTerm === true)}) process.exit(143);
+    });
+    if (${literal(options.forkDescendant === true)}) {
+      const descendant = spawn(process.execPath, ["-e", ${literal(
+        'process.on("SIGTERM", () => {}); process.send("ready"); setInterval(() => {}, 1000);',
+      )}], { stdio: ["inherit", "inherit", "inherit", "ipc"] });
+      descendant.once("message", markReady);
+    } else {
+      markReady();
+    }
+    setInterval(() => {}, 1000);
+    return;
+  }
+  fs.writeFileSync(${literal(readyPath)}, "ready\\n");
+  if (${literal(options.stderr ?? "")}) process.stderr.write(${literal(options.stderr ?? "")});
+  const value = schemaPath
+    ? ${structuredOutput}
+    : ${literal(options.textOutput ?? "Codex response")};
+  const stdoutBytes = ${literal(options.stdoutBytes ?? 0)}
+    + (args.includes("--json") ? ${literal(options.jsonStdoutBytes ?? 0)} : 0);
+  if (stdoutBytes > 0) process.stdout.write("x".repeat(stdoutBytes));
+  if (outputPath && !${literal(options.omitOutput === true)}) {
+    fs.writeFileSync(outputPath, value, { mode: 0o600 });
+  }
+  if (stdoutBytes === 0 && args.includes("--json")) {
+    process.stdout.write('{"type":"turn.completed"}\\n');
+  } else if (stdoutBytes === 0) {
+    process.stdout.write(value);
+  }
+  process.exit(${literal(options.exitCode ?? 0)});
+});
+`;
+}
+
+/** Install a configured fake `codex` binary in an isolated directory. */
+export async function installFakeCodex(options: FakeCodexOptions = {}): Promise<FakeCodex> {
+  const root = await mkdtemp(path.join(tmpdir(), "llmwiki-fake-codex-"));
+  const binDir = path.join(root, "bin");
+  const capturePath = path.join(root, "calls.jsonl");
+  const readyPath = path.join(root, "ready");
+  const signalPath = path.join(root, "signals.log");
+  await import("node:fs/promises").then(({ mkdir }) => mkdir(binDir));
+  const binaryPath = path.join(binDir, "codex");
+  await writeFile(binaryPath, fixtureSource(capturePath, readyPath, signalPath, options), "utf8");
+  await chmod(binaryPath, 0o755);
+  return {
+    binDir,
+    capturePath,
+    readyPath,
+    signalPath,
+    async calls() {
+      try {
+        const content = await readFile(capturePath, "utf8");
+        return content.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+      } catch {
+        return [];
+      }
+    },
+    ready: () => waitForFileContent(readyPath, "ready\n"),
+    waitForSignal: (signal) => waitForFileContent(signalPath, `${signal}\n`),
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}

--- a/test/fixtures/mock-embeddings.mjs
+++ b/test/fixtures/mock-embeddings.mjs
@@ -1,0 +1,20 @@
+/**
+ * Offline fetch preload for real-CLI tests that need a successful embeddings
+ * pass without opening a loopback listener in restricted CI sandboxes.
+ */
+
+const VECTOR = Array.from({ length: 8 }, (_, index) => index / 10);
+
+globalThis.fetch = async (_input, init = {}) => {
+  const body = typeof init.body === "string" ? JSON.parse(init.body) : {};
+  const inputs = Array.isArray(body.input) ? body.input : [body.input];
+  return new Response(JSON.stringify({
+    object: "list",
+    data: inputs.map((_value, index) => ({ object: "embedding", index, embedding: VECTOR })),
+    model: body.model ?? "nomic-embed-text",
+    usage: { prompt_tokens: 1, total_tokens: 1 },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+};

--- a/test/fixtures/run-cli.ts
+++ b/test/fixtures/run-cli.ts
@@ -99,7 +99,7 @@ export async function runCLI(
     // it via the normal CLIResult shape instead of as a raw throw.
     await access(cwd);
 
-    const { stdout, stderr } = await exec("node", [CLI, ...args], {
+    const { stdout, stderr } = await exec(process.execPath, [CLI, ...args], {
       cwd,
       env: { ...process.env, ...envOverrides },
     });

--- a/test/fixtures/track-dotenv-read.mjs
+++ b/test/fixtures/track-dotenv-read.mjs
@@ -1,0 +1,30 @@
+/**
+ * Records project `.env` reads made by a real CLI subprocess.
+ *
+ * Loaded through Node's `--import` hook before the built CLI. It wraps only the
+ * synchronous file API used by dotenv and leaves all file contents untouched.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const originalReadFileSync = fs.readFileSync;
+const logPath = process.env.LLMWIKI_TEST_DOTENV_READ_LOG;
+const configuredTarget = process.env.LLMWIKI_TEST_DOTENV_TARGET;
+
+/** Resolve the fs API's supported path inputs to one comparable path. */
+function resolveInput(file) {
+  return path.resolve(file instanceof URL ? file.pathname : String(file));
+}
+
+/** Limit tracking to dotenv's default or the test's explicit configured path. */
+function shouldTrack(filePath) {
+  if (path.basename(filePath) === ".env") return true;
+  return configuredTarget ? filePath === path.resolve(configuredTarget) : false;
+}
+
+fs.readFileSync = function trackedReadFileSync(file, ...args) {
+  const filePath = resolveInput(file);
+  if (logPath && shouldTrack(filePath)) fs.appendFileSync(logPath, `${filePath}\n`);
+  return originalReadFileSync.call(this, file, ...args);
+};

--- a/test/provider-codex-agent-live.test.ts
+++ b/test/provider-codex-agent-live.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Live smoke test for the installed Codex CLI.
+ *
+ * This is intentionally the only test that crosses the real Codex process and
+ * subscription boundary. It skips only when the executable is absent; an
+ * installed-but-unauthenticated CLI is a real actionable failure.
+ */
+
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { CodexAgentProvider } from "../src/providers/codex-agent.js";
+
+/** True when literal PATH lookup can launch the real installed CLI. */
+function hasCodexBinary(): boolean {
+  try {
+    execFileSync("codex", ["--version"], { stdio: "ignore", timeout: 5_000 });
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ENOENT";
+  }
+}
+
+describe("CodexAgentProvider live smoke", () => {
+  it.skipIf(!hasCodexBinary())("invokes the real installed codex exec binary", async () => {
+    const provider = new CodexAgentProvider(undefined, { timeoutMs: 120_000 });
+    const result = await provider.complete(
+      "Return the requested literal text and nothing else.",
+      [{ role: "user", content: "Reply exactly: codex-agent-smoke-ok" }],
+      32,
+    );
+    expect(result.trim()).toBe("codex-agent-smoke-ok");
+  }, 130_000);
+});

--- a/test/provider-codex-agent.test.ts
+++ b/test/provider-codex-agent.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Behavioral contract for the Codex CLI-backed LLM provider.
+ *
+ * The fake lives at the literal `codex` PATH boundary, making argv, environment,
+ * throwaway-directory cleanup, schema validation, resource caps, and process
+ * termination observable without mocking Node's child_process implementation.
+ */
+
+import { access, chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexAgentProvider } from "../src/providers/codex-agent.js";
+import type { LLMTool } from "../src/utils/provider.js";
+import { installFakeCodex, type FakeCodex } from "./fixtures/fake-codex.js";
+
+const originalEnv = { ...process.env };
+const fakes: FakeCodex[] = [];
+const tempRoots: string[] = [];
+const TOOL: LLMTool = {
+  name: "return_value",
+  description: "Return one string value",
+  input_schema: {
+    type: "object",
+    properties: { value: { type: "string" } },
+    required: ["value"],
+    additionalProperties: false,
+  },
+};
+
+/** Install a fake and steer literal PATH lookup to it. */
+async function useFake(options: Parameters<typeof installFakeCodex>[0] = {}): Promise<FakeCodex> {
+  const fake = await installFakeCodex(options);
+  fakes.push(fake);
+  process.env.PATH = `${fake.binDir}${path.delimiter}${originalEnv.PATH ?? ""}`;
+  return fake;
+}
+
+/** Install a PATH node wrapper that proves launcher-added variables cannot cross the boundary. */
+async function installInjectingNodeWrapper(): Promise<string> {
+  const root = await mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "llmwiki-node-wrapper-"));
+  tempRoots.push(root);
+  const executable = process.execPath.replaceAll("'", "'\\''");
+  const wrapper = path.join(root, "node");
+  await writeFile(
+    wrapper,
+    `#!/bin/sh\nexport LLMWIKI_LAUNCHER_INJECTED=1\nexec '${executable}' "$@"\n`,
+  );
+  await chmod(wrapper, 0o755);
+  return root;
+}
+
+/** Assert one completion failure and the cleanup of its captured invocation cwd. */
+async function expectCleanFailure(
+  fake: FakeCodex,
+  options: ConstructorParameters<typeof CodexAgentProvider>[1],
+  message: RegExp,
+): Promise<void> {
+  const provider = new CodexAgentProvider(undefined, options);
+  await expect(provider.complete("system", [{ role: "user", content: "x" }], 1))
+    .rejects.toThrow(message);
+  const [call] = await fake.calls();
+  await expect(access(call.cwd)).rejects.toThrow();
+}
+
+/** Complete one request with the deliberately small output cap used by boundary witnesses. */
+async function expectCappedCompletion(expected: string): Promise<void> {
+  const provider = new CodexAgentProvider(undefined, {
+    timeoutMs: 2_000,
+    maxOutputBytes: 1_024,
+  });
+  await expect(provider.complete("system", [{ role: "user", content: "x" }], 1))
+    .resolves.toBe(expected);
+}
+
+/** Release timeout stages only after the fake can observe the complete signal sequence. */
+async function expectBoundedTimeout(fake: FakeCodex): Promise<void> {
+  const provider = new CodexAgentProvider(undefined, {
+    timeoutMs: 400,
+    terminateGraceMs: 100,
+  });
+  vi.useFakeTimers();
+  try {
+    const outcome = provider.complete("system", [{ role: "user", content: "x" }], 1)
+      .then((value) => ({ value }), (error: Error) => ({ error }));
+    await fake.ready();
+    await vi.advanceTimersByTimeAsync(400);
+    await fake.waitForSignal("SIGTERM");
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await outcome;
+    expect(result).toEqual({
+      error: expect.objectContaining({ message: expect.stringMatching(/timed out/i) }),
+    });
+    expect(await readFile(fake.signalPath, "utf8")).toBe("SIGTERM\n");
+    const [call] = await fake.calls();
+    await expect(access(call.cwd)).rejects.toThrow();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  process.env = { ...originalEnv };
+  await Promise.all(fakes.splice(0).map((fake) => fake.cleanup()));
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("CodexAgentProvider process boundary", () => {
+  it("runs an ephemeral, read-only, non-interactive exec in a cleaned throwaway cwd", async () => {
+    const fake = await useFake({ textOutput: "compiled page" });
+    process.env.OPENAI_API_KEY = "sk-parent-must-not-leak";
+    process.env.ANTHROPIC_API_KEY = "parent-anthropic-secret";
+    process.env.UNRELATED_PARENT_VALUE = "not-allowed";
+    const provider = new CodexAgentProvider("gpt-test", { timeoutMs: 2_000 });
+
+    await expect(provider.complete("system", [{ role: "user", content: "source" }], 17))
+      .resolves.toBe("compiled page");
+    const [call] = await fake.calls();
+    expect(call.args).toEqual(expect.arrayContaining([
+      "exec", "--ephemeral", "--sandbox", "read-only", "--skip-git-repo-check",
+      "--ignore-user-config", "--ignore-rules", "--color", "never",
+      "--model", "gpt-test", "-",
+    ]));
+    expect(call.args).not.toContain("--json");
+    expect(call.args).not.toContain("--ask-for-approval");
+    const cdArg = call.args[call.args.indexOf("--cd") + 1].replace(/^\/private(?=\/var\/)/, "");
+    expect(cdArg).toBe(call.cwd.replace(/^\/private(?=\/var\/)/, ""));
+    expect(call.prompt).toContain("system");
+    expect(call.prompt).toContain("source");
+    expect(call.env.OPENAI_API_KEY).toBeUndefined();
+    expect(call.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(call.env.UNRELATED_PARENT_VALUE).toBeUndefined();
+    expect(Object.keys(call.env).sort()).toEqual(
+      expect.arrayContaining(["HOME", "NO_COLOR", "PATH"]),
+    );
+    const allowed = new Set([
+      "PATH", "HOME", "USERPROFILE", "CODEX_HOME", "TMPDIR", "TMP", "TEMP",
+      "LANG", "LC_ALL", "SSL_CERT_FILE", "SSL_CERT_DIR", "SYSTEMROOT", "COMSPEC",
+      "PATHEXT", "NO_COLOR",
+      // macOS injects this after spawn even when it is absent from the supplied env object.
+      "__CF_USER_TEXT_ENCODING",
+    ]);
+    expect(Object.keys(call.env).filter((name) => !allowed.has(name))).toEqual([]);
+    await expect(access(call.cwd)).rejects.toThrow();
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "bypasses PATH interpreter wrappers that would expand the child environment",
+    async () => {
+      const fake = await useFake();
+      const wrapperDirectory = await installInjectingNodeWrapper();
+      process.env.PATH = [fake.binDir, wrapperDirectory, originalEnv.PATH ?? ""]
+        .join(path.delimiter);
+      await new CodexAgentProvider(undefined, { timeoutMs: 2_000 })
+        .complete("system", [{ role: "user", content: "hello" }], 1);
+      const [call] = await fake.calls();
+      expect(call.env.LLMWIKI_LAUNCHER_INJECTED).toBeUndefined();
+    },
+  );
+
+  it("passes no model flag when the operator leaves model selection to Codex", async () => {
+    const fake = await useFake();
+    await new CodexAgentProvider(undefined, { timeoutMs: 2_000 })
+      .complete("system", [{ role: "user", content: "hello" }], 4096);
+    expect((await fake.calls())[0].args).not.toContain("--model");
+  });
+
+  it("delivers Codex's buffered stream result as one final callback chunk", async () => {
+    await useFake({ textOutput: "streamed page" });
+    const chunks: string[] = [];
+    const provider = new CodexAgentProvider(undefined, { timeoutMs: 2_000 });
+    await expect(provider.stream(
+      "system",
+      [{ role: "user", content: "hello" }],
+      4_096,
+      (chunk) => chunks.push(chunk),
+    )).resolves.toBe("streamed page");
+    expect(chunks).toEqual(["streamed page"]);
+  });
+
+  it("rejects malformed JSON before a structured response can be consumed", async () => {
+    await useFake({ rawToolOutput: "not-json" });
+    const provider = new CodexAgentProvider(undefined, { timeoutMs: 2_000 });
+    await expect(provider.toolCall("system", [{ role: "user", content: "x" }], [TOOL], 99))
+      .rejects.toThrow(/invalid JSON/i);
+  });
+
+  it("validates structured last-message JSON against the requested schema", async () => {
+    const fake = await useFake({ toolOutput: { value: 7 } });
+    const provider = new CodexAgentProvider(undefined, { timeoutMs: 2_000 });
+    await expect(provider.toolCall("system", [{ role: "user", content: "x" }], [TOOL], 99))
+      .rejects.toThrow(/schema validation/i);
+    const [call] = await fake.calls();
+    await expect(access(call.cwd)).rejects.toThrow();
+  });
+
+  it("returns schema-valid structured output and cleans schema artifacts", async () => {
+    const fake = await useFake({ toolOutput: { value: "safe" } });
+    const provider = new CodexAgentProvider(undefined, { timeoutMs: 2_000 });
+    await expect(provider.toolCall("system", [{ role: "user", content: "x" }], [TOOL], 99))
+      .resolves.toBe('{"value":"safe"}');
+    const [call] = await fake.calls();
+    expect(call.schema).toEqual(TOOL.input_schema);
+    expect(call.args).toContain("--output-schema");
+    await expect(access(call.cwd)).rejects.toThrow();
+  });
+
+  it("rejects structured requests that do not provide exactly one schema", async () => {
+    const provider = new CodexAgentProvider(undefined, { timeoutMs: 2_000 });
+    await expect(provider.toolCall("system", [], [], 99)).rejects.toThrow(/exactly one/);
+    await expect(provider.toolCall("system", [], [TOOL, TOOL], 99)).rejects.toThrow(/exactly one/);
+  });
+
+  it("drains unconsumed stdout without charging it to the diagnostic cap", async () => {
+    const fake = await useFake({ stdoutBytes: 8_192 });
+    const provider = new CodexAgentProvider(undefined, {
+      timeoutMs: 2_000,
+      maxOutputBytes: 1_024,
+      terminateGraceMs: 50,
+    });
+
+    await expect(provider.complete("system", [{ role: "user", content: "x" }], 1))
+      .resolves.toBe("Codex response");
+    const [call] = await fake.calls();
+    await expect(access(call.cwd)).rejects.toThrow();
+  });
+
+  it("does not charge an unread JSON event stream against final-message delivery", async () => {
+    const answer = "x".repeat(768);
+    const fake = await useFake({ textOutput: answer, jsonStdoutBytes: 2_048 });
+
+    await expectCappedCompletion(answer);
+    expect((await fake.calls())[0].args).not.toContain("--json");
+  });
+
+  it("does not double-charge final stdout duplicated into the last-message file", async () => {
+    const answer = "x".repeat(768);
+    await useFake({ textOutput: answer, stderr: "d".repeat(400) });
+
+    await expectCappedCompletion(answer);
+  });
+
+  it("keeps stderr inside the subprocess output cap", async () => {
+    const fake = await useFake({ stderr: "x".repeat(8_192) });
+    await expectCleanFailure(fake, {
+      timeoutMs: 2_000,
+      maxOutputBytes: 1_024,
+      terminateGraceMs: 50,
+    }, /output limit/i);
+  });
+
+  it("caps the final-message artifact and cleans its throwaway directory", async () => {
+    const fake = await useFake({ textOutput: "x".repeat(2_048) });
+    await expectCleanFailure(fake, {
+      timeoutMs: 2_000,
+      maxOutputBytes: 1_024,
+    }, /last message.*output limit/i);
+  });
+
+  it("cleans its throwaway directory when Codex omits the final message", async () => {
+    const fake = await useFake({ omitOutput: true });
+    await expectCleanFailure(fake, { timeoutMs: 2_000 }, /without a readable final message/i);
+  });
+
+  it("cleans its throwaway directory when the codex binary is absent", async () => {
+    const root = await mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "llmwiki-codex-missing-"));
+    tempRoots.push(root);
+    const emptyBin = path.join(root, "bin");
+    await mkdir(emptyBin);
+    process.env.TMPDIR = root;
+    process.env.PATH = emptyBin;
+    await expect(new CodexAgentProvider(undefined, { timeoutMs: 2_000 })
+      .complete("system", [{ role: "user", content: "x" }], 1))
+      .rejects.toThrow(/Codex CLI.*not installed/i);
+    expect((await readdir(root)).filter((name) => name.startsWith("llmwiki-codex-agent-")))
+      .toEqual([]);
+  });
+
+  it("scrubs secret-shaped subprocess output from actionable failures", async () => {
+    await useFake({
+      exitCode: 7,
+      stderr:
+        'authentication failed: Bearer abc.secret, OPENAI_API_KEY=sk-live-secret, ' +
+        'GITHUB_TOKEN="ghp-another-secret", password=hunter2',
+    });
+    const provider = new CodexAgentProvider(undefined, { timeoutMs: 2_000 });
+    const failure = provider.complete("system", [{ role: "user", content: "x" }], 1);
+    await expect(failure).rejects.toThrow(/Codex CLI.*authentication failed/i);
+    await expect(failure).rejects.not.toThrow(/abc\.secret|sk-live-secret|ghp-another-secret|hunter2/);
+  });
+
+  it("bounds lifetime with graceful SIGTERM followed by forced termination", async () => {
+    const fake = await useFake({ hang: true, ignoreTerm: true });
+    await expectBoundedTimeout(fake);
+  });
+
+  it("bounds timeout lifetime when Codex leaves a descendant holding its pipes", async () => {
+    const fake = await useFake({ hang: true, ignoreTerm: true, forkDescendant: true });
+    await expectBoundedTimeout(fake);
+  });
+});


### PR DESCRIPTION
Closes #56.

## What this adds

`--provider codex-agent`: completions run through the locally installed Codex CLI, so the CLI's own login is the only credential. No API key is read or forwarded.

- **Process boundary.** Every call is `codex exec --ephemeral --sandbox read-only --skip-git-repo-check --ignore-user-config --ignore-rules --color never`, prompt on stdin, in a per-call throwaway cwd that is removed on every exit path. The child gets a 14-key environment allowlist and runs in its own process group; termination is SIGTERM then SIGKILL, and it also fires on parent SIGINT, SIGTERM, and exit, so an interrupted `llmwiki` never orphans a Codex process tree.
- **Executable lookup fails closed.** `codex` is resolved only from absolute PATH entries pointing at regular executable files; when none matches the call fails with an actionable error instead of launching a binary that happens to sit beside the Node runtime.
- **Output handling.** The answer is read from `--output-last-message` with a bounded `O_NOFOLLOW` read; stdout is drained uncounted; only stderr counts against the 1 MiB cap. Tool calls are validated against the requested tool's `input_schema` with Ajv (exactly one tool; malformed JSON and schema failures are rejected).
- **Credential hygiene.** Child output never enters an error message. Stderr is classified into actionable failures: not installed, not logged in, CLI too old for these flags (0.152.1 or newer), timed out. Selecting `codex-agent` on argv or in the shell environment skips loading the project `.env`.
- **Honesty.** `maxTokens` is documented as not forwarded. An unset model passes no `--model` and reports the `codex-cli-default` sentinel. Embeddings must name an explicit provider; the startup guard refuses an implicit one before Codex is spawned.
- **CLI.** A uniform `--provider` option on the seven commands that take a provider, each pinned by a `--help` test, with preservation tests for every existing provider.
- **Docs.** providers, environment variables, installation, FAQ, compile reference, README, CHANGELOG.

## Verification

- 51 new vitest cases across six files. The process-boundary tests drive the real built CLI: exact env allowlist, launcher-wrapper injection bypass, PATH fail-closed with a copied Node binary beside a trap `codex`, `.env` isolation observed at the `readFileSync` call, and interrupt custody for SIGINT, repeated SIGINT, and SIGTERM.
- A live smoke test runs against the installed Codex binary and skips only when `codex` is absent (ENOENT). Every argv flag was checked against `codex exec --help` of codex-cli 0.152.1.
- Timeout and interrupt tests wait on the fake Codex's readiness marker and drive the provider's timers with fake timers; nothing depends on process start-up speed.
- Full suite on this branch: 677 files passed, 5087 tests passed, 3 skipped.

## Known limits

- The version floor (0.152.1) is enforced by classifying the CLI's rejection of unknown flags, not by a `codex --version` check.
- Child diagnostics are withheld from error messages by design; there is no scrubbed debug channel yet.
- Windows executable lookup is untested.


