### PR TITLE
chore(release): prepare 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-09-09
+
+### Highlights
+
+- Profile-aware viewer navigation, declared record fields, relationships, provenance and evidence drill-down. Stored source previews are distinguished from original-publication links; artifact bytes are freshly verified and served only on loopback. Narrow layouts, plain-language labels and initially fitted, yielding graph layouts improve browsing.
+- OrcaRouter provider support with `openai/gpt-4o-mini` as its default and explicit credentials; embeddings remain unwired and fail closed.
+- Typed pages use the profile's declared title field. Citation line-list parsing is shared across consumers and accepts whitespace around commas.
+- Invalid concurrency warnings use stderr, preserving the quickstart JSON output channel.
+
+### Contributors
+
+Credit includes original proposals, reports and diagnoses, including work completed or extended by maintainers:
+
+- @PipDscvr: profile-aware viewer and declared fields (#176, #177, #180, #189), Windows path fixes (#172), separate embedding providers (#174), and source removal (#179).
+- @LorenzoGentile: optional Sources sections (#183), reasoning-model request compatibility (#184), and abbreviated-wikilink repair (#193).
+- @Marc-oss-hub: OrcaRouter provider support (#182).
+- @typevolant: citation line-list parsing and validation (#166), including the groundwork for #168.
+- @TigerOfCountryYao: original embedding opt-out, additive system policy, and shared-page reconciliation contributions (#169, #170, #171), completed in #198, #195 and #199.
+- @binyangzhu000-sudo: original Atlas Cloud provider contribution (#167), completed in #190.
+- @suyunzzz: subscription-authentication request (#56), addressed through local CLI-session reuse in #205.
+- @tienlx91: source-removal request (#60), implemented in #179.
+- @carmilso: project-level compile-instructions request (#144), partly addressed by the SDK system policy in #195.
+- @knew-inventai: separate embedding-endpoint request (#154), implemented in #174.
+- @squ1ddy: Windows profile-path report and diagnosis (#163), addressed in #172.
+- @graysoncooper: quickstart JSON-output corruption report (#191), addressed in #204.
+- @ddiall: ingestion-quality feedback in the source-removal discussion (#60).
+
+### Known limitations
+
+- Windows path fixes are included, but release CI remains Linux-only. Full Windows filesystem-confinement guarantees are not verified; use Linux for untrusted projects until #175 is resolved.
+
 ### Added
 
 - **OpenAI Codex CLI provider** — `LLMWIKI_PROVIDER=codex-agent` or
@@ -489,6 +520,8 @@ Initial release.
 - Atomic writes, lock-protected compilation, orphan marking for deleted sources.
 - `[[wikilink]]` resolution and auto-generated `wiki/index.md`.
 
+[Unreleased]: https://github.com/atomicstrata/llm-wiki-compiler/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/atomicstrata/llm-wiki-compiler/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/atomicstrata/llm-wiki-compiler/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/atomicstrata/llm-wiki-compiler/compare/v0.11.0...v1.0.0
 [0.2.0]: https://github.com/atomicmemory/llm-wiki-compiler/compare/v0.1.1...v0.2.0

--- a/README.md
+++ b/README.md
@@ -342,6 +342,15 @@ volta run --node 24 npx mint dev --port 3001
 
 ## Current release
 
+**Released `1.2.0`:**
+
+- Profile-aware viewer with document categories, record relationships, provenance, source previews, verified local artifact access, responsive navigation and fitted graphs.
+- Additional providers and OpenAI-compatible reasoning-model controls, independent embedding configuration, and SDK embedding opt-out.
+- Optional Sources sections and additive SDK system policies with prompt-change invalidation and per-page provenance.
+- Shared-page recovery after source removal, citation line-list fixes, and conservative abbreviated-wikilink repair.
+
+Windows path fixes are included, but Windows is not covered by release CI and its full filesystem-confinement guarantees remain unverified. Use a supported Linux environment for untrusted projects; see [#175](https://github.com/atomicstrata/llm-wiki-compiler/issues/175).
+
 **Released `1.1.0`:**
 
 - Template distribution ecosystem: publishers author signed, offline distributions with `template publish init | add | build | rotate | revoke` (Ed25519 signing, key rotation, package revocation) and verify them with `template publish verify`.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -18,6 +18,8 @@ llmwiki is a Node.js CLI that you install once globally with npm. After installa
 
 ## Install llmwiki
 
+Version **1.2.0** includes profile-aware browsing, source and artifact drill-down, and compile/provider improvements. Windows path fixes are included, but release CI is Linux-only and full Windows filesystem-confinement guarantees remain unverified. Use Linux for untrusted projects until [the Windows safety work](https://github.com/atomicstrata/llm-wiki-compiler/issues/175) is complete.
+
 Install the `llm-wiki-compiler` package globally. The package registers the `llmwiki` binary on your `PATH`:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-wiki-compiler",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.163",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Prepare version 1.2.0 from the existing public main. No runtime code or dependency versions change.

- Version the accumulated compiler, provider, citation and viewer improvements.
- Update README and installation guidance, including the known Windows limitation.
- Credit implementation contributors, original takeover authors, issue reporters and discussion input with links to their work.

## Verification

- The underlying public main passed its full hosted suite and code-health checks; the integrated local suite passed 5,327 tests with 3 skipped (live-provider smoke excluded).
- Fresh type-check, build, full-tree and diff-scoped code-health checks pass.
- Install-from-tarball SDK smoke passes.
- Targeted viewer byte-access checks pass, including probes with the no-follow flag disabled. These probes are not a native Windows certification.
- Local installation docs preview renders the new version, platform warning and install command; release-doc checks pass.

After merge, publication is gated by the exact-SHA publishing preflight, production documentation verification and registry provenance checks.
